### PR TITLE
feat(billing): lazy reset for all pooled balances + next-cycle contribution promotion

### DIFF
--- a/server/experiments/benchPooledPromotion.ts
+++ b/server/experiments/benchPooledPromotion.ts
@@ -34,17 +34,29 @@ const rearmDueRows = () =>
 		WHERE pooled_balance_id = ${POOL_ID}
 			AND id IN (SELECT 'benchpromo_pbc_' || g.n FROM generate_series(1, ${DUE}) AS g(n))`);
 
-// Promote due rows + recompute granted from ALL contributions (self-healing).
-// totals reads the pre-update snapshot, so due rows count at their promoted value.
+// Mirrors production promoteDuePooledContributions: guarded pool_update first
+// (updated_at latest vs snapshot), contribution promotion gated on it.
 const fullRecomputePromotion = () =>
 	db.execute(sql`
 		WITH totals AS (
 			SELECT
 				COALESCE(SUM(CASE WHEN effective_at IS NOT NULL AND effective_at <= ${NOW}::numeric
 					THEN next_cycle_contribution ELSE current_contribution END), 0) AS granted,
+				COUNT(*) AS total_count,
 				COUNT(*) FILTER (WHERE effective_at IS NOT NULL AND effective_at <= ${NOW}::numeric) AS due_count
 			FROM pooled_balance_contributions
 			WHERE pooled_balance_id = ${POOL_ID}
+		),
+		pool_update AS (
+			UPDATE pooled_balances
+			SET granted = totals.granted, updated_at = ${NOW}::numeric
+			FROM totals
+			WHERE pooled_balances.id = ${POOL_ID}
+				AND totals.total_count > 0
+				AND pooled_balances.updated_at = (
+					SELECT updated_at FROM pooled_balances WHERE id = ${POOL_ID}
+				)
+			RETURNING pooled_balances.granted, totals.due_count
 		),
 		promoted AS (
 			UPDATE pooled_balance_contributions
@@ -52,13 +64,11 @@ const fullRecomputePromotion = () =>
 				effective_at = NULL, updated_at = ${NOW}::numeric
 			WHERE pooled_balance_id = ${POOL_ID}
 				AND effective_at IS NOT NULL AND effective_at <= ${NOW}::numeric
+				AND EXISTS (SELECT 1 FROM pool_update)
 			RETURNING id
 		)
-		UPDATE pooled_balances pb
-		SET granted = totals.granted, updated_at = ${NOW}::numeric
-		FROM totals
-		WHERE pb.id = ${POOL_ID} AND totals.due_count > 0
-		RETURNING pb.granted`);
+		SELECT pool_update.granted::float8 AS granted, pool_update.due_count::int AS due_count
+		FROM pool_update`);
 
 // Promote due rows + apply only the delta (bounded by due rows).
 const deltaPromotion = () =>

--- a/server/experiments/benchPooledPromotion.ts
+++ b/server/experiments/benchPooledPromotion.ts
@@ -1,0 +1,179 @@
+/** Benchmarks pooled contribution promotion strategies at 100k and 1M
+ * contributions. Seeds a synthetic pool (benchpromo_ prefix), times the
+ * full-recompute and delta promotion statements, cleans up. */
+
+import { sql } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+
+const { db } = initDrizzle();
+const POOL_ID = "benchpromo_pool";
+const DUE = 1_000;
+const NOW = Date.now();
+
+const time = async (label: string, fn: () => Promise<unknown>) => {
+	const start = performance.now();
+	const result = await fn();
+	console.log(`${label}: ${(performance.now() - start).toFixed(1)}ms`);
+	return result;
+};
+
+const cleanup = async () => {
+	await db.execute(
+		sql`DELETE FROM pooled_balance_contributions WHERE pooled_balance_id = ${POOL_ID}`,
+	);
+	await db.execute(sql`DELETE FROM pooled_balances WHERE id = ${POOL_ID}`);
+	await db.execute(
+		sql`DELETE FROM customer_entitlements WHERE id LIKE 'benchpromo_ce_%'`,
+	);
+	await db.execute(sql`DROP INDEX IF EXISTS benchpromo_pending_idx`);
+};
+
+const rearmDueRows = () =>
+	db.execute(sql`
+		UPDATE pooled_balance_contributions SET effective_at = ${NOW - 1000}::numeric
+		WHERE pooled_balance_id = ${POOL_ID}
+			AND id IN (SELECT 'benchpromo_pbc_' || g.n FROM generate_series(1, ${DUE}) AS g(n))`);
+
+// Promote due rows + recompute granted from ALL contributions (self-healing).
+// totals reads the pre-update snapshot, so due rows count at their promoted value.
+const fullRecomputePromotion = () =>
+	db.execute(sql`
+		WITH totals AS (
+			SELECT
+				COALESCE(SUM(CASE WHEN effective_at IS NOT NULL AND effective_at <= ${NOW}::numeric
+					THEN next_cycle_contribution ELSE current_contribution END), 0) AS granted,
+				COUNT(*) FILTER (WHERE effective_at IS NOT NULL AND effective_at <= ${NOW}::numeric) AS due_count
+			FROM pooled_balance_contributions
+			WHERE pooled_balance_id = ${POOL_ID}
+		),
+		promoted AS (
+			UPDATE pooled_balance_contributions
+			SET current_contribution = next_cycle_contribution,
+				effective_at = NULL, updated_at = ${NOW}::numeric
+			WHERE pooled_balance_id = ${POOL_ID}
+				AND effective_at IS NOT NULL AND effective_at <= ${NOW}::numeric
+			RETURNING id
+		)
+		UPDATE pooled_balances pb
+		SET granted = totals.granted, updated_at = ${NOW}::numeric
+		FROM totals
+		WHERE pb.id = ${POOL_ID} AND totals.due_count > 0
+		RETURNING pb.granted`);
+
+// Promote due rows + apply only the delta (bounded by due rows).
+const deltaPromotion = () =>
+	db.execute(sql`
+		WITH due AS (
+			SELECT id, current_contribution, next_cycle_contribution
+			FROM pooled_balance_contributions
+			WHERE pooled_balance_id = ${POOL_ID}
+				AND effective_at IS NOT NULL AND effective_at <= ${NOW}::numeric
+			FOR UPDATE
+		),
+		promoted AS (
+			UPDATE pooled_balance_contributions pbc
+			SET current_contribution = due.next_cycle_contribution,
+				effective_at = NULL, updated_at = ${NOW}::numeric
+			FROM due WHERE pbc.id = due.id
+			RETURNING due.next_cycle_contribution - due.current_contribution AS delta
+		)
+		UPDATE pooled_balances pb
+		SET granted = pb.granted + COALESCE((SELECT SUM(delta) FROM promoted), 0)
+		WHERE pb.id = ${POOL_ID} AND EXISTS (SELECT 1 FROM promoted)
+		RETURNING pb.granted`);
+
+const runAtScale = async (total: number) => {
+	console.log(`\n===== ${total.toLocaleString()} contributions =====`);
+	await cleanup();
+
+	const templates = await db.execute<{
+		ce_id: string;
+		cp_id: string;
+		pool_id: string;
+	}>(sql`
+		SELECT pbc.source_customer_entitlement_id AS ce_id,
+			pbc.source_customer_product_id AS cp_id, pb.id AS pool_id
+		FROM pooled_balance_contributions pbc
+		JOIN pooled_balances pb ON pb.id = pbc.pooled_balance_id
+		WHERE pbc.id NOT LIKE 'benchpromo%' LIMIT 1`);
+	const template = templates[0];
+	if (!template) throw new Error("No pooled setup found in dev DB to clone");
+
+	const columns = await db.execute<{ column_name: string }>(sql`
+		SELECT column_name FROM information_schema.columns
+		WHERE table_name = 'customer_entitlements' AND table_schema = 'public'
+		ORDER BY ordinal_position`);
+	const selectList = columns
+		.map(({ column_name }) => {
+			if (column_name === "id") return `'benchpromo_ce_' || g.n`;
+			if (
+				["external_id", "pooled_contribution_id", "pooled_balance_id"].includes(
+					column_name,
+				)
+			)
+				return "NULL";
+			return `ce."${column_name}"`;
+		})
+		.join(", ");
+	const columnList = columns
+		.map(({ column_name }) => `"${column_name}"`)
+		.join(", ");
+
+	await time(`seed ${total} customer_entitlements`, () =>
+		db.execute(
+			sql.raw(`
+			INSERT INTO customer_entitlements (${columnList})
+			SELECT ${selectList}
+			FROM customer_entitlements ce, generate_series(1, ${total}) AS g(n)
+			WHERE ce.id = '${template.ce_id}'`),
+		),
+	);
+
+	await db.execute(sql`
+		INSERT INTO pooled_balances (id, org_id, env, internal_customer_id, internal_feature_id,
+			unlimited, granted, interval, interval_count, reset_cycle_anchor, reset_mode,
+			stripe_subscription_id, customer_license_link_id, rollover_signature,
+			customer_entitlement_id, last_applied_reset_at)
+		SELECT ${POOL_ID}, org_id, env, internal_customer_id, internal_feature_id,
+			false, ${total * 10}, interval, interval_count, 42, 'lazy',
+			NULL, NULL, 'benchpromo', 'benchpromo_ce_1', NULL
+		FROM pooled_balances WHERE id = ${template.pool_id}`);
+
+	await time(`seed ${total} contributions (${DUE} due)`, () =>
+		db.execute(sql`
+			INSERT INTO pooled_balance_contributions (id, pooled_balance_id,
+				source_customer_product_id, source_customer_entitlement_id,
+				current_contribution, next_cycle_contribution, effective_at)
+			SELECT 'benchpromo_pbc_' || g.n, ${POOL_ID}, ${template.cp_id},
+				'benchpromo_ce_' || g.n, 10, 12,
+				CASE WHEN g.n <= ${DUE} THEN ${NOW - 1000}::numeric ELSE NULL END
+			FROM generate_series(1, ${total}) AS g(n)`),
+	);
+	await db.execute(sql`
+		CREATE INDEX benchpromo_pending_idx ON pooled_balance_contributions
+		(pooled_balance_id, effective_at) WHERE effective_at IS NOT NULL`);
+	await db.execute(sql`ANALYZE pooled_balance_contributions`);
+
+	await time("bare SUM over all contributions", () =>
+		db.execute(sql`
+			SELECT COALESCE(SUM(current_contribution), 0)::float8
+			FROM pooled_balance_contributions WHERE pooled_balance_id = ${POOL_ID}`),
+	);
+
+	await time(`FULL-RECOMPUTE promotion (${DUE} due, sum over all)`, fullRecomputePromotion);
+	await rearmDueRows();
+	await time(`FULL-RECOMPUTE promotion again (warm cache)`, fullRecomputePromotion);
+	await rearmDueRows();
+	await time(`DELTA promotion (${DUE} due)`, deltaPromotion);
+	await time("FULL-RECOMPUTE no-op (0 due rows)", fullRecomputePromotion);
+};
+
+try {
+	await runAtScale(100_000);
+	await runAtScale(1_000_000);
+} catch (error) {
+	console.error("BENCH FAILED:", error);
+} finally {
+	await time("cleanup", cleanup);
+	process.exit(0);
+}

--- a/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/applyFieldUpdates.lua
+++ b/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/applyFieldUpdates.lua
@@ -223,3 +223,13 @@ local function apply_replaceable_updates(params)
     end
   end
 end
+
+local function apply_pooled_granted_update(params)
+  local subject_balance = params.subject_balance
+  local update = params.update
+
+  if is_absent(update.pooled_granted) then return end
+  if type(subject_balance.pooled_balance) ~= 'table' then return end
+
+  subject_balance.pooled_balance.granted = update.pooled_granted
+end

--- a/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/updateSubjectBalances.lua
+++ b/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/updateSubjectBalances.lua
@@ -33,6 +33,7 @@
         reset_cycle_anchor: number | null,
         next_reset_at: number | null,
         expected_next_reset_at: number | null,
+        pooled_granted: number | null,
         rollover_insert: { id, cus_ent_id, balance, usage, expires_at, entities } | null,
         rollover_overwrites: [{ id, balance, usage, entities }] | null,
         rollover_delete_ids: string[] | null,
@@ -109,6 +110,7 @@ for _, update in ipairs(updates) do
       apply_entities_update(helper_params)
       apply_reset_cycle_anchor_update(helper_params)
       apply_next_reset_at_update(helper_params)
+      apply_pooled_granted_update(helper_params)
       apply_rollover_updates(helper_params)
       apply_replaceable_updates(helper_params)
 

--- a/server/src/cron/resetCron/resetCustomerEntitlement.ts
+++ b/server/src/cron/resetCron/resetCustomerEntitlement.ts
@@ -12,6 +12,8 @@ import { format } from "date-fns";
 import type { RepoContext } from "@/db/repoContext";
 import { resolveCustomerRedisRouting } from "@/external/redis/customerRedisRouting.js";
 import type { OrgWithRedisConfig } from "@/external/redis/orgRedisPool.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { promoteDuePooledContributions } from "@/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.js";
 import { invalidateCustomerEntitlementBalance } from "@/internal/customers/cache/fullSubject/actions/invalidate/invalidateCustomerEntitlementBalance.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { getRelatedCusPrice } from "@/internal/customers/cusProducts/cusEnts/cusEntUtils.js";
@@ -58,9 +60,16 @@ const resetCustomerEntitlementInDb = async ({
 		const ent = cusEnt.entitlement;
 		if (
 			cusEnt.pooled_balance &&
-			cusEnt.pooled_balance.reset_mode !== PooledBalanceResetMode.Lazy
+			cusEnt.pooled_balance.reset_mode === PooledBalanceResetMode.Lifetime
 		) {
 			return;
+		}
+		if (cusEnt.pooled_balance) {
+			await promoteDuePooledContributions({
+				ctx: repoContext as AutumnContext,
+				customerEntitlement: cusEnt,
+				now: Date.now(),
+			});
 		}
 		const shortDurationInterval = ent.interval;
 

--- a/server/src/internal/balances/batchReset/compute/classifyNoAction.ts
+++ b/server/src/internal/balances/batchReset/compute/classifyNoAction.ts
@@ -28,9 +28,7 @@ export const classifyNoAction = ({
 		};
 	}
 
-	if (
-		isPooledBalanceSourceCustomerEntitlement({ customerEntitlement })
-	) {
+	if (isPooledBalanceSourceCustomerEntitlement({ customerEntitlement })) {
 		return {
 			kind: "no_action",
 			customerEntitlementId: customerEntitlement.id,
@@ -38,9 +36,7 @@ export const classifyNoAction = ({
 		};
 	}
 
-	if (
-		isSyntheticPooledBalanceCustomerEntitlement({ customerEntitlement })
-	) {
+	if (isSyntheticPooledBalanceCustomerEntitlement({ customerEntitlement })) {
 		if (!customerEntitlement.pooled_balance) {
 			return {
 				kind: "no_action",
@@ -51,11 +47,12 @@ export const classifyNoAction = ({
 
 		if (
 			customerEntitlement.pooled_balance.reset_mode ===
-			PooledBalanceResetMode.Subscription
+			PooledBalanceResetMode.Lifetime
 		) {
 			return {
-				kind: "resets_via_invoice",
+				kind: "no_action",
 				customerEntitlementId: customerEntitlement.id,
+				reason: "pooled_balance_lifetime",
 			};
 		}
 	}

--- a/server/src/internal/balances/batchReset/types.ts
+++ b/server/src/internal/balances/batchReset/types.ts
@@ -32,7 +32,8 @@ export type ResetVerdict = {
 		| "product_not_active"
 		| "not_due"
 		| "pooled_balance_source"
-		| "pooled_balance_missing";
+		| "pooled_balance_missing"
+		| "pooled_balance_lifetime";
 	unlimited?: boolean;
 };
 

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityDetails.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityDetails.ts
@@ -1,3 +1,4 @@
+import type { DbPooledBalanceContribution } from "@autumn/shared";
 import {
 	addCusProductToCusEnt,
 	customerPriceToCustomerEntitlement,
@@ -19,6 +20,7 @@ import { getLineItemBillingPeriod } from "@/internal/billing/v2/utils/lineItems/
 import { calculateUpdateQuantityDifferences } from "./calculateUpdateQuantityDifferences";
 import { computeUpdateQuantityCustomerEntitlementChanges } from "./computeUpdateQuantityCustomerEntitlementChanges";
 import { computeUpdateQuantityLineItems } from "./computeUpdateQuantityLineItems";
+import { computeUpdateQuantityPooledContributionUpdate } from "./computeUpdateQuantityPooledContributionUpdate";
 
 /**
  * Computes all details needed for a feature quantity update operation.
@@ -46,6 +48,7 @@ export const computeUpdateQuantityDetails = ({
 	updateCustomerEntitlements: UpdateCustomerEntitlement[];
 	lineItems: LineItem[];
 	updatedOptions: FeatureOptions;
+	pooledContributionUpdate: DbPooledBalanceContribution | null;
 } => {
 	const { customerProduct, currentEpochMs, billingCycleAnchorMs } =
 		updateSubscriptionContext;
@@ -147,10 +150,20 @@ export const computeUpdateQuantityDetails = ({
 		currentEpochMs,
 	});
 
+	const pooledContributionUpdate =
+		computeUpdateQuantityPooledContributionUpdate({
+			customerEntitlement,
+			customerProduct,
+			updatedOptions,
+			effectiveAt: billingPeriod.end,
+			now: currentEpochMs,
+		});
+
 	return {
 		featureId,
 		updateCustomerEntitlements,
 		lineItems,
 		updatedOptions,
+		pooledContributionUpdate,
 	};
 };

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan.ts
@@ -1,9 +1,11 @@
 import {
 	type AutumnBillingPlan,
 	isOneOffPrice,
+	notNullish,
 	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { emptyPooledBalancePlan } from "@/internal/billing/v2/utils/billingPlan/pooledBalancePlan";
 import { computeUpdateQuantityDetails } from "./computeUpdateQuantityDetails";
 
 export const computeUpdateQuantityPlan = ({
@@ -38,8 +40,19 @@ export const computeUpdateQuantityPlan = ({
 	const updatedOptions = quantityUpdateDetails.map(
 		(detail) => detail.updatedOptions,
 	);
+	const updatePoolContributions = quantityUpdateDetails
+		.map((detail) => detail.pooledContributionUpdate)
+		.filter(notNullish);
 
 	return {
+		...(updatePoolContributions.length > 0
+			? {
+					pooledBalancePlan: {
+						...emptyPooledBalancePlan(),
+						updatePoolContributions,
+					},
+				}
+			: {}),
 		customerId: updateSubscriptionContext.fullCustomer?.id ?? "",
 		insertCustomerProducts: [],
 		customPrices: [],

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPooledContributionUpdate.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPooledContributionUpdate.ts
@@ -1,0 +1,60 @@
+import {
+	type DbPooledBalanceContribution,
+	type FeatureOptions,
+	type FullCusProduct,
+	type FullCustomerEntitlement,
+	notNullish,
+} from "@autumn/shared";
+import { computePooledBalanceContributionAmounts } from "@/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/computePooledBalanceContributionAmounts";
+
+/**
+ * Deferred (next-cycle) quantity changes on a pooled prepaid contributor are
+ * recorded on its contribution row and promoted at the pool's next reset.
+ * Immediate quantity changes are not handled here.
+ */
+export const computeUpdateQuantityPooledContributionUpdate = ({
+	customerEntitlement,
+	customerProduct,
+	updatedOptions,
+	effectiveAt,
+	now,
+}: {
+	customerEntitlement: FullCustomerEntitlement;
+	customerProduct: FullCusProduct;
+	updatedOptions: FeatureOptions;
+	effectiveAt: number;
+	now: number;
+}): DbPooledBalanceContribution | null => {
+	const contribution = customerEntitlement.pooled_balance_contribution;
+	if (!contribution) return null;
+
+	const hasDeferredQuantityChange =
+		notNullish(updatedOptions.upcoming_quantity) &&
+		updatedOptions.upcoming_quantity !== updatedOptions.quantity;
+	if (!hasDeferredQuantityChange) return null;
+
+	const customerProductWithUpdatedOptions: FullCusProduct = {
+		...customerProduct,
+		options: customerProduct.options.map((options) =>
+			options.feature_id === updatedOptions.feature_id
+				? updatedOptions
+				: options,
+		),
+	};
+	const contributionAmounts = computePooledBalanceContributionAmounts({
+		contributionCustomerEntitlement: customerEntitlement,
+		customerProduct: customerProductWithUpdatedOptions,
+	});
+
+	return {
+		...contribution,
+		current_contribution: contributionAmounts.currentContribution,
+		next_cycle_contribution: contributionAmounts.nextCycleContribution,
+		effective_at:
+			contributionAmounts.nextCycleContribution !==
+			contributionAmounts.currentContribution
+				? effectiveAt
+				: null,
+		updated_at: now,
+	};
+};

--- a/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceGraph.ts
+++ b/server/src/internal/billing/v2/pooledBalances/compute/applyIncomingPooledBalanceSources/initPooledBalanceGraph.ts
@@ -4,7 +4,6 @@ import {
 	type FullCustomerEntitlement,
 	isBooleanEntitlement,
 	type PooledBalanceIdentity,
-	PooledBalanceResetMode,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { generateId } from "@/utils/genUtils";
@@ -62,11 +61,6 @@ export const initPooledBalanceGraph = ({
 		unlimited: identity.unlimited,
 		rollover: contributionCustomerEntitlement.entitlement.rollover,
 	});
-	const resetsViaInvoice =
-		!isBoolean &&
-		!identity.unlimited &&
-		identity.resetMode === PooledBalanceResetMode.Subscription;
-
 	return {
 		...structuredClone(contributionCustomerEntitlement),
 		id: customerEntitlementId,
@@ -94,7 +88,9 @@ export const initPooledBalanceGraph = ({
 		next_reset_at: nextResetAt,
 		cache_version: 0,
 		external_id: null,
-		reset_by_invoice: resetsViaInvoice,
+		// Pools reset through the lazy/cron paths regardless of mode; the batch
+		// scan must keep seeing them, so never stamp reset_by_invoice.
+		reset_by_invoice: false,
 		is_pooled_balance: true,
 		pooled_balance_id: pooledBalanceId,
 		pooled_contribution_id: null,

--- a/server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts
@@ -31,6 +31,9 @@ export const promoteDuePooledContributions = async ({
 
 	// totals reads the pre-update snapshot: due rows count at their promoted
 	// value, so the recomputed granted matches the post-promotion state.
+	// The pool UPDATE guards on updated_at (latest row version vs statement
+	// snapshot): a transition committing mid-statement makes it 0 rows, and
+	// the contribution promotion is gated on it, so the whole statement no-ops.
 	const rows = await ctx.db.execute<{
 		granted: number | string;
 		due_count: number | string;
@@ -49,6 +52,18 @@ export const promoteDuePooledContributions = async ({
 			FROM pooled_balance_contributions
 			WHERE pooled_balance_id = ${pooledBalance.id}
 		),
+		pool_update AS (
+			UPDATE pooled_balances
+			SET granted = totals.granted, updated_at = ${now}::numeric
+			FROM totals
+			WHERE pooled_balances.id = ${pooledBalance.id}
+				AND totals.total_count > 0
+				AND pooled_balances.updated_at = (
+					SELECT updated_at FROM pooled_balances
+					WHERE id = ${pooledBalance.id}
+				)
+			RETURNING pooled_balances.granted, totals.due_count
+		),
 		promoted AS (
 			UPDATE pooled_balance_contributions
 			SET current_contribution = next_cycle_contribution,
@@ -57,15 +72,12 @@ export const promoteDuePooledContributions = async ({
 			WHERE pooled_balance_id = ${pooledBalance.id}
 				AND effective_at IS NOT NULL
 				AND effective_at <= ${now}::numeric
+				AND EXISTS (SELECT 1 FROM pool_update)
 			RETURNING id
 		)
-		UPDATE pooled_balances
-		SET granted = totals.granted, updated_at = ${now}::numeric
-		FROM totals
-		WHERE pooled_balances.id = ${pooledBalance.id}
-			AND totals.total_count > 0
-		RETURNING pooled_balances.granted::float8 AS granted,
-			totals.due_count::int AS due_count
+		SELECT pool_update.granted::float8 AS granted,
+			pool_update.due_count::int AS due_count
+		FROM pool_update
 		${planetScaleTag({ query: "promoteDuePooledContributions" })}
 	`);
 

--- a/server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts
@@ -1,5 +1,5 @@
-import type { FullCustomerEntitlement } from "@autumn/shared";
-import { sql } from "drizzle-orm";
+import { type FullCustomerEntitlement, pooledBalances } from "@autumn/shared";
+import { eq, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
@@ -82,7 +82,17 @@ export const promoteDuePooledContributions = async ({
 	`);
 
 	const row = rows[0];
-	if (row === undefined) return null;
+	if (row === undefined) {
+		// Guard trip (or contribution-less pool): a concurrent writer owns the
+		// latest granted — refresh it so the caller can't refill from a stale
+		// in-memory value if it goes on to win the reset CAS.
+		const [freshPool] = await ctx.db
+			.select({ granted: pooledBalances.granted })
+			.from(pooledBalances)
+			.where(eq(pooledBalances.id, pooledBalance.id));
+		if (freshPool) pooledBalance.granted = freshPool.granted;
+		return null;
+	}
 
 	const promotedGranted = Number(row.granted);
 	if (!Number.isFinite(promotedGranted)) {

--- a/server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts
@@ -1,0 +1,86 @@
+import type { FullCustomerEntitlement } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { planetScaleTag } from "@/db/dbUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export type PromoteDuePooledContributionsResult = {
+	granted: number;
+	promotedCount: number;
+};
+
+/**
+ * Promotes due next-cycle contributions (effective_at passed) and recomputes
+ * granted from ALL contributions in one statement. When the pool has any
+ * contributions, granted is ALWAYS written back — self-heals drift and gives
+ * concurrent resetters the authoritative value instead of their stale
+ * in-memory copy. Contribution-less pools are left untouched.
+ * DB + memory only — cache propagation is the caller's job, AFTER its own
+ * cache writes (the lazy path patches the subject cache post-reset).
+ */
+export const promoteDuePooledContributions = async ({
+	ctx,
+	customerEntitlement,
+	now,
+}: {
+	ctx: AutumnContext;
+	customerEntitlement: FullCustomerEntitlement;
+	now: number;
+}): Promise<PromoteDuePooledContributionsResult | null> => {
+	const pooledBalance = customerEntitlement.pooled_balance;
+	if (!pooledBalance || pooledBalance.unlimited) return null;
+
+	// totals reads the pre-update snapshot: due rows count at their promoted
+	// value, so the recomputed granted matches the post-promotion state.
+	const rows = await ctx.db.execute<{
+		granted: number | string;
+		due_count: number | string;
+	}>(sql`
+		WITH totals AS (
+			SELECT
+				COALESCE(SUM(CASE
+					WHEN effective_at IS NOT NULL AND effective_at <= ${now}::numeric
+					THEN next_cycle_contribution
+					ELSE current_contribution
+				END), 0) AS granted,
+				COUNT(*) AS total_count,
+				COUNT(*) FILTER (
+					WHERE effective_at IS NOT NULL AND effective_at <= ${now}::numeric
+				) AS due_count
+			FROM pooled_balance_contributions
+			WHERE pooled_balance_id = ${pooledBalance.id}
+		),
+		promoted AS (
+			UPDATE pooled_balance_contributions
+			SET current_contribution = next_cycle_contribution,
+				effective_at = NULL,
+				updated_at = ${now}::numeric
+			WHERE pooled_balance_id = ${pooledBalance.id}
+				AND effective_at IS NOT NULL
+				AND effective_at <= ${now}::numeric
+			RETURNING id
+		)
+		UPDATE pooled_balances
+		SET granted = totals.granted, updated_at = ${now}::numeric
+		FROM totals
+		WHERE pooled_balances.id = ${pooledBalance.id}
+			AND totals.total_count > 0
+		RETURNING pooled_balances.granted::float8 AS granted,
+			totals.due_count::int AS due_count
+		${planetScaleTag({ query: "promoteDuePooledContributions" })}
+	`);
+
+	const row = rows[0];
+	if (row === undefined) return null;
+
+	const promotedGranted = Number(row.granted);
+	if (!Number.isFinite(promotedGranted)) {
+		ctx.logger.error(
+			`[promoteDuePooledContributions] non-numeric granted '${row.granted}' for pool ${pooledBalance.id}`,
+		);
+		return null;
+	}
+
+	pooledBalance.granted = promotedGranted;
+
+	return { granted: promotedGranted, promotedCount: Number(row.due_count) };
+};

--- a/server/src/internal/billing/v2/pooledBalances/execute/resetPooledBalances.ts
+++ b/server/src/internal/billing/v2/pooledBalances/execute/resetPooledBalances.ts
@@ -50,7 +50,12 @@ export const resetPooledBalances = async ({
 		skipped,
 	});
 
-	if (Object.keys(applied).length > 0) {
+	// Promotion changes granted even when the balance reset lost its CAS race,
+	// so a promoted-but-skipped pool still needs the cache dropped.
+	const anyPromoted = computed.some(
+		({ result }) => result.pooledContributionsPromoted,
+	);
+	if (Object.keys(applied).length > 0 || anyPromoted) {
 		await invalidateCachedFullSubject({
 			ctx,
 			customerId: fullCustomer.id ?? fullCustomer.internal_id,

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/processReset.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/processReset.ts
@@ -10,6 +10,7 @@ import {
 } from "@autumn/shared";
 import { logger } from "better-auth";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { promoteDuePooledContributions } from "@/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.js";
 import { getRolloverUpdates } from "@/internal/customers/cusProducts/cusEnts/cusRollovers/rolloverUtils.js";
 import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils.js";
 import { getResetAtUpdate } from "./getResetAtUpdate.js";
@@ -28,6 +29,10 @@ export type ProcessResetResult = {
 		rows: Rollover[];
 		fullCusEnt: FullCusEntWithProduct;
 	};
+	/** Authoritative pool granted after contribution promotion/drift-healing;
+	 * callers must propagate it to their caches after their own cache writes. */
+	pooledGranted?: number;
+	pooledContributionsPromoted?: boolean;
 };
 
 /** Processes a single cusEnt reset. Returns updates + optional rollover insert, or null if skipped. */
@@ -48,6 +53,22 @@ export const processReset = async ({
 		isLifetimeEntitlement({ entitlement: ent })
 	) {
 		return null;
+	}
+
+	// Due next-cycle contributions change the pool's granted, so promote
+	// before deriving the refill amount.
+	let pooledGranted: number | undefined;
+	let pooledContributionsPromoted: boolean | undefined;
+	if (cusEnt.pooled_balance) {
+		const promotion = await promoteDuePooledContributions({
+			ctx,
+			customerEntitlement: cusEnt,
+			now: Date.now(),
+		});
+		if (promotion !== null) {
+			pooledGranted = promotion.granted;
+			pooledContributionsPromoted = promotion.promotedCount > 0;
+		}
 	}
 
 	const resetBalance = cusEntToStartingBalance({ cusEnt });
@@ -119,5 +140,10 @@ export const processReset = async ({
 		};
 	}
 
-	return { updates, rolloverInsert };
+	return {
+		updates,
+		rolloverInsert,
+		pooledGranted,
+		pooledContributionsPromoted,
+	};
 };

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/applyResetResultsToFullSubject.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/applyResetResultsToFullSubject.ts
@@ -127,5 +127,8 @@ export const applyResetResultsToNormalized = ({
 		subjectBalance.adjustment = updates.adjustment;
 		if (updates.entities !== null) subjectBalance.entities = updates.entities;
 		subjectBalance.next_reset_at = updates.next_reset_at;
+		if (result.pooledGranted !== undefined && subjectBalance.pooled_balance) {
+			subjectBalance.pooled_balance.granted = result.pooledGranted;
+		}
 	}
 };

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/getResettableCustomerEntitlements.ts
@@ -37,11 +37,13 @@ export const getResettableCustomerEntitlements = ({
 		) {
 			continue;
 		}
+		// Subscription pools reset here too — invoice.created is a redundant
+		// fast path, guarded against double-apply by the reset CAS.
 		if (
 			isSyntheticPooledBalanceCustomerEntitlement({
 				customerEntitlement: cusEnt,
 			}) &&
-			cusEnt.pooled_balance?.reset_mode !== PooledBalanceResetMode.Lazy
+			cusEnt.pooled_balance?.reset_mode === PooledBalanceResetMode.Lifetime
 		) {
 			continue;
 		}

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts
@@ -102,6 +102,7 @@ export const lazyResetSubjectEntitlements = async ({
 		if (Object.keys(applied).length > 0) {
 			const oldNextResetAts: Record<string, number> = {};
 			const customerEntitlementFeatureIds: Record<string, string> = {};
+			const pooledGrantedByCusEntId: Record<string, number> = {};
 
 			for (const customerEntitlement of customerEntitlementsNeedingReset) {
 				if (customerEntitlement.next_reset_at) {
@@ -111,6 +112,11 @@ export const lazyResetSubjectEntitlements = async ({
 				customerEntitlementFeatureIds[customerEntitlement.id] =
 					customerEntitlement.feature_id;
 			}
+			for (const { customerEntitlementId, result } of computed) {
+				if (result.pooledGranted !== undefined) {
+					pooledGrantedByCusEntId[customerEntitlementId] = result.pooledGranted;
+				}
+			}
 
 			await resetSubjectCache({
 				ctx,
@@ -119,6 +125,7 @@ export const lazyResetSubjectEntitlements = async ({
 				oldNextResetAts,
 				clearingMap,
 				customerEntitlementFeatureIds,
+				pooledGrantedByCusEntId,
 			});
 
 			logger.info(

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/resetSubjectCache.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/resetSubjectCache.ts
@@ -13,6 +13,7 @@ interface SubjectBalanceUpdate {
 	entities: Record<string, unknown> | null;
 	next_reset_at: number | null;
 	expected_next_reset_at: number | null;
+	pooled_granted: number | null;
 	rollover_insert: unknown | null;
 	rollover_overwrites: unknown[] | null;
 	rollover_delete_ids: string[] | null;
@@ -33,6 +34,7 @@ export const resetSubjectCache = async ({
 	oldNextResetAts,
 	clearingMap,
 	customerEntitlementFeatureIds,
+	pooledGrantedByCusEntId,
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -40,6 +42,7 @@ export const resetSubjectCache = async ({
 	oldNextResetAts: Record<string, number>;
 	clearingMap: Record<string, RolloverClearingInfo>;
 	customerEntitlementFeatureIds: Record<string, string>;
+	pooledGrantedByCusEntId?: Record<string, number>;
 }): Promise<void> => {
 	if (resets.length === 0) return;
 
@@ -62,6 +65,7 @@ export const resetSubjectCache = async ({
 				entities: reset.entities,
 				next_reset_at: reset.next_reset_at,
 				expected_next_reset_at: oldNextResetAts[reset.cus_ent_id] ?? null,
+				pooled_granted: pooledGrantedByCusEntId?.[reset.cus_ent_id] ?? null,
 				rollover_insert: reset.rollover_insert,
 				rollover_overwrites:
 					clearing && clearing.overwrites.length > 0

--- a/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/CusEntitlementService.ts
@@ -29,6 +29,7 @@ import {
 	inArray,
 	isNull,
 	lt,
+	ne,
 	notExists,
 	or,
 	sql,
@@ -304,7 +305,7 @@ export class CusEntService {
 				eq(customerEntitlements.is_pooled_balance, false),
 				and(
 					eq(customerEntitlements.is_pooled_balance, true),
-					eq(pooledBalances.reset_mode, PooledBalanceResetMode.Lazy),
+					ne(pooledBalances.reset_mode, PooledBalanceResetMode.Lifetime),
 				),
 			);
 

--- a/server/tests/integration/billing/pooled-balances/pooled-balance-reset-flow.test.ts
+++ b/server/tests/integration/billing/pooled-balances/pooled-balance-reset-flow.test.ts
@@ -3,10 +3,11 @@
  *
  * New behavior:
  *   - overdue lazy pools reset through customer reads to pooled_balances.granted;
- *   - subscription pools reset only from their matching subscription invoice;
+ *   - subscription pools also reset lazily once overdue; their subscription
+ *     invoice remains a redundant boundary-aligned reset (CAS-guarded);
  *   - lifetime pools and pooled source entitlements never reset lazily or by cron;
  *   - rollover max_percentage is based on the complete pool grant;
- *   - the cron loader selects and hydrates only overdue lazy synthetic pools.
+ *   - the cron loader selects and hydrates overdue non-lifetime synthetic pools.
  *
  * Side effects:
  *   - reset writes the synthetic customer entitlement balance/next_reset_at;
@@ -259,7 +260,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("pooled reset: subscription pool waits for and resets on its invoice")}`,
+	`${chalk.yellowBright("pooled reset: subscription pool resets on its invoice when due at the boundary")}`,
 	async () => {
 		const customerId = "pooled-reset-subscription";
 		const grant = 500;
@@ -286,12 +287,9 @@ test.concurrent(
 				}),
 			],
 		});
-		await expirePooledBalanceForReset({
-			ctx,
-			customerId,
-			resetMode: PooledBalanceResetMode.Subscription,
-		});
 
+		// Not yet due (real time hasn't moved), so a read must not reset —
+		// the boundary reset below is proven to come from invoice.created.
 		const beforeInvoice = await autumnV2_2.customers.get<ApiCustomerV5>(
 			customerId,
 			{ skip_cache: "true" },
@@ -383,10 +381,12 @@ test.concurrent(
 			testClockId,
 			currentEpochMs,
 		});
-		const afterFirstInvoice =
-			await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+		const afterFirstInvoice = await autumnV2_2.customers.get<ApiCustomerV5>(
+			customerId,
+			{
 				skip_cache: "true",
-			});
+			},
+		);
 		expectBalanceCorrect({
 			customer: afterFirstInvoice,
 			featureId: TestFeature.Messages,
@@ -455,7 +455,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("pooled reset: cron selects and resets only a lazy synthetic pool")}`,
+	`${chalk.yellowBright("pooled reset: cron selects and resets an overdue synthetic pool and skips lifetime")}`,
 	async () => {
 		const customerId = "pooled-reset-cron";
 		const grant = 250;

--- a/server/tests/integration/billing/pooled-balances/pooled-balance-subscription-lazy-reset.test.ts
+++ b/server/tests/integration/billing/pooled-balances/pooled-balance-subscription-lazy-reset.test.ts
@@ -1,0 +1,191 @@
+/**
+ * TDD contract for lazy/cron reset ownership of subscription-mode pooled
+ * balances. A pool whose reset interval is shorter than its subscription's
+ * invoice cadence (e.g. a monthly pool on an annual sub) previously never
+ * reset — invoice.created was its only trigger.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - overdue subscription-mode pool resets on customer read (lazy path):
+ *       balance -> pooled_balances.granted, next_reset_at advances past now;
+ *     - the V1 cron loader (CusEntService.getActiveResetPassed) selects
+ *       overdue subscription-mode pools and resetCustomerEntitlement resets
+ *       them to the pooled grant;
+ *     - the pool keeps reset_mode 'subscription' and its Stripe sub linkage —
+ *       only the reset trigger widens, invoice.created remains a valid
+ *       (now redundant) reset path.
+ *   Side effects:
+ *     - synthetic pool customer entitlements are no longer stamped
+ *       reset_by_invoice = true at attach, so the batch-reset scan sees them.
+ *
+ * Pre-impl red: the lazy filter and both cron loaders skip pools whose
+ * reset_mode !== 'lazy', and initPooledBalanceGraph stamps reset_by_invoice.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	customerEntitlements,
+	EntInterval,
+	PooledBalanceResetMode,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { resetCustomerEntitlement } from "@/cron/resetCron/resetCustomerEntitlement.js";
+import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
+import { expectPooledBalanceCorrect } from "./utils/expectPooledBalanceCorrect.js";
+import { expirePooledBalanceForReset } from "./utils/expirePooledBalanceForReset.js";
+import { getPooledBalanceDbState } from "./utils/getPooledBalanceDbState.js";
+
+const attachAnnualPooledPlan = async ({
+	customerId,
+	grant,
+	trackedUsage,
+}: {
+	customerId: string;
+	grant: number;
+	trackedUsage: number;
+}) => {
+	const pooledPlan = products.proAnnual({
+		id: `${customerId}-plan`,
+		items: [
+			{ ...items.monthlyMessages({ includedUsage: grant }), pooled: true },
+		],
+	});
+
+	return initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [pooledPlan] }),
+		],
+		actions: [
+			s.billing.attach({ productId: pooledPlan.id, entityIndex: 0 }),
+			s.track({
+				featureId: TestFeature.Messages,
+				value: trackedUsage,
+				entityIndex: 1,
+				timeout: 2_000,
+			}),
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled reset: overdue subscription pool on an annual sub resets on read")}`,
+	async () => {
+		const customerId = "pooled-sub-lazy-annual";
+		const grant = 500;
+		const { autumnV2_2, ctx } = await attachAnnualPooledPlan({
+			customerId,
+			grant,
+			trackedUsage: 200,
+		});
+
+		// ── Contract: pool cusEnt is not stamped reset_by_invoice at attach ──
+		const attachedState = await getPooledBalanceDbState({
+			db: ctx.db,
+			customerId,
+		});
+		expect(
+			attachedState.poolCustomerEntitlements[0]?.reset_by_invoice,
+		).not.toBe(true);
+
+		await expirePooledBalanceForReset({
+			ctx,
+			customerId,
+			resetMode: PooledBalanceResetMode.Subscription,
+		});
+
+		// ── Contract: overdue subscription pool resets on customer read ──
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: grant,
+			remaining: grant,
+			usage: 0,
+		});
+
+		// ── Contract: pool keeps subscription mode + Stripe sub linkage ──
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			pool: {
+				balance: grant,
+				adjustment: 0,
+				granted: grant,
+				interval: EntInterval.Month,
+				nextResetAt: "present",
+				resetCycleAnchor: "present",
+				resetMode: PooledBalanceResetMode.Subscription,
+				stripeSubscriptionId: "stripe_subscription",
+				rollovers: [],
+			},
+			contributions: { count: 1, currentContribution: grant },
+			sources: { count: 1, balance: 0, adjustment: 0 },
+		});
+
+		// ── Contract: next_reset_at catches up past now in a single reset ──
+		const resetState = await getPooledBalanceDbState({
+			db: ctx.db,
+			customerId,
+		});
+		expect(
+			resetState.poolCustomerEntitlements[0]?.next_reset_at,
+		).toBeGreaterThan(Date.now());
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("pooled reset: cron loader selects and resets an overdue subscription pool")}`,
+	async () => {
+		const customerId = "pooled-sub-lazy-cron";
+		const grant = 400;
+		const { ctx } = await attachAnnualPooledPlan({
+			customerId,
+			grant,
+			trackedUsage: 150,
+		});
+
+		const { pooledCustomerEntitlement } = await expirePooledBalanceForReset({
+			ctx,
+			customerId,
+			resetMode: PooledBalanceResetMode.Subscription,
+		});
+
+		// ── Contract: cron loader includes the overdue subscription pool ──
+		const resettable = await CusEntService.getActiveResetPassed({
+			db: ctx.db,
+			customDateUnix: Date.now(),
+		});
+		const cronCustomerEntitlement = resettable.find(
+			(candidate) => candidate.id === pooledCustomerEntitlement.id,
+		);
+		if (!cronCustomerEntitlement) {
+			throw new Error(
+				"Expected cron to return the subscription pooled balance",
+			);
+		}
+
+		// ── Contract: cron reset refills to the pooled grant ──
+		await resetCustomerEntitlement({
+			ctx,
+			cusEnt: cronCustomerEntitlement,
+			updatedCusEnts: [],
+		});
+		const afterReset = await ctx.db.query.customerEntitlements.findFirst({
+			where: eq(customerEntitlements.id, pooledCustomerEntitlement.id),
+		});
+		expect(afterReset?.balance).toBe(grant);
+		expect(afterReset?.next_reset_at).toBeGreaterThan(Date.now());
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/race-condition/pooled-promotion-transition-guard.test.ts
+++ b/server/tests/integration/billing/pooled-balances/race-condition/pooled-promotion-transition-guard.test.ts
@@ -117,6 +117,12 @@ test(`${chalk.yellowBright("pooled promotion: concurrent pool-row write makes th
 	// ── Contract: guard trips → whole statement no-ops, helper returns null ──
 	expect(promotionResult).toBeNull();
 
+	// ── Contract: in-memory granted is refreshed to the winner's value, so a
+	// CAS-winning caller cannot refill the balance from its stale snapshot ──
+	expect(poolCustomerEntitlement.pooled_balance.granted).toBe(
+		TRANSITION_GRANTED,
+	);
+
 	const guardedState = await getPooledBalanceDbState({
 		db: ctx.db,
 		customerId,

--- a/server/tests/integration/billing/pooled-balances/race-condition/pooled-promotion-transition-guard.test.ts
+++ b/server/tests/integration/billing/pooled-balances/race-condition/pooled-promotion-transition-guard.test.ts
@@ -1,0 +1,158 @@
+/**
+ * TDD contract for the promotion-vs-transition guard.
+ *
+ * Contract under test:
+ *   - promoteDuePooledContributions must NOT apply when a concurrent
+ *     transaction (attach/updateSubscription writing the pool row) commits
+ *     mid-statement: the pool UPDATE's row-version check (updated_at latest
+ *     vs statement snapshot) fails, and the WHOLE statement no-ops —
+ *     granted keeps the transition's value, the due contribution stays
+ *     pending, and the helper returns null (so no cache patch is emitted);
+ *   - a follow-up promotion with no concurrency applies normally and
+ *     converges granted to the contribution sum.
+ *
+ * Pre-impl red: the pool write has no row-version guard, so the unblocked
+ * statement stomps the transition's granted with its stale snapshot sum.
+ */
+
+import { expect, test } from "bun:test";
+import { pooledBalanceContributions, pooledBalances } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { promoteDuePooledContributions } from "@/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { getPooledBalanceDbState } from "../utils/getPooledBalanceDbState.js";
+
+const ENTITY_GRANT = 250;
+const DOWNGRADED_CONTRIBUTION = 100;
+const TRANSITION_GRANTED = 900;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test(`${chalk.yellowBright("pooled promotion: concurrent pool-row write makes the promotion no-op")}`, async () => {
+	const customerId = "pooled-promo-transition-guard";
+	const pooledPlan = products.base({
+		id: `${customerId}-plan`,
+		items: [
+			{
+				...items.monthlyMessages({ includedUsage: ENTITY_GRANT }),
+				pooled: true,
+			},
+		],
+	});
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.entities({ count: 2, featureId: TestFeature.Users }),
+			s.products({ list: [pooledPlan] }),
+		],
+		actions: [
+			s.billing.attach({ productId: pooledPlan.id, entityIndex: 0 }),
+			s.billing.attach({ productId: pooledPlan.id, entityIndex: 1 }),
+		],
+	});
+
+	// Pending deferred downgrade on one contribution, already due.
+	const state = await getPooledBalanceDbState({ db: ctx.db, customerId });
+	const pool = state.pools[0];
+	const pendingContribution = state.contributions[0];
+	if (!pool || !pendingContribution) {
+		throw new Error("Expected a pooled balance with contributions");
+	}
+	await ctx.db
+		.update(pooledBalanceContributions)
+		.set({
+			next_cycle_contribution: DOWNGRADED_CONTRIBUTION,
+			effective_at: Date.now() - 1_000,
+		})
+		.where(eq(pooledBalanceContributions.id, pendingContribution.id));
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const poolCustomerEntitlement =
+		fullCustomer.pooled_customer_entitlements?.[0];
+	if (!poolCustomerEntitlement?.pooled_balance) {
+		throw new Error("Expected the synthetic pooled customer entitlement");
+	}
+
+	// ── Hold a pool-row lock from a "transition" transaction, run the
+	// promotion into it, then commit the transition mid-statement. ──
+	let releaseTransition!: () => void;
+	const transitionHold = new Promise<void>((resolve) => {
+		releaseTransition = resolve;
+	});
+	let transitionLockAcquired!: () => void;
+	const transitionLockAcquiredPromise = new Promise<void>((resolve) => {
+		transitionLockAcquired = resolve;
+	});
+
+	const transitionTransaction = ctx.db.transaction(async (tx) => {
+		await tx
+			.update(pooledBalances)
+			.set({ granted: TRANSITION_GRANTED, updated_at: Date.now() })
+			.where(eq(pooledBalances.id, pool.id));
+		transitionLockAcquired();
+		await transitionHold;
+	});
+
+	await transitionLockAcquiredPromise;
+	const promotionPromise = promoteDuePooledContributions({
+		ctx,
+		customerEntitlement: poolCustomerEntitlement,
+		now: Date.now(),
+	});
+	// Let the promotion statement reach (and block on) the locked pool row.
+	await sleep(500);
+	releaseTransition();
+	await transitionTransaction;
+	const promotionResult = await promotionPromise;
+
+	// ── Contract: guard trips → whole statement no-ops, helper returns null ──
+	expect(promotionResult).toBeNull();
+
+	const guardedState = await getPooledBalanceDbState({
+		db: ctx.db,
+		customerId,
+	});
+	expect(guardedState.pools[0]?.granted).toBe(TRANSITION_GRANTED);
+	const guardedContribution = guardedState.contributions.find(
+		(contribution) => contribution.id === pendingContribution.id,
+	);
+	expect(guardedContribution?.current_contribution).toBe(ENTITY_GRANT);
+	expect(guardedContribution?.next_cycle_contribution).toBe(
+		DOWNGRADED_CONTRIBUTION,
+	);
+	expect(guardedContribution?.effective_at).not.toBeNull();
+
+	// ── Contract: uncontended re-run converges to the contribution sum ──
+	const retryResult = await promoteDuePooledContributions({
+		ctx,
+		customerEntitlement: poolCustomerEntitlement,
+		now: Date.now(),
+	});
+	const convergedGrant = DOWNGRADED_CONTRIBUTION + ENTITY_GRANT;
+	expect(retryResult).toEqual({
+		granted: convergedGrant,
+		promotedCount: 1,
+	});
+
+	const convergedState = await getPooledBalanceDbState({
+		db: ctx.db,
+		customerId,
+	});
+	expect(convergedState.pools[0]?.granted).toBe(convergedGrant);
+	const convergedContribution = convergedState.contributions.find(
+		(contribution) => contribution.id === pendingContribution.id,
+	);
+	expect(convergedContribution?.current_contribution).toBe(
+		DOWNGRADED_CONTRIBUTION,
+	);
+	expect(convergedContribution?.effective_at).toBeNull();
+}, 60_000);

--- a/server/tests/integration/billing/pooled-balances/update/pooled-prepaid-next-cycle-contribution.test.ts
+++ b/server/tests/integration/billing/pooled-balances/update/pooled-prepaid-next-cycle-contribution.test.ts
@@ -1,0 +1,300 @@
+/**
+ * TDD contract for pooled prepaid next-cycle contribution promotion.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - updateSubscription quantity DECREASE (OnDecrease.NoProrations) on a
+ *       pooled prepaid contributor writes the pending amount on its
+ *       contribution row: current_contribution unchanged,
+ *       next_cycle_contribution = new amount, effective_at = sub period end;
+ *       pool granted and balance are unchanged this cycle;
+ *     - a pool reset with a contribution whose effective_at has passed
+ *       promotes it (current = next_cycle, effective_at cleared), recomputes
+ *       pooled_balances.granted from ALL contributions in one statement, and
+ *       refills the pool balance to the NEW granted;
+ *     - contributions whose effective_at is still in the future are untouched
+ *       (staggered boundaries promote independently);
+ *     - the recompute self-heals a drifted pooled_balances.granted.
+ *   Side effects:
+ *     - pooled_balance_contributions and pooled_balances.granted are updated
+ *       at reset time.
+ *
+ * Pre-impl red: the UpdateQuantity plan never touches contributions
+ * (effective_at stays null) and no reset path promotes next_cycle_contribution.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	entities as entityTable,
+	OnDecrease,
+	OnIncrease,
+	PooledBalanceResetMode,
+	pooledBalanceContributions,
+	pooledBalances,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq, inArray } from "drizzle-orm";
+import { expirePooledBalanceForReset } from "../utils/expirePooledBalanceForReset.js";
+import { getPooledBalanceDbState } from "../utils/getPooledBalanceDbState.js";
+
+const BILLING_UNITS = 100;
+const ATTACHED_QUANTITY = 300;
+const DOWNGRADED_QUANTITY = 100;
+const SECOND_DOWNGRADED_QUANTITY = 200;
+
+const sortedContributions = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: { db: Parameters<typeof getPooledBalanceDbState>[0]["db"] };
+	customerId: string;
+}) => {
+	const state = await getPooledBalanceDbState({ db: ctx.db, customerId });
+	return {
+		state,
+		contributions: [...state.contributions].sort(
+			(a, b) => a.next_cycle_contribution - b.next_cycle_contribution,
+		),
+	};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("pooled prepaid: quantity downgrades defer to next cycle and promote on reset")}`,
+	async () => {
+		const customerId = "pooled-prepaid-next-cycle";
+		const prepaidPooledItem = {
+			...items.prepaid({
+				featureId: TestFeature.Messages,
+				billingUnits: BILLING_UNITS,
+				price: 10,
+				config: {
+					on_increase: OnIncrease.ProrateImmediately,
+					on_decrease: OnDecrease.NoProrations,
+				},
+			}),
+			pooled: true,
+		};
+		const pooledPlan = products.pro({
+			id: `${customerId}-plan`,
+			items: [prepaidPooledItem],
+		});
+
+		const { autumnV2_2, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [pooledPlan] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pooledPlan.id,
+					entityIndex: 0,
+					options: [
+						{ feature_id: TestFeature.Messages, quantity: ATTACHED_QUANTITY },
+					],
+				}),
+				s.billing.attach({
+					productId: pooledPlan.id,
+					entityIndex: 1,
+					options: [
+						{ feature_id: TestFeature.Messages, quantity: ATTACHED_QUANTITY },
+					],
+				}),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: 100,
+					timeout: 2_000,
+				}),
+			],
+		});
+		const pooledGrant = ATTACHED_QUANTITY * 2;
+
+		// ── Contract: pool cusEnts are not stamped, sources resolvable per entity ──
+		const { state: attachedState } = await sortedContributions({
+			ctx,
+			customerId,
+		});
+		const internalCustomerId = attachedState.pools[0]?.internal_customer_id;
+		if (!internalCustomerId) throw new Error("Expected a pooled balance");
+		const entityRows = await ctx.db
+			.select({ id: entityTable.id, internal_id: entityTable.internal_id })
+			.from(entityTable)
+			.where(
+				and(
+					eq(entityTable.internal_customer_id, internalCustomerId),
+					inArray(
+						entityTable.id,
+						entities.map((entity) => entity.id),
+					),
+				),
+			);
+		const customerProductForEntity = (entityIndex: number) => {
+			const internalEntityId = entityRows.find(
+				(row) => row.id === entities[entityIndex].id,
+			)?.internal_id;
+			const customerProduct = attachedState.sourceCustomerProducts.find(
+				(candidate) => candidate.internal_entity_id === internalEntityId,
+			);
+			if (!customerProduct) {
+				throw new Error(
+					`Expected a pooled customer product for entity ${entityIndex}`,
+				);
+			}
+			return customerProduct;
+		};
+
+		const downgradeEntityQuantity = async ({
+			entityIndex,
+			quantity,
+		}: {
+			entityIndex: number;
+			quantity: number;
+		}) =>
+			autumnV2_2.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				customer_product_id: customerProductForEntity(entityIndex).id,
+				entity_id: entities[entityIndex].id,
+				feature_quantities: [{ feature_id: TestFeature.Messages, quantity }],
+				redirect_mode: "if_required",
+			});
+
+		// ── Contract: downgrades write next_cycle_contribution + effective_at ──
+		await downgradeEntityQuantity({
+			entityIndex: 0,
+			quantity: DOWNGRADED_QUANTITY,
+		});
+		await downgradeEntityQuantity({
+			entityIndex: 1,
+			quantity: SECOND_DOWNGRADED_QUANTITY,
+		});
+
+		const { state: downgradedState, contributions: downgradedContributions } =
+			await sortedContributions({ ctx, customerId });
+		expect(downgradedContributions).toHaveLength(2);
+		expect(downgradedContributions[0]).toMatchObject({
+			current_contribution: ATTACHED_QUANTITY,
+			next_cycle_contribution: DOWNGRADED_QUANTITY,
+		});
+		expect(downgradedContributions[0].effective_at).toBeGreaterThan(Date.now());
+		expect(downgradedContributions[1]).toMatchObject({
+			current_contribution: ATTACHED_QUANTITY,
+			next_cycle_contribution: SECOND_DOWNGRADED_QUANTITY,
+		});
+		expect(downgradedContributions[1].effective_at).toBeGreaterThan(Date.now());
+
+		// ── Contract: pool untouched until a boundary passes ──
+		expect(downgradedState.pools[0]?.granted).toBe(pooledGrant);
+		expect(downgradedState.poolCustomerEntitlements[0]?.balance).toBe(
+			pooledGrant - 100,
+		);
+
+		// ── Staggered boundary: only entity 0's downgrade becomes due ──
+		await expirePooledBalanceForReset({
+			ctx,
+			customerId,
+			resetMode: PooledBalanceResetMode.Subscription,
+		});
+		await ctx.db
+			.update(pooledBalanceContributions)
+			.set({ effective_at: Date.now() - 1_000 })
+			.where(eq(pooledBalanceContributions.id, downgradedContributions[0].id));
+
+		// ── Contract: reset promotes only the due contribution ──
+		const staggeredGrant = DOWNGRADED_QUANTITY + ATTACHED_QUANTITY;
+		const afterFirstReset = await autumnV2_2.customers.get<ApiCustomerV5>(
+			customerId,
+			{ skip_cache: "true" },
+		);
+		expectBalanceCorrect({
+			customer: afterFirstReset,
+			featureId: TestFeature.Messages,
+			granted: staggeredGrant,
+			remaining: staggeredGrant,
+			usage: 0,
+		});
+
+		const { state: staggeredState, contributions: staggeredContributions } =
+			await sortedContributions({ ctx, customerId });
+		expect(staggeredContributions[0]).toMatchObject({
+			current_contribution: DOWNGRADED_QUANTITY,
+			next_cycle_contribution: DOWNGRADED_QUANTITY,
+			effective_at: null,
+		});
+		expect(staggeredContributions[1]).toMatchObject({
+			current_contribution: ATTACHED_QUANTITY,
+			next_cycle_contribution: SECOND_DOWNGRADED_QUANTITY,
+		});
+		expect(staggeredContributions[1].effective_at).not.toBeNull();
+		expect(staggeredState.pools[0]?.granted).toBe(staggeredGrant);
+		expect(staggeredState.poolCustomerEntitlements[0]?.balance).toBe(
+			staggeredGrant,
+		);
+
+		// ── Contract: second boundary promotes entity 1 AND heals drifted granted ──
+		// Warm the cache first so this reset runs on the CACHE-HIT lazy path and
+		// must patch granted into the cached subject (not just the DB).
+		await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		const poolId = staggeredState.pools[0]?.id;
+		if (!poolId) throw new Error("Expected the pooled balance to persist");
+		await ctx.db
+			.update(pooledBalances)
+			.set({ granted: 9_999 })
+			.where(eq(pooledBalances.id, poolId));
+		await expirePooledBalanceForReset({
+			ctx,
+			customerId,
+			resetMode: PooledBalanceResetMode.Subscription,
+		});
+		await ctx.db
+			.update(pooledBalanceContributions)
+			.set({ effective_at: Date.now() - 1_000 })
+			.where(eq(pooledBalanceContributions.id, staggeredContributions[1].id));
+
+		const settledGrant = DOWNGRADED_QUANTITY + SECOND_DOWNGRADED_QUANTITY;
+		const afterSecondReset =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: afterSecondReset,
+			featureId: TestFeature.Messages,
+			granted: settledGrant,
+			remaining: settledGrant,
+			usage: 0,
+		});
+
+		// ── Contract: the patched granted persists on a later cached read ──
+		const cachedRead =
+			await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer: cachedRead,
+			featureId: TestFeature.Messages,
+			granted: settledGrant,
+			remaining: settledGrant,
+			usage: 0,
+		});
+
+		const { state: settledState, contributions: settledContributions } =
+			await sortedContributions({ ctx, customerId });
+		expect(settledContributions[0]).toMatchObject({
+			current_contribution: DOWNGRADED_QUANTITY,
+			next_cycle_contribution: DOWNGRADED_QUANTITY,
+			effective_at: null,
+		});
+		expect(settledContributions[1]).toMatchObject({
+			current_contribution: SECOND_DOWNGRADED_QUANTITY,
+			next_cycle_contribution: SECOND_DOWNGRADED_QUANTITY,
+			effective_at: null,
+		});
+		expect(settledState.pools[0]?.granted).toBe(settledGrant);
+		expect(settledState.poolCustomerEntitlements[0]?.balance).toBe(
+			settledGrant,
+		);
+	},
+);

--- a/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
+++ b/server/tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect.ts
@@ -1,5 +1,5 @@
 import { expect } from "bun:test";
-import { type EntInterval, PooledBalanceResetMode } from "@autumn/shared";
+import type { EntInterval, PooledBalanceResetMode } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getPooledBalanceDbState } from "./getPooledBalanceDbState.js";
 
@@ -86,11 +86,9 @@ export const expectPooledBalanceCorrect = async ({
 		} else {
 			expect(pooledCustomerEntitlement.next_reset_at).toBeNull();
 		}
-		if (pool.resetMode === PooledBalanceResetMode.Subscription) {
-			expect(pooledCustomerEntitlement.reset_by_invoice).toBe(
-				!(pool.unlimited ?? false),
-			);
-		}
+		// Pools reset through the lazy/cron paths regardless of mode, so they
+		// are never stamped out of the batch-reset scan.
+		expect(pooledCustomerEntitlement.reset_by_invoice).not.toBe(true);
 		if (pool.rollovers) {
 			expect(pooledCustomerEntitlement.rollovers).toHaveLength(
 				pool.rollovers.length,

--- a/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-pooled-balances.test.ts
+++ b/server/tests/integration/cron/batch-reset-v2/batch-reset-v2-pooled-balances.test.ts
@@ -1,4 +1,5 @@
-/** Regression: batch reset must use pooled grants and leave subscription pools to invoice.created. */
+/** Regression: batch reset must use pooled grants and reset pools of every
+ * non-lifetime mode — invoice.created is only a redundant fast path. */
 
 import { expect, test } from "bun:test";
 import {
@@ -157,7 +158,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("batch-reset-v2 pooled: subscription pool remains owned by invoice.created")}`,
+	`${chalk.yellowBright("batch-reset-v2 pooled: subscription pool resets like a lazy pool")}`,
 	async () => {
 		const granted = 300;
 		await withPooledResetScenario({
@@ -171,10 +172,39 @@ test.concurrent(
 					customerEntitlementIds: [customerEntitlementId],
 				});
 
+				expect(result.resetMutations).toHaveLength(1);
+				const row = await fetchCustomerEntitlementRow({
+					db: ctx.db,
+					customerEntitlementId,
+				});
+				expect(row.balance).toBe(granted);
+				expect(row.next_reset_at).toBeGreaterThan(pastTime);
+				expect(row.reset_by_invoice).not.toBe(true);
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch-reset-v2 pooled: lifetime pool is never reset")}`,
+	async () => {
+		const granted = 200;
+		await withPooledResetScenario({
+			name: "batch-reset-v2-pooled-lifetime",
+			granted,
+			resetMode: PooledBalanceResetMode.Lifetime,
+			withRollover: false,
+			run: async ({ customerEntitlementId, pastTime }) => {
+				const result = await runBatchResetV2({
+					ctx,
+					customerEntitlementIds: [customerEntitlementId],
+				});
+
 				expect(result.resetMutations).toHaveLength(0);
 				expect(result.verdicts).toEqual([
 					expect.objectContaining({
-						kind: "resets_via_invoice",
+						kind: "no_action",
+						reason: "pooled_balance_lifetime",
 						customerEntitlementId,
 					}),
 				]);
@@ -185,7 +215,6 @@ test.concurrent(
 				});
 				expect(row.balance).toBe(granted);
 				expect(row.next_reset_at).toBe(pastTime);
-				expect(row.reset_by_invoice).toBe(true);
 			},
 		});
 	},

--- a/server/tests/unit/customers/reset/getResettableCustomerEntitlements.test.ts
+++ b/server/tests/unit/customers/reset/getResettableCustomerEntitlements.test.ts
@@ -335,12 +335,24 @@ describe(chalk.yellowBright("getResettableCustomerEntitlements"), () => {
 		]);
 	});
 
-	test("skips subscription and lifetime synthetic pooled customer entitlements", () => {
+	test("returns an overdue subscription synthetic pooled customer entitlement", () => {
+		const customerEntitlement = buildSyntheticPooledCustomerEntitlement({
+			resetMode: PooledBalanceResetMode.Subscription,
+		});
+
+		const result = getResettableCustomerEntitlements({
+			customerEntitlements: [customerEntitlement],
+			now: NOW,
+		});
+
+		expect(result.map((candidate) => candidate.id)).toEqual([
+			customerEntitlement.id,
+		]);
+	});
+
+	test("skips lifetime synthetic pooled customer entitlements", () => {
 		const result = getResettableCustomerEntitlements({
 			customerEntitlements: [
-				buildSyntheticPooledCustomerEntitlement({
-					resetMode: PooledBalanceResetMode.Subscription,
-				}),
 				buildSyntheticPooledCustomerEntitlement({
 					resetMode: PooledBalanceResetMode.Lifetime,
 				}),

--- a/shared/drizzle/0059_unstamp_pooled_reset_by_invoice.sql
+++ b/shared/drizzle/0059_unstamp_pooled_reset_by_invoice.sql
@@ -1,7 +1,0 @@
--- Pooled balances now reset through the lazy/cron paths regardless of
--- reset_mode; un-stamp synthetic pool cusEnts so the batch-reset scan and its
--- partial index see them again.
-UPDATE "customer_entitlements"
-SET "reset_by_invoice" = false
-WHERE "is_pooled_balance" = true
-	AND "reset_by_invoice" IS TRUE;

--- a/shared/drizzle/0059_unstamp_pooled_reset_by_invoice.sql
+++ b/shared/drizzle/0059_unstamp_pooled_reset_by_invoice.sql
@@ -1,0 +1,7 @@
+-- Pooled balances now reset through the lazy/cron paths regardless of
+-- reset_mode; un-stamp synthetic pool cusEnts so the batch-reset scan and its
+-- partial index see them again.
+UPDATE "customer_entitlements"
+SET "reset_by_invoice" = false
+WHERE "is_pooled_balance" = true
+	AND "reset_by_invoice" IS TRUE;

--- a/shared/drizzle/meta/0059_snapshot.json
+++ b/shared/drizzle/meta/0059_snapshot.json
@@ -1,10245 +1,10811 @@
 {
-	"id": "0b5556ee-cf85-4e54-8e3f-f39e2bf0f897",
-	"prevId": "bd665ee9-449f-4070-95f2-ff1176231a48",
-	"version": "7",
-	"dialect": "postgresql",
-	"tables": {
-		"public.account": {
-			"name": "account",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"account_id": {
-					"name": "account_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"provider_id": {
-					"name": "provider_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"access_token": {
-					"name": "access_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"refresh_token": {
-					"name": "refresh_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"id_token": {
-					"name": "id_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"access_token_expires_at": {
-					"name": "access_token_expires_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"refresh_token_expires_at": {
-					"name": "refresh_token_expires_at",
-					"type": "timestamp",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scope": {
-					"name": "scope",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"password": {
-					"name": "password",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"account_userId_idx": {
-					"name": "account_userId_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"account_user_id_user_id_fk": {
-					"name": "account_user_id_user_id_fk",
-					"tableFrom": "account",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.actions": {
-			"name": "actions",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"request_id": {
-					"name": "request_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_slug": {
-					"name": "org_slug",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"customer_id": {
-					"name": "customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"entity_id": {
-					"name": "entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_entity_id": {
-					"name": "internal_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"type": {
-					"name": "type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"auth_type": {
-					"name": "auth_type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"method": {
-					"name": "method",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"path": {
-					"name": "path",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"timestamp": {
-					"name": "timestamp",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"properties": {
-					"name": "properties",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_actions_on_internal_entity_id": {
-					"name": "idx_actions_on_internal_entity_id",
-					"columns": [
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"actions_org_id_fkey": {
-					"name": "actions_org_id_fkey",
-					"tableFrom": "actions",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				},
-				"actions_customer_id_fkey": {
-					"name": "actions_customer_id_fkey",
-					"tableFrom": "actions",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				},
-				"actions_entity_id_fkey": {
-					"name": "actions_entity_id_fkey",
-					"tableFrom": "actions",
-					"columnsFrom": ["internal_entity_id"],
-					"tableTo": "entities",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.agent_rules": {
-			"name": "agent_rules",
-			"schema": "",
-			"columns": {
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_slug": {
-					"name": "org_slug",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"entity_rules": {
-					"name": "entity_rules",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"credit_rules": {
-					"name": "credit_rules",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"notes": {
-					"name": "notes",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "''"
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'::jsonb"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"agent_rules_org_id_fkey": {
-					"name": "agent_rules_org_id_fkey",
-					"tableFrom": "agent_rules",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.api_keys": {
-			"name": "api_keys",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"prefix": {
-					"name": "prefix",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"hashed_key": {
-					"name": "hashed_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"meta": {
-					"name": "meta",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scopes": {
-					"name": "scopes",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"api_keys_org_id_fkey": {
-					"name": "api_keys_org_id_fkey",
-					"tableFrom": "api_keys",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"api_keys_hashed_key_key": {
-					"name": "api_keys_hashed_key_key",
-					"columns": ["hashed_key"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.auto_topup_limit_states": {
-			"name": "auto_topup_limit_states",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"customer_id": {
-					"name": "customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"feature_id": {
-					"name": "feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"purchase_window_ends_at": {
-					"name": "purchase_window_ends_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"purchase_count": {
-					"name": "purchase_count",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"attempt_window_ends_at": {
-					"name": "attempt_window_ends_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"attempt_count": {
-					"name": "attempt_count",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"failed_attempt_window_ends_at": {
-					"name": "failed_attempt_window_ends_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"failed_attempt_count": {
-					"name": "failed_attempt_count",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"last_attempt_at": {
-					"name": "last_attempt_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"last_failed_attempt_at": {
-					"name": "last_failed_attempt_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"consecutive_failure_count": {
-					"name": "consecutive_failure_count",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"suspended_at": {
-					"name": "suspended_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"suspended_reason": {
-					"name": "suspended_reason",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"suspended_payment_method_fingerprint": {
-					"name": "suspended_payment_method_fingerprint",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"auto_topup_limits_org_env_internal_customer_feature_unique": {
-					"name": "auto_topup_limits_org_env_internal_customer_feature_unique",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"auto_topup_limits_org_id_fkey": {
-					"name": "auto_topup_limits_org_id_fkey",
-					"tableFrom": "auto_topup_limit_states",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"auto_topup_limits_internal_customer_id_fkey": {
-					"name": "auto_topup_limits_internal_customer_id_fkey",
-					"tableFrom": "auto_topup_limit_states",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.chat_approvals": {
-			"name": "chat_approvals",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"provider": {
-					"name": "provider",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"workspace_id": {
-					"name": "workspace_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"channel_id": {
-					"name": "channel_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"message_ts": {
-					"name": "message_ts",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"provider_user_id": {
-					"name": "provider_user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"run_id": {
-					"name": "run_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"harness": {
-					"name": "harness",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"tool_call_id": {
-					"name": "tool_call_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"tool_name": {
-					"name": "tool_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"tool_args": {
-					"name": "tool_args",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"preview": {
-					"name": "preview",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"decided_at": {
-					"name": "decided_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"decided_by_provider_user_id": {
-					"name": "decided_by_provider_user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"chat_approvals_org_id_fkey": {
-					"name": "chat_approvals_org_id_fkey",
-					"tableFrom": "chat_approvals",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.chat_installations": {
-			"name": "chat_installations",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"provider": {
-					"name": "provider",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"workspace_id": {
-					"name": "workspace_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"workspace_name": {
-					"name": "workspace_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"bot_user_id": {
-					"name": "bot_user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"bot_access_token": {
-					"name": "bot_access_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"scopes": {
-					"name": "scopes",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"auth_mode": {
-					"name": "auth_mode",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"default_env": {
-					"name": "default_env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"sandbox_api_key_id": {
-					"name": "sandbox_api_key_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"sandbox_api_key": {
-					"name": "sandbox_api_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"live_api_key_id": {
-					"name": "live_api_key_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"live_api_key": {
-					"name": "live_api_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"installed_by_user_id": {
-					"name": "installed_by_user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"installed_by_provider_user_id": {
-					"name": "installed_by_provider_user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"chat_installations_org_id_fkey": {
-					"name": "chat_installations_org_id_fkey",
-					"tableFrom": "chat_installations",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"chat_installations_org_provider_key": {
-					"name": "chat_installations_org_provider_key",
-					"columns": ["org_id", "provider"],
-					"nullsNotDistinct": false
-				},
-				"chat_installations_provider_workspace_key": {
-					"name": "chat_installations_provider_workspace_key",
-					"columns": ["provider", "workspace_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.chat_oauth_credentials": {
-			"name": "chat_oauth_credentials",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"chat_installation_id": {
-					"name": "chat_installation_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"oauth_client_id": {
-					"name": "oauth_client_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"oauth_consent_id": {
-					"name": "oauth_consent_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"access_token": {
-					"name": "access_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"refresh_token": {
-					"name": "refresh_token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"access_token_expires_at": {
-					"name": "access_token_expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"refresh_token_expires_at": {
-					"name": "refresh_token_expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scopes": {
-					"name": "scopes",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"chat_oauth_credentials_installation_id_fkey": {
-					"name": "chat_oauth_credentials_installation_id_fkey",
-					"tableFrom": "chat_oauth_credentials",
-					"columnsFrom": ["chat_installation_id"],
-					"tableTo": "chat_installations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"chat_oauth_credentials_org_id_fkey": {
-					"name": "chat_oauth_credentials_org_id_fkey",
-					"tableFrom": "chat_oauth_credentials",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"chat_oauth_credentials_installation_org_env_user_key": {
-					"name": "chat_oauth_credentials_installation_org_env_user_key",
-					"columns": ["chat_installation_id", "org_id", "env", "user_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.chat_results": {
-			"name": "chat_results",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"data": {
-					"name": "data",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"leaf.chat_thread_contexts": {
-			"name": "chat_thread_contexts",
-			"schema": "leaf",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"chat_installation_id": {
-					"name": "chat_installation_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"workspace_id": {
-					"name": "workspace_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"channel_id": {
-					"name": "channel_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"thread_id": {
-					"name": "thread_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_slug": {
-					"name": "org_slug",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"source": {
-					"name": "source",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"target_identifier": {
-					"name": "target_identifier",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_by_provider_user_id": {
-					"name": "created_by_provider_user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"chat_thread_contexts_thread_key": {
-					"name": "chat_thread_contexts_thread_key",
-					"columns": ["workspace_id", "channel_id", "thread_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.checkouts": {
-			"name": "checkouts",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"customer_id": {
-					"name": "customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"action": {
-					"name": "action",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"params": {
-					"name": "params",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"params_version": {
-					"name": "params_version",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'pending'"
-				},
-				"response": {
-					"name": "response",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_invoice_id": {
-					"name": "stripe_invoice_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"completed_at": {
-					"name": "completed_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_checkouts_stripe_invoice_id": {
-					"name": "idx_checkouts_stripe_invoice_id",
-					"columns": [
-						{
-							"expression": "stripe_invoice_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"leaf.cma_memory": {
-			"name": "cma_memory",
-			"schema": "leaf",
-			"columns": {
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"memory_store_id": {
-					"name": "memory_store_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {
-				"cma_memory_org_id_env_pk": {
-					"name": "cma_memory_org_id_env_pk",
-					"columns": ["org_id", "env"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"leaf.cma_sessions": {
-			"name": "cma_sessions",
-			"schema": "leaf",
-			"columns": {
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"thread_key": {
-					"name": "thread_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"session_id": {
-					"name": "session_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"braintrust_parent": {
-					"name": "braintrust_parent",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {
-				"cma_sessions_org_id_env_thread_key_pk": {
-					"name": "cma_sessions_org_id_env_thread_key_pk",
-					"columns": ["org_id", "env", "thread_key"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"leaf.cma_vaults": {
-			"name": "cma_vaults",
-			"schema": "leaf",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"chat_installation_id": {
-					"name": "chat_installation_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"vault_id": {
-					"name": "vault_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"credential_id": {
-					"name": "credential_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"cma_vaults_installation_org_env_user_key": {
-					"name": "cma_vaults_installation_org_env_user_key",
-					"columns": ["chat_installation_id", "org_id", "env", "user_id"],
-					"nullsNotDistinct": true
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.customer_entitlements": {
-			"name": "customer_entitlements",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"customer_product_id": {
-					"name": "customer_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"entitlement_id": {
-					"name": "entitlement_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_entity_id": {
-					"name": "internal_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_feature_id": {
-					"name": "internal_feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"unlimited": {
-					"name": "unlimited",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"balance": {
-					"name": "balance",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"reset_cycle_anchor": {
-					"name": "reset_cycle_anchor",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"next_reset_at": {
-					"name": "next_reset_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_allowed": {
-					"name": "usage_allowed",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"separate_interval": {
-					"name": "separate_interval",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"is_pooled_balance": {
-					"name": "is_pooled_balance",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"pooled_balance_id": {
-					"name": "pooled_balance_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"pooled_contribution_id": {
-					"name": "pooled_contribution_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"adjustment": {
-					"name": "adjustment",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"additional_balance": {
-					"name": "additional_balance",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"entities": {
-					"name": "entities",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"cache_version": {
-					"name": "cache_version",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false,
-					"default": 0
-				},
-				"customer_id": {
-					"name": "customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"feature_id": {
-					"name": "feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"external_id": {
-					"name": "external_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"expired": {
-					"name": "expired",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"reset_by_invoice": {
-					"name": "reset_by_invoice",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_customer_entitlements_product_id": {
-					"name": "idx_customer_entitlements_product_id",
-					"columns": [
-						{
-							"expression": "customer_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_entitlements_internal_customer_id": {
-					"name": "idx_customer_entitlements_internal_customer_id",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "hash",
-					"concurrently": false
-				},
-				"idx_customer_entitlements_internal_customer_id_btree": {
-					"name": "idx_customer_entitlements_internal_customer_id_btree",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_entitlements_entitlement_id": {
-					"name": "idx_customer_entitlements_entitlement_id",
-					"columns": [
-						{
-							"expression": "entitlement_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_entitlements_internal_feature_id_c": {
-					"name": "idx_customer_entitlements_internal_feature_id_c",
-					"columns": [
-						{
-							"expression": "\"internal_feature_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_ce_internal_feature_id": {
-					"name": "idx_ce_internal_feature_id",
-					"columns": [
-						{
-							"expression": "internal_feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_ce_customer_product_id_c": {
-					"name": "idx_ce_customer_product_id_c",
-					"columns": [
-						{
-							"expression": "\"customer_product_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_ce_loose_next_reset": {
-					"name": "idx_ce_loose_next_reset",
-					"columns": [
-						{
-							"expression": "next_reset_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
-					"concurrently": true
-				},
-				"idx_customer_entitlements_nonnull_entity_by_id": {
-					"name": "idx_customer_entitlements_nonnull_entity_by_id",
-					"columns": [
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_entitlements\".\"internal_entity_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_entitlements_internal_entity_id": {
-					"name": "idx_customer_entitlements_internal_entity_id",
-					"columns": [
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "hash",
-					"concurrently": false
-				},
-				"idx_customer_entitlements_on_next_reset_at": {
-					"name": "idx_customer_entitlements_on_next_reset_at",
-					"columns": [
-						{
-							"expression": "next_reset_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_entitlements_separate_interval_reset": {
-					"name": "idx_customer_entitlements_separate_interval_reset",
-					"columns": [
-						{
-							"expression": "next_reset_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_entitlements\".\"separate_interval\" = true AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_entitlements_loose_customer_expires": {
-					"name": "idx_customer_entitlements_loose_customer_expires",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "expires_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
-					"concurrently": false
-				},
-				"idx_customer_entitlements_next_reset_not_expired": {
-					"name": "idx_customer_entitlements_next_reset_not_expired",
-					"columns": [
-						{
-							"expression": "next_reset_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_entitlements_pooled_contribution": {
-					"name": "idx_customer_entitlements_pooled_contribution",
-					"columns": [
-						{
-							"expression": "pooled_contribution_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_entitlements\".\"pooled_contribution_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_entitlements_reset_scan": {
-					"name": "idx_customer_entitlements_reset_scan",
-					"columns": [
-						{
-							"expression": "next_reset_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"reset_by_invoice\" IS NOT TRUE AND \"customer_entitlements\".\"pooled_contribution_id\" IS NULL AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"entitlements_internal_feature_id_fkey": {
-					"name": "entitlements_internal_feature_id_fkey",
-					"tableFrom": "customer_entitlements",
-					"columnsFrom": ["internal_feature_id"],
-					"tableTo": "features",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"customer_entitlements_internal_entity_id_fkey": {
-					"name": "customer_entitlements_internal_entity_id_fkey",
-					"tableFrom": "customer_entitlements",
-					"columnsFrom": ["internal_entity_id"],
-					"tableTo": "entities",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"customer_entitlements_customer_product_id_fkey": {
-					"name": "customer_entitlements_customer_product_id_fkey",
-					"tableFrom": "customer_entitlements",
-					"columnsFrom": ["customer_product_id"],
-					"tableTo": "customer_products",
-					"columnsTo": ["id"],
-					"onUpdate": "cascade",
-					"onDelete": "cascade"
-				},
-				"customer_entitlements_entitlement_id_fkey": {
-					"name": "customer_entitlements_entitlement_id_fkey",
-					"tableFrom": "customer_entitlements",
-					"columnsFrom": ["entitlement_id"],
-					"tableTo": "entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "cascade",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.customer_jwt_families": {
-			"name": "customer_jwt_families",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"epoch": {
-					"name": "epoch",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"refresh_kid": {
-					"name": "refresh_kid",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"indefinite": {
-					"name": "indefinite",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"customer_jwt_families_internal_customer_id_fkey": {
-					"name": "customer_jwt_families_internal_customer_id_fkey",
-					"tableFrom": "customer_jwt_families",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"customer_jwt_families_internal_customer_id_key": {
-					"name": "customer_jwt_families_internal_customer_id_key",
-					"columns": ["internal_customer_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.customer_licenses": {
-			"name": "customer_licenses",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"link_id": {
-					"name": "link_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"parent_customer_product_id": {
-					"name": "parent_customer_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"license_internal_product_id": {
-					"name": "license_internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"plan_license_id": {
-					"name": "plan_license_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"granted": {
-					"name": "granted",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"remaining": {
-					"name": "remaining",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"paid_quantity": {
-					"name": "paid_quantity",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"idx_customer_licenses_plan_license": {
-					"name": "idx_customer_licenses_plan_license",
-					"columns": [
-						{
-							"expression": "plan_license_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"unique_customer_license": {
-					"name": "unique_customer_license",
-					"columns": [
-						{
-							"expression": "parent_customer_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "license_internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_customer_licenses_customer": {
-					"name": "idx_customer_licenses_customer",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_customer_licenses_link": {
-					"name": "idx_customer_licenses_link",
-					"columns": [
-						{
-							"expression": "link_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"customer_licenses_customer_fkey": {
-					"name": "customer_licenses_customer_fkey",
-					"tableFrom": "customer_licenses",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"customer_licenses_parent_customer_product_fkey": {
-					"name": "customer_licenses_parent_customer_product_fkey",
-					"tableFrom": "customer_licenses",
-					"columnsFrom": ["parent_customer_product_id"],
-					"tableTo": "customer_products",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"customer_licenses_license_product_fkey": {
-					"name": "customer_licenses_license_product_fkey",
-					"tableFrom": "customer_licenses",
-					"columnsFrom": ["license_internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"customer_licenses_plan_license_fkey": {
-					"name": "customer_licenses_plan_license_fkey",
-					"tableFrom": "customer_licenses",
-					"columnsFrom": ["plan_license_id"],
-					"tableTo": "plan_license",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.customer_prices": {
-			"name": "customer_prices",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"price_id": {
-					"name": "price_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"options": {
-					"name": "options",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"customer_product_id": {
-					"name": "customer_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_customer_prices_product_id": {
-					"name": "idx_customer_prices_product_id",
-					"columns": [
-						{
-							"expression": "customer_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_prices_price_id": {
-					"name": "idx_customer_prices_price_id",
-					"columns": [
-						{
-							"expression": "price_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_prices_internal_customer_id": {
-					"name": "idx_customer_prices_internal_customer_id",
-					"columns": [
-						{
-							"expression": "\"internal_customer_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_cpr_customer_product_id_c": {
-					"name": "idx_cpr_customer_product_id_c",
-					"columns": [
-						{
-							"expression": "\"customer_product_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"customer_prices_customer_product_id_fkey": {
-					"name": "customer_prices_customer_product_id_fkey",
-					"tableFrom": "customer_prices",
-					"columnsFrom": ["customer_product_id"],
-					"tableTo": "customer_products",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"customer_prices_internal_customer_id_fkey": {
-					"name": "customer_prices_internal_customer_id_fkey",
-					"tableFrom": "customer_prices",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"customer_prices_price_id_fkey": {
-					"name": "customer_prices_price_id_fkey",
-					"tableFrom": "customer_prices",
-					"columnsFrom": ["price_id"],
-					"tableTo": "prices",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.customer_products": {
-			"name": "customer_products",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_product_id": {
-					"name": "internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_entity_id": {
-					"name": "internal_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"processor": {
-					"name": "processor",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"canceled": {
-					"name": "canceled",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"canceled_at": {
-					"name": "canceled_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"ended_at": {
-					"name": "ended_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"starts_at": {
-					"name": "starts_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"access_starts_at": {
-					"name": "access_starts_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"options": {
-					"name": "options",
-					"type": "jsonb[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"product_id": {
-					"name": "product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"free_trial_id": {
-					"name": "free_trial_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"trial_ends_at": {
-					"name": "trial_ends_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"billing_cycle_anchor": {
-					"name": "billing_cycle_anchor",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"billing_cycle_anchor_resets_at": {
-					"name": "billing_cycle_anchor_resets_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"collection_method": {
-					"name": "collection_method",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'charge_automatically'"
-				},
-				"subscription_ids": {
-					"name": "subscription_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scheduled_ids": {
-					"name": "scheduled_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"quantity": {
-					"name": "quantity",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false,
-					"default": 1
-				},
-				"is_custom": {
-					"name": "is_custom",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"customer_license_link_id": {
-					"name": "customer_license_link_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"released_at": {
-					"name": "released_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"customer_id": {
-					"name": "customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"entity_id": {
-					"name": "entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"billing_version": {
-					"name": "billing_version",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"api_version": {
-					"name": "api_version",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"api_semver": {
-					"name": "api_semver",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"external_id": {
-					"name": "external_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_checkout_session_id": {
-					"name": "stripe_checkout_session_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"previous_customer_product_id": {
-					"name": "previous_customer_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"on_trial_end": {
-					"name": "on_trial_end",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_customer_products_customer_status": {
-					"name": "idx_customer_products_customer_status",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "status",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_products_customer_status_created_at": {
-					"name": "idx_customer_products_customer_status_created_at",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "status",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"created_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_customer_products_product_status": {
-					"name": "idx_customer_products_product_status",
-					"columns": [
-						{
-							"expression": "internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "status",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_customer_products_on_internal_entity_id": {
-					"name": "idx_customer_products_on_internal_entity_id",
-					"columns": [
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_products_product_customer_c": {
-					"name": "idx_customer_products_product_customer_c",
-					"columns": [
-						{
-							"expression": "internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"internal_customer_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_customer_products_on_internal_product_id": {
-					"name": "idx_customer_products_on_internal_product_id",
-					"columns": [
-						{
-							"expression": "internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_products_subscription_ids": {
-					"name": "idx_customer_products_subscription_ids",
-					"columns": [
-						{
-							"expression": "subscription_ids",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"concurrently": false
-				},
-				"idx_customer_products_scheduled_ids": {
-					"name": "idx_customer_products_scheduled_ids",
-					"columns": [
-						{
-							"expression": "scheduled_ids",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"concurrently": false
-				},
-				"idx_customer_products_stripe_checkout_session_id": {
-					"name": "idx_customer_products_stripe_checkout_session_id",
-					"columns": [
-						{
-							"expression": "stripe_checkout_session_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customer_products_customer_license": {
-					"name": "idx_customer_products_customer_license",
-					"columns": [
-						{
-							"expression": "customer_license_link_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_products_license_seat_order": {
-					"name": "idx_customer_products_license_seat_order",
-					"columns": [
-						{
-							"expression": "customer_license_link_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "created_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_products_seat_sync": {
-					"name": "idx_customer_products_seat_sync",
-					"columns": [
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_products_unused_seats": {
-					"name": "idx_customer_products_unused_seats",
-					"columns": [
-						{
-							"expression": "customer_license_link_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "released_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
-					"concurrently": true
-				},
-				"unique_active_pool_assignment": {
-					"name": "unique_active_pool_assignment",
-					"columns": [
-						{
-							"expression": "customer_license_link_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
-					"concurrently": true
-				},
-				"idx_customer_products_free_trial_id": {
-					"name": "idx_customer_products_free_trial_id",
-					"columns": [
-						{
-							"expression": "free_trial_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_products_revenuecat_processor": {
-					"name": "idx_customer_products_revenuecat_processor",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
-					"concurrently": false
-				},
-				"idx_customer_products_ended_at": {
-					"name": "idx_customer_products_ended_at",
-					"columns": [
-						{
-							"expression": "ended_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_products_trial_ends_at": {
-					"name": "idx_customer_products_trial_ends_at",
-					"columns": [
-						{
-							"expression": "trial_ends_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_customer_products_product_id": {
-					"name": "idx_customer_products_product_id",
-					"columns": [
-						{
-							"expression": "product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"customer_products_free_trial_id_fkey": {
-					"name": "customer_products_free_trial_id_fkey",
-					"tableFrom": "customer_products",
-					"columnsFrom": ["free_trial_id"],
-					"tableTo": "free_trials",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "no action"
-				},
-				"customer_products_internal_customer_id_fkey": {
-					"name": "customer_products_internal_customer_id_fkey",
-					"tableFrom": "customer_products",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "cascade",
-					"onDelete": "cascade"
-				},
-				"customer_products_internal_product_id_fkey": {
-					"name": "customer_products_internal_product_id_fkey",
-					"tableFrom": "customer_products",
-					"columnsFrom": ["internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "no action"
-				},
-				"customer_products_internal_entity_id_fkey": {
-					"name": "customer_products_internal_entity_id_fkey",
-					"tableFrom": "customer_products",
-					"columnsFrom": ["internal_entity_id"],
-					"tableTo": "entities",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.customers": {
-			"name": "customers",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"email": {
-					"name": "email",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"fingerprint": {
-					"name": "fingerprint",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"processor": {
-					"name": "processor",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"processors": {
-					"name": "processors",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"send_email_receipts": {
-					"name": "send_email_receipts",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"currency": {
-					"name": "currency",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"auto_topups": {
-					"name": "auto_topups",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"spend_limits": {
-					"name": "spend_limits",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_limits": {
-					"name": "usage_limits",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_alerts": {
-					"name": "usage_alerts",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"overage_allowed": {
-					"name": "overage_allowed",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"config": {
-					"name": "config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				}
-			},
-			"indexes": {
-				"customers_email_null_id_unique": {
-					"name": "customers_email_null_id_unique",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "lower(\"email\")",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
-					"concurrently": false
-				},
-				"idx_customers_org_env_fingerprint": {
-					"name": "idx_customers_org_env_fingerprint",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "fingerprint",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"customers\".\"fingerprint\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_customers_processor_id": {
-					"name": "idx_customers_processor_id",
-					"columns": [
-						{
-							"expression": "(\"processor\" ->> 'id')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customers_composite": {
-					"name": "idx_customers_composite",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customers_org_env_internal_id": {
-					"name": "idx_customers_org_env_internal_id",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"internal_id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customers_email_trgm": {
-					"name": "idx_customers_email_trgm",
-					"columns": [
-						{
-							"expression": "\"email\" gin_trgm_ops",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"where": "\"customers\".\"email\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_customers_name_trgm": {
-					"name": "idx_customers_name_trgm",
-					"columns": [
-						{
-							"expression": "\"name\" gin_trgm_ops",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"where": "\"customers\".\"name\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_customers_id_trgm": {
-					"name": "idx_customers_id_trgm",
-					"columns": [
-						{
-							"expression": "\"id\" gin_trgm_ops",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"where": "\"customers\".\"id\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_customers_org_id_env_created_at": {
-					"name": "idx_customers_org_id_env_created_at",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"created_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customers_cursor": {
-					"name": "idx_customers_cursor",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"created_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customers_processors_revenuecat": {
-					"name": "idx_customers_processors_revenuecat",
-					"columns": [
-						{
-							"expression": "(\"processors\" ->> 'revenuecat')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customers_processors_revenuecat_id": {
-					"name": "idx_customers_processors_revenuecat_id",
-					"columns": [
-						{
-							"expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_customers_processors_revenuecat_aliases": {
-					"name": "idx_customers_processors_revenuecat_aliases",
-					"columns": [
-						{
-							"expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"concurrently": false
-				},
-				"idx_customers_processors_vercel": {
-					"name": "idx_customers_processors_vercel",
-					"columns": [
-						{
-							"expression": "(\"processors\" ->> 'vercel')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"customers_org_id_fkey": {
-					"name": "customers_org_id_fkey",
-					"tableFrom": "customers",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"cus_id_constraint": {
-					"name": "cus_id_constraint",
-					"columns": ["org_id", "id", "env"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.entities": {
-			"name": "entities",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"deleted": {
-					"name": "deleted",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"internal_feature_id": {
-					"name": "internal_feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"spend_limits": {
-					"name": "spend_limits",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_limits": {
-					"name": "usage_limits",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_alerts": {
-					"name": "usage_alerts",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"overage_allowed": {
-					"name": "overage_allowed",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"feature_id": {
-					"name": "feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_entities_internal_customer_id": {
-					"name": "idx_entities_internal_customer_id",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_entities_internal_feature_id_c": {
-					"name": "idx_entities_internal_feature_id_c",
-					"columns": [
-						{
-							"expression": "\"internal_feature_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_entities_internal_feature_id": {
-					"name": "idx_entities_internal_feature_id",
-					"columns": [
-						{
-							"expression": "internal_feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_entities_customer_internal_desc": {
-					"name": "idx_entities_customer_internal_desc",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"internal_id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_entities_org_env_id": {
-					"name": "idx_entities_org_env_id",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_entities_cursor": {
-					"name": "idx_entities_cursor",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"created_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_entities_customer_created_at": {
-					"name": "idx_entities_customer_created_at",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"created_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"entities_internal_customer_id_fkey": {
-					"name": "entities_internal_customer_id_fkey",
-					"tableFrom": "entities",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"entities_internal_feature_id_fkey": {
-					"name": "entities_internal_feature_id_fkey",
-					"tableFrom": "entities",
-					"columnsFrom": ["internal_feature_id"],
-					"tableTo": "features",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"entities_org_id_fkey": {
-					"name": "entities_org_id_fkey",
-					"tableFrom": "entities",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"entity_id_constraint": {
-					"name": "entity_id_constraint",
-					"columns": ["org_id", "env", "internal_customer_id", "id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.entitlements": {
-			"name": "entitlements",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_feature_id": {
-					"name": "internal_feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_product_id": {
-					"name": "internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_reward_id": {
-					"name": "internal_reward_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"is_custom": {
-					"name": "is_custom",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"allowance_type": {
-					"name": "allowance_type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"allowance": {
-					"name": "allowance",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"interval": {
-					"name": "interval",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"interval_count": {
-					"name": "interval_count",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false,
-					"default": 1
-				},
-				"carry_from_previous": {
-					"name": "carry_from_previous",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"entity_feature_id": {
-					"name": "entity_feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"pooled": {
-					"name": "pooled",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"feature_id": {
-					"name": "feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_limit": {
-					"name": "usage_limit",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"expiry_duration": {
-					"name": "expiry_duration",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"expiry_length": {
-					"name": "expiry_length",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"rollover": {
-					"name": "rollover",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_entitlements_internal_product_id": {
-					"name": "idx_entitlements_internal_product_id",
-					"columns": [
-						{
-							"expression": "internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_entitlements_internal_reward_id": {
-					"name": "idx_entitlements_internal_reward_id",
-					"columns": [
-						{
-							"expression": "internal_reward_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_entitlements_reward_feature": {
-					"name": "idx_entitlements_reward_feature",
-					"columns": [
-						{
-							"expression": "internal_reward_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "internal_feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_entitlements_internal_feature_id_c": {
-					"name": "idx_entitlements_internal_feature_id_c",
-					"columns": [
-						{
-							"expression": "\"internal_feature_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_entitlements_internal_feature_id": {
-					"name": "idx_entitlements_internal_feature_id",
-					"columns": [
-						{
-							"expression": "internal_feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_entitlements_internal_reward_id_c_partial": {
-					"name": "idx_entitlements_internal_reward_id_c_partial",
-					"columns": [
-						{
-							"expression": "\"internal_reward_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"entitlements_internal_feature_id_fkey": {
-					"name": "entitlements_internal_feature_id_fkey",
-					"tableFrom": "entitlements",
-					"columnsFrom": ["internal_feature_id"],
-					"tableTo": "features",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"entitlements_internal_product_id_fkey": {
-					"name": "entitlements_internal_product_id_fkey",
-					"tableFrom": "entitlements",
-					"columnsFrom": ["internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "cascade",
-					"onDelete": "cascade"
-				},
-				"entitlements_internal_reward_id_fkey": {
-					"name": "entitlements_internal_reward_id_fkey",
-					"tableFrom": "entitlements",
-					"columnsFrom": ["internal_reward_id"],
-					"tableTo": "rewards",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "cascade",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"entitlements_id_key": {
-					"name": "entitlements_id_key",
-					"columns": ["id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.events": {
-			"name": "events",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_slug": {
-					"name": "org_slug",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "bigint",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"timestamp": {
-					"name": "timestamp",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"event_name": {
-					"name": "event_name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"idempotency_key": {
-					"name": "idempotency_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"value": {
-					"name": "value",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"set_usage": {
-					"name": "set_usage",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"entity_id": {
-					"name": "entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_entity_id": {
-					"name": "internal_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_product_id": {
-					"name": "internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"customer_id": {
-					"name": "customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"properties": {
-					"name": "properties",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"deductions": {
-					"name": "deductions",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_events_internal_customer_id": {
-					"name": "idx_events_internal_customer_id",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_events_internal_entity_id": {
-					"name": "idx_events_internal_entity_id",
-					"columns": [
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_events_customer_non_usage_ts": {
-					"name": "idx_events_customer_non_usage_ts",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"timestamp\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"events\".\"set_usage\" = false",
-					"concurrently": false
-				},
-				"idx_events_timestamp": {
-					"name": "idx_events_timestamp",
-					"columns": [
-						{
-							"expression": "timestamp",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"events_internal_customer_id_fkey": {
-					"name": "events_internal_customer_id_fkey",
-					"tableFrom": "events",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"unique_event_constraint": {
-					"name": "unique_event_constraint",
-					"columns": [
-						"org_id",
-						"env",
-						"customer_id",
-						"event_name",
-						"idempotency_key"
-					],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.features": {
-			"name": "features",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"type": {
-					"name": "type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"config": {
-					"name": "config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"display": {
-					"name": "display",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"archived": {
-					"name": "archived",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"event_names": {
-					"name": "event_names",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'"
-				},
-				"model_markups": {
-					"name": "model_markups",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"stripe_meter": {
-					"name": "stripe_meter",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				}
-			},
-			"indexes": {
-				"idx_features_composite": {
-					"name": "idx_features_composite",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"features_org_id_fkey": {
-					"name": "features_org_id_fkey",
-					"tableFrom": "features",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"feature_id_constraint": {
-					"name": "feature_id_constraint",
-					"columns": ["org_id", "id", "env"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.free_trials": {
-			"name": "free_trials",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_product_id": {
-					"name": "internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"duration": {
-					"name": "duration",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'day'"
-				},
-				"length": {
-					"name": "length",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"unique_fingerprint": {
-					"name": "unique_fingerprint",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"is_custom": {
-					"name": "is_custom",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"card_required": {
-					"name": "card_required",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"on_end": {
-					"name": "on_end",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_free_trials_internal_product_id": {
-					"name": "idx_free_trials_internal_product_id",
-					"columns": [
-						{
-							"expression": "internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"free_trials_internal_product_id_fkey": {
-					"name": "free_trials_internal_product_id_fkey",
-					"tableFrom": "free_trials",
-					"columnsFrom": ["internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"leaf.harness_sessions": {
-			"name": "harness_sessions",
-			"schema": "leaf",
-			"columns": {
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"thread_key": {
-					"name": "thread_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"session_id": {
-					"name": "session_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"resume_state": {
-					"name": "resume_state",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"title": {
-					"name": "title",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"braintrust_parent": {
-					"name": "braintrust_parent",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"idx_harness_sessions_session_id": {
-					"name": "idx_harness_sessions_session_id",
-					"columns": [
-						{
-							"expression": "session_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {
-				"harness_sessions_org_id_env_thread_key_pk": {
-					"name": "harness_sessions_org_id_env_thread_key_pk",
-					"columns": ["org_id", "env", "thread_key"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.invitation": {
-			"name": "invitation",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"organization_id": {
-					"name": "organization_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"email": {
-					"name": "email",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"role": {
-					"name": "role",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'pending'"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"inviter_id": {
-					"name": "inviter_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"invitation_organizationId_idx": {
-					"name": "invitation_organizationId_idx",
-					"columns": [
-						{
-							"expression": "organization_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"invitation_email_idx": {
-					"name": "invitation_email_idx",
-					"columns": [
-						{
-							"expression": "email",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"invitation_organization_id_organizations_id_fk": {
-					"name": "invitation_organization_id_organizations_id_fk",
-					"tableFrom": "invitation",
-					"columnsFrom": ["organization_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"invitation_inviter_id_user_id_fk": {
-					"name": "invitation_inviter_id_user_id_fk",
-					"tableFrom": "invitation",
-					"columnsFrom": ["inviter_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.invoice_line_items": {
-			"name": "invoice_line_items",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"invoice_id": {
-					"name": "invoice_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_id": {
-					"name": "stripe_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_invoice_id": {
-					"name": "stripe_invoice_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_invoice_item_id": {
-					"name": "stripe_invoice_item_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_subscription_item_id": {
-					"name": "stripe_subscription_item_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_product_id": {
-					"name": "stripe_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_price_id": {
-					"name": "stripe_price_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_discountable": {
-					"name": "stripe_discountable",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": true
-				},
-				"amount": {
-					"name": "amount",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"amount_after_discounts": {
-					"name": "amount_after_discounts",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"currency": {
-					"name": "currency",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'usd'"
-				},
-				"stripe_quantity": {
-					"name": "stripe_quantity",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"total_quantity": {
-					"name": "total_quantity",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"paid_quantity": {
-					"name": "paid_quantity",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"description": {
-					"name": "description",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"description_source": {
-					"name": "description_source",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"direction": {
-					"name": "direction",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"billing_timing": {
-					"name": "billing_timing",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"prorated": {
-					"name": "prorated",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"price_id": {
-					"name": "price_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"customer_product_ids": {
-					"name": "customer_product_ids",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'[]'::jsonb"
-				},
-				"customer_price_ids": {
-					"name": "customer_price_ids",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'[]'::jsonb"
-				},
-				"customer_entitlement_ids": {
-					"name": "customer_entitlement_ids",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'[]'::jsonb"
-				},
-				"internal_product_id": {
-					"name": "internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"product_id": {
-					"name": "product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_feature_id": {
-					"name": "internal_feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"feature_id": {
-					"name": "feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"effective_period_start": {
-					"name": "effective_period_start",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"effective_period_end": {
-					"name": "effective_period_end",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"discounts": {
-					"name": "discounts",
-					"type": "jsonb[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'"
-				}
-			},
-			"indexes": {
-				"idx_invoice_line_items_customer_product_ids": {
-					"name": "idx_invoice_line_items_customer_product_ids",
-					"columns": [
-						{
-							"expression": "customer_product_ids",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"concurrently": false
-				},
-				"idx_invoice_line_items_stripe_invoice_id": {
-					"name": "idx_invoice_line_items_stripe_invoice_id",
-					"columns": [
-						{
-							"expression": "stripe_invoice_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_invoice_line_items_invoice_id": {
-					"name": "idx_invoice_line_items_invoice_id",
-					"columns": [
-						{
-							"expression": "invoice_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_invoice_line_items_stripe_invoice_item_id": {
-					"name": "idx_invoice_line_items_stripe_invoice_item_id",
-					"columns": [
-						{
-							"expression": "stripe_invoice_item_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"invoice_line_items_invoice_id_fkey": {
-					"name": "invoice_line_items_invoice_id_fkey",
-					"tableFrom": "invoice_line_items",
-					"columnsFrom": ["invoice_id"],
-					"tableTo": "invoices",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"invoice_line_items_stripe_id_unique": {
-					"name": "invoice_line_items_stripe_id_unique",
-					"columns": ["stripe_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.invoice_templates": {
-			"name": "invoice_templates",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"footer": {
-					"name": "footer",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"memo": {
-					"name": "memo",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"net_terms_days": {
-					"name": "net_terms_days",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_invoice_templates_org_id": {
-					"name": "idx_invoice_templates_org_id",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"invoice_templates_org_id_fkey": {
-					"name": "invoice_templates_org_id_fkey",
-					"tableFrom": "invoice_templates",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"invoice_templates_id_unique": {
-					"name": "invoice_templates_id_unique",
-					"columns": ["id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.invoices": {
-			"name": "invoices",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"product_ids": {
-					"name": "product_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'"
-				},
-				"internal_product_ids": {
-					"name": "internal_product_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'"
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_entity_id": {
-					"name": "internal_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_id": {
-					"name": "stripe_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"processor_type": {
-					"name": "processor_type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'draft'"
-				},
-				"hosted_invoice_url": {
-					"name": "hosted_invoice_url",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"total": {
-					"name": "total",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"amount_paid": {
-					"name": "amount_paid",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"refunded_amount": {
-					"name": "refunded_amount",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"currency": {
-					"name": "currency",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'usd'"
-				},
-				"discounts": {
-					"name": "discounts",
-					"type": "jsonb[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'"
-				},
-				"items": {
-					"name": "items",
-					"type": "jsonb[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'"
-				}
-			},
-			"indexes": {
-				"idx_invoices_customer_created": {
-					"name": "idx_invoices_customer_created",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"created_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_invoices_internal_entity_id": {
-					"name": "idx_invoices_internal_entity_id",
-					"columns": [
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"invoices_internal_customer_id_fkey": {
-					"name": "invoices_internal_customer_id_fkey",
-					"tableFrom": "invoices",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"invoices_internal_entity_id_fkey": {
-					"name": "invoices_internal_entity_id_fkey",
-					"tableFrom": "invoices",
-					"columnsFrom": ["internal_entity_id"],
-					"tableTo": "entities",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"invoices_stripe_id_key": {
-					"name": "invoices_stripe_id_key",
-					"columns": ["stripe_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.jwks": {
-			"name": "jwks",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"public_key": {
-					"name": "public_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"private_key": {
-					"name": "private_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.license_entitlements": {
-			"name": "license_entitlements",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"plan_license_id": {
-					"name": "plan_license_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"entitlement_id": {
-					"name": "entitlement_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"unique_license_entitlement": {
-					"name": "unique_license_entitlement",
-					"columns": [
-						{
-							"expression": "plan_license_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "entitlement_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_license_entitlements_entitlement": {
-					"name": "idx_license_entitlements_entitlement",
-					"columns": [
-						{
-							"expression": "entitlement_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"license_entitlements_plan_license_fkey": {
-					"name": "license_entitlements_plan_license_fkey",
-					"tableFrom": "license_entitlements",
-					"columnsFrom": ["plan_license_id"],
-					"tableTo": "plan_license",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"license_entitlements_entitlement_fkey": {
-					"name": "license_entitlements_entitlement_fkey",
-					"tableFrom": "license_entitlements",
-					"columnsFrom": ["entitlement_id"],
-					"tableTo": "entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "restrict"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.license_prices": {
-			"name": "license_prices",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"plan_license_id": {
-					"name": "plan_license_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"price_id": {
-					"name": "price_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"unique_license_price": {
-					"name": "unique_license_price",
-					"columns": [
-						{
-							"expression": "plan_license_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "price_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_license_prices_price": {
-					"name": "idx_license_prices_price",
-					"columns": [
-						{
-							"expression": "price_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"license_prices_plan_license_fkey": {
-					"name": "license_prices_plan_license_fkey",
-					"tableFrom": "license_prices",
-					"columnsFrom": ["plan_license_id"],
-					"tableTo": "plan_license",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"license_prices_price_fkey": {
-					"name": "license_prices_price_fkey",
-					"tableFrom": "license_prices",
-					"columnsFrom": ["price_id"],
-					"tableTo": "prices",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "restrict"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.member": {
-			"name": "member",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"organization_id": {
-					"name": "organization_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"role": {
-					"name": "role",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'member'"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"member_organizationId_idx": {
-					"name": "member_organizationId_idx",
-					"columns": [
-						{
-							"expression": "organization_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"member_userId_idx": {
-					"name": "member_userId_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"member_organization_id_organizations_id_fk": {
-					"name": "member_organization_id_organizations_id_fk",
-					"tableFrom": "member",
-					"columnsFrom": ["organization_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"member_user_id_user_id_fk": {
-					"name": "member_user_id_user_id_fk",
-					"tableFrom": "member",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.metadata": {
-			"name": "metadata",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"data": {
-					"name": "data",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"type": {
-					"name": "type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_invoice_id": {
-					"name": "stripe_invoice_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_checkout_session_id": {
-					"name": "stripe_checkout_session_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_metadata_on_type_expires_at": {
-					"name": "idx_metadata_on_type_expires_at",
-					"columns": [
-						{
-							"expression": "type",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "expires_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"metadata_expires_at_idx": {
-					"name": "metadata_expires_at_idx",
-					"columns": [
-						{
-							"expression": "expires_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"metadata\".\"expires_at\" IS NOT NULL",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.migration_errors": {
-			"name": "migration_errors",
-			"schema": "",
-			"columns": {
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"migration_job_id": {
-					"name": "migration_job_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"data": {
-					"name": "data",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"message": {
-					"name": "message",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"code": {
-					"name": "code",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"migration_customers_internal_customer_id_fkey": {
-					"name": "migration_customers_internal_customer_id_fkey",
-					"tableFrom": "migration_errors",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"migration_customers_migration_job_id_fkey": {
-					"name": "migration_customers_migration_job_id_fkey",
-					"tableFrom": "migration_errors",
-					"columnsFrom": ["migration_job_id"],
-					"tableTo": "migration_jobs",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {
-				"migration_errors_pkey": {
-					"name": "migration_errors_pkey",
-					"columns": ["internal_customer_id", "migration_job_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.migration_item_runs": {
-			"name": "migration_item_runs",
-			"schema": "",
-			"columns": {
-				"migration_item_run_id": {
-					"name": "migration_item_run_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"migration_internal_id": {
-					"name": "migration_internal_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"migration_run_id": {
-					"name": "migration_run_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"dry_run": {
-					"name": "dry_run",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"item_kind": {
-					"name": "item_kind",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"item_id": {
-					"name": "item_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"timestamp": {
-					"name": "timestamp",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "now()"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"migration_item_runs_live_unique": {
-					"name": "migration_item_runs_live_unique",
-					"columns": [
-						{
-							"expression": "migration_internal_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "item_kind",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "item_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"migration_item_runs\".\"dry_run\" = false",
-					"concurrently": false
-				},
-				"migration_item_runs_live_c_idx": {
-					"name": "migration_item_runs_live_c_idx",
-					"columns": [
-						{
-							"expression": "migration_internal_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "item_kind",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"item_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"migration_item_runs\".\"dry_run\" = false",
-					"concurrently": true
-				},
-				"migration_item_runs_live_item_exclusive": {
-					"name": "migration_item_runs_live_item_exclusive",
-					"columns": [
-						{
-							"expression": "item_kind",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"item_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"migration_item_runs\".\"status\" = 'running' AND \"migration_item_runs\".\"dry_run\" = false",
-					"concurrently": true
-				},
-				"migration_item_runs_dry_run_unique": {
-					"name": "migration_item_runs_dry_run_unique",
-					"columns": [
-						{
-							"expression": "migration_internal_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "migration_run_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "item_kind",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "item_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"migration_item_runs\".\"dry_run\" = true",
-					"concurrently": false
-				},
-				"migration_item_runs_customer_recent_idx": {
-					"name": "migration_item_runs_customer_recent_idx",
-					"columns": [
-						{
-							"expression": "item_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"updated_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.migration_jobs": {
-			"name": "migration_jobs",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"current_step": {
-					"name": "current_step",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"from_internal_product_id": {
-					"name": "from_internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"to_internal_product_id": {
-					"name": "to_internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"step_details": {
-					"name": "step_details",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"migration_jobs_from_internal_product_id_fkey": {
-					"name": "migration_jobs_from_internal_product_id_fkey",
-					"tableFrom": "migration_jobs",
-					"columnsFrom": ["from_internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"migration_jobs_org_id_fkey": {
-					"name": "migration_jobs_org_id_fkey",
-					"tableFrom": "migration_jobs",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"migration_jobs_to_internal_product_id_fkey": {
-					"name": "migration_jobs_to_internal_product_id_fkey",
-					"tableFrom": "migration_jobs",
-					"columnsFrom": ["to_internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.migration_runs": {
-			"name": "migration_runs",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"migration_internal_id": {
-					"name": "migration_internal_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"dry_run": {
-					"name": "dry_run",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"lazy_run": {
-					"name": "lazy_run",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"trigger_run_id": {
-					"name": "trigger_run_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"error_message": {
-					"name": "error_message",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"only_ids": {
-					"name": "only_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"target_limit": {
-					"name": "target_limit",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"started_at": {
-					"name": "started_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"finished_at": {
-					"name": "finished_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"migration_runs_active_per_migration_unique": {
-					"name": "migration_runs_active_per_migration_unique",
-					"columns": [
-						{
-							"expression": "migration_internal_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"migration_runs_migration_internal_id_fkey": {
-					"name": "migration_runs_migration_internal_id_fkey",
-					"tableFrom": "migration_runs",
-					"columnsFrom": ["migration_internal_id"],
-					"tableTo": "migrations",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"migration_runs_org_id_fkey": {
-					"name": "migration_runs_org_id_fkey",
-					"tableFrom": "migration_runs",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.migrations": {
-			"name": "migrations",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"filter": {
-					"name": "filter",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"operations": {
-					"name": "operations",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"prepared_state": {
-					"name": "prepared_state",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"no_billing_changes": {
-					"name": "no_billing_changes",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"retry_failed": {
-					"name": "retry_failed",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"archived": {
-					"name": "archived",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"migrations_org_env_id_unique": {
-					"name": "migrations_org_env_id_unique",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"migrations_org_id_fkey": {
-					"name": "migrations_org_id_fkey",
-					"tableFrom": "migrations",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.oauth_access_token": {
-			"name": "oauth_access_token",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"token": {
-					"name": "token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"client_id": {
-					"name": "client_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"session_id": {
-					"name": "session_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"reference_id": {
-					"name": "reference_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"oauth_consent_id": {
-					"name": "oauth_consent_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"refresh_id": {
-					"name": "refresh_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scopes": {
-					"name": "scopes",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"oauth_access_token_client_id_oauth_client_client_id_fk": {
-					"name": "oauth_access_token_client_id_oauth_client_client_id_fk",
-					"tableFrom": "oauth_access_token",
-					"columnsFrom": ["client_id"],
-					"tableTo": "oauth_client",
-					"columnsTo": ["client_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"oauth_access_token_session_id_session_id_fk": {
-					"name": "oauth_access_token_session_id_session_id_fk",
-					"tableFrom": "oauth_access_token",
-					"columnsFrom": ["session_id"],
-					"tableTo": "session",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				},
-				"oauth_access_token_user_id_user_id_fk": {
-					"name": "oauth_access_token_user_id_user_id_fk",
-					"tableFrom": "oauth_access_token",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
-					"name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
-					"tableFrom": "oauth_access_token",
-					"columnsFrom": ["oauth_consent_id"],
-					"tableTo": "oauth_consent",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
-					"name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
-					"tableFrom": "oauth_access_token",
-					"columnsFrom": ["refresh_id"],
-					"tableTo": "oauth_refresh_token",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"oauth_access_token_token_unique": {
-					"name": "oauth_access_token_token_unique",
-					"columns": ["token"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.oauth_client": {
-			"name": "oauth_client",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"client_id": {
-					"name": "client_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"client_secret": {
-					"name": "client_secret",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"disabled": {
-					"name": "disabled",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"skip_consent": {
-					"name": "skip_consent",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"enable_end_session": {
-					"name": "enable_end_session",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scopes": {
-					"name": "scopes",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"uri": {
-					"name": "uri",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"icon": {
-					"name": "icon",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"contacts": {
-					"name": "contacts",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"tos": {
-					"name": "tos",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"policy": {
-					"name": "policy",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"software_id": {
-					"name": "software_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"software_version": {
-					"name": "software_version",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"software_statement": {
-					"name": "software_statement",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"redirect_uris": {
-					"name": "redirect_uris",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"post_logout_redirect_uris": {
-					"name": "post_logout_redirect_uris",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"token_endpoint_auth_method": {
-					"name": "token_endpoint_auth_method",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"grant_types": {
-					"name": "grant_types",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"response_types": {
-					"name": "response_types",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"public": {
-					"name": "public",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"type": {
-					"name": "type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"reference_id": {
-					"name": "reference_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"oauth_client_user_id_user_id_fk": {
-					"name": "oauth_client_user_id_user_id_fk",
-					"tableFrom": "oauth_client",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"oauth_client_client_id_unique": {
-					"name": "oauth_client_client_id_unique",
-					"columns": ["client_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.oauth_consent": {
-			"name": "oauth_consent",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"client_id": {
-					"name": "client_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"reference_id": {
-					"name": "reference_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scopes": {
-					"name": "scopes",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"redirect_uri": {
-					"name": "redirect_uri",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"oauth_api_key_id": {
-					"name": "oauth_api_key_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"oauth_consent_client_id_oauth_client_client_id_fk": {
-					"name": "oauth_consent_client_id_oauth_client_client_id_fk",
-					"tableFrom": "oauth_consent",
-					"columnsFrom": ["client_id"],
-					"tableTo": "oauth_client",
-					"columnsTo": ["client_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"oauth_consent_user_id_user_id_fk": {
-					"name": "oauth_consent_user_id_user_id_fk",
-					"tableFrom": "oauth_consent",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.oauth_refresh_token": {
-			"name": "oauth_refresh_token",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"token": {
-					"name": "token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"client_id": {
-					"name": "client_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"session_id": {
-					"name": "session_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"reference_id": {
-					"name": "reference_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"oauth_consent_id": {
-					"name": "oauth_consent_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"revoked": {
-					"name": "revoked",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"auth_time": {
-					"name": "auth_time",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"scopes": {
-					"name": "scopes",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"oauth_refresh_token_client_id_oauth_client_client_id_fk": {
-					"name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
-					"tableFrom": "oauth_refresh_token",
-					"columnsFrom": ["client_id"],
-					"tableTo": "oauth_client",
-					"columnsTo": ["client_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"oauth_refresh_token_session_id_session_id_fk": {
-					"name": "oauth_refresh_token_session_id_session_id_fk",
-					"tableFrom": "oauth_refresh_token",
-					"columnsFrom": ["session_id"],
-					"tableTo": "session",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				},
-				"oauth_refresh_token_user_id_user_id_fk": {
-					"name": "oauth_refresh_token_user_id_user_id_fk",
-					"tableFrom": "oauth_refresh_token",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
-					"name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
-					"tableFrom": "oauth_refresh_token",
-					"columnsFrom": ["oauth_consent_id"],
-					"tableTo": "oauth_consent",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.organizations": {
-			"name": "organizations",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"slug": {
-					"name": "slug",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"logo": {
-					"name": "logo",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"createdAt": {
-					"name": "createdAt",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"default_currency": {
-					"name": "default_currency",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'usd'"
-				},
-				"stripe_connected": {
-					"name": "stripe_connected",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"stripe_config": {
-					"name": "stripe_config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"test_stripe_connect": {
-					"name": "test_stripe_connect",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"live_stripe_connect": {
-					"name": "live_stripe_connect",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"processor_configs": {
-					"name": "processor_configs",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"test_pkey": {
-					"name": "test_pkey",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"live_pkey": {
-					"name": "live_pkey",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"svix_config": {
-					"name": "svix_config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"config": {
-					"name": "config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'::jsonb"
-				},
-				"custom_buttons": {
-					"name": "custom_buttons",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'[]'::jsonb"
-				},
-				"created_by": {
-					"name": "created_by",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"onboarded": {
-					"name": "onboarded",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"deployed": {
-					"name": "deployed",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"is_sandbox": {
-					"name": "is_sandbox",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"sandbox_color": {
-					"name": "sandbox_color",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"sandbox_icon": {
-					"name": "sandbox_icon",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"redis_config": {
-					"name": "redis_config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_organizations_name_trgm": {
-					"name": "idx_organizations_name_trgm",
-					"columns": [
-						{
-							"expression": "\"name\" gin_trgm_ops",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"where": "\"organizations\".\"name\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_organizations_slug_trgm": {
-					"name": "idx_organizations_slug_trgm",
-					"columns": [
-						{
-							"expression": "\"slug\" gin_trgm_ops",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"where": "\"organizations\".\"slug\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_organizations_created_at_id": {
-					"name": "idx_organizations_created_at_id",
-					"columns": [
-						{
-							"expression": "\"createdAt\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_orgs_test_connect_default_account": {
-					"name": "idx_orgs_test_connect_default_account",
-					"columns": [
-						{
-							"expression": "(\"test_stripe_connect\"->>'default_account_id')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_orgs_test_connect_account": {
-					"name": "idx_orgs_test_connect_account",
-					"columns": [
-						{
-							"expression": "(\"test_stripe_connect\"->>'account_id')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_orgs_live_connect_account": {
-					"name": "idx_orgs_live_connect_account",
-					"columns": [
-						{
-							"expression": "(\"live_stripe_connect\"->>'account_id')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"organizations_slug_unique": {
-					"name": "organizations_slug_unique",
-					"columns": ["slug"],
-					"nullsNotDistinct": false
-				},
-				"organizations_test_pkey_key": {
-					"name": "organizations_test_pkey_key",
-					"columns": ["test_pkey"],
-					"nullsNotDistinct": false
-				},
-				"organizations_live_pkey_key": {
-					"name": "organizations_live_pkey_key",
-					"columns": ["live_pkey"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.passkey": {
-			"name": "passkey",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"public_key": {
-					"name": "public_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"credential_id": {
-					"name": "credential_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"counter": {
-					"name": "counter",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"device_type": {
-					"name": "device_type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"backed_up": {
-					"name": "backed_up",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"transports": {
-					"name": "transports",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"aaguid": {
-					"name": "aaguid",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"passkey_userId_idx": {
-					"name": "passkey_userId_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"passkey_credentialId_idx": {
-					"name": "passkey_credentialId_idx",
-					"columns": [
-						{
-							"expression": "credential_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"passkey_user_id_user_id_fk": {
-					"name": "passkey_user_id_user_id_fk",
-					"tableFrom": "passkey",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"passkey_credential_id_unique": {
-					"name": "passkey_credential_id_unique",
-					"columns": ["credential_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.plan_license": {
-			"name": "plan_license",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"parent_internal_product_id": {
-					"name": "parent_internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"license_internal_product_id": {
-					"name": "license_internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"is_custom": {
-					"name": "is_custom",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"included": {
-					"name": "included",
-					"type": "integer",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"prepaid_only": {
-					"name": "prepaid_only",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": true
-				},
-				"customized": {
-					"name": "customized",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"unique_plan_license": {
-					"name": "unique_plan_license",
-					"columns": [
-						{
-							"expression": "parent_internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "license_internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"plan_license\".\"is_custom\" = false",
-					"concurrently": true
-				},
-				"idx_plan_license_parent_product": {
-					"name": "idx_plan_license_parent_product",
-					"columns": [
-						{
-							"expression": "parent_internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_plan_license_license": {
-					"name": "idx_plan_license_license",
-					"columns": [
-						{
-							"expression": "license_internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"plan_license_parent_product_fkey": {
-					"name": "plan_license_parent_product_fkey",
-					"tableFrom": "plan_license",
-					"columnsFrom": ["parent_internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"plan_license_license_product_fkey": {
-					"name": "plan_license_license_product_fkey",
-					"tableFrom": "plan_license",
-					"columnsFrom": ["license_internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.pooled_balance_contributions": {
-			"name": "pooled_balance_contributions",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"pooled_balance_id": {
-					"name": "pooled_balance_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"source_customer_product_id": {
-					"name": "source_customer_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"source_customer_entitlement_id": {
-					"name": "source_customer_entitlement_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"current_contribution": {
-					"name": "current_contribution",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"next_cycle_contribution": {
-					"name": "next_cycle_contribution",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"effective_at": {
-					"name": "effective_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"idx_pooled_balance_contributions_pool": {
-					"name": "idx_pooled_balance_contributions_pool",
-					"columns": [
-						{
-							"expression": "pooled_balance_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_pooled_balance_contributions_source_customer_entitlement": {
-					"name": "idx_pooled_balance_contributions_source_customer_entitlement",
-					"columns": [
-						{
-							"expression": "source_customer_entitlement_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"pooled_balance_contributions_pool_fkey": {
-					"name": "pooled_balance_contributions_pool_fkey",
-					"tableFrom": "pooled_balance_contributions",
-					"columnsFrom": ["pooled_balance_id"],
-					"tableTo": "pooled_balances",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"pooled_balance_contributions_customer_product_fkey": {
-					"name": "pooled_balance_contributions_customer_product_fkey",
-					"tableFrom": "pooled_balance_contributions",
-					"columnsFrom": ["source_customer_product_id"],
-					"tableTo": "customer_products",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"pooled_balance_contributions_customer_entitlement_fkey": {
-					"name": "pooled_balance_contributions_customer_entitlement_fkey",
-					"tableFrom": "pooled_balance_contributions",
-					"columnsFrom": ["source_customer_entitlement_id"],
-					"tableTo": "customer_entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"unique_pooled_balance_contribution": {
-					"name": "unique_pooled_balance_contribution",
-					"columns": ["source_customer_entitlement_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {
-				"pooled_balance_contributions_current_non_negative": {
-					"name": "pooled_balance_contributions_current_non_negative",
-					"value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
-				},
-				"pooled_balance_contributions_next_non_negative": {
-					"name": "pooled_balance_contributions_next_non_negative",
-					"value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
-				}
-			},
-			"isRLSEnabled": false
-		},
-		"public.pooled_balances": {
-			"name": "pooled_balances",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_feature_id": {
-					"name": "internal_feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"unlimited": {
-					"name": "unlimited",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"granted": {
-					"name": "granted",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"interval": {
-					"name": "interval",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"interval_count": {
-					"name": "interval_count",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 1
-				},
-				"reset_cycle_anchor": {
-					"name": "reset_cycle_anchor",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"reset_mode": {
-					"name": "reset_mode",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"stripe_subscription_id": {
-					"name": "stripe_subscription_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"customer_license_link_id": {
-					"name": "customer_license_link_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"rollover_signature": {
-					"name": "rollover_signature",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'none'"
-				},
-				"customer_entitlement_id": {
-					"name": "customer_entitlement_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"last_applied_reset_at": {
-					"name": "last_applied_reset_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {
-				"idx_pooled_balances_org": {
-					"name": "idx_pooled_balances_org",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_pooled_balances_reset_mode": {
-					"name": "idx_pooled_balances_reset_mode",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "reset_mode",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_pooled_balances_feature": {
-					"name": "idx_pooled_balances_feature",
-					"columns": [
-						{
-							"expression": "internal_feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_pooled_balances_stripe_subscription": {
-					"name": "idx_pooled_balances_stripe_subscription",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "stripe_subscription_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
-					"concurrently": true
-				},
-				"idx_pooled_balances_customer_license": {
-					"name": "idx_pooled_balances_customer_license",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "customer_license_link_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"pooled_balances_customer_fkey": {
-					"name": "pooled_balances_customer_fkey",
-					"tableFrom": "pooled_balances",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"pooled_balances_feature_fkey": {
-					"name": "pooled_balances_feature_fkey",
-					"tableFrom": "pooled_balances",
-					"columnsFrom": ["internal_feature_id"],
-					"tableTo": "features",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "restrict"
-				},
-				"pooled_balances_customer_entitlement_fkey": {
-					"name": "pooled_balances_customer_entitlement_fkey",
-					"tableFrom": "pooled_balances",
-					"columnsFrom": ["customer_entitlement_id"],
-					"tableTo": "customer_entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "restrict"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"unique_pooled_balance": {
-					"name": "unique_pooled_balance",
-					"columns": [
-						"internal_customer_id",
-						"internal_feature_id",
-						"unlimited",
-						"interval",
-						"interval_count",
-						"reset_cycle_anchor",
-						"reset_mode",
-						"stripe_subscription_id",
-						"customer_license_link_id",
-						"rollover_signature",
-						"expires_at"
-					],
-					"nullsNotDistinct": true
-				},
-				"unique_pooled_balance_customer_entitlement": {
-					"name": "unique_pooled_balance_customer_entitlement",
-					"columns": ["customer_entitlement_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {
-				"pooled_balances_interval_count_positive": {
-					"name": "pooled_balances_interval_count_positive",
-					"value": "\"pooled_balances\".\"interval_count\" > 0"
-				},
-				"pooled_balances_granted_non_negative": {
-					"name": "pooled_balances_granted_non_negative",
-					"value": "\"pooled_balances\".\"granted\" >= 0"
-				},
-				"pooled_balances_reset_mode_valid": {
-					"name": "pooled_balances_reset_mode_valid",
-					"value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
-				},
-				"pooled_balances_lifecycle_ids_valid": {
-					"name": "pooled_balances_lifecycle_ids_valid",
-					"value": "(\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'subscription'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lazy'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lifetime'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t)"
-				}
-			},
-			"isRLSEnabled": false
-		},
-		"public.prices": {
-			"name": "prices",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_product_id": {
-					"name": "internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"config": {
-					"name": "config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"billing_type": {
-					"name": "billing_type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"tier_behavior": {
-					"name": "tier_behavior",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"is_custom": {
-					"name": "is_custom",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"entitlement_id": {
-					"name": "entitlement_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"proration_config": {
-					"name": "proration_config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				}
-			},
-			"indexes": {
-				"idx_prices_internal_product_id": {
-					"name": "idx_prices_internal_product_id",
-					"columns": [
-						{
-							"expression": "internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_prices_entitlement_id": {
-					"name": "idx_prices_entitlement_id",
-					"columns": [
-						{
-							"expression": "entitlement_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"prices_entitlement_id_fkey": {
-					"name": "prices_entitlement_id_fkey",
-					"tableFrom": "prices",
-					"columnsFrom": ["entitlement_id"],
-					"tableTo": "entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "no action"
-				},
-				"prices_internal_product_id_fkey": {
-					"name": "prices_internal_product_id_fkey",
-					"tableFrom": "prices",
-					"columnsFrom": ["internal_product_id"],
-					"tableTo": "products",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "cascade",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"prices_id_key": {
-					"name": "prices_id_key",
-					"columns": ["id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.products": {
-			"name": "products",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"description": {
-					"name": "description",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"is_add_on": {
-					"name": "is_add_on",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"is_default": {
-					"name": "is_default",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"group": {
-					"name": "group",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "''"
-				},
-				"version": {
-					"name": "version",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 1
-				},
-				"processor": {
-					"name": "processor",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "null"
-				},
-				"base_variant_id": {
-					"name": "base_variant_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"base_internal_product_id": {
-					"name": "base_internal_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"archived": {
-					"name": "archived",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				},
-				"config": {
-					"name": "config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'::jsonb"
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'::jsonb"
-				},
-				"auto_topups": {
-					"name": "auto_topups",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"spend_limits": {
-					"name": "spend_limits",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_limits": {
-					"name": "usage_limits",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage_alerts": {
-					"name": "usage_alerts",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"overage_allowed": {
-					"name": "overage_allowed",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_products_org_env_id_version": {
-					"name": "idx_products_org_env_id_version",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "version",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_products_org_env_base_internal_product_id": {
-					"name": "idx_products_org_env_base_internal_product_id",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "base_internal_product_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"products_org_id_fkey": {
-					"name": "products_org_id_fkey",
-					"tableFrom": "products",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"unique_product": {
-					"name": "unique_product",
-					"columns": ["org_id", "id", "env", "version"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.referral_codes": {
-			"name": "referral_codes",
-			"schema": "",
-			"columns": {
-				"code": {
-					"name": "code",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_reward_program_id": {
-					"name": "internal_reward_program_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_referral_codes_internal_customer_id": {
-					"name": "idx_referral_codes_internal_customer_id",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"referral_codes_internal_customer_id_fkey": {
-					"name": "referral_codes_internal_customer_id_fkey",
-					"tableFrom": "referral_codes",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"referral_codes_internal_reward_program_id_fkey": {
-					"name": "referral_codes_internal_reward_program_id_fkey",
-					"tableFrom": "referral_codes",
-					"columnsFrom": ["internal_reward_program_id"],
-					"tableTo": "reward_programs",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"referral_codes_org_id_fkey": {
-					"name": "referral_codes_org_id_fkey",
-					"tableFrom": "referral_codes",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {
-				"referral_codes_pkey": {
-					"name": "referral_codes_pkey",
-					"columns": ["code", "org_id", "env"]
-				}
-			},
-			"uniqueConstraints": {
-				"referral_codes_id_key": {
-					"name": "referral_codes_id_key",
-					"columns": ["id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.replaceables": {
-			"name": "replaceables",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"cus_ent_id": {
-					"name": "cus_ent_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "bigint",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"from_entity_id": {
-					"name": "from_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"delete_next_cycle": {
-					"name": "delete_next_cycle",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				}
-			},
-			"indexes": {
-				"idx_replaceables_cus_ent_id": {
-					"name": "idx_replaceables_cus_ent_id",
-					"columns": [
-						{
-							"expression": "cus_ent_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"replaceables_cus_ent_id_fkey": {
-					"name": "replaceables_cus_ent_id_fkey",
-					"tableFrom": "replaceables",
-					"columnsFrom": ["cus_ent_id"],
-					"tableTo": "customer_entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.revenuecat_mappings": {
-			"name": "revenuecat_mappings",
-			"schema": "",
-			"columns": {
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"autumn_product_id": {
-					"name": "autumn_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"revenuecat_product_ids": {
-					"name": "revenuecat_product_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'"
-				},
-				"feature_quantities": {
-					"name": "feature_quantities",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"revenuecat_mappings_org_id_fkey": {
-					"name": "revenuecat_mappings_org_id_fkey",
-					"tableFrom": "revenuecat_mappings",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {
-				"revenuecat_mappings_pkey": {
-					"name": "revenuecat_mappings_pkey",
-					"columns": ["org_id", "env", "autumn_product_id"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.reward_programs": {
-			"name": "reward_programs",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_reward_id": {
-					"name": "internal_reward_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"max_redemptions": {
-					"name": "max_redemptions",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"unlimited_redemptions": {
-					"name": "unlimited_redemptions",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"when": {
-					"name": "when",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'immediately'"
-				},
-				"product_ids": {
-					"name": "product_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{\"\"}'"
-				},
-				"exclude_trial": {
-					"name": "exclude_trial",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"received_by": {
-					"name": "received_by",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"reward_triggers_internal_reward_id_fkey": {
-					"name": "reward_triggers_internal_reward_id_fkey",
-					"tableFrom": "reward_programs",
-					"columnsFrom": ["internal_reward_id"],
-					"tableTo": "rewards",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"reward_triggers_org_id_fkey": {
-					"name": "reward_triggers_org_id_fkey",
-					"tableFrom": "reward_programs",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.reward_redemptions": {
-			"name": "reward_redemptions",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text COLLATE \"C\"",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"triggered": {
-					"name": "triggered",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"internal_reward_program_id": {
-					"name": "internal_reward_program_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"applied": {
-					"name": "applied",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"redeemer_applied": {
-					"name": "redeemer_applied",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false,
-					"default": false
-				},
-				"referral_code_id": {
-					"name": "referral_code_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"reward_internal_id": {
-					"name": "reward_internal_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"promo_code": {
-					"name": "promo_code",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_reward_redemptions_referral_code_id": {
-					"name": "idx_reward_redemptions_referral_code_id",
-					"columns": [
-						{
-							"expression": "referral_code_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_reward_redemptions_reward_internal_id": {
-					"name": "idx_reward_redemptions_reward_internal_id",
-					"columns": [
-						{
-							"expression": "reward_internal_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_reward_redemptions_customer_reward": {
-					"name": "idx_reward_redemptions_customer_reward",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "reward_internal_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"reward_redemptions_internal_customer_id_fkey": {
-					"name": "reward_redemptions_internal_customer_id_fkey",
-					"tableFrom": "reward_redemptions",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"reward_redemptions_internal_reward_program_id_fkey": {
-					"name": "reward_redemptions_internal_reward_program_id_fkey",
-					"tableFrom": "reward_redemptions",
-					"columnsFrom": ["internal_reward_program_id"],
-					"tableTo": "reward_programs",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"reward_redemptions_referral_code_id_fkey": {
-					"name": "reward_redemptions_referral_code_id_fkey",
-					"tableFrom": "reward_redemptions",
-					"columnsFrom": ["referral_code_id"],
-					"tableTo": "referral_codes",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.rewards": {
-			"name": "rewards",
-			"schema": "",
-			"columns": {
-				"internal_id": {
-					"name": "internal_id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"discount_config": {
-					"name": "discount_config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"free_product_config": {
-					"name": "free_product_config",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"free_product_id": {
-					"name": "free_product_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"promo_codes": {
-					"name": "promo_codes",
-					"type": "jsonb[]",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"type": {
-					"name": "type",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_rewards_org_id_env": {
-					"name": "idx_rewards_org_id_env",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"coupons_org_id_fkey": {
-					"name": "coupons_org_id_fkey",
-					"tableFrom": "rewards",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.rollovers": {
-			"name": "rollovers",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"cus_ent_id": {
-					"name": "cus_ent_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"balance": {
-					"name": "balance",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"usage": {
-					"name": "usage",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"entities": {
-					"name": "entities",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'::jsonb"
-				}
-			},
-			"indexes": {
-				"idx_rollovers_cus_ent_id": {
-					"name": "idx_rollovers_cus_ent_id",
-					"columns": [
-						{
-							"expression": "cus_ent_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_rollovers_cus_ent_expires": {
-					"name": "idx_rollovers_cus_ent_expires",
-					"columns": [
-						{
-							"expression": "cus_ent_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "expires_at",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"rollover_cus_ent_id_fkey": {
-					"name": "rollover_cus_ent_id_fkey",
-					"tableFrom": "rollovers",
-					"columnsFrom": ["cus_ent_id"],
-					"tableTo": "customer_entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "cascade",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.phases": {
-			"name": "phases",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"schedule_id": {
-					"name": "schedule_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"starts_at": {
-					"name": "starts_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"customer_product_ids": {
-					"name": "customer_product_ids",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'"
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"phases_schedule_id_fkey": {
-					"name": "phases_schedule_id_fkey",
-					"tableFrom": "phases",
-					"columnsFrom": ["schedule_id"],
-					"tableTo": "schedules",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"phases_schedule_id_starts_at_key": {
-					"name": "phases_schedule_id_starts_at_key",
-					"columns": ["schedule_id", "starts_at"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.schedules": {
-			"name": "schedules",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"customer_id": {
-					"name": "customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_entity_id": {
-					"name": "internal_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"entity_id": {
-					"name": "entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"schedules_customer_scope_unique": {
-					"name": "schedules_customer_scope_unique",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"schedules\".\"internal_entity_id\" IS NULL",
-					"concurrently": false
-				},
-				"schedules_entity_scope_unique": {
-					"name": "schedules_entity_scope_unique",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_schedules_internal_customer_id": {
-					"name": "idx_schedules_internal_customer_id",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_schedules_internal_entity_id": {
-					"name": "idx_schedules_internal_entity_id",
-					"columns": [
-						{
-							"expression": "internal_entity_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"schedules_org_id_fkey": {
-					"name": "schedules_org_id_fkey",
-					"tableFrom": "schedules",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"schedules_internal_customer_id_fkey": {
-					"name": "schedules_internal_customer_id_fkey",
-					"tableFrom": "schedules",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"schedules_internal_entity_id_fkey": {
-					"name": "schedules_internal_entity_id_fkey",
-					"tableFrom": "schedules",
-					"columnsFrom": ["internal_entity_id"],
-					"tableTo": "entities",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "set null"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.session": {
-			"name": "session",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"token": {
-					"name": "token",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"ip_address": {
-					"name": "ip_address",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_agent": {
-					"name": "user_agent",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"impersonated_by": {
-					"name": "impersonated_by",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"active_organization_id": {
-					"name": "active_organization_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"city": {
-					"name": "city",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"country": {
-					"name": "country",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"session_userId_idx": {
-					"name": "session_userId_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"session_user_id_user_id_fk": {
-					"name": "session_user_id_user_id_fk",
-					"tableFrom": "session",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"session_token_unique": {
-					"name": "session_token_unique",
-					"columns": ["token"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"leaf.slack_admin_threads": {
-			"name": "slack_admin_threads",
-			"schema": "leaf",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"chat_installation_id": {
-					"name": "chat_installation_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"workspace_id": {
-					"name": "workspace_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"channel_id": {
-					"name": "channel_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"thread_id": {
-					"name": "thread_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"org_slug": {
-					"name": "org_slug",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"target_identifier": {
-					"name": "target_identifier",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_by_provider_user_id": {
-					"name": "created_by_provider_user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"slack_admin_threads_thread_key": {
-					"name": "slack_admin_threads_thread_key",
-					"columns": ["workspace_id", "channel_id", "thread_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.sso_connection": {
-			"name": "sso_connection",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"provider_id": {
-					"name": "provider_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"organization_id": {
-					"name": "organization_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'pending_domain_verification'"
-				},
-				"activated_at": {
-					"name": "activated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"sso_connection_organization_id_idx": {
-					"name": "sso_connection_organization_id_idx",
-					"columns": [
-						{
-							"expression": "organization_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"sso_connection_provider_id_sso_provider_provider_id_fk": {
-					"name": "sso_connection_provider_id_sso_provider_provider_id_fk",
-					"tableFrom": "sso_connection",
-					"columnsFrom": ["provider_id"],
-					"tableTo": "sso_provider",
-					"columnsTo": ["provider_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"sso_connection_organization_id_organizations_id_fk": {
-					"name": "sso_connection_organization_id_organizations_id_fk",
-					"tableFrom": "sso_connection",
-					"columnsFrom": ["organization_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"sso_connection_provider_id_unique": {
-					"name": "sso_connection_provider_id_unique",
-					"columns": ["provider_id"],
-					"nullsNotDistinct": false
-				},
-				"sso_connection_organization_id_unique": {
-					"name": "sso_connection_organization_id_unique",
-					"columns": ["organization_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.sso_provider": {
-			"name": "sso_provider",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"issuer": {
-					"name": "issuer",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"domain": {
-					"name": "domain",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"oidc_config": {
-					"name": "oidc_config",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"saml_config": {
-					"name": "saml_config",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"user_id": {
-					"name": "user_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"provider_id": {
-					"name": "provider_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"organization_id": {
-					"name": "organization_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"domain_verified": {
-					"name": "domain_verified",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true,
-					"default": false
-				}
-			},
-			"indexes": {
-				"sso_provider_user_id_idx": {
-					"name": "sso_provider_user_id_idx",
-					"columns": [
-						{
-							"expression": "user_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"sso_provider_organization_id_idx": {
-					"name": "sso_provider_organization_id_idx",
-					"columns": [
-						{
-							"expression": "organization_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"sso_provider_domain_idx": {
-					"name": "sso_provider_domain_idx",
-					"columns": [
-						{
-							"expression": "domain",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"sso_provider_user_id_user_id_fk": {
-					"name": "sso_provider_user_id_user_id_fk",
-					"tableFrom": "sso_provider",
-					"columnsFrom": ["user_id"],
-					"tableTo": "user",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"sso_provider_organization_id_organizations_id_fk": {
-					"name": "sso_provider_organization_id_organizations_id_fk",
-					"tableFrom": "sso_provider",
-					"columnsFrom": ["organization_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"sso_provider_domain_unique": {
-					"name": "sso_provider_domain_unique",
-					"columns": ["domain"],
-					"nullsNotDistinct": false
-				},
-				"sso_provider_provider_id_unique": {
-					"name": "sso_provider_provider_id_unique",
-					"columns": ["provider_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.subscriptions": {
-			"name": "subscriptions",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"stripe_id": {
-					"name": "stripe_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"stripe_schedule_id": {
-					"name": "stripe_schedule_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'::jsonb"
-				},
-				"usage_features": {
-					"name": "usage_features",
-					"type": "text[]",
-					"primaryKey": false,
-					"notNull": false,
-					"default": "'{}'"
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"current_period_start": {
-					"name": "current_period_start",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"current_period_end": {
-					"name": "current_period_end",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"billing_cycle_anchor_seconds": {
-					"name": "billing_cycle_anchor_seconds",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"subscriptions_org_id_fkey": {
-					"name": "subscriptions_org_id_fkey",
-					"tableFrom": "subscriptions",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"subscriptions_stripe_id_key": {
-					"name": "subscriptions_stripe_id_key",
-					"columns": ["stripe_id"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.transition_rules": {
-			"name": "transition_rules",
-			"schema": "",
-			"columns": {
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"carry_over_usages": {
-					"name": "carry_over_usages",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-				}
-			},
-			"indexes": {},
-			"foreignKeys": {
-				"transition_rules_org_id_fkey": {
-					"name": "transition_rules_org_id_fkey",
-					"tableFrom": "transition_rules",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {
-				"transition_rules_pkey": {
-					"name": "transition_rules_pkey",
-					"columns": ["org_id", "env"]
-				}
-			},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.usage_windows": {
-			"name": "usage_windows",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"internal_customer_id": {
-					"name": "internal_customer_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_entity_id": {
-					"name": "internal_entity_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"feature_id": {
-					"name": "feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"internal_feature_id": {
-					"name": "internal_feature_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"filter_key": {
-					"name": "filter_key",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"anchor_customer_entitlement_id": {
-					"name": "anchor_customer_entitlement_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"window_start_at": {
-					"name": "window_start_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"window_end_at": {
-					"name": "window_end_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"usage": {
-					"name": "usage",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true,
-					"default": 0
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "numeric",
-					"primaryKey": false,
-					"notNull": true
-				}
-			},
-			"indexes": {
-				"idx_usage_windows_internal_customer_id": {
-					"name": "idx_usage_windows_internal_customer_id",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				},
-				"idx_usage_windows_internal_customer_id_c": {
-					"name": "idx_usage_windows_internal_customer_id_c",
-					"columns": [
-						{
-							"expression": "\"internal_customer_id\" COLLATE \"C\"",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_uw_internal_feature_id": {
-					"name": "idx_uw_internal_feature_id",
-					"columns": [
-						{
-							"expression": "internal_feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				},
-				"idx_usage_windows_customer_feature_scope": {
-					"name": "idx_usage_windows_customer_feature_scope",
-					"columns": [
-						{
-							"expression": "internal_customer_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "internal_feature_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "COALESCE(\"internal_entity_id\", '')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "COALESCE(\"filter_key\", '')",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"concurrently": true
-				}
-			},
-			"foreignKeys": {
-				"usage_windows_internal_customer_id_fkey": {
-					"name": "usage_windows_internal_customer_id_fkey",
-					"tableFrom": "usage_windows",
-					"columnsFrom": ["internal_customer_id"],
-					"tableTo": "customers",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"usage_windows_internal_entity_id_fkey": {
-					"name": "usage_windows_internal_entity_id_fkey",
-					"tableFrom": "usage_windows",
-					"columnsFrom": ["internal_entity_id"],
-					"tableTo": "entities",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"usage_windows_internal_feature_id_fkey": {
-					"name": "usage_windows_internal_feature_id_fkey",
-					"tableFrom": "usage_windows",
-					"columnsFrom": ["internal_feature_id"],
-					"tableTo": "features",
-					"columnsTo": ["internal_id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				},
-				"usage_windows_anchor_customer_entitlement_id_fkey": {
-					"name": "usage_windows_anchor_customer_entitlement_id_fkey",
-					"tableFrom": "usage_windows",
-					"columnsFrom": ["anchor_customer_entitlement_id"],
-					"tableTo": "customer_entitlements",
-					"columnsTo": ["id"],
-					"onUpdate": "cascade",
-					"onDelete": "set null"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		},
-		"public.user": {
-			"name": "user",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"email": {
-					"name": "email",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"email_verified": {
-					"name": "email_verified",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"image": {
-					"name": "image",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"role": {
-					"name": "role",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"banned": {
-					"name": "banned",
-					"type": "boolean",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"ban_reason": {
-					"name": "ban_reason",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"ban_expires": {
-					"name": "ban_expires",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"created_by": {
-					"name": "created_by",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"last_active_at": {
-					"name": "last_active_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"idx_user_name_trgm": {
-					"name": "idx_user_name_trgm",
-					"columns": [
-						{
-							"expression": "\"name\" gin_trgm_ops",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"where": "\"user\".\"name\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_user_email_trgm": {
-					"name": "idx_user_email_trgm",
-					"columns": [
-						{
-							"expression": "\"email\" gin_trgm_ops",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "gin",
-					"where": "\"user\".\"email\" IS NOT NULL",
-					"concurrently": false
-				},
-				"idx_user_created_at_id": {
-					"name": "idx_user_created_at_id",
-					"columns": [
-						{
-							"expression": "\"created_at\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "\"id\" DESC",
-							"isExpression": true,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"user_created_by_fkey": {
-					"name": "user_created_by_fkey",
-					"tableFrom": "user",
-					"columnsFrom": ["created_by"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "no action"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {
-				"user_email_unique": {
-					"name": "user_email_unique",
-					"columns": ["email"],
-					"nullsNotDistinct": false
-				}
-			},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.vercel_resources": {
-			"name": "vercel_resources",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"org_id": {
-					"name": "org_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"env": {
-					"name": "env",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"installation_id": {
-					"name": "installation_id",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"name": {
-					"name": "name",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"status": {
-					"name": "status",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"metadata": {
-					"name": "metadata",
-					"type": "jsonb",
-					"primaryKey": false,
-					"notNull": true,
-					"default": "'{}'::jsonb"
-				}
-			},
-			"indexes": {
-				"vercel_resources_installation_name_unique_idx": {
-					"name": "vercel_resources_installation_name_unique_idx",
-					"columns": [
-						{
-							"expression": "org_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "env",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "installation_id",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						},
-						{
-							"expression": "name",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": true,
-					"with": {},
-					"method": "btree",
-					"where": "status <> 'uninstalled'",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {
-				"vercel_resources_org_id_fkey": {
-					"name": "vercel_resources_org_id_fkey",
-					"tableFrom": "vercel_resources",
-					"columnsFrom": ["org_id"],
-					"tableTo": "organizations",
-					"columnsTo": ["id"],
-					"onUpdate": "no action",
-					"onDelete": "cascade"
-				}
-			},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": false
-		},
-		"public.verification": {
-			"name": "verification",
-			"schema": "",
-			"columns": {
-				"id": {
-					"name": "id",
-					"type": "text",
-					"primaryKey": true,
-					"notNull": true
-				},
-				"identifier": {
-					"name": "identifier",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"value": {
-					"name": "value",
-					"type": "text",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"expires_at": {
-					"name": "expires_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": true
-				},
-				"created_at": {
-					"name": "created_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				},
-				"updated_at": {
-					"name": "updated_at",
-					"type": "timestamp with time zone",
-					"primaryKey": false,
-					"notNull": false
-				}
-			},
-			"indexes": {
-				"verification_identifier_idx": {
-					"name": "verification_identifier_idx",
-					"columns": [
-						{
-							"expression": "identifier",
-							"isExpression": false,
-							"asc": true,
-							"nulls": "last"
-						}
-					],
-					"isUnique": false,
-					"with": {},
-					"method": "btree",
-					"concurrently": false
-				}
-			},
-			"foreignKeys": {},
-			"compositePrimaryKeys": {},
-			"uniqueConstraints": {},
-			"policies": {},
-			"checkConstraints": {},
-			"isRLSEnabled": true
-		}
-	},
-	"enums": {},
-	"schemas": {
-		"leaf": "leaf"
-	},
-	"views": {},
-	"sequences": {},
-	"roles": {},
-	"policies": {},
-	"_meta": {
-		"columns": {},
-		"schemas": {},
-		"tables": {}
-	}
+  "id": "000b0110-cde3-4174-b5b2-219ea79cccd5",
+  "prevId": "bd665ee9-449f-4070-95f2-ff1176231a48",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_actions_on_internal_entity_id": {
+          "name": "idx_actions_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_org_id_fkey": {
+          "name": "actions_org_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_customer_id_fkey": {
+          "name": "actions_customer_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_entity_id_fkey": {
+          "name": "actions_entity_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.agent_rules": {
+      "name": "agent_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_rules": {
+          "name": "entity_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_rules": {
+          "name": "credit_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_rules_org_id_fkey": {
+          "name": "agent_rules_org_id_fkey",
+          "tableFrom": "agent_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_org_id_fkey": {
+          "name": "api_keys_org_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_key": {
+          "name": "api_keys_hashed_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_topup_limit_states": {
+      "name": "auto_topup_limit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_window_ends_at": {
+          "name": "purchase_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_window_ends_at": {
+          "name": "attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_attempt_window_ends_at": {
+          "name": "failed_attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempt_count": {
+          "name": "failed_attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_attempt_at": {
+          "name": "last_failed_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failure_count": {
+          "name": "consecutive_failure_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_payment_method_fingerprint": {
+          "name": "suspended_payment_method_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "auto_topup_limits_org_env_internal_customer_feature_unique": {
+          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_topup_limits_org_id_fkey": {
+          "name": "auto_topup_limits_org_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_topup_limits_internal_customer_id_fkey": {
+          "name": "auto_topup_limits_internal_customer_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approvals": {
+      "name": "chat_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_provider_user_id": {
+          "name": "decided_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approvals_org_id_fkey": {
+          "name": "chat_approvals_org_id_fkey",
+          "tableFrom": "chat_approvals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_installations": {
+      "name": "chat_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_env": {
+          "name": "default_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_api_key_id": {
+          "name": "sandbox_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_api_key": {
+          "name": "sandbox_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key_id": {
+          "name": "live_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key": {
+          "name": "live_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_provider_user_id": {
+          "name": "installed_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_installations_org_id_fkey": {
+          "name": "chat_installations_org_id_fkey",
+          "tableFrom": "chat_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_installations_org_provider_key": {
+          "name": "chat_installations_org_provider_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "provider"
+          ]
+        },
+        "chat_installations_provider_workspace_key": {
+          "name": "chat_installations_provider_workspace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_oauth_credentials": {
+      "name": "chat_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_oauth_credentials_installation_id_fkey": {
+          "name": "chat_oauth_credentials_installation_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "chat_installations",
+          "columnsFrom": [
+            "chat_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_oauth_credentials_org_id_fkey": {
+          "name": "chat_oauth_credentials_org_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_oauth_credentials_installation_org_env_user_key": {
+          "name": "chat_oauth_credentials_installation_org_env_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.chat_thread_contexts": {
+      "name": "chat_thread_contexts",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_thread_contexts_thread_key": {
+          "name": "chat_thread_contexts_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkouts": {
+      "name": "checkouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_version": {
+          "name": "params_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_checkouts_stripe_invoice_id": {
+          "name": "idx_checkouts_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_memory": {
+      "name": "cma_memory",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_store_id": {
+          "name": "memory_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_memory_org_id_env_pk": {
+          "name": "cma_memory_org_id_env_pk",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_sessions": {
+      "name": "cma_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_sessions_org_id_env_thread_key_pk": {
+          "name": "cma_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_vaults": {
+      "name": "cma_vaults",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_id": {
+          "name": "vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cma_vaults_installation_org_env_user_key": {
+          "name": "cma_vaults_installation_org_env_user_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_entitlements": {
+      "name": "customer_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reset_at": {
+          "name": "next_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_allowed": {
+          "name": "usage_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "separate_interval": {
+          "name": "separate_interval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pooled_balance": {
+          "name": "is_pooled_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pooled_contribution_id": {
+          "name": "pooled_contribution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjustment": {
+          "name": "adjustment",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_balance": {
+          "name": "additional_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_version": {
+          "name": "cache_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired": {
+          "name": "expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_by_invoice": {
+          "name": "reset_by_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_entitlements_product_id": {
+          "name": "idx_customer_entitlements_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id": {
+          "name": "idx_customer_entitlements_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id_btree": {
+          "name": "idx_customer_entitlements_internal_customer_id_btree",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_entitlement_id": {
+          "name": "idx_customer_entitlements_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_feature_id_c": {
+          "name": "idx_customer_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_internal_feature_id": {
+          "name": "idx_ce_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_customer_product_id_c": {
+          "name": "idx_ce_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_loose_next_reset": {
+          "name": "idx_ce_loose_next_reset",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_nonnull_entity_by_id": {
+          "name": "idx_customer_entitlements_nonnull_entity_by_id",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_entity_id": {
+          "name": "idx_customer_entitlements_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_on_next_reset_at": {
+          "name": "idx_customer_entitlements_on_next_reset_at",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_separate_interval_reset": {
+          "name": "idx_customer_entitlements_separate_interval_reset",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"separate_interval\" = true AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_loose_customer_expires": {
+          "name": "idx_customer_entitlements_loose_customer_expires",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_next_reset_not_expired": {
+          "name": "idx_customer_entitlements_next_reset_not_expired",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_pooled_contribution": {
+          "name": "idx_customer_entitlements_pooled_contribution",
+          "columns": [
+            {
+              "expression": "pooled_contribution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"pooled_contribution_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_reset_scan": {
+          "name": "idx_customer_entitlements_reset_scan",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"reset_by_invoice\" IS NOT TRUE AND \"customer_entitlements\".\"pooled_contribution_id\" IS NULL AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_internal_entity_id_fkey": {
+          "name": "customer_entitlements_internal_entity_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_customer_product_id_fkey": {
+          "name": "customer_entitlements_customer_product_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_entitlements_entitlement_id_fkey": {
+          "name": "customer_entitlements_entitlement_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_jwt_families": {
+      "name": "customer_jwt_families",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refresh_kid": {
+          "name": "refresh_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indefinite": {
+          "name": "indefinite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_jwt_families_internal_customer_id_fkey": {
+          "name": "customer_jwt_families_internal_customer_id_fkey",
+          "tableFrom": "customer_jwt_families",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customer_jwt_families_internal_customer_id_key": {
+          "name": "customer_jwt_families_internal_customer_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_licenses": {
+      "name": "customer_licenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_customer_product_id": {
+          "name": "parent_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_customer_licenses_plan_license": {
+          "name": "idx_customer_licenses_plan_license",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_customer_license": {
+          "name": "unique_customer_license",
+          "columns": [
+            {
+              "expression": "parent_customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_customer": {
+          "name": "idx_customer_licenses_customer",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_link": {
+          "name": "idx_customer_licenses_link",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_licenses_customer_fkey": {
+          "name": "customer_licenses_customer_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_parent_customer_product_fkey": {
+          "name": "customer_licenses_parent_customer_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "parent_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_license_product_fkey": {
+          "name": "customer_licenses_license_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_plan_license_fkey": {
+          "name": "customer_licenses_plan_license_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_prices": {
+      "name": "customer_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_prices_product_id": {
+          "name": "idx_customer_prices_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_price_id": {
+          "name": "idx_customer_prices_price_id",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_internal_customer_id": {
+          "name": "idx_customer_prices_internal_customer_id",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cpr_customer_product_id_c": {
+          "name": "idx_cpr_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_prices_customer_product_id_fkey": {
+          "name": "customer_prices_customer_product_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_internal_customer_id_fkey": {
+          "name": "customer_prices_internal_customer_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_price_id_fkey": {
+          "name": "customer_prices_price_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_products": {
+      "name": "customer_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_starts_at": {
+          "name": "access_starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_trial_id": {
+          "name": "free_trial_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor": {
+          "name": "billing_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_resets_at": {
+          "name": "billing_cycle_anchor_resets_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_method": {
+          "name": "collection_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'charge_automatically'"
+        },
+        "subscription_ids": {
+          "name": "subscription_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_ids": {
+          "name": "scheduled_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_version": {
+          "name": "billing_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_semver": {
+          "name": "api_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_customer_product_id": {
+          "name": "previous_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_trial_end": {
+          "name": "on_trial_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_products_customer_status": {
+          "name": "idx_customer_products_customer_status",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_status_created_at": {
+          "name": "idx_customer_products_customer_status_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_status": {
+          "name": "idx_customer_products_product_status",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_entity_id": {
+          "name": "idx_customer_products_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_customer_c": {
+          "name": "idx_customer_products_product_customer_c",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_product_id": {
+          "name": "idx_customer_products_on_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_subscription_ids": {
+          "name": "idx_customer_products_subscription_ids",
+          "columns": [
+            {
+              "expression": "subscription_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_scheduled_ids": {
+          "name": "idx_customer_products_scheduled_ids",
+          "columns": [
+            {
+              "expression": "scheduled_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_stripe_checkout_session_id": {
+          "name": "idx_customer_products_stripe_checkout_session_id",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_license": {
+          "name": "idx_customer_products_customer_license",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_license_seat_order": {
+          "name": "idx_customer_products_license_seat_order",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_seat_sync": {
+          "name": "idx_customer_products_seat_sync",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_unused_seats": {
+          "name": "idx_customer_products_unused_seats",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_pool_assignment": {
+          "name": "unique_active_pool_assignment",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_free_trial_id": {
+          "name": "idx_customer_products_free_trial_id",
+          "columns": [
+            {
+              "expression": "free_trial_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_revenuecat_processor": {
+          "name": "idx_customer_products_revenuecat_processor",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_ended_at": {
+          "name": "idx_customer_products_ended_at",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_trial_ends_at": {
+          "name": "idx_customer_products_trial_ends_at",
+          "columns": [
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_id": {
+          "name": "idx_customer_products_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_products_free_trial_id_fkey": {
+          "name": "customer_products_free_trial_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "free_trials",
+          "columnsFrom": [
+            "free_trial_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_customer_id_fkey": {
+          "name": "customer_products_internal_customer_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_products_internal_product_id_fkey": {
+          "name": "customer_products_internal_product_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_entity_id_fkey": {
+          "name": "customer_products_internal_entity_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processors": {
+          "name": "processors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "send_email_receipts": {
+          "name": "send_email_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "customers_email_null_id_unique": {
+          "name": "customers_email_null_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_fingerprint": {
+          "name": "idx_customers_org_env_fingerprint",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processor_id": {
+          "name": "idx_customers_processor_id",
+          "columns": [
+            {
+              "expression": "(\"processor\" ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_composite": {
+          "name": "idx_customers_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_internal_id": {
+          "name": "idx_customers_org_env_internal_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_email_trgm": {
+          "name": "idx_customers_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_name_trgm": {
+          "name": "idx_customers_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_id_trgm": {
+          "name": "idx_customers_id_trgm",
+          "columns": [
+            {
+              "expression": "\"id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_org_id_env_created_at": {
+          "name": "idx_customers_org_id_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_cursor": {
+          "name": "idx_customers_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat": {
+          "name": "idx_customers_processors_revenuecat",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'revenuecat')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_id": {
+          "name": "idx_customers_processors_revenuecat_id",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_aliases": {
+          "name": "idx_customers_processors_revenuecat_aliases",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_processors_vercel": {
+          "name": "idx_customers_processors_vercel",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'vercel')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_org_id_fkey": {
+          "name": "customers_org_id_fkey",
+          "tableFrom": "customers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cus_id_constraint": {
+          "name": "cus_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entities_internal_customer_id": {
+          "name": "idx_entities_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id_c": {
+          "name": "idx_entities_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id": {
+          "name": "idx_entities_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_internal_desc": {
+          "name": "idx_entities_customer_internal_desc",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_org_env_id": {
+          "name": "idx_entities_org_env_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_cursor": {
+          "name": "idx_entities_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_created_at": {
+          "name": "idx_entities_customer_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_internal_customer_id_fkey": {
+          "name": "entities_internal_customer_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_internal_feature_id_fkey": {
+          "name": "entities_internal_feature_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_org_id_fkey": {
+          "name": "entities_org_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_id_constraint": {
+          "name": "entity_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "internal_customer_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowance_type": {
+          "name": "allowance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowance": {
+          "name": "allowance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "carry_from_previous": {
+          "name": "carry_from_previous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_feature_id": {
+          "name": "entity_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "pooled": {
+          "name": "pooled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_duration": {
+          "name": "expiry_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_length": {
+          "name": "expiry_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover": {
+          "name": "rollover",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_internal_product_id": {
+          "name": "idx_entitlements_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id": {
+          "name": "idx_entitlements_internal_reward_id",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_reward_feature": {
+          "name": "idx_entitlements_reward_feature",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id_c": {
+          "name": "idx_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id": {
+          "name": "idx_entitlements_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id_c_partial": {
+          "name": "idx_entitlements_internal_reward_id_c_partial",
+          "columns": [
+            {
+              "expression": "\"internal_reward_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_internal_product_id_fkey": {
+          "name": "entitlements_internal_product_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "entitlements_internal_reward_id_fkey": {
+          "name": "entitlements_internal_reward_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entitlements_id_key": {
+          "name": "entitlements_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_usage": {
+          "name": "set_usage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductions": {
+          "name": "deductions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_internal_customer_id": {
+          "name": "idx_events_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_internal_entity_id": {
+          "name": "idx_events_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_customer_non_usage_ts": {
+          "name": "idx_events_customer_non_usage_ts",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"timestamp\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"set_usage\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_timestamp": {
+          "name": "idx_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_internal_customer_id_fkey": {
+          "name": "events_internal_customer_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_constraint": {
+          "name": "unique_event_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id",
+            "event_name",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.features": {
+      "name": "features",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_names": {
+          "name": "event_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "model_markups": {
+          "name": "model_markups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "stripe_meter": {
+          "name": "stripe_meter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_features_composite": {
+          "name": "idx_features_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_org_id_fkey": {
+          "name": "features_org_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_id_constraint": {
+          "name": "feature_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_trials": {
+      "name": "free_trials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'day'"
+        },
+        "length": {
+          "name": "length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_fingerprint": {
+          "name": "unique_fingerprint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "card_required": {
+          "name": "card_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "on_end": {
+          "name": "on_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_free_trials_internal_product_id": {
+          "name": "idx_free_trials_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_trials_internal_product_id_fkey": {
+          "name": "free_trials_internal_product_id_fkey",
+          "tableFrom": "free_trials",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.harness_sessions": {
+      "name": "harness_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_state": {
+          "name": "resume_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_harness_sessions_session_id": {
+          "name": "idx_harness_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "harness_sessions_org_id_env_thread_key_pk": {
+          "name": "harness_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organizations_id_fk": {
+          "name": "invitation_organization_id_organizations_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_item_id": {
+          "name": "stripe_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_discountable": {
+          "name": "stripe_discountable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_after_discounts": {
+          "name": "amount_after_discounts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_quantity": {
+          "name": "stripe_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_timing": {
+          "name": "billing_timing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorated": {
+          "name": "prorated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_price_ids": {
+          "name": "customer_price_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_entitlement_ids": {
+          "name": "customer_entitlement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_start": {
+          "name": "effective_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_end": {
+          "name": "effective_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoice_line_items_customer_product_ids": {
+          "name": "idx_invoice_line_items_customer_product_ids",
+          "columns": [
+            {
+              "expression": "customer_product_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_invoice_id": {
+          "name": "idx_invoice_line_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_item_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_item_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_fkey": {
+          "name": "invoice_line_items_invoice_id_fkey",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_items_stripe_id_unique": {
+          "name": "invoice_line_items_stripe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_templates": {
+      "name": "invoice_templates",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_terms_days": {
+          "name": "net_terms_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invoice_templates_org_id": {
+          "name": "idx_invoice_templates_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_templates_org_id_fkey": {
+          "name": "invoice_templates_org_id_fkey",
+          "tableFrom": "invoice_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_templates_id_unique": {
+          "name": "invoice_templates_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_product_ids": {
+          "name": "internal_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_type": {
+          "name": "processor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoices_customer_created": {
+          "name": "idx_invoices_customer_created",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_internal_entity_id": {
+          "name": "idx_invoices_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_internal_customer_id_fkey": {
+          "name": "invoices_internal_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_internal_entity_id_fkey": {
+          "name": "invoices_internal_entity_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_stripe_id_key": {
+          "name": "invoices_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.license_entitlements": {
+      "name": "license_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_entitlement": {
+          "name": "unique_license_entitlement",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_entitlements_entitlement": {
+          "name": "idx_license_entitlements_entitlement",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_entitlements_plan_license_fkey": {
+          "name": "license_entitlements_plan_license_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_entitlements_entitlement_fkey": {
+          "name": "license_entitlements_entitlement_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_prices": {
+      "name": "license_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_price": {
+          "name": "unique_license_price",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_prices_price": {
+          "name": "idx_license_prices_price",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_prices_plan_license_fkey": {
+          "name": "license_prices_plan_license_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_prices_price_fkey": {
+          "name": "license_prices_price_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organizations_id_fk": {
+          "name": "member_organization_id_organizations_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_metadata_on_type_expires_at": {
+          "name": "idx_metadata_on_type_expires_at",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "metadata_expires_at_idx": {
+          "name": "metadata_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metadata\".\"expires_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_errors": {
+      "name": "migration_errors",
+      "schema": "",
+      "columns": {
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_job_id": {
+          "name": "migration_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_customers_internal_customer_id_fkey": {
+          "name": "migration_customers_internal_customer_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_customers_migration_job_id_fkey": {
+          "name": "migration_customers_migration_job_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "migration_jobs",
+          "columnsFrom": [
+            "migration_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "migration_errors_pkey": {
+          "name": "migration_errors_pkey",
+          "columns": [
+            "internal_customer_id",
+            "migration_job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_item_runs": {
+      "name": "migration_item_runs",
+      "schema": "",
+      "columns": {
+        "migration_item_run_id": {
+          "name": "migration_item_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_run_id": {
+          "name": "migration_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_item_runs_live_unique": {
+          "name": "migration_item_runs_live_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_c_idx": {
+          "name": "migration_item_runs_live_c_idx",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_item_exclusive": {
+          "name": "migration_item_runs_live_item_exclusive",
+          "columns": [
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"status\" = 'running' AND \"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_dry_run_unique": {
+          "name": "migration_item_runs_dry_run_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "migration_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_customer_recent_idx": {
+          "name": "migration_item_runs_customer_recent_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_jobs": {
+      "name": "migration_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_internal_product_id": {
+          "name": "from_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_internal_product_id": {
+          "name": "to_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_details": {
+          "name": "step_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_jobs_from_internal_product_id_fkey": {
+          "name": "migration_jobs_from_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "from_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_org_id_fkey": {
+          "name": "migration_jobs_org_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_to_internal_product_id_fkey": {
+          "name": "migration_jobs_to_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "to_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lazy_run": {
+          "name": "lazy_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_ids": {
+          "name": "only_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_limit": {
+          "name": "target_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_per_migration_unique": {
+          "name": "migration_runs_active_per_migration_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_migration_internal_id_fkey": {
+          "name": "migration_runs_migration_internal_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "migrations",
+          "columnsFrom": [
+            "migration_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_org_id_fkey": {
+          "name": "migration_runs_org_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migrations": {
+      "name": "migrations",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_state": {
+          "name": "prepared_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_billing_changes": {
+          "name": "no_billing_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_failed": {
+          "name": "retry_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migrations_org_env_id_unique": {
+          "name": "migrations_org_env_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migrations_org_id_fkey": {
+          "name": "migrations_org_id_fkey",
+          "tableFrom": "migrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_api_key_id": {
+          "name": "oauth_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'usd'"
+        },
+        "stripe_connected": {
+          "name": "stripe_connected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_config": {
+          "name": "stripe_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_stripe_connect": {
+          "name": "test_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "live_stripe_connect": {
+          "name": "live_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "processor_configs": {
+          "name": "processor_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_pkey": {
+          "name": "test_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_pkey": {
+          "name": "live_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_config": {
+          "name": "svix_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "idempotency_config": {
+          "name": "idempotency_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_buttons": {
+          "name": "custom_buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deployed": {
+          "name": "deployed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_color": {
+          "name": "sandbox_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_icon": {
+          "name": "sandbox_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redis_config": {
+          "name": "redis_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_name_trgm": {
+          "name": "idx_organizations_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_slug_trgm": {
+          "name": "idx_organizations_slug_trgm",
+          "columns": [
+            {
+              "expression": "\"slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_created_at_id": {
+          "name": "idx_organizations_created_at_id",
+          "columns": [
+            {
+              "expression": "\"createdAt\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_default_account": {
+          "name": "idx_orgs_test_connect_default_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'default_account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_account": {
+          "name": "idx_orgs_test_connect_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_live_connect_account": {
+          "name": "idx_orgs_live_connect_account",
+          "columns": [
+            {
+              "expression": "(\"live_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_test_pkey_key": {
+          "name": "organizations_test_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_pkey"
+          ]
+        },
+        "organizations_live_pkey_key": {
+          "name": "organizations_live_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "live_pkey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialId_idx": {
+          "name": "passkey_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plan_license": {
+      "name": "plan_license",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_internal_product_id": {
+          "name": "parent_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "included": {
+          "name": "included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prepaid_only": {
+          "name": "prepaid_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "customized": {
+          "name": "customized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_plan_license": {
+          "name": "unique_plan_license",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"plan_license\".\"is_custom\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_parent_product": {
+          "name": "idx_plan_license_parent_product",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_license": {
+          "name": "idx_plan_license_license",
+          "columns": [
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_license_parent_product_fkey": {
+          "name": "plan_license_parent_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "parent_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_license_license_product_fkey": {
+          "name": "plan_license_license_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pooled_balance_contributions": {
+      "name": "pooled_balance_contributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_product_id": {
+          "name": "source_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_entitlement_id": {
+          "name": "source_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_contribution": {
+          "name": "current_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_cycle_contribution": {
+          "name": "next_cycle_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balance_contributions_pool": {
+          "name": "idx_pooled_balance_contributions_pool",
+          "columns": [
+            {
+              "expression": "pooled_balance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balance_contributions_source_customer_entitlement": {
+          "name": "idx_pooled_balance_contributions_source_customer_entitlement",
+          "columns": [
+            {
+              "expression": "source_customer_entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balance_contributions_pool_fkey": {
+          "name": "pooled_balance_contributions_pool_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "pooled_balances",
+          "columnsFrom": [
+            "pooled_balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_product_fkey": {
+          "name": "pooled_balance_contributions_customer_product_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "source_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_entitlement_fkey": {
+          "name": "pooled_balance_contributions_customer_entitlement_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "source_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance_contribution": {
+          "name": "unique_pooled_balance_contribution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balance_contributions_current_non_negative": {
+          "name": "pooled_balance_contributions_current_non_negative",
+          "value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
+        },
+        "pooled_balance_contributions_next_non_negative": {
+          "name": "pooled_balance_contributions_next_non_negative",
+          "value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pooled_balances": {
+      "name": "pooled_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_mode": {
+          "name": "reset_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover_signature": {
+          "name": "rollover_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "customer_entitlement_id": {
+          "name": "customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_applied_reset_at": {
+          "name": "last_applied_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balances_org": {
+          "name": "idx_pooled_balances_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_reset_mode": {
+          "name": "idx_pooled_balances_reset_mode",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reset_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_feature": {
+          "name": "idx_pooled_balances_feature",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_stripe_subscription": {
+          "name": "idx_pooled_balances_stripe_subscription",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_customer_license": {
+          "name": "idx_pooled_balances_customer_license",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balances_customer_fkey": {
+          "name": "pooled_balances_customer_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_feature_fkey": {
+          "name": "pooled_balances_feature_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_customer_entitlement_fkey": {
+          "name": "pooled_balances_customer_entitlement_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance": {
+          "name": "unique_pooled_balance",
+          "nullsNotDistinct": true,
+          "columns": [
+            "internal_customer_id",
+            "internal_feature_id",
+            "unlimited",
+            "interval",
+            "interval_count",
+            "reset_cycle_anchor",
+            "reset_mode",
+            "stripe_subscription_id",
+            "customer_license_link_id",
+            "rollover_signature",
+            "expires_at"
+          ]
+        },
+        "unique_pooled_balance_customer_entitlement": {
+          "name": "unique_pooled_balance_customer_entitlement",
+          "nullsNotDistinct": false,
+          "columns": [
+            "customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balances_interval_count_positive": {
+          "name": "pooled_balances_interval_count_positive",
+          "value": "\"pooled_balances\".\"interval_count\" > 0"
+        },
+        "pooled_balances_granted_non_negative": {
+          "name": "pooled_balances_granted_non_negative",
+          "value": "\"pooled_balances\".\"granted\" >= 0"
+        },
+        "pooled_balances_reset_mode_valid": {
+          "name": "pooled_balances_reset_mode_valid",
+          "value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
+        },
+        "pooled_balances_lifecycle_ids_valid": {
+          "name": "pooled_balances_lifecycle_ids_valid",
+          "value": "(\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'subscription'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lazy'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lifetime'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_behavior": {
+          "name": "tier_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "proration_config": {
+          "name": "proration_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_prices_internal_product_id": {
+          "name": "idx_prices_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_entitlement_id": {
+          "name": "idx_prices_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prices_entitlement_id_fkey": {
+          "name": "prices_entitlement_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prices_internal_product_id_fkey": {
+          "name": "prices_internal_product_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prices_id_key": {
+          "name": "prices_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_add_on": {
+          "name": "is_add_on",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "base_variant_id": {
+          "name": "base_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_internal_product_id": {
+          "name": "base_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_org_env_id_version": {
+          "name": "idx_products_org_env_id_version",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_org_env_base_internal_product_id": {
+          "name": "idx_products_org_env_base_internal_product_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_org_id_fkey": {
+          "name": "products_org_id_fkey",
+          "tableFrom": "products",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_product": {
+          "name": "unique_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_referral_codes_internal_customer_id": {
+          "name": "idx_referral_codes_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "referral_codes_internal_customer_id_fkey": {
+          "name": "referral_codes_internal_customer_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_internal_reward_program_id_fkey": {
+          "name": "referral_codes_internal_reward_program_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_org_id_fkey": {
+          "name": "referral_codes_org_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_codes_pkey": {
+          "name": "referral_codes_pkey",
+          "columns": [
+            "code",
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "referral_codes_id_key": {
+          "name": "referral_codes_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replaceables": {
+      "name": "replaceables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_next_cycle": {
+          "name": "delete_next_cycle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_replaceables_cus_ent_id": {
+          "name": "idx_replaceables_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replaceables_cus_ent_id_fkey": {
+          "name": "replaceables_cus_ent_id_fkey",
+          "tableFrom": "replaceables",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.revenuecat_mappings": {
+      "name": "revenuecat_mappings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autumn_product_id": {
+          "name": "autumn_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenuecat_product_ids": {
+          "name": "revenuecat_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "feature_quantities": {
+          "name": "feature_quantities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "revenuecat_mappings_org_id_fkey": {
+          "name": "revenuecat_mappings_org_id_fkey",
+          "tableFrom": "revenuecat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "revenuecat_mappings_pkey": {
+          "name": "revenuecat_mappings_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "autumn_product_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_programs": {
+      "name": "reward_programs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlimited_redemptions": {
+          "name": "unlimited_redemptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when": {
+          "name": "when",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'immediately'"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"\"}'"
+        },
+        "exclude_trial": {
+          "name": "exclude_trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reward_triggers_internal_reward_id_fkey": {
+          "name": "reward_triggers_internal_reward_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_triggers_org_id_fkey": {
+          "name": "reward_triggers_org_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_redemptions": {
+      "name": "reward_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered": {
+          "name": "triggered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "redeemer_applied": {
+          "name": "redeemer_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_internal_id": {
+          "name": "reward_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code": {
+          "name": "promo_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reward_redemptions_referral_code_id": {
+          "name": "idx_reward_redemptions_referral_code_id",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_reward_internal_id": {
+          "name": "idx_reward_redemptions_reward_internal_id",
+          "columns": [
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_customer_reward": {
+          "name": "idx_reward_redemptions_customer_reward",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reward_redemptions_internal_customer_id_fkey": {
+          "name": "reward_redemptions_internal_customer_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_internal_reward_program_id_fkey": {
+          "name": "reward_redemptions_internal_reward_program_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_referral_code_id_fkey": {
+          "name": "reward_redemptions_referral_code_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "referral_codes",
+          "columnsFrom": [
+            "referral_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_config": {
+          "name": "discount_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_config": {
+          "name": "free_product_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_id": {
+          "name": "free_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_codes": {
+          "name": "promo_codes",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_rewards_org_id_env": {
+          "name": "idx_rewards_org_id_env",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coupons_org_id_fkey": {
+          "name": "coupons_org_id_fkey",
+          "tableFrom": "rewards",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollovers": {
+      "name": "rollovers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_rollovers_cus_ent_id": {
+          "name": "idx_rollovers_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rollovers_cus_ent_expires": {
+          "name": "idx_rollovers_cus_ent_expires",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rollover_cus_ent_id_fkey": {
+          "name": "rollover_cus_ent_id_fkey",
+          "tableFrom": "rollovers",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.phases": {
+      "name": "phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phases_schedule_id_fkey": {
+          "name": "phases_schedule_id_fkey",
+          "tableFrom": "phases",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phases_schedule_id_starts_at_key": {
+          "name": "phases_schedule_id_starts_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "starts_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedules_customer_scope_unique": {
+          "name": "schedules_customer_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_entity_scope_unique": {
+          "name": "schedules_entity_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_customer_id": {
+          "name": "idx_schedules_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_entity_id": {
+          "name": "idx_schedules_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_org_id_fkey": {
+          "name": "schedules_org_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_customer_id_fkey": {
+          "name": "schedules_internal_customer_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_entity_id_fkey": {
+          "name": "schedules_internal_entity_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.slack_admin_threads": {
+      "name": "slack_admin_threads",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_admin_threads_thread_key": {
+          "name": "slack_admin_threads_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_connection": {
+      "name": "sso_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_domain_verification'"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id_idx": {
+          "name": "sso_connection_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_connection_provider_id_sso_provider_provider_id_fk": {
+          "name": "sso_connection_provider_id_sso_provider_provider_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "sso_provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "provider_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_connection_organization_id_organizations_id_fk": {
+          "name": "sso_connection_organization_id_organizations_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_connection_provider_id_unique": {
+          "name": "sso_connection_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        },
+        "sso_connection_organization_id_unique": {
+          "name": "sso_connection_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_domain_idx": {
+          "name": "sso_provider_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organizations_id_fk": {
+          "name": "sso_provider_organization_id_organizations_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_domain_unique": {
+          "name": "sso_provider_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        },
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "usage_features": {
+          "name": "usage_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_seconds": {
+          "name": "billing_cycle_anchor_seconds",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_org_id_fkey": {
+          "name": "subscriptions_org_id_fkey",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_id_key": {
+          "name": "subscriptions_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transition_rules": {
+      "name": "transition_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carry_over_usages": {
+          "name": "carry_over_usages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transition_rules_org_id_fkey": {
+          "name": "transition_rules_org_id_fkey",
+          "tableFrom": "transition_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transition_rules_pkey": {
+          "name": "transition_rules_pkey",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_windows": {
+      "name": "usage_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_key": {
+          "name": "filter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_customer_entitlement_id": {
+          "name": "anchor_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_windows_internal_customer_id": {
+          "name": "idx_usage_windows_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_internal_customer_id_c": {
+          "name": "idx_usage_windows_internal_customer_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uw_internal_feature_id": {
+          "name": "idx_uw_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_customer_feature_scope": {
+          "name": "idx_usage_windows_customer_feature_scope",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"internal_entity_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"filter_key\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_windows_internal_customer_id_fkey": {
+          "name": "usage_windows_internal_customer_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_entity_id_fkey": {
+          "name": "usage_windows_internal_entity_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_feature_id_fkey": {
+          "name": "usage_windows_internal_feature_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_anchor_customer_entitlement_id_fkey": {
+          "name": "usage_windows_anchor_customer_entitlement_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "anchor_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_name_trgm": {
+          "name": "idx_user_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_email_trgm": {
+          "name": "idx_user_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_created_at_id": {
+          "name": "idx_user_created_at_id",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_created_by_fkey": {
+          "name": "user_created_by_fkey",
+          "tableFrom": "user",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_resources": {
+      "name": "vercel_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "vercel_resources_installation_name_unique_idx": {
+          "name": "vercel_resources_installation_name_unique_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status <> 'uninstalled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_resources_org_id_fkey": {
+          "name": "vercel_resources_org_id_fkey",
+          "tableFrom": "vercel_resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "leaf": "leaf"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
 }

--- a/shared/drizzle/meta/0059_snapshot.json
+++ b/shared/drizzle/meta/0059_snapshot.json
@@ -1,10811 +1,10245 @@
 {
-  "id": "000b0110-cde3-4174-b5b2-219ea79cccd5",
-  "prevId": "bd665ee9-449f-4070-95f2-ff1176231a48",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.account": {
-      "name": "account",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "account_id": {
-          "name": "account_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider_id": {
-          "name": "provider_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id_token": {
-          "name": "id_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "access_token_expires_at": {
-          "name": "access_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_token_expires_at": {
-          "name": "refresh_token_expires_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scope": {
-          "name": "scope",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "password": {
-          "name": "password",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "account_userId_idx": {
-          "name": "account_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "account_user_id_user_id_fk": {
-          "name": "account_user_id_user_id_fk",
-          "tableFrom": "account",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.actions": {
-      "name": "actions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "request_id": {
-          "name": "request_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "auth_type": {
-          "name": "auth_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "method": {
-          "name": "method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "path": {
-          "name": "path",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "properties": {
-          "name": "properties",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_actions_on_internal_entity_id": {
-          "name": "idx_actions_on_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "actions_org_id_fkey": {
-          "name": "actions_org_id_fkey",
-          "tableFrom": "actions",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "actions_customer_id_fkey": {
-          "name": "actions_customer_id_fkey",
-          "tableFrom": "actions",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "actions_entity_id_fkey": {
-          "name": "actions_entity_id_fkey",
-          "tableFrom": "actions",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.agent_rules": {
-      "name": "agent_rules",
-      "schema": "",
-      "columns": {
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "entity_rules": {
-          "name": "entity_rules",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "credit_rules": {
-          "name": "credit_rules",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "notes": {
-          "name": "notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "''"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "agent_rules_org_id_fkey": {
-          "name": "agent_rules_org_id_fkey",
-          "tableFrom": "agent_rules",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.api_keys": {
-      "name": "api_keys",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "prefix": {
-          "name": "prefix",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hashed_key": {
-          "name": "hashed_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "meta": {
-          "name": "meta",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "api_keys_org_id_fkey": {
-          "name": "api_keys_org_id_fkey",
-          "tableFrom": "api_keys",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "api_keys_hashed_key_key": {
-          "name": "api_keys_hashed_key_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "hashed_key"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.auto_topup_limit_states": {
-      "name": "auto_topup_limit_states",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "purchase_window_ends_at": {
-          "name": "purchase_window_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "purchase_count": {
-          "name": "purchase_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "attempt_window_ends_at": {
-          "name": "attempt_window_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "attempt_count": {
-          "name": "attempt_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "failed_attempt_window_ends_at": {
-          "name": "failed_attempt_window_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "failed_attempt_count": {
-          "name": "failed_attempt_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "last_attempt_at": {
-          "name": "last_attempt_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_failed_attempt_at": {
-          "name": "last_failed_attempt_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "consecutive_failure_count": {
-          "name": "consecutive_failure_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "suspended_at": {
-          "name": "suspended_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "suspended_reason": {
-          "name": "suspended_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "suspended_payment_method_fingerprint": {
-          "name": "suspended_payment_method_fingerprint",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "auto_topup_limits_org_env_internal_customer_feature_unique": {
-          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "auto_topup_limits_org_id_fkey": {
-          "name": "auto_topup_limits_org_id_fkey",
-          "tableFrom": "auto_topup_limit_states",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "auto_topup_limits_internal_customer_id_fkey": {
-          "name": "auto_topup_limits_internal_customer_id_fkey",
-          "tableFrom": "auto_topup_limit_states",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.chat_approvals": {
-      "name": "chat_approvals",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_id": {
-          "name": "workspace_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "message_ts": {
-          "name": "message_ts",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "provider_user_id": {
-          "name": "provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "run_id": {
-          "name": "run_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "harness": {
-          "name": "harness",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tool_call_id": {
-          "name": "tool_call_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tool_name": {
-          "name": "tool_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "tool_args": {
-          "name": "tool_args",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "preview": {
-          "name": "preview",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decided_at": {
-          "name": "decided_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decided_by_provider_user_id": {
-          "name": "decided_by_provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "chat_approvals_org_id_fkey": {
-          "name": "chat_approvals_org_id_fkey",
-          "tableFrom": "chat_approvals",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.chat_installations": {
-      "name": "chat_installations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider": {
-          "name": "provider",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_id": {
-          "name": "workspace_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_name": {
-          "name": "workspace_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "bot_user_id": {
-          "name": "bot_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "bot_access_token": {
-          "name": "bot_access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "auth_mode": {
-          "name": "auth_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "default_env": {
-          "name": "default_env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "sandbox_api_key_id": {
-          "name": "sandbox_api_key_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sandbox_api_key": {
-          "name": "sandbox_api_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "live_api_key_id": {
-          "name": "live_api_key_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "live_api_key": {
-          "name": "live_api_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "installed_by_user_id": {
-          "name": "installed_by_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "installed_by_provider_user_id": {
-          "name": "installed_by_provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "chat_installations_org_id_fkey": {
-          "name": "chat_installations_org_id_fkey",
-          "tableFrom": "chat_installations",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "chat_installations_org_provider_key": {
-          "name": "chat_installations_org_provider_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "provider"
-          ]
-        },
-        "chat_installations_provider_workspace_key": {
-          "name": "chat_installations_provider_workspace_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "provider",
-            "workspace_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.chat_oauth_credentials": {
-      "name": "chat_oauth_credentials",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "chat_installation_id": {
-          "name": "chat_installation_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "oauth_client_id": {
-          "name": "oauth_client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "oauth_consent_id": {
-          "name": "oauth_consent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "access_token": {
-          "name": "access_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "refresh_token": {
-          "name": "refresh_token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "access_token_expires_at": {
-          "name": "access_token_expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "refresh_token_expires_at": {
-          "name": "refresh_token_expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "chat_oauth_credentials_installation_id_fkey": {
-          "name": "chat_oauth_credentials_installation_id_fkey",
-          "tableFrom": "chat_oauth_credentials",
-          "tableTo": "chat_installations",
-          "columnsFrom": [
-            "chat_installation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "chat_oauth_credentials_org_id_fkey": {
-          "name": "chat_oauth_credentials_org_id_fkey",
-          "tableFrom": "chat_oauth_credentials",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "chat_oauth_credentials_installation_org_env_user_key": {
-          "name": "chat_oauth_credentials_installation_org_env_user_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "chat_installation_id",
-            "org_id",
-            "env",
-            "user_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.chat_results": {
-      "name": "chat_results",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "leaf.chat_thread_contexts": {
-      "name": "chat_thread_contexts",
-      "schema": "leaf",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "chat_installation_id": {
-          "name": "chat_installation_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_id": {
-          "name": "workspace_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "thread_id": {
-          "name": "thread_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "source": {
-          "name": "source",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "target_identifier": {
-          "name": "target_identifier",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_by_provider_user_id": {
-          "name": "created_by_provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "chat_thread_contexts_thread_key": {
-          "name": "chat_thread_contexts_thread_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "workspace_id",
-            "channel_id",
-            "thread_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.checkouts": {
-      "name": "checkouts",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "action": {
-          "name": "action",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "params": {
-          "name": "params",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "params_version": {
-          "name": "params_version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "response": {
-          "name": "response",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_id": {
-          "name": "stripe_invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "completed_at": {
-          "name": "completed_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_checkouts_stripe_invoice_id": {
-          "name": "idx_checkouts_stripe_invoice_id",
-          "columns": [
-            {
-              "expression": "stripe_invoice_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "leaf.cma_memory": {
-      "name": "cma_memory",
-      "schema": "leaf",
-      "columns": {
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "memory_store_id": {
-          "name": "memory_store_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "cma_memory_org_id_env_pk": {
-          "name": "cma_memory_org_id_env_pk",
-          "columns": [
-            "org_id",
-            "env"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "leaf.cma_sessions": {
-      "name": "cma_sessions",
-      "schema": "leaf",
-      "columns": {
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "thread_key": {
-          "name": "thread_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "braintrust_parent": {
-          "name": "braintrust_parent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "cma_sessions_org_id_env_thread_key_pk": {
-          "name": "cma_sessions_org_id_env_thread_key_pk",
-          "columns": [
-            "org_id",
-            "env",
-            "thread_key"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "leaf.cma_vaults": {
-      "name": "cma_vaults",
-      "schema": "leaf",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "chat_installation_id": {
-          "name": "chat_installation_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "vault_id": {
-          "name": "vault_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "credential_id": {
-          "name": "credential_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cma_vaults_installation_org_env_user_key": {
-          "name": "cma_vaults_installation_org_env_user_key",
-          "nullsNotDistinct": true,
-          "columns": [
-            "chat_installation_id",
-            "org_id",
-            "env",
-            "user_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_entitlements": {
-      "name": "customer_entitlements",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "customer_product_id": {
-          "name": "customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entitlement_id": {
-          "name": "entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "unlimited": {
-          "name": "unlimited",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "balance": {
-          "name": "balance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reset_cycle_anchor": {
-          "name": "reset_cycle_anchor",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "next_reset_at": {
-          "name": "next_reset_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_allowed": {
-          "name": "usage_allowed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "separate_interval": {
-          "name": "separate_interval",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "is_pooled_balance": {
-          "name": "is_pooled_balance",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "pooled_balance_id": {
-          "name": "pooled_balance_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "pooled_contribution_id": {
-          "name": "pooled_contribution_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "adjustment": {
-          "name": "adjustment",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "additional_balance": {
-          "name": "additional_balance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "entities": {
-          "name": "entities",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cache_version": {
-          "name": "cache_version",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "external_id": {
-          "name": "external_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expired": {
-          "name": "expired",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reset_by_invoice": {
-          "name": "reset_by_invoice",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_customer_entitlements_product_id": {
-          "name": "idx_customer_entitlements_product_id",
-          "columns": [
-            {
-              "expression": "customer_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_internal_customer_id": {
-          "name": "idx_customer_entitlements_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "hash",
-          "with": {}
-        },
-        "idx_customer_entitlements_internal_customer_id_btree": {
-          "name": "idx_customer_entitlements_internal_customer_id_btree",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_entitlement_id": {
-          "name": "idx_customer_entitlements_entitlement_id",
-          "columns": [
-            {
-              "expression": "entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_internal_feature_id_c": {
-          "name": "idx_customer_entitlements_internal_feature_id_c",
-          "columns": [
-            {
-              "expression": "\"internal_feature_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_ce_internal_feature_id": {
-          "name": "idx_ce_internal_feature_id",
-          "columns": [
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_ce_customer_product_id_c": {
-          "name": "idx_ce_customer_product_id_c",
-          "columns": [
-            {
-              "expression": "\"customer_product_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_ce_loose_next_reset": {
-          "name": "idx_ce_loose_next_reset",
-          "columns": [
-            {
-              "expression": "next_reset_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_nonnull_entity_by_id": {
-          "name": "idx_customer_entitlements_nonnull_entity_by_id",
-          "columns": [
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"internal_entity_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_internal_entity_id": {
-          "name": "idx_customer_entitlements_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "hash",
-          "with": {}
-        },
-        "idx_customer_entitlements_on_next_reset_at": {
-          "name": "idx_customer_entitlements_on_next_reset_at",
-          "columns": [
-            {
-              "expression": "next_reset_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_separate_interval_reset": {
-          "name": "idx_customer_entitlements_separate_interval_reset",
-          "columns": [
-            {
-              "expression": "next_reset_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"separate_interval\" = true AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_loose_customer_expires": {
-          "name": "idx_customer_entitlements_loose_customer_expires",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_next_reset_not_expired": {
-          "name": "idx_customer_entitlements_next_reset_not_expired",
-          "columns": [
-            {
-              "expression": "next_reset_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_pooled_contribution": {
-          "name": "idx_customer_entitlements_pooled_contribution",
-          "columns": [
-            {
-              "expression": "pooled_contribution_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"pooled_contribution_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_entitlements_reset_scan": {
-          "name": "idx_customer_entitlements_reset_scan",
-          "columns": [
-            {
-              "expression": "next_reset_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"reset_by_invoice\" IS NOT TRUE AND \"customer_entitlements\".\"pooled_contribution_id\" IS NULL AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "entitlements_internal_feature_id_fkey": {
-          "name": "entitlements_internal_feature_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_entitlements_internal_entity_id_fkey": {
-          "name": "customer_entitlements_internal_entity_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_entitlements_customer_product_id_fkey": {
-          "name": "customer_entitlements_customer_product_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "customer_products",
-          "columnsFrom": [
-            "customer_product_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        },
-        "customer_entitlements_entitlement_id_fkey": {
-          "name": "customer_entitlements_entitlement_id_fkey",
-          "tableFrom": "customer_entitlements",
-          "tableTo": "entitlements",
-          "columnsFrom": [
-            "entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_jwt_families": {
-      "name": "customer_jwt_families",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "epoch": {
-          "name": "epoch",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "refresh_kid": {
-          "name": "refresh_kid",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "indefinite": {
-          "name": "indefinite",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "customer_jwt_families_internal_customer_id_fkey": {
-          "name": "customer_jwt_families_internal_customer_id_fkey",
-          "tableFrom": "customer_jwt_families",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "customer_jwt_families_internal_customer_id_key": {
-          "name": "customer_jwt_families_internal_customer_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "internal_customer_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_licenses": {
-      "name": "customer_licenses",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "link_id": {
-          "name": "link_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "parent_customer_product_id": {
-          "name": "parent_customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "license_internal_product_id": {
-          "name": "license_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "plan_license_id": {
-          "name": "plan_license_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "granted": {
-          "name": "granted",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "remaining": {
-          "name": "remaining",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "paid_quantity": {
-          "name": "paid_quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "idx_customer_licenses_plan_license": {
-          "name": "idx_customer_licenses_plan_license",
-          "columns": [
-            {
-              "expression": "plan_license_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "unique_customer_license": {
-          "name": "unique_customer_license",
-          "columns": [
-            {
-              "expression": "parent_customer_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "license_internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_licenses_customer": {
-          "name": "idx_customer_licenses_customer",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_licenses_link": {
-          "name": "idx_customer_licenses_link",
-          "columns": [
-            {
-              "expression": "link_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "customer_licenses_customer_fkey": {
-          "name": "customer_licenses_customer_fkey",
-          "tableFrom": "customer_licenses",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_licenses_parent_customer_product_fkey": {
-          "name": "customer_licenses_parent_customer_product_fkey",
-          "tableFrom": "customer_licenses",
-          "tableTo": "customer_products",
-          "columnsFrom": [
-            "parent_customer_product_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_licenses_license_product_fkey": {
-          "name": "customer_licenses_license_product_fkey",
-          "tableFrom": "customer_licenses",
-          "tableTo": "products",
-          "columnsFrom": [
-            "license_internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_licenses_plan_license_fkey": {
-          "name": "customer_licenses_plan_license_fkey",
-          "tableFrom": "customer_licenses",
-          "tableTo": "plan_license",
-          "columnsFrom": [
-            "plan_license_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_prices": {
-      "name": "customer_prices",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "price_id": {
-          "name": "price_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "options": {
-          "name": "options",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_product_id": {
-          "name": "customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_customer_prices_product_id": {
-          "name": "idx_customer_prices_product_id",
-          "columns": [
-            {
-              "expression": "customer_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_prices_price_id": {
-          "name": "idx_customer_prices_price_id",
-          "columns": [
-            {
-              "expression": "price_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_prices_internal_customer_id": {
-          "name": "idx_customer_prices_internal_customer_id",
-          "columns": [
-            {
-              "expression": "\"internal_customer_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_cpr_customer_product_id_c": {
-          "name": "idx_cpr_customer_product_id_c",
-          "columns": [
-            {
-              "expression": "\"customer_product_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "customer_prices_customer_product_id_fkey": {
-          "name": "customer_prices_customer_product_id_fkey",
-          "tableFrom": "customer_prices",
-          "tableTo": "customer_products",
-          "columnsFrom": [
-            "customer_product_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_prices_internal_customer_id_fkey": {
-          "name": "customer_prices_internal_customer_id_fkey",
-          "tableFrom": "customer_prices",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "customer_prices_price_id_fkey": {
-          "name": "customer_prices_price_id_fkey",
-          "tableFrom": "customer_prices",
-          "tableTo": "prices",
-          "columnsFrom": [
-            "price_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customer_products": {
-      "name": "customer_products",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "processor": {
-          "name": "processor",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "canceled": {
-          "name": "canceled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "canceled_at": {
-          "name": "canceled_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ended_at": {
-          "name": "ended_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "starts_at": {
-          "name": "starts_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "access_starts_at": {
-          "name": "access_starts_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "options": {
-          "name": "options",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "product_id": {
-          "name": "product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "free_trial_id": {
-          "name": "free_trial_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "trial_ends_at": {
-          "name": "trial_ends_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "billing_cycle_anchor": {
-          "name": "billing_cycle_anchor",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "billing_cycle_anchor_resets_at": {
-          "name": "billing_cycle_anchor_resets_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "collection_method": {
-          "name": "collection_method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'charge_automatically'"
-        },
-        "subscription_ids": {
-          "name": "subscription_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scheduled_ids": {
-          "name": "scheduled_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "quantity": {
-          "name": "quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 1
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "customer_license_link_id": {
-          "name": "customer_license_link_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "released_at": {
-          "name": "released_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "billing_version": {
-          "name": "billing_version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "api_version": {
-          "name": "api_version",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "api_semver": {
-          "name": "api_semver",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "external_id": {
-          "name": "external_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_checkout_session_id": {
-          "name": "stripe_checkout_session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "previous_customer_product_id": {
-          "name": "previous_customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "on_trial_end": {
-          "name": "on_trial_end",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_customer_products_customer_status": {
-          "name": "idx_customer_products_customer_status",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "status",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_customer_status_created_at": {
-          "name": "idx_customer_products_customer_status_created_at",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "status",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_product_status": {
-          "name": "idx_customer_products_product_status",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "status",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_on_internal_entity_id": {
-          "name": "idx_customer_products_on_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_product_customer_c": {
-          "name": "idx_customer_products_product_customer_c",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"internal_customer_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_on_internal_product_id": {
-          "name": "idx_customer_products_on_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_subscription_ids": {
-          "name": "idx_customer_products_subscription_ids",
-          "columns": [
-            {
-              "expression": "subscription_ids",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customer_products_scheduled_ids": {
-          "name": "idx_customer_products_scheduled_ids",
-          "columns": [
-            {
-              "expression": "scheduled_ids",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customer_products_stripe_checkout_session_id": {
-          "name": "idx_customer_products_stripe_checkout_session_id",
-          "columns": [
-            {
-              "expression": "stripe_checkout_session_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_customer_license": {
-          "name": "idx_customer_products_customer_license",
-          "columns": [
-            {
-              "expression": "customer_license_link_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_license_seat_order": {
-          "name": "idx_customer_products_license_seat_order",
-          "columns": [
-            {
-              "expression": "customer_license_link_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_seat_sync": {
-          "name": "idx_customer_products_seat_sync",
-          "columns": [
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_unused_seats": {
-          "name": "idx_customer_products_unused_seats",
-          "columns": [
-            {
-              "expression": "customer_license_link_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "released_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "unique_active_pool_assignment": {
-          "name": "unique_active_pool_assignment",
-          "columns": [
-            {
-              "expression": "customer_license_link_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_free_trial_id": {
-          "name": "idx_customer_products_free_trial_id",
-          "columns": [
-            {
-              "expression": "free_trial_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_revenuecat_processor": {
-          "name": "idx_customer_products_revenuecat_processor",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_ended_at": {
-          "name": "idx_customer_products_ended_at",
-          "columns": [
-            {
-              "expression": "ended_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_trial_ends_at": {
-          "name": "idx_customer_products_trial_ends_at",
-          "columns": [
-            {
-              "expression": "trial_ends_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customer_products_product_id": {
-          "name": "idx_customer_products_product_id",
-          "columns": [
-            {
-              "expression": "product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "customer_products_free_trial_id_fkey": {
-          "name": "customer_products_free_trial_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "free_trials",
-          "columnsFrom": [
-            "free_trial_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "customer_products_internal_customer_id_fkey": {
-          "name": "customer_products_internal_customer_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        },
-        "customer_products_internal_product_id_fkey": {
-          "name": "customer_products_internal_product_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "customer_products_internal_entity_id_fkey": {
-          "name": "customer_products_internal_entity_id_fkey",
-          "tableFrom": "customer_products",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.customers": {
-      "name": "customers",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "fingerprint": {
-          "name": "fingerprint",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "processor": {
-          "name": "processor",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "processors": {
-          "name": "processors",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "send_email_receipts": {
-          "name": "send_email_receipts",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "currency": {
-          "name": "currency",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "auto_topups": {
-          "name": "auto_topups",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "spend_limits": {
-          "name": "spend_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_limits": {
-          "name": "usage_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_alerts": {
-          "name": "usage_alerts",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "overage_allowed": {
-          "name": "overage_allowed",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        }
-      },
-      "indexes": {
-        "customers_email_null_id_unique": {
-          "name": "customers_email_null_id_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "lower(\"email\")",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_org_env_fingerprint": {
-          "name": "idx_customers_org_env_fingerprint",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "fingerprint",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_processor_id": {
-          "name": "idx_customers_processor_id",
-          "columns": [
-            {
-              "expression": "(\"processor\" ->> 'id')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_composite": {
-          "name": "idx_customers_composite",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_org_env_internal_id": {
-          "name": "idx_customers_org_env_internal_id",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"internal_id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_email_trgm": {
-          "name": "idx_customers_email_trgm",
-          "columns": [
-            {
-              "expression": "\"email\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"email\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customers_name_trgm": {
-          "name": "idx_customers_name_trgm",
-          "columns": [
-            {
-              "expression": "\"name\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"name\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customers_id_trgm": {
-          "name": "idx_customers_id_trgm",
-          "columns": [
-            {
-              "expression": "\"id\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"customers\".\"id\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customers_org_id_env_created_at": {
-          "name": "idx_customers_org_id_env_created_at",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_cursor": {
-          "name": "idx_customers_cursor",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_processors_revenuecat": {
-          "name": "idx_customers_processors_revenuecat",
-          "columns": [
-            {
-              "expression": "(\"processors\" ->> 'revenuecat')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_processors_revenuecat_id": {
-          "name": "idx_customers_processors_revenuecat_id",
-          "columns": [
-            {
-              "expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_customers_processors_revenuecat_aliases": {
-          "name": "idx_customers_processors_revenuecat_aliases",
-          "columns": [
-            {
-              "expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_customers_processors_vercel": {
-          "name": "idx_customers_processors_vercel",
-          "columns": [
-            {
-              "expression": "(\"processors\" ->> 'vercel')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "customers_org_id_fkey": {
-          "name": "customers_org_id_fkey",
-          "tableFrom": "customers",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cus_id_constraint": {
-          "name": "cus_id_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "id",
-            "env"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.entities": {
-      "name": "entities",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted": {
-          "name": "deleted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "spend_limits": {
-          "name": "spend_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_limits": {
-          "name": "usage_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_alerts": {
-          "name": "usage_alerts",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "overage_allowed": {
-          "name": "overage_allowed",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_entities_internal_customer_id": {
-          "name": "idx_entities_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_internal_feature_id_c": {
-          "name": "idx_entities_internal_feature_id_c",
-          "columns": [
-            {
-              "expression": "\"internal_feature_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_internal_feature_id": {
-          "name": "idx_entities_internal_feature_id",
-          "columns": [
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_customer_internal_desc": {
-          "name": "idx_entities_customer_internal_desc",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"internal_id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_org_env_id": {
-          "name": "idx_entities_org_env_id",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_cursor": {
-          "name": "idx_entities_cursor",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entities_customer_created_at": {
-          "name": "idx_entities_customer_created_at",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "entities_internal_customer_id_fkey": {
-          "name": "entities_internal_customer_id_fkey",
-          "tableFrom": "entities",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "entities_internal_feature_id_fkey": {
-          "name": "entities_internal_feature_id_fkey",
-          "tableFrom": "entities",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "entities_org_id_fkey": {
-          "name": "entities_org_id_fkey",
-          "tableFrom": "entities",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "entity_id_constraint": {
-          "name": "entity_id_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "env",
-            "internal_customer_id",
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.entitlements": {
-      "name": "entitlements",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_id": {
-          "name": "internal_reward_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "allowance_type": {
-          "name": "allowance_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "allowance": {
-          "name": "allowance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interval": {
-          "name": "interval",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "interval_count": {
-          "name": "interval_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 1
-        },
-        "carry_from_previous": {
-          "name": "carry_from_previous",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "entity_feature_id": {
-          "name": "entity_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "pooled": {
-          "name": "pooled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_limit": {
-          "name": "usage_limit",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expiry_duration": {
-          "name": "expiry_duration",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expiry_length": {
-          "name": "expiry_length",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "rollover": {
-          "name": "rollover",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_entitlements_internal_product_id": {
-          "name": "idx_entitlements_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_internal_reward_id": {
-          "name": "idx_entitlements_internal_reward_id",
-          "columns": [
-            {
-              "expression": "internal_reward_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_reward_feature": {
-          "name": "idx_entitlements_reward_feature",
-          "columns": [
-            {
-              "expression": "internal_reward_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_internal_feature_id_c": {
-          "name": "idx_entitlements_internal_feature_id_c",
-          "columns": [
-            {
-              "expression": "\"internal_feature_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_internal_feature_id": {
-          "name": "idx_entitlements_internal_feature_id",
-          "columns": [
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_entitlements_internal_reward_id_c_partial": {
-          "name": "idx_entitlements_internal_reward_id_c_partial",
-          "columns": [
-            {
-              "expression": "\"internal_reward_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "entitlements_internal_feature_id_fkey": {
-          "name": "entitlements_internal_feature_id_fkey",
-          "tableFrom": "entitlements",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "entitlements_internal_product_id_fkey": {
-          "name": "entitlements_internal_product_id_fkey",
-          "tableFrom": "entitlements",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        },
-        "entitlements_internal_reward_id_fkey": {
-          "name": "entitlements_internal_reward_id_fkey",
-          "tableFrom": "entitlements",
-          "tableTo": "rewards",
-          "columnsFrom": [
-            "internal_reward_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "entitlements_id_key": {
-          "name": "entitlements_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.events": {
-      "name": "events",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "event_name": {
-          "name": "event_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "idempotency_key": {
-          "name": "idempotency_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "value": {
-          "name": "value",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "set_usage": {
-          "name": "set_usage",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "properties": {
-          "name": "properties",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deductions": {
-          "name": "deductions",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_events_internal_customer_id": {
-          "name": "idx_events_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_events_internal_entity_id": {
-          "name": "idx_events_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_events_customer_non_usage_ts": {
-          "name": "idx_events_customer_non_usage_ts",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"timestamp\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"events\".\"set_usage\" = false",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_events_timestamp": {
-          "name": "idx_events_timestamp",
-          "columns": [
-            {
-              "expression": "timestamp",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "events_internal_customer_id_fkey": {
-          "name": "events_internal_customer_id_fkey",
-          "tableFrom": "events",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "unique_event_constraint": {
-          "name": "unique_event_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "env",
-            "customer_id",
-            "event_name",
-            "idempotency_key"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.features": {
-      "name": "features",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "display": {
-          "name": "display",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "archived": {
-          "name": "archived",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "event_names": {
-          "name": "event_names",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "model_markups": {
-          "name": "model_markups",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "stripe_meter": {
-          "name": "stripe_meter",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        }
-      },
-      "indexes": {
-        "idx_features_composite": {
-          "name": "idx_features_composite",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "features_org_id_fkey": {
-          "name": "features_org_id_fkey",
-          "tableFrom": "features",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "feature_id_constraint": {
-          "name": "feature_id_constraint",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "id",
-            "env"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.free_trials": {
-      "name": "free_trials",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration": {
-          "name": "duration",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'day'"
-        },
-        "length": {
-          "name": "length",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "unique_fingerprint": {
-          "name": "unique_fingerprint",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "card_required": {
-          "name": "card_required",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "on_end": {
-          "name": "on_end",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_free_trials_internal_product_id": {
-          "name": "idx_free_trials_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "free_trials_internal_product_id_fkey": {
-          "name": "free_trials_internal_product_id_fkey",
-          "tableFrom": "free_trials",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "leaf.harness_sessions": {
-      "name": "harness_sessions",
-      "schema": "leaf",
-      "columns": {
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "thread_key": {
-          "name": "thread_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resume_state": {
-          "name": "resume_state",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "braintrust_parent": {
-          "name": "braintrust_parent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "idx_harness_sessions_session_id": {
-          "name": "idx_harness_sessions_session_id",
-          "columns": [
-            {
-              "expression": "session_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "harness_sessions_org_id_env_thread_key_pk": {
-          "name": "harness_sessions_org_id_env_thread_key_pk",
-          "columns": [
-            "org_id",
-            "env",
-            "thread_key"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.invitation": {
-      "name": "invitation",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "role": {
-          "name": "role",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "inviter_id": {
-          "name": "inviter_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "invitation_organizationId_idx": {
-          "name": "invitation_organizationId_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "invitation_email_idx": {
-          "name": "invitation_email_idx",
-          "columns": [
-            {
-              "expression": "email",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "invitation_organization_id_organizations_id_fk": {
-          "name": "invitation_organization_id_organizations_id_fk",
-          "tableFrom": "invitation",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "invitation_inviter_id_user_id_fk": {
-          "name": "invitation_inviter_id_user_id_fk",
-          "tableFrom": "invitation",
-          "tableTo": "user",
-          "columnsFrom": [
-            "inviter_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.invoice_line_items": {
-      "name": "invoice_line_items",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "invoice_id": {
-          "name": "invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_id": {
-          "name": "stripe_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_id": {
-          "name": "stripe_invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_item_id": {
-          "name": "stripe_invoice_item_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_subscription_item_id": {
-          "name": "stripe_subscription_item_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_product_id": {
-          "name": "stripe_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_price_id": {
-          "name": "stripe_price_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_discountable": {
-          "name": "stripe_discountable",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "amount": {
-          "name": "amount",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "amount_after_discounts": {
-          "name": "amount_after_discounts",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "currency": {
-          "name": "currency",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'usd'"
-        },
-        "stripe_quantity": {
-          "name": "stripe_quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total_quantity": {
-          "name": "total_quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "paid_quantity": {
-          "name": "paid_quantity",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description_source": {
-          "name": "description_source",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "direction": {
-          "name": "direction",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "billing_timing": {
-          "name": "billing_timing",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "prorated": {
-          "name": "prorated",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "price_id": {
-          "name": "price_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_product_ids": {
-          "name": "customer_product_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "customer_price_ids": {
-          "name": "customer_price_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "customer_entitlement_ids": {
-          "name": "customer_entitlement_ids",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "product_id": {
-          "name": "product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "effective_period_start": {
-          "name": "effective_period_start",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "effective_period_end": {
-          "name": "effective_period_end",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "discounts": {
-          "name": "discounts",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        }
-      },
-      "indexes": {
-        "idx_invoice_line_items_customer_product_ids": {
-          "name": "idx_invoice_line_items_customer_product_ids",
-          "columns": [
-            {
-              "expression": "customer_product_ids",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_invoice_line_items_stripe_invoice_id": {
-          "name": "idx_invoice_line_items_stripe_invoice_id",
-          "columns": [
-            {
-              "expression": "stripe_invoice_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_invoice_line_items_invoice_id": {
-          "name": "idx_invoice_line_items_invoice_id",
-          "columns": [
-            {
-              "expression": "invoice_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_invoice_line_items_stripe_invoice_item_id": {
-          "name": "idx_invoice_line_items_stripe_invoice_item_id",
-          "columns": [
-            {
-              "expression": "stripe_invoice_item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "invoice_line_items_invoice_id_fkey": {
-          "name": "invoice_line_items_invoice_id_fkey",
-          "tableFrom": "invoice_line_items",
-          "tableTo": "invoices",
-          "columnsFrom": [
-            "invoice_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "invoice_line_items_stripe_id_unique": {
-          "name": "invoice_line_items_stripe_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "stripe_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.invoice_templates": {
-      "name": "invoice_templates",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "footer": {
-          "name": "footer",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "memo": {
-          "name": "memo",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "net_terms_days": {
-          "name": "net_terms_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_invoice_templates_org_id": {
-          "name": "idx_invoice_templates_org_id",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "invoice_templates_org_id_fkey": {
-          "name": "invoice_templates_org_id_fkey",
-          "tableFrom": "invoice_templates",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "invoice_templates_id_unique": {
-          "name": "invoice_templates_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.invoices": {
-      "name": "invoices",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "product_ids": {
-          "name": "product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "internal_product_ids": {
-          "name": "internal_product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_id": {
-          "name": "stripe_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "processor_type": {
-          "name": "processor_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'draft'"
-        },
-        "hosted_invoice_url": {
-          "name": "hosted_invoice_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total": {
-          "name": "total",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "amount_paid": {
-          "name": "amount_paid",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refunded_amount": {
-          "name": "refunded_amount",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "currency": {
-          "name": "currency",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'usd'"
-        },
-        "discounts": {
-          "name": "discounts",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "items": {
-          "name": "items",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        }
-      },
-      "indexes": {
-        "idx_invoices_customer_created": {
-          "name": "idx_invoices_customer_created",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_invoices_internal_entity_id": {
-          "name": "idx_invoices_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "invoices_internal_customer_id_fkey": {
-          "name": "invoices_internal_customer_id_fkey",
-          "tableFrom": "invoices",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "invoices_internal_entity_id_fkey": {
-          "name": "invoices_internal_entity_id_fkey",
-          "tableFrom": "invoices",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "invoices_stripe_id_key": {
-          "name": "invoices_stripe_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "stripe_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.jwks": {
-      "name": "jwks",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "public_key": {
-          "name": "public_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "private_key": {
-          "name": "private_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.license_entitlements": {
-      "name": "license_entitlements",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "plan_license_id": {
-          "name": "plan_license_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "entitlement_id": {
-          "name": "entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "unique_license_entitlement": {
-          "name": "unique_license_entitlement",
-          "columns": [
-            {
-              "expression": "plan_license_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_license_entitlements_entitlement": {
-          "name": "idx_license_entitlements_entitlement",
-          "columns": [
-            {
-              "expression": "entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "license_entitlements_plan_license_fkey": {
-          "name": "license_entitlements_plan_license_fkey",
-          "tableFrom": "license_entitlements",
-          "tableTo": "plan_license",
-          "columnsFrom": [
-            "plan_license_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "license_entitlements_entitlement_fkey": {
-          "name": "license_entitlements_entitlement_fkey",
-          "tableFrom": "license_entitlements",
-          "tableTo": "entitlements",
-          "columnsFrom": [
-            "entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.license_prices": {
-      "name": "license_prices",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "plan_license_id": {
-          "name": "plan_license_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "price_id": {
-          "name": "price_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "unique_license_price": {
-          "name": "unique_license_price",
-          "columns": [
-            {
-              "expression": "plan_license_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "price_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_license_prices_price": {
-          "name": "idx_license_prices_price",
-          "columns": [
-            {
-              "expression": "price_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "license_prices_plan_license_fkey": {
-          "name": "license_prices_plan_license_fkey",
-          "tableFrom": "license_prices",
-          "tableTo": "plan_license",
-          "columnsFrom": [
-            "plan_license_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "license_prices_price_fkey": {
-          "name": "license_prices_price_fkey",
-          "tableFrom": "license_prices",
-          "tableTo": "prices",
-          "columnsFrom": [
-            "price_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.member": {
-      "name": "member",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "role": {
-          "name": "role",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'member'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "member_organizationId_idx": {
-          "name": "member_organizationId_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "member_userId_idx": {
-          "name": "member_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "member_organization_id_organizations_id_fk": {
-          "name": "member_organization_id_organizations_id_fk",
-          "tableFrom": "member",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "member_user_id_user_id_fk": {
-          "name": "member_user_id_user_id_fk",
-          "tableFrom": "member",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.metadata": {
-      "name": "metadata",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_invoice_id": {
-          "name": "stripe_invoice_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_checkout_session_id": {
-          "name": "stripe_checkout_session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_metadata_on_type_expires_at": {
-          "name": "idx_metadata_on_type_expires_at",
-          "columns": [
-            {
-              "expression": "type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "metadata_expires_at_idx": {
-          "name": "metadata_expires_at_idx",
-          "columns": [
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"metadata\".\"expires_at\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_errors": {
-      "name": "migration_errors",
-      "schema": "",
-      "columns": {
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "migration_job_id": {
-          "name": "migration_job_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "message": {
-          "name": "message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "code": {
-          "name": "code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "migration_customers_internal_customer_id_fkey": {
-          "name": "migration_customers_internal_customer_id_fkey",
-          "tableFrom": "migration_errors",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_customers_migration_job_id_fkey": {
-          "name": "migration_customers_migration_job_id_fkey",
-          "tableFrom": "migration_errors",
-          "tableTo": "migration_jobs",
-          "columnsFrom": [
-            "migration_job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "migration_errors_pkey": {
-          "name": "migration_errors_pkey",
-          "columns": [
-            "internal_customer_id",
-            "migration_job_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_item_runs": {
-      "name": "migration_item_runs",
-      "schema": "",
-      "columns": {
-        "migration_item_run_id": {
-          "name": "migration_item_run_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "migration_internal_id": {
-          "name": "migration_internal_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "migration_run_id": {
-          "name": "migration_run_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "dry_run": {
-          "name": "dry_run",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "item_kind": {
-          "name": "item_kind",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "item_id": {
-          "name": "item_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "timestamp": {
-          "name": "timestamp",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "migration_item_runs_live_unique": {
-          "name": "migration_item_runs_live_unique",
-          "columns": [
-            {
-              "expression": "migration_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"migration_item_runs\".\"dry_run\" = false",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "migration_item_runs_live_c_idx": {
-          "name": "migration_item_runs_live_c_idx",
-          "columns": [
-            {
-              "expression": "migration_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"item_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"migration_item_runs\".\"dry_run\" = false",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "migration_item_runs_live_item_exclusive": {
-          "name": "migration_item_runs_live_item_exclusive",
-          "columns": [
-            {
-              "expression": "item_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"item_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"migration_item_runs\".\"status\" = 'running' AND \"migration_item_runs\".\"dry_run\" = false",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "migration_item_runs_dry_run_unique": {
-          "name": "migration_item_runs_dry_run_unique",
-          "columns": [
-            {
-              "expression": "migration_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "migration_run_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_kind",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"migration_item_runs\".\"dry_run\" = true",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "migration_item_runs_customer_recent_idx": {
-          "name": "migration_item_runs_customer_recent_idx",
-          "columns": [
-            {
-              "expression": "item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"updated_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_jobs": {
-      "name": "migration_jobs",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "from_internal_product_id": {
-          "name": "from_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "to_internal_product_id": {
-          "name": "to_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "step_details": {
-          "name": "step_details",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "migration_jobs_from_internal_product_id_fkey": {
-          "name": "migration_jobs_from_internal_product_id_fkey",
-          "tableFrom": "migration_jobs",
-          "tableTo": "products",
-          "columnsFrom": [
-            "from_internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_jobs_org_id_fkey": {
-          "name": "migration_jobs_org_id_fkey",
-          "tableFrom": "migration_jobs",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_jobs_to_internal_product_id_fkey": {
-          "name": "migration_jobs_to_internal_product_id_fkey",
-          "tableFrom": "migration_jobs",
-          "tableTo": "products",
-          "columnsFrom": [
-            "to_internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migration_runs": {
-      "name": "migration_runs",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "migration_internal_id": {
-          "name": "migration_internal_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "dry_run": {
-          "name": "dry_run",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "lazy_run": {
-          "name": "lazy_run",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "trigger_run_id": {
-          "name": "trigger_run_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "only_ids": {
-          "name": "only_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_limit": {
-          "name": "target_limit",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "finished_at": {
-          "name": "finished_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "migration_runs_active_per_migration_unique": {
-          "name": "migration_runs_active_per_migration_unique",
-          "columns": [
-            {
-              "expression": "migration_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "migration_runs_migration_internal_id_fkey": {
-          "name": "migration_runs_migration_internal_id_fkey",
-          "tableFrom": "migration_runs",
-          "tableTo": "migrations",
-          "columnsFrom": [
-            "migration_internal_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "migration_runs_org_id_fkey": {
-          "name": "migration_runs_org_id_fkey",
-          "tableFrom": "migration_runs",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.migrations": {
-      "name": "migrations",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "filter": {
-          "name": "filter",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "operations": {
-          "name": "operations",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "prepared_state": {
-          "name": "prepared_state",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "no_billing_changes": {
-          "name": "no_billing_changes",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "retry_failed": {
-          "name": "retry_failed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "archived": {
-          "name": "archived",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "migrations_org_env_id_unique": {
-          "name": "migrations_org_env_id_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "migrations_org_id_fkey": {
-          "name": "migrations_org_id_fkey",
-          "tableFrom": "migrations",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.oauth_access_token": {
-      "name": "oauth_access_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "oauth_consent_id": {
-          "name": "oauth_consent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "refresh_id": {
-          "name": "refresh_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_access_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_session_id_session_id_fk": {
-          "name": "oauth_access_token_session_id_session_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_user_id_user_id_fk": {
-          "name": "oauth_access_token_user_id_user_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
-          "name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_consent",
-          "columnsFrom": [
-            "oauth_consent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
-          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
-          "tableFrom": "oauth_access_token",
-          "tableTo": "oauth_refresh_token",
-          "columnsFrom": [
-            "refresh_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_access_token_token_unique": {
-          "name": "oauth_access_token_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.oauth_client": {
-      "name": "oauth_client",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_secret": {
-          "name": "client_secret",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "disabled": {
-          "name": "disabled",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "skip_consent": {
-          "name": "skip_consent",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "enable_end_session": {
-          "name": "enable_end_session",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "uri": {
-          "name": "uri",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "icon": {
-          "name": "icon",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "contacts": {
-          "name": "contacts",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tos": {
-          "name": "tos",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "policy": {
-          "name": "policy",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_id": {
-          "name": "software_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_version": {
-          "name": "software_version",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "software_statement": {
-          "name": "software_statement",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "redirect_uris": {
-          "name": "redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "post_logout_redirect_uris": {
-          "name": "post_logout_redirect_uris",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "token_endpoint_auth_method": {
-          "name": "token_endpoint_auth_method",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "grant_types": {
-          "name": "grant_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "response_types": {
-          "name": "response_types",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "public": {
-          "name": "public",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_client_user_id_user_id_fk": {
-          "name": "oauth_client_user_id_user_id_fk",
-          "tableFrom": "oauth_client",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "oauth_client_client_id_unique": {
-          "name": "oauth_client_client_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "client_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.oauth_consent": {
-      "name": "oauth_consent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "redirect_uri": {
-          "name": "redirect_uri",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "oauth_api_key_id": {
-          "name": "oauth_api_key_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_consent_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_consent_user_id_user_id_fk": {
-          "name": "oauth_consent_user_id_user_id_fk",
-          "tableFrom": "oauth_consent",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.oauth_refresh_token": {
-      "name": "oauth_refresh_token",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "client_id": {
-          "name": "client_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "session_id": {
-          "name": "session_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reference_id": {
-          "name": "reference_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "oauth_consent_id": {
-          "name": "oauth_consent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "revoked": {
-          "name": "revoked",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "auth_time": {
-          "name": "auth_time",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "scopes": {
-          "name": "scopes",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
-          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "oauth_client",
-          "columnsFrom": [
-            "client_id"
-          ],
-          "columnsTo": [
-            "client_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_session_id_session_id_fk": {
-          "name": "oauth_refresh_token_session_id_session_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "session",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_user_id_user_id_fk": {
-          "name": "oauth_refresh_token_user_id_user_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
-          "name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
-          "tableFrom": "oauth_refresh_token",
-          "tableTo": "oauth_consent",
-          "columnsFrom": [
-            "oauth_consent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.organizations": {
-      "name": "organizations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "slug": {
-          "name": "slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "logo": {
-          "name": "logo",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "default_currency": {
-          "name": "default_currency",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'usd'"
-        },
-        "stripe_connected": {
-          "name": "stripe_connected",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "stripe_config": {
-          "name": "stripe_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "test_stripe_connect": {
-          "name": "test_stripe_connect",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "live_stripe_connect": {
-          "name": "live_stripe_connect",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "processor_configs": {
-          "name": "processor_configs",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "test_pkey": {
-          "name": "test_pkey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "live_pkey": {
-          "name": "live_pkey",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "svix_config": {
-          "name": "svix_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "idempotency_config": {
-          "name": "idempotency_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "custom_buttons": {
-          "name": "custom_buttons",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'[]'::jsonb"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "onboarded": {
-          "name": "onboarded",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "deployed": {
-          "name": "deployed",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "is_sandbox": {
-          "name": "is_sandbox",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "sandbox_color": {
-          "name": "sandbox_color",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "sandbox_icon": {
-          "name": "sandbox_icon",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "redis_config": {
-          "name": "redis_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_organizations_name_trgm": {
-          "name": "idx_organizations_name_trgm",
-          "columns": [
-            {
-              "expression": "\"name\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"organizations\".\"name\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_organizations_slug_trgm": {
-          "name": "idx_organizations_slug_trgm",
-          "columns": [
-            {
-              "expression": "\"slug\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"organizations\".\"slug\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_organizations_created_at_id": {
-          "name": "idx_organizations_created_at_id",
-          "columns": [
-            {
-              "expression": "\"createdAt\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_orgs_test_connect_default_account": {
-          "name": "idx_orgs_test_connect_default_account",
-          "columns": [
-            {
-              "expression": "(\"test_stripe_connect\"->>'default_account_id')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_orgs_test_connect_account": {
-          "name": "idx_orgs_test_connect_account",
-          "columns": [
-            {
-              "expression": "(\"test_stripe_connect\"->>'account_id')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_orgs_live_connect_account": {
-          "name": "idx_orgs_live_connect_account",
-          "columns": [
-            {
-              "expression": "(\"live_stripe_connect\"->>'account_id')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "organizations_slug_unique": {
-          "name": "organizations_slug_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "slug"
-          ]
-        },
-        "organizations_test_pkey_key": {
-          "name": "organizations_test_pkey_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "test_pkey"
-          ]
-        },
-        "organizations_live_pkey_key": {
-          "name": "organizations_live_pkey_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "live_pkey"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.passkey": {
-      "name": "passkey",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "public_key": {
-          "name": "public_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "credential_id": {
-          "name": "credential_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "counter": {
-          "name": "counter",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "device_type": {
-          "name": "device_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "backed_up": {
-          "name": "backed_up",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "transports": {
-          "name": "transports",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "aaguid": {
-          "name": "aaguid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "passkey_userId_idx": {
-          "name": "passkey_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "passkey_credentialId_idx": {
-          "name": "passkey_credentialId_idx",
-          "columns": [
-            {
-              "expression": "credential_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "passkey_user_id_user_id_fk": {
-          "name": "passkey_user_id_user_id_fk",
-          "tableFrom": "passkey",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "passkey_credential_id_unique": {
-          "name": "passkey_credential_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "credential_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.plan_license": {
-      "name": "plan_license",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "parent_internal_product_id": {
-          "name": "parent_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "license_internal_product_id": {
-          "name": "license_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "included": {
-          "name": "included",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "prepaid_only": {
-          "name": "prepaid_only",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": true
-        },
-        "customized": {
-          "name": "customized",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "unique_plan_license": {
-          "name": "unique_plan_license",
-          "columns": [
-            {
-              "expression": "parent_internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "license_internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"plan_license\".\"is_custom\" = false",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_plan_license_parent_product": {
-          "name": "idx_plan_license_parent_product",
-          "columns": [
-            {
-              "expression": "parent_internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_plan_license_license": {
-          "name": "idx_plan_license_license",
-          "columns": [
-            {
-              "expression": "license_internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "plan_license_parent_product_fkey": {
-          "name": "plan_license_parent_product_fkey",
-          "tableFrom": "plan_license",
-          "tableTo": "products",
-          "columnsFrom": [
-            "parent_internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "plan_license_license_product_fkey": {
-          "name": "plan_license_license_product_fkey",
-          "tableFrom": "plan_license",
-          "tableTo": "products",
-          "columnsFrom": [
-            "license_internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.pooled_balance_contributions": {
-      "name": "pooled_balance_contributions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "pooled_balance_id": {
-          "name": "pooled_balance_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source_customer_product_id": {
-          "name": "source_customer_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source_customer_entitlement_id": {
-          "name": "source_customer_entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "current_contribution": {
-          "name": "current_contribution",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "next_cycle_contribution": {
-          "name": "next_cycle_contribution",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "effective_at": {
-          "name": "effective_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "idx_pooled_balance_contributions_pool": {
-          "name": "idx_pooled_balance_contributions_pool",
-          "columns": [
-            {
-              "expression": "pooled_balance_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_pooled_balance_contributions_source_customer_entitlement": {
-          "name": "idx_pooled_balance_contributions_source_customer_entitlement",
-          "columns": [
-            {
-              "expression": "source_customer_entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "pooled_balance_contributions_pool_fkey": {
-          "name": "pooled_balance_contributions_pool_fkey",
-          "tableFrom": "pooled_balance_contributions",
-          "tableTo": "pooled_balances",
-          "columnsFrom": [
-            "pooled_balance_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "pooled_balance_contributions_customer_product_fkey": {
-          "name": "pooled_balance_contributions_customer_product_fkey",
-          "tableFrom": "pooled_balance_contributions",
-          "tableTo": "customer_products",
-          "columnsFrom": [
-            "source_customer_product_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "pooled_balance_contributions_customer_entitlement_fkey": {
-          "name": "pooled_balance_contributions_customer_entitlement_fkey",
-          "tableFrom": "pooled_balance_contributions",
-          "tableTo": "customer_entitlements",
-          "columnsFrom": [
-            "source_customer_entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "unique_pooled_balance_contribution": {
-          "name": "unique_pooled_balance_contribution",
-          "nullsNotDistinct": false,
-          "columns": [
-            "source_customer_entitlement_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {
-        "pooled_balance_contributions_current_non_negative": {
-          "name": "pooled_balance_contributions_current_non_negative",
-          "value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
-        },
-        "pooled_balance_contributions_next_non_negative": {
-          "name": "pooled_balance_contributions_next_non_negative",
-          "value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.pooled_balances": {
-      "name": "pooled_balances",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "unlimited": {
-          "name": "unlimited",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "granted": {
-          "name": "granted",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "interval": {
-          "name": "interval",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "interval_count": {
-          "name": "interval_count",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "reset_cycle_anchor": {
-          "name": "reset_cycle_anchor",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reset_mode": {
-          "name": "reset_mode",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stripe_subscription_id": {
-          "name": "stripe_subscription_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "customer_license_link_id": {
-          "name": "customer_license_link_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "rollover_signature": {
-          "name": "rollover_signature",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'none'"
-        },
-        "customer_entitlement_id": {
-          "name": "customer_entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_applied_reset_at": {
-          "name": "last_applied_reset_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {
-        "idx_pooled_balances_org": {
-          "name": "idx_pooled_balances_org",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_pooled_balances_reset_mode": {
-          "name": "idx_pooled_balances_reset_mode",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "reset_mode",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_pooled_balances_feature": {
-          "name": "idx_pooled_balances_feature",
-          "columns": [
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_pooled_balances_stripe_subscription": {
-          "name": "idx_pooled_balances_stripe_subscription",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "stripe_subscription_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_pooled_balances_customer_license": {
-          "name": "idx_pooled_balances_customer_license",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "customer_license_link_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "pooled_balances_customer_fkey": {
-          "name": "pooled_balances_customer_fkey",
-          "tableFrom": "pooled_balances",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "pooled_balances_feature_fkey": {
-          "name": "pooled_balances_feature_fkey",
-          "tableFrom": "pooled_balances",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        },
-        "pooled_balances_customer_entitlement_fkey": {
-          "name": "pooled_balances_customer_entitlement_fkey",
-          "tableFrom": "pooled_balances",
-          "tableTo": "customer_entitlements",
-          "columnsFrom": [
-            "customer_entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "restrict",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "unique_pooled_balance": {
-          "name": "unique_pooled_balance",
-          "nullsNotDistinct": true,
-          "columns": [
-            "internal_customer_id",
-            "internal_feature_id",
-            "unlimited",
-            "interval",
-            "interval_count",
-            "reset_cycle_anchor",
-            "reset_mode",
-            "stripe_subscription_id",
-            "customer_license_link_id",
-            "rollover_signature",
-            "expires_at"
-          ]
-        },
-        "unique_pooled_balance_customer_entitlement": {
-          "name": "unique_pooled_balance_customer_entitlement",
-          "nullsNotDistinct": false,
-          "columns": [
-            "customer_entitlement_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {
-        "pooled_balances_interval_count_positive": {
-          "name": "pooled_balances_interval_count_positive",
-          "value": "\"pooled_balances\".\"interval_count\" > 0"
-        },
-        "pooled_balances_granted_non_negative": {
-          "name": "pooled_balances_granted_non_negative",
-          "value": "\"pooled_balances\".\"granted\" >= 0"
-        },
-        "pooled_balances_reset_mode_valid": {
-          "name": "pooled_balances_reset_mode_valid",
-          "value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
-        },
-        "pooled_balances_lifecycle_ids_valid": {
-          "name": "pooled_balances_lifecycle_ids_valid",
-          "value": "(\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'subscription'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lazy'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lifetime'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t)"
-        }
-      },
-      "isRLSEnabled": false
-    },
-    "public.prices": {
-      "name": "prices",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_product_id": {
-          "name": "internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "billing_type": {
-          "name": "billing_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tier_behavior": {
-          "name": "tier_behavior",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "is_custom": {
-          "name": "is_custom",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "entitlement_id": {
-          "name": "entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "proration_config": {
-          "name": "proration_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        }
-      },
-      "indexes": {
-        "idx_prices_internal_product_id": {
-          "name": "idx_prices_internal_product_id",
-          "columns": [
-            {
-              "expression": "internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_prices_entitlement_id": {
-          "name": "idx_prices_entitlement_id",
-          "columns": [
-            {
-              "expression": "entitlement_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "prices_entitlement_id_fkey": {
-          "name": "prices_entitlement_id_fkey",
-          "tableFrom": "prices",
-          "tableTo": "entitlements",
-          "columnsFrom": [
-            "entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "prices_internal_product_id_fkey": {
-          "name": "prices_internal_product_id_fkey",
-          "tableFrom": "prices",
-          "tableTo": "products",
-          "columnsFrom": [
-            "internal_product_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "prices_id_key": {
-          "name": "prices_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.products": {
-      "name": "products",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "is_add_on": {
-          "name": "is_add_on",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "is_default": {
-          "name": "is_default",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "group": {
-          "name": "group",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "''"
-        },
-        "version": {
-          "name": "version",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 1
-        },
-        "processor": {
-          "name": "processor",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "null"
-        },
-        "base_variant_id": {
-          "name": "base_variant_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "base_internal_product_id": {
-          "name": "base_internal_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "archived": {
-          "name": "archived",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "config": {
-          "name": "config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        },
-        "auto_topups": {
-          "name": "auto_topups",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "spend_limits": {
-          "name": "spend_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_limits": {
-          "name": "usage_limits",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage_alerts": {
-          "name": "usage_alerts",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "overage_allowed": {
-          "name": "overage_allowed",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_products_org_env_id_version": {
-          "name": "idx_products_org_env_id_version",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "version",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_products_org_env_base_internal_product_id": {
-          "name": "idx_products_org_env_base_internal_product_id",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "base_internal_product_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "products_org_id_fkey": {
-          "name": "products_org_id_fkey",
-          "tableFrom": "products",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "unique_product": {
-          "name": "unique_product",
-          "nullsNotDistinct": false,
-          "columns": [
-            "org_id",
-            "id",
-            "env",
-            "version"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.referral_codes": {
-      "name": "referral_codes",
-      "schema": "",
-      "columns": {
-        "code": {
-          "name": "code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_program_id": {
-          "name": "internal_reward_program_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_referral_codes_internal_customer_id": {
-          "name": "idx_referral_codes_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "referral_codes_internal_customer_id_fkey": {
-          "name": "referral_codes_internal_customer_id_fkey",
-          "tableFrom": "referral_codes",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "referral_codes_internal_reward_program_id_fkey": {
-          "name": "referral_codes_internal_reward_program_id_fkey",
-          "tableFrom": "referral_codes",
-          "tableTo": "reward_programs",
-          "columnsFrom": [
-            "internal_reward_program_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "referral_codes_org_id_fkey": {
-          "name": "referral_codes_org_id_fkey",
-          "tableFrom": "referral_codes",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "referral_codes_pkey": {
-          "name": "referral_codes_pkey",
-          "columns": [
-            "code",
-            "org_id",
-            "env"
-          ]
-        }
-      },
-      "uniqueConstraints": {
-        "referral_codes_id_key": {
-          "name": "referral_codes_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.replaceables": {
-      "name": "replaceables",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "cus_ent_id": {
-          "name": "cus_ent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "bigint",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "from_entity_id": {
-          "name": "from_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "delete_next_cycle": {
-          "name": "delete_next_cycle",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {
-        "idx_replaceables_cus_ent_id": {
-          "name": "idx_replaceables_cus_ent_id",
-          "columns": [
-            {
-              "expression": "cus_ent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "replaceables_cus_ent_id_fkey": {
-          "name": "replaceables_cus_ent_id_fkey",
-          "tableFrom": "replaceables",
-          "tableTo": "customer_entitlements",
-          "columnsFrom": [
-            "cus_ent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.revenuecat_mappings": {
-      "name": "revenuecat_mappings",
-      "schema": "",
-      "columns": {
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "autumn_product_id": {
-          "name": "autumn_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "revenuecat_product_ids": {
-          "name": "revenuecat_product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "feature_quantities": {
-          "name": "feature_quantities",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "revenuecat_mappings_org_id_fkey": {
-          "name": "revenuecat_mappings_org_id_fkey",
-          "tableFrom": "revenuecat_mappings",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "revenuecat_mappings_pkey": {
-          "name": "revenuecat_mappings_pkey",
-          "columns": [
-            "org_id",
-            "env",
-            "autumn_product_id"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reward_programs": {
-      "name": "reward_programs",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_id": {
-          "name": "internal_reward_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "max_redemptions": {
-          "name": "max_redemptions",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "unlimited_redemptions": {
-          "name": "unlimited_redemptions",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "when": {
-          "name": "when",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'immediately'"
-        },
-        "product_ids": {
-          "name": "product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{\"\"}'"
-        },
-        "exclude_trial": {
-          "name": "exclude_trial",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "received_by": {
-          "name": "received_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "reward_triggers_internal_reward_id_fkey": {
-          "name": "reward_triggers_internal_reward_id_fkey",
-          "tableFrom": "reward_programs",
-          "tableTo": "rewards",
-          "columnsFrom": [
-            "internal_reward_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reward_triggers_org_id_fkey": {
-          "name": "reward_triggers_org_id_fkey",
-          "tableFrom": "reward_programs",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.reward_redemptions": {
-      "name": "reward_redemptions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text COLLATE \"C\"",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "triggered": {
-          "name": "triggered",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "internal_reward_program_id": {
-          "name": "internal_reward_program_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "applied": {
-          "name": "applied",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "redeemer_applied": {
-          "name": "redeemer_applied",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false,
-          "default": false
-        },
-        "referral_code_id": {
-          "name": "referral_code_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reward_internal_id": {
-          "name": "reward_internal_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "promo_code": {
-          "name": "promo_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_reward_redemptions_referral_code_id": {
-          "name": "idx_reward_redemptions_referral_code_id",
-          "columns": [
-            {
-              "expression": "referral_code_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_reward_redemptions_reward_internal_id": {
-          "name": "idx_reward_redemptions_reward_internal_id",
-          "columns": [
-            {
-              "expression": "reward_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_reward_redemptions_customer_reward": {
-          "name": "idx_reward_redemptions_customer_reward",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "reward_internal_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "reward_redemptions_internal_customer_id_fkey": {
-          "name": "reward_redemptions_internal_customer_id_fkey",
-          "tableFrom": "reward_redemptions",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reward_redemptions_internal_reward_program_id_fkey": {
-          "name": "reward_redemptions_internal_reward_program_id_fkey",
-          "tableFrom": "reward_redemptions",
-          "tableTo": "reward_programs",
-          "columnsFrom": [
-            "internal_reward_program_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "reward_redemptions_referral_code_id_fkey": {
-          "name": "reward_redemptions_referral_code_id_fkey",
-          "tableFrom": "reward_redemptions",
-          "tableTo": "referral_codes",
-          "columnsFrom": [
-            "referral_code_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rewards": {
-      "name": "rewards",
-      "schema": "",
-      "columns": {
-        "internal_id": {
-          "name": "internal_id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "discount_config": {
-          "name": "discount_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "free_product_config": {
-          "name": "free_product_config",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "free_product_id": {
-          "name": "free_product_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "promo_codes": {
-          "name": "promo_codes",
-          "type": "jsonb[]",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_rewards_org_id_env": {
-          "name": "idx_rewards_org_id_env",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "coupons_org_id_fkey": {
-          "name": "coupons_org_id_fkey",
-          "tableFrom": "rewards",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.rollovers": {
-      "name": "rollovers",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "cus_ent_id": {
-          "name": "cus_ent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "balance": {
-          "name": "balance",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "usage": {
-          "name": "usage",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "entities": {
-          "name": "entities",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        }
-      },
-      "indexes": {
-        "idx_rollovers_cus_ent_id": {
-          "name": "idx_rollovers_cus_ent_id",
-          "columns": [
-            {
-              "expression": "cus_ent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_rollovers_cus_ent_expires": {
-          "name": "idx_rollovers_cus_ent_expires",
-          "columns": [
-            {
-              "expression": "cus_ent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "rollover_cus_ent_id_fkey": {
-          "name": "rollover_cus_ent_id_fkey",
-          "tableFrom": "rollovers",
-          "tableTo": "customer_entitlements",
-          "columnsFrom": [
-            "cus_ent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.phases": {
-      "name": "phases",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "schedule_id": {
-          "name": "schedule_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "starts_at": {
-          "name": "starts_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_product_ids": {
-          "name": "customer_product_ids",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "phases_schedule_id_fkey": {
-          "name": "phases_schedule_id_fkey",
-          "tableFrom": "phases",
-          "tableTo": "schedules",
-          "columnsFrom": [
-            "schedule_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "phases_schedule_id_starts_at_key": {
-          "name": "phases_schedule_id_starts_at_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "schedule_id",
-            "starts_at"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.schedules": {
-      "name": "schedules",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "customer_id": {
-          "name": "customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "entity_id": {
-          "name": "entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "schedules_customer_scope_unique": {
-          "name": "schedules_customer_scope_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "schedules_entity_scope_unique": {
-          "name": "schedules_entity_scope_unique",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_schedules_internal_customer_id": {
-          "name": "idx_schedules_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_schedules_internal_entity_id": {
-          "name": "idx_schedules_internal_entity_id",
-          "columns": [
-            {
-              "expression": "internal_entity_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "schedules_org_id_fkey": {
-          "name": "schedules_org_id_fkey",
-          "tableFrom": "schedules",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "schedules_internal_customer_id_fkey": {
-          "name": "schedules_internal_customer_id_fkey",
-          "tableFrom": "schedules",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "schedules_internal_entity_id_fkey": {
-          "name": "schedules_internal_entity_id_fkey",
-          "tableFrom": "schedules",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.session": {
-      "name": "session",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "token": {
-          "name": "token",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "impersonated_by": {
-          "name": "impersonated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "active_organization_id": {
-          "name": "active_organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "city": {
-          "name": "city",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "country": {
-          "name": "country",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "session_userId_idx": {
-          "name": "session_userId_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "session_user_id_user_id_fk": {
-          "name": "session_user_id_user_id_fk",
-          "tableFrom": "session",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "session_token_unique": {
-          "name": "session_token_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "token"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "leaf.slack_admin_threads": {
-      "name": "slack_admin_threads",
-      "schema": "leaf",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "chat_installation_id": {
-          "name": "chat_installation_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "workspace_id": {
-          "name": "workspace_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "channel_id": {
-          "name": "channel_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "thread_id": {
-          "name": "thread_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "org_slug": {
-          "name": "org_slug",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "target_identifier": {
-          "name": "target_identifier",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_by_provider_user_id": {
-          "name": "created_by_provider_user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "slack_admin_threads_thread_key": {
-          "name": "slack_admin_threads_thread_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "workspace_id",
-            "channel_id",
-            "thread_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.sso_connection": {
-      "name": "sso_connection",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "provider_id": {
-          "name": "provider_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending_domain_verification'"
-        },
-        "activated_at": {
-          "name": "activated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "sso_connection_organization_id_idx": {
-          "name": "sso_connection_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "sso_connection_provider_id_sso_provider_provider_id_fk": {
-          "name": "sso_connection_provider_id_sso_provider_provider_id_fk",
-          "tableFrom": "sso_connection",
-          "tableTo": "sso_provider",
-          "columnsFrom": [
-            "provider_id"
-          ],
-          "columnsTo": [
-            "provider_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "sso_connection_organization_id_organizations_id_fk": {
-          "name": "sso_connection_organization_id_organizations_id_fk",
-          "tableFrom": "sso_connection",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "sso_connection_provider_id_unique": {
-          "name": "sso_connection_provider_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "provider_id"
-          ]
-        },
-        "sso_connection_organization_id_unique": {
-          "name": "sso_connection_organization_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "organization_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.sso_provider": {
-      "name": "sso_provider",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "issuer": {
-          "name": "issuer",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "domain": {
-          "name": "domain",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "oidc_config": {
-          "name": "oidc_config",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "saml_config": {
-          "name": "saml_config",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "provider_id": {
-          "name": "provider_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "domain_verified": {
-          "name": "domain_verified",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {
-        "sso_provider_user_id_idx": {
-          "name": "sso_provider_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "sso_provider_organization_id_idx": {
-          "name": "sso_provider_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "sso_provider_domain_idx": {
-          "name": "sso_provider_domain_idx",
-          "columns": [
-            {
-              "expression": "domain",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "sso_provider_user_id_user_id_fk": {
-          "name": "sso_provider_user_id_user_id_fk",
-          "tableFrom": "sso_provider",
-          "tableTo": "user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "sso_provider_organization_id_organizations_id_fk": {
-          "name": "sso_provider_organization_id_organizations_id_fk",
-          "tableFrom": "sso_provider",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "sso_provider_domain_unique": {
-          "name": "sso_provider_domain_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "domain"
-          ]
-        },
-        "sso_provider_provider_id_unique": {
-          "name": "sso_provider_provider_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "provider_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.subscriptions": {
-      "name": "subscriptions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stripe_id": {
-          "name": "stripe_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "stripe_schedule_id": {
-          "name": "stripe_schedule_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'::jsonb"
-        },
-        "usage_features": {
-          "name": "usage_features",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'{}'"
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_period_start": {
-          "name": "current_period_start",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_period_end": {
-          "name": "current_period_end",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "billing_cycle_anchor_seconds": {
-          "name": "billing_cycle_anchor_seconds",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "subscriptions_org_id_fkey": {
-          "name": "subscriptions_org_id_fkey",
-          "tableFrom": "subscriptions",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "subscriptions_stripe_id_key": {
-          "name": "subscriptions_stripe_id_key",
-          "nullsNotDistinct": false,
-          "columns": [
-            "stripe_id"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.transition_rules": {
-      "name": "transition_rules",
-      "schema": "",
-      "columns": {
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "carry_over_usages": {
-          "name": "carry_over_usages",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "transition_rules_org_id_fkey": {
-          "name": "transition_rules_org_id_fkey",
-          "tableFrom": "transition_rules",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "transition_rules_pkey": {
-          "name": "transition_rules_pkey",
-          "columns": [
-            "org_id",
-            "env"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.usage_windows": {
-      "name": "usage_windows",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "internal_customer_id": {
-          "name": "internal_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_entity_id": {
-          "name": "internal_entity_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "feature_id": {
-          "name": "feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "internal_feature_id": {
-          "name": "internal_feature_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "filter_key": {
-          "name": "filter_key",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "anchor_customer_entitlement_id": {
-          "name": "anchor_customer_entitlement_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "window_start_at": {
-          "name": "window_start_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "window_end_at": {
-          "name": "window_end_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "usage": {
-          "name": "usage",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 0
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "idx_usage_windows_internal_customer_id": {
-          "name": "idx_usage_windows_internal_customer_id",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_usage_windows_internal_customer_id_c": {
-          "name": "idx_usage_windows_internal_customer_id_c",
-          "columns": [
-            {
-              "expression": "\"internal_customer_id\" COLLATE \"C\"",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_uw_internal_feature_id": {
-          "name": "idx_uw_internal_feature_id",
-          "columns": [
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_usage_windows_customer_feature_scope": {
-          "name": "idx_usage_windows_customer_feature_scope",
-          "columns": [
-            {
-              "expression": "internal_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "internal_feature_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "COALESCE(\"internal_entity_id\", '')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "COALESCE(\"filter_key\", '')",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": true,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "usage_windows_internal_customer_id_fkey": {
-          "name": "usage_windows_internal_customer_id_fkey",
-          "tableFrom": "usage_windows",
-          "tableTo": "customers",
-          "columnsFrom": [
-            "internal_customer_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "usage_windows_internal_entity_id_fkey": {
-          "name": "usage_windows_internal_entity_id_fkey",
-          "tableFrom": "usage_windows",
-          "tableTo": "entities",
-          "columnsFrom": [
-            "internal_entity_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "usage_windows_internal_feature_id_fkey": {
-          "name": "usage_windows_internal_feature_id_fkey",
-          "tableFrom": "usage_windows",
-          "tableTo": "features",
-          "columnsFrom": [
-            "internal_feature_id"
-          ],
-          "columnsTo": [
-            "internal_id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "usage_windows_anchor_customer_entitlement_id_fkey": {
-          "name": "usage_windows_anchor_customer_entitlement_id_fkey",
-          "tableFrom": "usage_windows",
-          "tableTo": "customer_entitlements",
-          "columnsFrom": [
-            "anchor_customer_entitlement_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "cascade"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    },
-    "public.user": {
-      "name": "user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "image": {
-          "name": "image",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "role": {
-          "name": "role",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "banned": {
-          "name": "banned",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ban_reason": {
-          "name": "ban_reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ban_expires": {
-          "name": "ban_expires",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_active_at": {
-          "name": "last_active_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "idx_user_name_trgm": {
-          "name": "idx_user_name_trgm",
-          "columns": [
-            {
-              "expression": "\"name\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"user\".\"name\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_user_email_trgm": {
-          "name": "idx_user_email_trgm",
-          "columns": [
-            {
-              "expression": "\"email\" gin_trgm_ops",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "where": "\"user\".\"email\" IS NOT NULL",
-          "concurrently": false,
-          "method": "gin",
-          "with": {}
-        },
-        "idx_user_created_at_id": {
-          "name": "idx_user_created_at_id",
-          "columns": [
-            {
-              "expression": "\"created_at\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "\"id\" DESC",
-              "asc": true,
-              "isExpression": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "user_created_by_fkey": {
-          "name": "user_created_by_fkey",
-          "tableFrom": "user",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "created_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "user_email_unique": {
-          "name": "user_email_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.vercel_resources": {
-      "name": "vercel_resources",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "org_id": {
-          "name": "org_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "env": {
-          "name": "env",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "installation_id": {
-          "name": "installation_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'{}'::jsonb"
-        }
-      },
-      "indexes": {
-        "vercel_resources_installation_name_unique_idx": {
-          "name": "vercel_resources_installation_name_unique_idx",
-          "columns": [
-            {
-              "expression": "org_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "env",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "installation_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "status <> 'uninstalled'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "vercel_resources_org_id_fkey": {
-          "name": "vercel_resources_org_id_fkey",
-          "tableFrom": "vercel_resources",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "org_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.verification": {
-      "name": "verification",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "identifier": {
-          "name": "identifier",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "verification_identifier_idx": {
-          "name": "verification_identifier_idx",
-          "columns": [
-            {
-              "expression": "identifier",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": true
-    }
-  },
-  "enums": {},
-  "schemas": {
-    "leaf": "leaf"
-  },
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "0b5556ee-cf85-4e54-8e3f-f39e2bf0f897",
+	"prevId": "bd665ee9-449f-4070-95f2-ff1176231a48",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account": {
+			"name": "account",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_userId_idx": {
+					"name": "account_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"account_user_id_user_id_fk": {
+					"name": "account_user_id_user_id_fk",
+					"tableFrom": "account",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.actions": {
+			"name": "actions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"request_id": {
+					"name": "request_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_slug": {
+					"name": "org_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"auth_type": {
+					"name": "auth_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"method": {
+					"name": "method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"path": {
+					"name": "path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"properties": {
+					"name": "properties",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_actions_on_internal_entity_id": {
+					"name": "idx_actions_on_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"actions_org_id_fkey": {
+					"name": "actions_org_id_fkey",
+					"tableFrom": "actions",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				},
+				"actions_customer_id_fkey": {
+					"name": "actions_customer_id_fkey",
+					"tableFrom": "actions",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				},
+				"actions_entity_id_fkey": {
+					"name": "actions_entity_id_fkey",
+					"tableFrom": "actions",
+					"columnsFrom": ["internal_entity_id"],
+					"tableTo": "entities",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.agent_rules": {
+			"name": "agent_rules",
+			"schema": "",
+			"columns": {
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_slug": {
+					"name": "org_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"entity_rules": {
+					"name": "entity_rules",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credit_rules": {
+					"name": "credit_rules",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"notes": {
+					"name": "notes",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "''"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"agent_rules_org_id_fkey": {
+					"name": "agent_rules_org_id_fkey",
+					"tableFrom": "agent_rules",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.api_keys": {
+			"name": "api_keys",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prefix": {
+					"name": "prefix",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hashed_key": {
+					"name": "hashed_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"meta": {
+					"name": "meta",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"api_keys_org_id_fkey": {
+					"name": "api_keys_org_id_fkey",
+					"tableFrom": "api_keys",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"api_keys_hashed_key_key": {
+					"name": "api_keys_hashed_key_key",
+					"columns": ["hashed_key"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.auto_topup_limit_states": {
+			"name": "auto_topup_limit_states",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"purchase_window_ends_at": {
+					"name": "purchase_window_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"purchase_count": {
+					"name": "purchase_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"attempt_window_ends_at": {
+					"name": "attempt_window_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"attempt_count": {
+					"name": "attempt_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"failed_attempt_window_ends_at": {
+					"name": "failed_attempt_window_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failed_attempt_count": {
+					"name": "failed_attempt_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"last_attempt_at": {
+					"name": "last_attempt_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_failed_attempt_at": {
+					"name": "last_failed_attempt_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"consecutive_failure_count": {
+					"name": "consecutive_failure_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"suspended_at": {
+					"name": "suspended_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"suspended_reason": {
+					"name": "suspended_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"suspended_payment_method_fingerprint": {
+					"name": "suspended_payment_method_fingerprint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"auto_topup_limits_org_env_internal_customer_feature_unique": {
+					"name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"auto_topup_limits_org_id_fkey": {
+					"name": "auto_topup_limits_org_id_fkey",
+					"tableFrom": "auto_topup_limit_states",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"auto_topup_limits_internal_customer_id_fkey": {
+					"name": "auto_topup_limits_internal_customer_id_fkey",
+					"tableFrom": "auto_topup_limit_states",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.chat_approvals": {
+			"name": "chat_approvals",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"message_ts": {
+					"name": "message_ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_user_id": {
+					"name": "provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"harness": {
+					"name": "harness",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_call_id": {
+					"name": "tool_call_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tool_args": {
+					"name": "tool_args",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"preview": {
+					"name": "preview",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decided_at": {
+					"name": "decided_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decided_by_provider_user_id": {
+					"name": "decided_by_provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"chat_approvals_org_id_fkey": {
+					"name": "chat_approvals_org_id_fkey",
+					"tableFrom": "chat_approvals",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.chat_installations": {
+			"name": "chat_installations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_name": {
+					"name": "workspace_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"bot_user_id": {
+					"name": "bot_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"bot_access_token": {
+					"name": "bot_access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"auth_mode": {
+					"name": "auth_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_env": {
+					"name": "default_env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sandbox_api_key_id": {
+					"name": "sandbox_api_key_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_api_key": {
+					"name": "sandbox_api_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"live_api_key_id": {
+					"name": "live_api_key_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"live_api_key": {
+					"name": "live_api_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"installed_by_user_id": {
+					"name": "installed_by_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"installed_by_provider_user_id": {
+					"name": "installed_by_provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"chat_installations_org_id_fkey": {
+					"name": "chat_installations_org_id_fkey",
+					"tableFrom": "chat_installations",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"chat_installations_org_provider_key": {
+					"name": "chat_installations_org_provider_key",
+					"columns": ["org_id", "provider"],
+					"nullsNotDistinct": false
+				},
+				"chat_installations_provider_workspace_key": {
+					"name": "chat_installations_provider_workspace_key",
+					"columns": ["provider", "workspace_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.chat_oauth_credentials": {
+			"name": "chat_oauth_credentials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"chat_installation_id": {
+					"name": "chat_installation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"oauth_client_id": {
+					"name": "oauth_client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"oauth_consent_id": {
+					"name": "oauth_consent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"access_token_expires_at": {
+					"name": "access_token_expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token_expires_at": {
+					"name": "refresh_token_expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"chat_oauth_credentials_installation_id_fkey": {
+					"name": "chat_oauth_credentials_installation_id_fkey",
+					"tableFrom": "chat_oauth_credentials",
+					"columnsFrom": ["chat_installation_id"],
+					"tableTo": "chat_installations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"chat_oauth_credentials_org_id_fkey": {
+					"name": "chat_oauth_credentials_org_id_fkey",
+					"tableFrom": "chat_oauth_credentials",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"chat_oauth_credentials_installation_org_env_user_key": {
+					"name": "chat_oauth_credentials_installation_org_env_user_key",
+					"columns": ["chat_installation_id", "org_id", "env", "user_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.chat_results": {
+			"name": "chat_results",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"leaf.chat_thread_contexts": {
+			"name": "chat_thread_contexts",
+			"schema": "leaf",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"chat_installation_id": {
+					"name": "chat_installation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_slug": {
+					"name": "org_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"target_identifier": {
+					"name": "target_identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_by_provider_user_id": {
+					"name": "created_by_provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"chat_thread_contexts_thread_key": {
+					"name": "chat_thread_contexts_thread_key",
+					"columns": ["workspace_id", "channel_id", "thread_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.checkouts": {
+			"name": "checkouts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params": {
+					"name": "params",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"params_version": {
+					"name": "params_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"response": {
+					"name": "response",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_id": {
+					"name": "stripe_invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"completed_at": {
+					"name": "completed_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_checkouts_stripe_invoice_id": {
+					"name": "idx_checkouts_stripe_invoice_id",
+					"columns": [
+						{
+							"expression": "stripe_invoice_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"leaf.cma_memory": {
+			"name": "cma_memory",
+			"schema": "leaf",
+			"columns": {
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"memory_store_id": {
+					"name": "memory_store_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"cma_memory_org_id_env_pk": {
+					"name": "cma_memory_org_id_env_pk",
+					"columns": ["org_id", "env"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"leaf.cma_sessions": {
+			"name": "cma_sessions",
+			"schema": "leaf",
+			"columns": {
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"thread_key": {
+					"name": "thread_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"braintrust_parent": {
+					"name": "braintrust_parent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"cma_sessions_org_id_env_thread_key_pk": {
+					"name": "cma_sessions_org_id_env_thread_key_pk",
+					"columns": ["org_id", "env", "thread_key"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"leaf.cma_vaults": {
+			"name": "cma_vaults",
+			"schema": "leaf",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"chat_installation_id": {
+					"name": "chat_installation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"vault_id": {
+					"name": "vault_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cma_vaults_installation_org_env_user_key": {
+					"name": "cma_vaults_installation_org_env_user_key",
+					"columns": ["chat_installation_id", "org_id", "env", "user_id"],
+					"nullsNotDistinct": true
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_entitlements": {
+			"name": "customer_entitlements",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"customer_product_id": {
+					"name": "customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entitlement_id": {
+					"name": "entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unlimited": {
+					"name": "unlimited",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"balance": {
+					"name": "balance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reset_cycle_anchor": {
+					"name": "reset_cycle_anchor",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_reset_at": {
+					"name": "next_reset_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_allowed": {
+					"name": "usage_allowed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"separate_interval": {
+					"name": "separate_interval",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_pooled_balance": {
+					"name": "is_pooled_balance",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"pooled_balance_id": {
+					"name": "pooled_balance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pooled_contribution_id": {
+					"name": "pooled_contribution_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"adjustment": {
+					"name": "adjustment",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"additional_balance": {
+					"name": "additional_balance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"entities": {
+					"name": "entities",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cache_version": {
+					"name": "cache_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_id": {
+					"name": "external_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expired": {
+					"name": "expired",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reset_by_invoice": {
+					"name": "reset_by_invoice",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_customer_entitlements_product_id": {
+					"name": "idx_customer_entitlements_product_id",
+					"columns": [
+						{
+							"expression": "customer_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_entitlements_internal_customer_id": {
+					"name": "idx_customer_entitlements_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "hash",
+					"concurrently": false
+				},
+				"idx_customer_entitlements_internal_customer_id_btree": {
+					"name": "idx_customer_entitlements_internal_customer_id_btree",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_entitlements_entitlement_id": {
+					"name": "idx_customer_entitlements_entitlement_id",
+					"columns": [
+						{
+							"expression": "entitlement_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_entitlements_internal_feature_id_c": {
+					"name": "idx_customer_entitlements_internal_feature_id_c",
+					"columns": [
+						{
+							"expression": "\"internal_feature_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_ce_internal_feature_id": {
+					"name": "idx_ce_internal_feature_id",
+					"columns": [
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_ce_customer_product_id_c": {
+					"name": "idx_ce_customer_product_id_c",
+					"columns": [
+						{
+							"expression": "\"customer_product_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_ce_loose_next_reset": {
+					"name": "idx_ce_loose_next_reset",
+					"columns": [
+						{
+							"expression": "next_reset_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+					"concurrently": true
+				},
+				"idx_customer_entitlements_nonnull_entity_by_id": {
+					"name": "idx_customer_entitlements_nonnull_entity_by_id",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_entitlements\".\"internal_entity_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_entitlements_internal_entity_id": {
+					"name": "idx_customer_entitlements_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "hash",
+					"concurrently": false
+				},
+				"idx_customer_entitlements_on_next_reset_at": {
+					"name": "idx_customer_entitlements_on_next_reset_at",
+					"columns": [
+						{
+							"expression": "next_reset_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_entitlements_separate_interval_reset": {
+					"name": "idx_customer_entitlements_separate_interval_reset",
+					"columns": [
+						{
+							"expression": "next_reset_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_entitlements\".\"separate_interval\" = true AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_entitlements_loose_customer_expires": {
+					"name": "idx_customer_entitlements_loose_customer_expires",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+					"concurrently": false
+				},
+				"idx_customer_entitlements_next_reset_not_expired": {
+					"name": "idx_customer_entitlements_next_reset_not_expired",
+					"columns": [
+						{
+							"expression": "next_reset_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_entitlements_pooled_contribution": {
+					"name": "idx_customer_entitlements_pooled_contribution",
+					"columns": [
+						{
+							"expression": "pooled_contribution_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_entitlements\".\"pooled_contribution_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_entitlements_reset_scan": {
+					"name": "idx_customer_entitlements_reset_scan",
+					"columns": [
+						{
+							"expression": "next_reset_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"reset_by_invoice\" IS NOT TRUE AND \"customer_entitlements\".\"pooled_contribution_id\" IS NULL AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"entitlements_internal_feature_id_fkey": {
+					"name": "entitlements_internal_feature_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"columnsFrom": ["internal_feature_id"],
+					"tableTo": "features",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"customer_entitlements_internal_entity_id_fkey": {
+					"name": "customer_entitlements_internal_entity_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"columnsFrom": ["internal_entity_id"],
+					"tableTo": "entities",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"customer_entitlements_customer_product_id_fkey": {
+					"name": "customer_entitlements_customer_product_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"columnsFrom": ["customer_product_id"],
+					"tableTo": "customer_products",
+					"columnsTo": ["id"],
+					"onUpdate": "cascade",
+					"onDelete": "cascade"
+				},
+				"customer_entitlements_entitlement_id_fkey": {
+					"name": "customer_entitlements_entitlement_id_fkey",
+					"tableFrom": "customer_entitlements",
+					"columnsFrom": ["entitlement_id"],
+					"tableTo": "entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "cascade",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_jwt_families": {
+			"name": "customer_jwt_families",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"epoch": {
+					"name": "epoch",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"refresh_kid": {
+					"name": "refresh_kid",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"indefinite": {
+					"name": "indefinite",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"customer_jwt_families_internal_customer_id_fkey": {
+					"name": "customer_jwt_families_internal_customer_id_fkey",
+					"tableFrom": "customer_jwt_families",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"customer_jwt_families_internal_customer_id_key": {
+					"name": "customer_jwt_families_internal_customer_id_key",
+					"columns": ["internal_customer_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_licenses": {
+			"name": "customer_licenses",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"link_id": {
+					"name": "link_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"parent_customer_product_id": {
+					"name": "parent_customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"license_internal_product_id": {
+					"name": "license_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"plan_license_id": {
+					"name": "plan_license_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"granted": {
+					"name": "granted",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"remaining": {
+					"name": "remaining",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"paid_quantity": {
+					"name": "paid_quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"idx_customer_licenses_plan_license": {
+					"name": "idx_customer_licenses_plan_license",
+					"columns": [
+						{
+							"expression": "plan_license_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"unique_customer_license": {
+					"name": "unique_customer_license",
+					"columns": [
+						{
+							"expression": "parent_customer_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "license_internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_customer_licenses_customer": {
+					"name": "idx_customer_licenses_customer",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_customer_licenses_link": {
+					"name": "idx_customer_licenses_link",
+					"columns": [
+						{
+							"expression": "link_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"customer_licenses_customer_fkey": {
+					"name": "customer_licenses_customer_fkey",
+					"tableFrom": "customer_licenses",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"customer_licenses_parent_customer_product_fkey": {
+					"name": "customer_licenses_parent_customer_product_fkey",
+					"tableFrom": "customer_licenses",
+					"columnsFrom": ["parent_customer_product_id"],
+					"tableTo": "customer_products",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"customer_licenses_license_product_fkey": {
+					"name": "customer_licenses_license_product_fkey",
+					"tableFrom": "customer_licenses",
+					"columnsFrom": ["license_internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"customer_licenses_plan_license_fkey": {
+					"name": "customer_licenses_plan_license_fkey",
+					"tableFrom": "customer_licenses",
+					"columnsFrom": ["plan_license_id"],
+					"tableTo": "plan_license",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_prices": {
+			"name": "customer_prices",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"price_id": {
+					"name": "price_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_product_id": {
+					"name": "customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_customer_prices_product_id": {
+					"name": "idx_customer_prices_product_id",
+					"columns": [
+						{
+							"expression": "customer_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_prices_price_id": {
+					"name": "idx_customer_prices_price_id",
+					"columns": [
+						{
+							"expression": "price_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_prices_internal_customer_id": {
+					"name": "idx_customer_prices_internal_customer_id",
+					"columns": [
+						{
+							"expression": "\"internal_customer_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_cpr_customer_product_id_c": {
+					"name": "idx_cpr_customer_product_id_c",
+					"columns": [
+						{
+							"expression": "\"customer_product_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"customer_prices_customer_product_id_fkey": {
+					"name": "customer_prices_customer_product_id_fkey",
+					"tableFrom": "customer_prices",
+					"columnsFrom": ["customer_product_id"],
+					"tableTo": "customer_products",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"customer_prices_internal_customer_id_fkey": {
+					"name": "customer_prices_internal_customer_id_fkey",
+					"tableFrom": "customer_prices",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"customer_prices_price_id_fkey": {
+					"name": "customer_prices_price_id_fkey",
+					"tableFrom": "customer_prices",
+					"columnsFrom": ["price_id"],
+					"tableTo": "prices",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customer_products": {
+			"name": "customer_products",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"processor": {
+					"name": "processor",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"canceled": {
+					"name": "canceled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"canceled_at": {
+					"name": "canceled_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"starts_at": {
+					"name": "starts_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_starts_at": {
+					"name": "access_starts_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"options": {
+					"name": "options",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"free_trial_id": {
+					"name": "free_trial_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trial_ends_at": {
+					"name": "trial_ends_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"billing_cycle_anchor": {
+					"name": "billing_cycle_anchor",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"billing_cycle_anchor_resets_at": {
+					"name": "billing_cycle_anchor_resets_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"collection_method": {
+					"name": "collection_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'charge_automatically'"
+				},
+				"subscription_ids": {
+					"name": "subscription_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scheduled_ids": {
+					"name": "scheduled_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quantity": {
+					"name": "quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"customer_license_link_id": {
+					"name": "customer_license_link_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"released_at": {
+					"name": "released_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"billing_version": {
+					"name": "billing_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"api_version": {
+					"name": "api_version",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"api_semver": {
+					"name": "api_semver",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"external_id": {
+					"name": "external_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_checkout_session_id": {
+					"name": "stripe_checkout_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"previous_customer_product_id": {
+					"name": "previous_customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"on_trial_end": {
+					"name": "on_trial_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_customer_products_customer_status": {
+					"name": "idx_customer_products_customer_status",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_products_customer_status_created_at": {
+					"name": "idx_customer_products_customer_status_created_at",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_customer_products_product_status": {
+					"name": "idx_customer_products_product_status",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "status",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_customer_products_on_internal_entity_id": {
+					"name": "idx_customer_products_on_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_products_product_customer_c": {
+					"name": "idx_customer_products_product_customer_c",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"internal_customer_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_customer_products_on_internal_product_id": {
+					"name": "idx_customer_products_on_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_products_subscription_ids": {
+					"name": "idx_customer_products_subscription_ids",
+					"columns": [
+						{
+							"expression": "subscription_ids",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"concurrently": false
+				},
+				"idx_customer_products_scheduled_ids": {
+					"name": "idx_customer_products_scheduled_ids",
+					"columns": [
+						{
+							"expression": "scheduled_ids",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"concurrently": false
+				},
+				"idx_customer_products_stripe_checkout_session_id": {
+					"name": "idx_customer_products_stripe_checkout_session_id",
+					"columns": [
+						{
+							"expression": "stripe_checkout_session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customer_products_customer_license": {
+					"name": "idx_customer_products_customer_license",
+					"columns": [
+						{
+							"expression": "customer_license_link_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_products_license_seat_order": {
+					"name": "idx_customer_products_license_seat_order",
+					"columns": [
+						{
+							"expression": "customer_license_link_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_products_seat_sync": {
+					"name": "idx_customer_products_seat_sync",
+					"columns": [
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_products_unused_seats": {
+					"name": "idx_customer_products_unused_seats",
+					"columns": [
+						{
+							"expression": "customer_license_link_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "released_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
+					"concurrently": true
+				},
+				"unique_active_pool_assignment": {
+					"name": "unique_active_pool_assignment",
+					"columns": [
+						{
+							"expression": "customer_license_link_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
+					"concurrently": true
+				},
+				"idx_customer_products_free_trial_id": {
+					"name": "idx_customer_products_free_trial_id",
+					"columns": [
+						{
+							"expression": "free_trial_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_products_revenuecat_processor": {
+					"name": "idx_customer_products_revenuecat_processor",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+					"concurrently": false
+				},
+				"idx_customer_products_ended_at": {
+					"name": "idx_customer_products_ended_at",
+					"columns": [
+						{
+							"expression": "ended_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_products_trial_ends_at": {
+					"name": "idx_customer_products_trial_ends_at",
+					"columns": [
+						{
+							"expression": "trial_ends_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_customer_products_product_id": {
+					"name": "idx_customer_products_product_id",
+					"columns": [
+						{
+							"expression": "product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"customer_products_free_trial_id_fkey": {
+					"name": "customer_products_free_trial_id_fkey",
+					"tableFrom": "customer_products",
+					"columnsFrom": ["free_trial_id"],
+					"tableTo": "free_trials",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				},
+				"customer_products_internal_customer_id_fkey": {
+					"name": "customer_products_internal_customer_id_fkey",
+					"tableFrom": "customer_products",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "cascade",
+					"onDelete": "cascade"
+				},
+				"customer_products_internal_product_id_fkey": {
+					"name": "customer_products_internal_product_id_fkey",
+					"tableFrom": "customer_products",
+					"columnsFrom": ["internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				},
+				"customer_products_internal_entity_id_fkey": {
+					"name": "customer_products_internal_entity_id_fkey",
+					"tableFrom": "customer_products",
+					"columnsFrom": ["internal_entity_id"],
+					"tableTo": "entities",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.customers": {
+			"name": "customers",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"fingerprint": {
+					"name": "fingerprint",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"processor": {
+					"name": "processor",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"processors": {
+					"name": "processors",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"send_email_receipts": {
+					"name": "send_email_receipts",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"currency": {
+					"name": "currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auto_topups": {
+					"name": "auto_topups",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spend_limits": {
+					"name": "spend_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_limits": {
+					"name": "usage_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_alerts": {
+					"name": "usage_alerts",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overage_allowed": {
+					"name": "overage_allowed",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"customers_email_null_id_unique": {
+					"name": "customers_email_null_id_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "lower(\"email\")",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+					"concurrently": false
+				},
+				"idx_customers_org_env_fingerprint": {
+					"name": "idx_customers_org_env_fingerprint",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "fingerprint",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"customers\".\"fingerprint\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_customers_processor_id": {
+					"name": "idx_customers_processor_id",
+					"columns": [
+						{
+							"expression": "(\"processor\" ->> 'id')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customers_composite": {
+					"name": "idx_customers_composite",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customers_org_env_internal_id": {
+					"name": "idx_customers_org_env_internal_id",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"internal_id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customers_email_trgm": {
+					"name": "idx_customers_email_trgm",
+					"columns": [
+						{
+							"expression": "\"email\" gin_trgm_ops",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"where": "\"customers\".\"email\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_customers_name_trgm": {
+					"name": "idx_customers_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"where": "\"customers\".\"name\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_customers_id_trgm": {
+					"name": "idx_customers_id_trgm",
+					"columns": [
+						{
+							"expression": "\"id\" gin_trgm_ops",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"where": "\"customers\".\"id\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_customers_org_id_env_created_at": {
+					"name": "idx_customers_org_id_env_created_at",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customers_cursor": {
+					"name": "idx_customers_cursor",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customers_processors_revenuecat": {
+					"name": "idx_customers_processors_revenuecat",
+					"columns": [
+						{
+							"expression": "(\"processors\" ->> 'revenuecat')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customers_processors_revenuecat_id": {
+					"name": "idx_customers_processors_revenuecat_id",
+					"columns": [
+						{
+							"expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_customers_processors_revenuecat_aliases": {
+					"name": "idx_customers_processors_revenuecat_aliases",
+					"columns": [
+						{
+							"expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"concurrently": false
+				},
+				"idx_customers_processors_vercel": {
+					"name": "idx_customers_processors_vercel",
+					"columns": [
+						{
+							"expression": "(\"processors\" ->> 'vercel')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"customers_org_id_fkey": {
+					"name": "customers_org_id_fkey",
+					"tableFrom": "customers",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cus_id_constraint": {
+					"name": "cus_id_constraint",
+					"columns": ["org_id", "id", "env"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.entities": {
+			"name": "entities",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"deleted": {
+					"name": "deleted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spend_limits": {
+					"name": "spend_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_limits": {
+					"name": "usage_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_alerts": {
+					"name": "usage_alerts",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overage_allowed": {
+					"name": "overage_allowed",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_entities_internal_customer_id": {
+					"name": "idx_entities_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_entities_internal_feature_id_c": {
+					"name": "idx_entities_internal_feature_id_c",
+					"columns": [
+						{
+							"expression": "\"internal_feature_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_entities_internal_feature_id": {
+					"name": "idx_entities_internal_feature_id",
+					"columns": [
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_entities_customer_internal_desc": {
+					"name": "idx_entities_customer_internal_desc",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"internal_id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_entities_org_env_id": {
+					"name": "idx_entities_org_env_id",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_entities_cursor": {
+					"name": "idx_entities_cursor",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_entities_customer_created_at": {
+					"name": "idx_entities_customer_created_at",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"entities_internal_customer_id_fkey": {
+					"name": "entities_internal_customer_id_fkey",
+					"tableFrom": "entities",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"entities_internal_feature_id_fkey": {
+					"name": "entities_internal_feature_id_fkey",
+					"tableFrom": "entities",
+					"columnsFrom": ["internal_feature_id"],
+					"tableTo": "features",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"entities_org_id_fkey": {
+					"name": "entities_org_id_fkey",
+					"tableFrom": "entities",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"entity_id_constraint": {
+					"name": "entity_id_constraint",
+					"columns": ["org_id", "env", "internal_customer_id", "id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.entitlements": {
+			"name": "entitlements",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_id": {
+					"name": "internal_reward_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"allowance_type": {
+					"name": "allowance_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"allowance": {
+					"name": "allowance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval": {
+					"name": "interval",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"interval_count": {
+					"name": "interval_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 1
+				},
+				"carry_from_previous": {
+					"name": "carry_from_previous",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"entity_feature_id": {
+					"name": "entity_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"pooled": {
+					"name": "pooled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_limit": {
+					"name": "usage_limit",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expiry_duration": {
+					"name": "expiry_duration",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expiry_length": {
+					"name": "expiry_length",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rollover": {
+					"name": "rollover",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_entitlements_internal_product_id": {
+					"name": "idx_entitlements_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_entitlements_internal_reward_id": {
+					"name": "idx_entitlements_internal_reward_id",
+					"columns": [
+						{
+							"expression": "internal_reward_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_entitlements_reward_feature": {
+					"name": "idx_entitlements_reward_feature",
+					"columns": [
+						{
+							"expression": "internal_reward_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_entitlements_internal_feature_id_c": {
+					"name": "idx_entitlements_internal_feature_id_c",
+					"columns": [
+						{
+							"expression": "\"internal_feature_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_entitlements_internal_feature_id": {
+					"name": "idx_entitlements_internal_feature_id",
+					"columns": [
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_entitlements_internal_reward_id_c_partial": {
+					"name": "idx_entitlements_internal_reward_id_c_partial",
+					"columns": [
+						{
+							"expression": "\"internal_reward_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"entitlements_internal_feature_id_fkey": {
+					"name": "entitlements_internal_feature_id_fkey",
+					"tableFrom": "entitlements",
+					"columnsFrom": ["internal_feature_id"],
+					"tableTo": "features",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"entitlements_internal_product_id_fkey": {
+					"name": "entitlements_internal_product_id_fkey",
+					"tableFrom": "entitlements",
+					"columnsFrom": ["internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "cascade",
+					"onDelete": "cascade"
+				},
+				"entitlements_internal_reward_id_fkey": {
+					"name": "entitlements_internal_reward_id_fkey",
+					"tableFrom": "entitlements",
+					"columnsFrom": ["internal_reward_id"],
+					"tableTo": "rewards",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "cascade",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"entitlements_id_key": {
+					"name": "entitlements_id_key",
+					"columns": ["id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_slug": {
+					"name": "org_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"event_name": {
+					"name": "event_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"idempotency_key": {
+					"name": "idempotency_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"value": {
+					"name": "value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"set_usage": {
+					"name": "set_usage",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"properties": {
+					"name": "properties",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"deductions": {
+					"name": "deductions",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_events_internal_customer_id": {
+					"name": "idx_events_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_events_internal_entity_id": {
+					"name": "idx_events_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_events_customer_non_usage_ts": {
+					"name": "idx_events_customer_non_usage_ts",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"timestamp\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"events\".\"set_usage\" = false",
+					"concurrently": false
+				},
+				"idx_events_timestamp": {
+					"name": "idx_events_timestamp",
+					"columns": [
+						{
+							"expression": "timestamp",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"events_internal_customer_id_fkey": {
+					"name": "events_internal_customer_id_fkey",
+					"tableFrom": "events",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_event_constraint": {
+					"name": "unique_event_constraint",
+					"columns": [
+						"org_id",
+						"env",
+						"customer_id",
+						"event_name",
+						"idempotency_key"
+					],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.features": {
+			"name": "features",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"display": {
+					"name": "display",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"archived": {
+					"name": "archived",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"event_names": {
+					"name": "event_names",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"model_markups": {
+					"name": "model_markups",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"stripe_meter": {
+					"name": "stripe_meter",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				}
+			},
+			"indexes": {
+				"idx_features_composite": {
+					"name": "idx_features_composite",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"features_org_id_fkey": {
+					"name": "features_org_id_fkey",
+					"tableFrom": "features",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"feature_id_constraint": {
+					"name": "feature_id_constraint",
+					"columns": ["org_id", "id", "env"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.free_trials": {
+			"name": "free_trials",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration": {
+					"name": "duration",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'day'"
+				},
+				"length": {
+					"name": "length",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unique_fingerprint": {
+					"name": "unique_fingerprint",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"card_required": {
+					"name": "card_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"on_end": {
+					"name": "on_end",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_free_trials_internal_product_id": {
+					"name": "idx_free_trials_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"free_trials_internal_product_id_fkey": {
+					"name": "free_trials_internal_product_id_fkey",
+					"tableFrom": "free_trials",
+					"columnsFrom": ["internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"leaf.harness_sessions": {
+			"name": "harness_sessions",
+			"schema": "leaf",
+			"columns": {
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"thread_key": {
+					"name": "thread_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resume_state": {
+					"name": "resume_state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"braintrust_parent": {
+					"name": "braintrust_parent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"idx_harness_sessions_session_id": {
+					"name": "idx_harness_sessions_session_id",
+					"columns": [
+						{
+							"expression": "session_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"harness_sessions_org_id_env_thread_key_pk": {
+					"name": "harness_sessions_org_id_env_thread_key_pk",
+					"columns": ["org_id", "env", "thread_key"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invitation": {
+			"name": "invitation",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"inviter_id": {
+					"name": "inviter_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"invitation_organizationId_idx": {
+					"name": "invitation_organizationId_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"invitation_email_idx": {
+					"name": "invitation_email_idx",
+					"columns": [
+						{
+							"expression": "email",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"invitation_organization_id_organizations_id_fk": {
+					"name": "invitation_organization_id_organizations_id_fk",
+					"tableFrom": "invitation",
+					"columnsFrom": ["organization_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"invitation_inviter_id_user_id_fk": {
+					"name": "invitation_inviter_id_user_id_fk",
+					"tableFrom": "invitation",
+					"columnsFrom": ["inviter_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.invoice_line_items": {
+			"name": "invoice_line_items",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"invoice_id": {
+					"name": "invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_id": {
+					"name": "stripe_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_id": {
+					"name": "stripe_invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_item_id": {
+					"name": "stripe_invoice_item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_subscription_item_id": {
+					"name": "stripe_subscription_item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_product_id": {
+					"name": "stripe_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_price_id": {
+					"name": "stripe_price_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_discountable": {
+					"name": "stripe_discountable",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"amount": {
+					"name": "amount",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"amount_after_discounts": {
+					"name": "amount_after_discounts",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"currency": {
+					"name": "currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'usd'"
+				},
+				"stripe_quantity": {
+					"name": "stripe_quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_quantity": {
+					"name": "total_quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"paid_quantity": {
+					"name": "paid_quantity",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"description_source": {
+					"name": "description_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"direction": {
+					"name": "direction",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"billing_timing": {
+					"name": "billing_timing",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prorated": {
+					"name": "prorated",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"price_id": {
+					"name": "price_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_product_ids": {
+					"name": "customer_product_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"customer_price_ids": {
+					"name": "customer_price_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"customer_entitlement_ids": {
+					"name": "customer_entitlement_ids",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"product_id": {
+					"name": "product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"effective_period_start": {
+					"name": "effective_period_start",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"effective_period_end": {
+					"name": "effective_period_end",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"discounts": {
+					"name": "discounts",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				}
+			},
+			"indexes": {
+				"idx_invoice_line_items_customer_product_ids": {
+					"name": "idx_invoice_line_items_customer_product_ids",
+					"columns": [
+						{
+							"expression": "customer_product_ids",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"concurrently": false
+				},
+				"idx_invoice_line_items_stripe_invoice_id": {
+					"name": "idx_invoice_line_items_stripe_invoice_id",
+					"columns": [
+						{
+							"expression": "stripe_invoice_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_invoice_line_items_invoice_id": {
+					"name": "idx_invoice_line_items_invoice_id",
+					"columns": [
+						{
+							"expression": "invoice_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_invoice_line_items_stripe_invoice_item_id": {
+					"name": "idx_invoice_line_items_stripe_invoice_item_id",
+					"columns": [
+						{
+							"expression": "stripe_invoice_item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"invoice_line_items_invoice_id_fkey": {
+					"name": "invoice_line_items_invoice_id_fkey",
+					"tableFrom": "invoice_line_items",
+					"columnsFrom": ["invoice_id"],
+					"tableTo": "invoices",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"invoice_line_items_stripe_id_unique": {
+					"name": "invoice_line_items_stripe_id_unique",
+					"columns": ["stripe_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invoice_templates": {
+			"name": "invoice_templates",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"footer": {
+					"name": "footer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"memo": {
+					"name": "memo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"net_terms_days": {
+					"name": "net_terms_days",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_invoice_templates_org_id": {
+					"name": "idx_invoice_templates_org_id",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"invoice_templates_org_id_fkey": {
+					"name": "invoice_templates_org_id_fkey",
+					"tableFrom": "invoice_templates",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"invoice_templates_id_unique": {
+					"name": "invoice_templates_id_unique",
+					"columns": ["id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.invoices": {
+			"name": "invoices",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"product_ids": {
+					"name": "product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"internal_product_ids": {
+					"name": "internal_product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_id": {
+					"name": "stripe_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"processor_type": {
+					"name": "processor_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"hosted_invoice_url": {
+					"name": "hosted_invoice_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total": {
+					"name": "total",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"amount_paid": {
+					"name": "amount_paid",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refunded_amount": {
+					"name": "refunded_amount",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"currency": {
+					"name": "currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'usd'"
+				},
+				"discounts": {
+					"name": "discounts",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"items": {
+					"name": "items",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				}
+			},
+			"indexes": {
+				"idx_invoices_customer_created": {
+					"name": "idx_invoices_customer_created",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"created_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_invoices_internal_entity_id": {
+					"name": "idx_invoices_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"invoices_internal_customer_id_fkey": {
+					"name": "invoices_internal_customer_id_fkey",
+					"tableFrom": "invoices",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"invoices_internal_entity_id_fkey": {
+					"name": "invoices_internal_entity_id_fkey",
+					"tableFrom": "invoices",
+					"columnsFrom": ["internal_entity_id"],
+					"tableTo": "entities",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"invoices_stripe_id_key": {
+					"name": "invoices_stripe_id_key",
+					"columns": ["stripe_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.jwks": {
+			"name": "jwks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"private_key": {
+					"name": "private_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.license_entitlements": {
+			"name": "license_entitlements",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"plan_license_id": {
+					"name": "plan_license_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"entitlement_id": {
+					"name": "entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"unique_license_entitlement": {
+					"name": "unique_license_entitlement",
+					"columns": [
+						{
+							"expression": "plan_license_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "entitlement_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_license_entitlements_entitlement": {
+					"name": "idx_license_entitlements_entitlement",
+					"columns": [
+						{
+							"expression": "entitlement_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"license_entitlements_plan_license_fkey": {
+					"name": "license_entitlements_plan_license_fkey",
+					"tableFrom": "license_entitlements",
+					"columnsFrom": ["plan_license_id"],
+					"tableTo": "plan_license",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"license_entitlements_entitlement_fkey": {
+					"name": "license_entitlements_entitlement_fkey",
+					"tableFrom": "license_entitlements",
+					"columnsFrom": ["entitlement_id"],
+					"tableTo": "entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "restrict"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.license_prices": {
+			"name": "license_prices",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"plan_license_id": {
+					"name": "plan_license_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"price_id": {
+					"name": "price_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"unique_license_price": {
+					"name": "unique_license_price",
+					"columns": [
+						{
+							"expression": "plan_license_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "price_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_license_prices_price": {
+					"name": "idx_license_prices_price",
+					"columns": [
+						{
+							"expression": "price_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"license_prices_plan_license_fkey": {
+					"name": "license_prices_plan_license_fkey",
+					"tableFrom": "license_prices",
+					"columnsFrom": ["plan_license_id"],
+					"tableTo": "plan_license",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"license_prices_price_fkey": {
+					"name": "license_prices_price_fkey",
+					"tableFrom": "license_prices",
+					"columnsFrom": ["price_id"],
+					"tableTo": "prices",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "restrict"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.member": {
+			"name": "member",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'member'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"member_organizationId_idx": {
+					"name": "member_organizationId_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"member_userId_idx": {
+					"name": "member_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"member_organization_id_organizations_id_fk": {
+					"name": "member_organization_id_organizations_id_fk",
+					"tableFrom": "member",
+					"columnsFrom": ["organization_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"member_user_id_user_id_fk": {
+					"name": "member_user_id_user_id_fk",
+					"tableFrom": "member",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.metadata": {
+			"name": "metadata",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_invoice_id": {
+					"name": "stripe_invoice_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_checkout_session_id": {
+					"name": "stripe_checkout_session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_metadata_on_type_expires_at": {
+					"name": "idx_metadata_on_type_expires_at",
+					"columns": [
+						{
+							"expression": "type",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"metadata_expires_at_idx": {
+					"name": "metadata_expires_at_idx",
+					"columns": [
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"metadata\".\"expires_at\" IS NOT NULL",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_errors": {
+			"name": "migration_errors",
+			"schema": "",
+			"columns": {
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"migration_job_id": {
+					"name": "migration_job_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"data": {
+					"name": "data",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"message": {
+					"name": "message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"migration_customers_internal_customer_id_fkey": {
+					"name": "migration_customers_internal_customer_id_fkey",
+					"tableFrom": "migration_errors",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"migration_customers_migration_job_id_fkey": {
+					"name": "migration_customers_migration_job_id_fkey",
+					"tableFrom": "migration_errors",
+					"columnsFrom": ["migration_job_id"],
+					"tableTo": "migration_jobs",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"migration_errors_pkey": {
+					"name": "migration_errors_pkey",
+					"columns": ["internal_customer_id", "migration_job_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_item_runs": {
+			"name": "migration_item_runs",
+			"schema": "",
+			"columns": {
+				"migration_item_run_id": {
+					"name": "migration_item_run_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"migration_internal_id": {
+					"name": "migration_internal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"migration_run_id": {
+					"name": "migration_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dry_run": {
+					"name": "dry_run",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"item_kind": {
+					"name": "item_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"item_id": {
+					"name": "item_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"timestamp": {
+					"name": "timestamp",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "now()"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"migration_item_runs_live_unique": {
+					"name": "migration_item_runs_live_unique",
+					"columns": [
+						{
+							"expression": "migration_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"migration_item_runs\".\"dry_run\" = false",
+					"concurrently": false
+				},
+				"migration_item_runs_live_c_idx": {
+					"name": "migration_item_runs_live_c_idx",
+					"columns": [
+						{
+							"expression": "migration_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"item_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"migration_item_runs\".\"dry_run\" = false",
+					"concurrently": true
+				},
+				"migration_item_runs_live_item_exclusive": {
+					"name": "migration_item_runs_live_item_exclusive",
+					"columns": [
+						{
+							"expression": "item_kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"item_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"migration_item_runs\".\"status\" = 'running' AND \"migration_item_runs\".\"dry_run\" = false",
+					"concurrently": true
+				},
+				"migration_item_runs_dry_run_unique": {
+					"name": "migration_item_runs_dry_run_unique",
+					"columns": [
+						{
+							"expression": "migration_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "migration_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"migration_item_runs\".\"dry_run\" = true",
+					"concurrently": false
+				},
+				"migration_item_runs_customer_recent_idx": {
+					"name": "migration_item_runs_customer_recent_idx",
+					"columns": [
+						{
+							"expression": "item_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"updated_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_jobs": {
+			"name": "migration_jobs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"from_internal_product_id": {
+					"name": "from_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"to_internal_product_id": {
+					"name": "to_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"step_details": {
+					"name": "step_details",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"migration_jobs_from_internal_product_id_fkey": {
+					"name": "migration_jobs_from_internal_product_id_fkey",
+					"tableFrom": "migration_jobs",
+					"columnsFrom": ["from_internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"migration_jobs_org_id_fkey": {
+					"name": "migration_jobs_org_id_fkey",
+					"tableFrom": "migration_jobs",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"migration_jobs_to_internal_product_id_fkey": {
+					"name": "migration_jobs_to_internal_product_id_fkey",
+					"tableFrom": "migration_jobs",
+					"columnsFrom": ["to_internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migration_runs": {
+			"name": "migration_runs",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"migration_internal_id": {
+					"name": "migration_internal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"dry_run": {
+					"name": "dry_run",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"lazy_run": {
+					"name": "lazy_run",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"trigger_run_id": {
+					"name": "trigger_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"only_ids": {
+					"name": "only_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_limit": {
+					"name": "target_limit",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"finished_at": {
+					"name": "finished_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"migration_runs_active_per_migration_unique": {
+					"name": "migration_runs_active_per_migration_unique",
+					"columns": [
+						{
+							"expression": "migration_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"migration_runs_migration_internal_id_fkey": {
+					"name": "migration_runs_migration_internal_id_fkey",
+					"tableFrom": "migration_runs",
+					"columnsFrom": ["migration_internal_id"],
+					"tableTo": "migrations",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"migration_runs_org_id_fkey": {
+					"name": "migration_runs_org_id_fkey",
+					"tableFrom": "migration_runs",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.migrations": {
+			"name": "migrations",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"filter": {
+					"name": "filter",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"operations": {
+					"name": "operations",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prepared_state": {
+					"name": "prepared_state",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"no_billing_changes": {
+					"name": "no_billing_changes",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_failed": {
+					"name": "retry_failed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"archived": {
+					"name": "archived",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"migrations_org_env_id_unique": {
+					"name": "migrations_org_env_id_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"migrations_org_id_fkey": {
+					"name": "migrations_org_id_fkey",
+					"tableFrom": "migrations",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.oauth_access_token": {
+			"name": "oauth_access_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"oauth_consent_id": {
+					"name": "oauth_consent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"refresh_id": {
+					"name": "refresh_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_access_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_access_token",
+					"columnsFrom": ["client_id"],
+					"tableTo": "oauth_client",
+					"columnsTo": ["client_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"oauth_access_token_session_id_session_id_fk": {
+					"name": "oauth_access_token_session_id_session_id_fk",
+					"tableFrom": "oauth_access_token",
+					"columnsFrom": ["session_id"],
+					"tableTo": "session",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				},
+				"oauth_access_token_user_id_user_id_fk": {
+					"name": "oauth_access_token_user_id_user_id_fk",
+					"tableFrom": "oauth_access_token",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
+					"name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
+					"tableFrom": "oauth_access_token",
+					"columnsFrom": ["oauth_consent_id"],
+					"tableTo": "oauth_consent",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+					"name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+					"tableFrom": "oauth_access_token",
+					"columnsFrom": ["refresh_id"],
+					"tableTo": "oauth_refresh_token",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_access_token_token_unique": {
+					"name": "oauth_access_token_token_unique",
+					"columns": ["token"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.oauth_client": {
+			"name": "oauth_client",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_secret": {
+					"name": "client_secret",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"disabled": {
+					"name": "disabled",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"skip_consent": {
+					"name": "skip_consent",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"enable_end_session": {
+					"name": "enable_end_session",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"uri": {
+					"name": "uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"contacts": {
+					"name": "contacts",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tos": {
+					"name": "tos",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"policy": {
+					"name": "policy",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_id": {
+					"name": "software_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_version": {
+					"name": "software_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"software_statement": {
+					"name": "software_statement",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redirect_uris": {
+					"name": "redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"post_logout_redirect_uris": {
+					"name": "post_logout_redirect_uris",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_endpoint_auth_method": {
+					"name": "token_endpoint_auth_method",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"grant_types": {
+					"name": "grant_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"response_types": {
+					"name": "response_types",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public": {
+					"name": "public",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_client_user_id_user_id_fk": {
+					"name": "oauth_client_user_id_user_id_fk",
+					"tableFrom": "oauth_client",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"oauth_client_client_id_unique": {
+					"name": "oauth_client_client_id_unique",
+					"columns": ["client_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.oauth_consent": {
+			"name": "oauth_consent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redirect_uri": {
+					"name": "redirect_uri",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"oauth_api_key_id": {
+					"name": "oauth_api_key_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_consent_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_consent_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_consent",
+					"columnsFrom": ["client_id"],
+					"tableTo": "oauth_client",
+					"columnsTo": ["client_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"oauth_consent_user_id_user_id_fk": {
+					"name": "oauth_consent_user_id_user_id_fk",
+					"tableFrom": "oauth_consent",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.oauth_refresh_token": {
+			"name": "oauth_refresh_token",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"client_id": {
+					"name": "client_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"session_id": {
+					"name": "session_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"reference_id": {
+					"name": "reference_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"oauth_consent_id": {
+					"name": "oauth_consent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"revoked": {
+					"name": "revoked",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"auth_time": {
+					"name": "auth_time",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scopes": {
+					"name": "scopes",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+					"name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"columnsFrom": ["client_id"],
+					"tableTo": "oauth_client",
+					"columnsTo": ["client_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"oauth_refresh_token_session_id_session_id_fk": {
+					"name": "oauth_refresh_token_session_id_session_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"columnsFrom": ["session_id"],
+					"tableTo": "session",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				},
+				"oauth_refresh_token_user_id_user_id_fk": {
+					"name": "oauth_refresh_token_user_id_user_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
+					"name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
+					"tableFrom": "oauth_refresh_token",
+					"columnsFrom": ["oauth_consent_id"],
+					"tableTo": "oauth_consent",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.organizations": {
+			"name": "organizations",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"logo": {
+					"name": "logo",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"default_currency": {
+					"name": "default_currency",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'usd'"
+				},
+				"stripe_connected": {
+					"name": "stripe_connected",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"stripe_config": {
+					"name": "stripe_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"test_stripe_connect": {
+					"name": "test_stripe_connect",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"live_stripe_connect": {
+					"name": "live_stripe_connect",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"processor_configs": {
+					"name": "processor_configs",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"test_pkey": {
+					"name": "test_pkey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"live_pkey": {
+					"name": "live_pkey",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"svix_config": {
+					"name": "svix_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"custom_buttons": {
+					"name": "custom_buttons",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'[]'::jsonb"
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"onboarded": {
+					"name": "onboarded",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"deployed": {
+					"name": "deployed",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"is_sandbox": {
+					"name": "is_sandbox",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"sandbox_color": {
+					"name": "sandbox_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_icon": {
+					"name": "sandbox_icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"redis_config": {
+					"name": "redis_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_organizations_name_trgm": {
+					"name": "idx_organizations_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"where": "\"organizations\".\"name\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_organizations_slug_trgm": {
+					"name": "idx_organizations_slug_trgm",
+					"columns": [
+						{
+							"expression": "\"slug\" gin_trgm_ops",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"where": "\"organizations\".\"slug\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_organizations_created_at_id": {
+					"name": "idx_organizations_created_at_id",
+					"columns": [
+						{
+							"expression": "\"createdAt\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_orgs_test_connect_default_account": {
+					"name": "idx_orgs_test_connect_default_account",
+					"columns": [
+						{
+							"expression": "(\"test_stripe_connect\"->>'default_account_id')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_orgs_test_connect_account": {
+					"name": "idx_orgs_test_connect_account",
+					"columns": [
+						{
+							"expression": "(\"test_stripe_connect\"->>'account_id')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_orgs_live_connect_account": {
+					"name": "idx_orgs_live_connect_account",
+					"columns": [
+						{
+							"expression": "(\"live_stripe_connect\"->>'account_id')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"organizations_slug_unique": {
+					"name": "organizations_slug_unique",
+					"columns": ["slug"],
+					"nullsNotDistinct": false
+				},
+				"organizations_test_pkey_key": {
+					"name": "organizations_test_pkey_key",
+					"columns": ["test_pkey"],
+					"nullsNotDistinct": false
+				},
+				"organizations_live_pkey_key": {
+					"name": "organizations_live_pkey_key",
+					"columns": ["live_pkey"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.passkey": {
+			"name": "passkey",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public_key": {
+					"name": "public_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"credential_id": {
+					"name": "credential_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"counter": {
+					"name": "counter",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"device_type": {
+					"name": "device_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"backed_up": {
+					"name": "backed_up",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"transports": {
+					"name": "transports",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"aaguid": {
+					"name": "aaguid",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"passkey_userId_idx": {
+					"name": "passkey_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"passkey_credentialId_idx": {
+					"name": "passkey_credentialId_idx",
+					"columns": [
+						{
+							"expression": "credential_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"passkey_user_id_user_id_fk": {
+					"name": "passkey_user_id_user_id_fk",
+					"tableFrom": "passkey",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"passkey_credential_id_unique": {
+					"name": "passkey_credential_id_unique",
+					"columns": ["credential_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.plan_license": {
+			"name": "plan_license",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"parent_internal_product_id": {
+					"name": "parent_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"license_internal_product_id": {
+					"name": "license_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"included": {
+					"name": "included",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"prepaid_only": {
+					"name": "prepaid_only",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": true
+				},
+				"customized": {
+					"name": "customized",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"unique_plan_license": {
+					"name": "unique_plan_license",
+					"columns": [
+						{
+							"expression": "parent_internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "license_internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"plan_license\".\"is_custom\" = false",
+					"concurrently": true
+				},
+				"idx_plan_license_parent_product": {
+					"name": "idx_plan_license_parent_product",
+					"columns": [
+						{
+							"expression": "parent_internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_plan_license_license": {
+					"name": "idx_plan_license_license",
+					"columns": [
+						{
+							"expression": "license_internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"plan_license_parent_product_fkey": {
+					"name": "plan_license_parent_product_fkey",
+					"tableFrom": "plan_license",
+					"columnsFrom": ["parent_internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"plan_license_license_product_fkey": {
+					"name": "plan_license_license_product_fkey",
+					"tableFrom": "plan_license",
+					"columnsFrom": ["license_internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.pooled_balance_contributions": {
+			"name": "pooled_balance_contributions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"pooled_balance_id": {
+					"name": "pooled_balance_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_customer_product_id": {
+					"name": "source_customer_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source_customer_entitlement_id": {
+					"name": "source_customer_entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"current_contribution": {
+					"name": "current_contribution",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"next_cycle_contribution": {
+					"name": "next_cycle_contribution",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"effective_at": {
+					"name": "effective_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"idx_pooled_balance_contributions_pool": {
+					"name": "idx_pooled_balance_contributions_pool",
+					"columns": [
+						{
+							"expression": "pooled_balance_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_pooled_balance_contributions_source_customer_entitlement": {
+					"name": "idx_pooled_balance_contributions_source_customer_entitlement",
+					"columns": [
+						{
+							"expression": "source_customer_entitlement_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"pooled_balance_contributions_pool_fkey": {
+					"name": "pooled_balance_contributions_pool_fkey",
+					"tableFrom": "pooled_balance_contributions",
+					"columnsFrom": ["pooled_balance_id"],
+					"tableTo": "pooled_balances",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"pooled_balance_contributions_customer_product_fkey": {
+					"name": "pooled_balance_contributions_customer_product_fkey",
+					"tableFrom": "pooled_balance_contributions",
+					"columnsFrom": ["source_customer_product_id"],
+					"tableTo": "customer_products",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"pooled_balance_contributions_customer_entitlement_fkey": {
+					"name": "pooled_balance_contributions_customer_entitlement_fkey",
+					"tableFrom": "pooled_balance_contributions",
+					"columnsFrom": ["source_customer_entitlement_id"],
+					"tableTo": "customer_entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_pooled_balance_contribution": {
+					"name": "unique_pooled_balance_contribution",
+					"columns": ["source_customer_entitlement_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {
+				"pooled_balance_contributions_current_non_negative": {
+					"name": "pooled_balance_contributions_current_non_negative",
+					"value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
+				},
+				"pooled_balance_contributions_next_non_negative": {
+					"name": "pooled_balance_contributions_next_non_negative",
+					"value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.pooled_balances": {
+			"name": "pooled_balances",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"unlimited": {
+					"name": "unlimited",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"granted": {
+					"name": "granted",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"interval": {
+					"name": "interval",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"interval_count": {
+					"name": "interval_count",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"reset_cycle_anchor": {
+					"name": "reset_cycle_anchor",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reset_mode": {
+					"name": "reset_mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_subscription_id": {
+					"name": "stripe_subscription_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"customer_license_link_id": {
+					"name": "customer_license_link_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rollover_signature": {
+					"name": "rollover_signature",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'none'"
+				},
+				"customer_entitlement_id": {
+					"name": "customer_entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_applied_reset_at": {
+					"name": "last_applied_reset_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {
+				"idx_pooled_balances_org": {
+					"name": "idx_pooled_balances_org",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_pooled_balances_reset_mode": {
+					"name": "idx_pooled_balances_reset_mode",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reset_mode",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_pooled_balances_feature": {
+					"name": "idx_pooled_balances_feature",
+					"columns": [
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_pooled_balances_stripe_subscription": {
+					"name": "idx_pooled_balances_stripe_subscription",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "stripe_subscription_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
+					"concurrently": true
+				},
+				"idx_pooled_balances_customer_license": {
+					"name": "idx_pooled_balances_customer_license",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "customer_license_link_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"pooled_balances_customer_fkey": {
+					"name": "pooled_balances_customer_fkey",
+					"tableFrom": "pooled_balances",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"pooled_balances_feature_fkey": {
+					"name": "pooled_balances_feature_fkey",
+					"tableFrom": "pooled_balances",
+					"columnsFrom": ["internal_feature_id"],
+					"tableTo": "features",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "restrict"
+				},
+				"pooled_balances_customer_entitlement_fkey": {
+					"name": "pooled_balances_customer_entitlement_fkey",
+					"tableFrom": "pooled_balances",
+					"columnsFrom": ["customer_entitlement_id"],
+					"tableTo": "customer_entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "restrict"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_pooled_balance": {
+					"name": "unique_pooled_balance",
+					"columns": [
+						"internal_customer_id",
+						"internal_feature_id",
+						"unlimited",
+						"interval",
+						"interval_count",
+						"reset_cycle_anchor",
+						"reset_mode",
+						"stripe_subscription_id",
+						"customer_license_link_id",
+						"rollover_signature",
+						"expires_at"
+					],
+					"nullsNotDistinct": true
+				},
+				"unique_pooled_balance_customer_entitlement": {
+					"name": "unique_pooled_balance_customer_entitlement",
+					"columns": ["customer_entitlement_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {
+				"pooled_balances_interval_count_positive": {
+					"name": "pooled_balances_interval_count_positive",
+					"value": "\"pooled_balances\".\"interval_count\" > 0"
+				},
+				"pooled_balances_granted_non_negative": {
+					"name": "pooled_balances_granted_non_negative",
+					"value": "\"pooled_balances\".\"granted\" >= 0"
+				},
+				"pooled_balances_reset_mode_valid": {
+					"name": "pooled_balances_reset_mode_valid",
+					"value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
+				},
+				"pooled_balances_lifecycle_ids_valid": {
+					"name": "pooled_balances_lifecycle_ids_valid",
+					"value": "(\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'subscription'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lazy'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lifetime'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t)"
+				}
+			},
+			"isRLSEnabled": false
+		},
+		"public.prices": {
+			"name": "prices",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_product_id": {
+					"name": "internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"billing_type": {
+					"name": "billing_type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tier_behavior": {
+					"name": "tier_behavior",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"is_custom": {
+					"name": "is_custom",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"entitlement_id": {
+					"name": "entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"proration_config": {
+					"name": "proration_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				}
+			},
+			"indexes": {
+				"idx_prices_internal_product_id": {
+					"name": "idx_prices_internal_product_id",
+					"columns": [
+						{
+							"expression": "internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_prices_entitlement_id": {
+					"name": "idx_prices_entitlement_id",
+					"columns": [
+						{
+							"expression": "entitlement_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"prices_entitlement_id_fkey": {
+					"name": "prices_entitlement_id_fkey",
+					"tableFrom": "prices",
+					"columnsFrom": ["entitlement_id"],
+					"tableTo": "entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				},
+				"prices_internal_product_id_fkey": {
+					"name": "prices_internal_product_id_fkey",
+					"tableFrom": "prices",
+					"columnsFrom": ["internal_product_id"],
+					"tableTo": "products",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "cascade",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"prices_id_key": {
+					"name": "prices_id_key",
+					"columns": ["id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.products": {
+			"name": "products",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"is_add_on": {
+					"name": "is_add_on",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"is_default": {
+					"name": "is_default",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"group": {
+					"name": "group",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "''"
+				},
+				"version": {
+					"name": "version",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 1
+				},
+				"processor": {
+					"name": "processor",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "null"
+				},
+				"base_variant_id": {
+					"name": "base_variant_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"base_internal_product_id": {
+					"name": "base_internal_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"archived": {
+					"name": "archived",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"config": {
+					"name": "config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				},
+				"auto_topups": {
+					"name": "auto_topups",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"spend_limits": {
+					"name": "spend_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_limits": {
+					"name": "usage_limits",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage_alerts": {
+					"name": "usage_alerts",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"overage_allowed": {
+					"name": "overage_allowed",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_products_org_env_id_version": {
+					"name": "idx_products_org_env_id_version",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "version",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_products_org_env_base_internal_product_id": {
+					"name": "idx_products_org_env_base_internal_product_id",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "base_internal_product_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"products_org_id_fkey": {
+					"name": "products_org_id_fkey",
+					"tableFrom": "products",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"unique_product": {
+					"name": "unique_product",
+					"columns": ["org_id", "id", "env", "version"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.referral_codes": {
+			"name": "referral_codes",
+			"schema": "",
+			"columns": {
+				"code": {
+					"name": "code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_program_id": {
+					"name": "internal_reward_program_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_referral_codes_internal_customer_id": {
+					"name": "idx_referral_codes_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"referral_codes_internal_customer_id_fkey": {
+					"name": "referral_codes_internal_customer_id_fkey",
+					"tableFrom": "referral_codes",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"referral_codes_internal_reward_program_id_fkey": {
+					"name": "referral_codes_internal_reward_program_id_fkey",
+					"tableFrom": "referral_codes",
+					"columnsFrom": ["internal_reward_program_id"],
+					"tableTo": "reward_programs",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"referral_codes_org_id_fkey": {
+					"name": "referral_codes_org_id_fkey",
+					"tableFrom": "referral_codes",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"referral_codes_pkey": {
+					"name": "referral_codes_pkey",
+					"columns": ["code", "org_id", "env"]
+				}
+			},
+			"uniqueConstraints": {
+				"referral_codes_id_key": {
+					"name": "referral_codes_id_key",
+					"columns": ["id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.replaceables": {
+			"name": "replaceables",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"cus_ent_id": {
+					"name": "cus_ent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"from_entity_id": {
+					"name": "from_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"delete_next_cycle": {
+					"name": "delete_next_cycle",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {
+				"idx_replaceables_cus_ent_id": {
+					"name": "idx_replaceables_cus_ent_id",
+					"columns": [
+						{
+							"expression": "cus_ent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"replaceables_cus_ent_id_fkey": {
+					"name": "replaceables_cus_ent_id_fkey",
+					"tableFrom": "replaceables",
+					"columnsFrom": ["cus_ent_id"],
+					"tableTo": "customer_entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.revenuecat_mappings": {
+			"name": "revenuecat_mappings",
+			"schema": "",
+			"columns": {
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"autumn_product_id": {
+					"name": "autumn_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"revenuecat_product_ids": {
+					"name": "revenuecat_product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"feature_quantities": {
+					"name": "feature_quantities",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"revenuecat_mappings_org_id_fkey": {
+					"name": "revenuecat_mappings_org_id_fkey",
+					"tableFrom": "revenuecat_mappings",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"revenuecat_mappings_pkey": {
+					"name": "revenuecat_mappings_pkey",
+					"columns": ["org_id", "env", "autumn_product_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.reward_programs": {
+			"name": "reward_programs",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_id": {
+					"name": "internal_reward_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_redemptions": {
+					"name": "max_redemptions",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"unlimited_redemptions": {
+					"name": "unlimited_redemptions",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"when": {
+					"name": "when",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'immediately'"
+				},
+				"product_ids": {
+					"name": "product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{\"\"}'"
+				},
+				"exclude_trial": {
+					"name": "exclude_trial",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"received_by": {
+					"name": "received_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"reward_triggers_internal_reward_id_fkey": {
+					"name": "reward_triggers_internal_reward_id_fkey",
+					"tableFrom": "reward_programs",
+					"columnsFrom": ["internal_reward_id"],
+					"tableTo": "rewards",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"reward_triggers_org_id_fkey": {
+					"name": "reward_triggers_org_id_fkey",
+					"tableFrom": "reward_programs",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.reward_redemptions": {
+			"name": "reward_redemptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text COLLATE \"C\"",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"triggered": {
+					"name": "triggered",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"internal_reward_program_id": {
+					"name": "internal_reward_program_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"applied": {
+					"name": "applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"redeemer_applied": {
+					"name": "redeemer_applied",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false,
+					"default": false
+				},
+				"referral_code_id": {
+					"name": "referral_code_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reward_internal_id": {
+					"name": "reward_internal_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"promo_code": {
+					"name": "promo_code",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_reward_redemptions_referral_code_id": {
+					"name": "idx_reward_redemptions_referral_code_id",
+					"columns": [
+						{
+							"expression": "referral_code_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_reward_redemptions_reward_internal_id": {
+					"name": "idx_reward_redemptions_reward_internal_id",
+					"columns": [
+						{
+							"expression": "reward_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_reward_redemptions_customer_reward": {
+					"name": "idx_reward_redemptions_customer_reward",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "reward_internal_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"reward_redemptions_internal_customer_id_fkey": {
+					"name": "reward_redemptions_internal_customer_id_fkey",
+					"tableFrom": "reward_redemptions",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"reward_redemptions_internal_reward_program_id_fkey": {
+					"name": "reward_redemptions_internal_reward_program_id_fkey",
+					"tableFrom": "reward_redemptions",
+					"columnsFrom": ["internal_reward_program_id"],
+					"tableTo": "reward_programs",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"reward_redemptions_referral_code_id_fkey": {
+					"name": "reward_redemptions_referral_code_id_fkey",
+					"tableFrom": "reward_redemptions",
+					"columnsFrom": ["referral_code_id"],
+					"tableTo": "referral_codes",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.rewards": {
+			"name": "rewards",
+			"schema": "",
+			"columns": {
+				"internal_id": {
+					"name": "internal_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"discount_config": {
+					"name": "discount_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"free_product_config": {
+					"name": "free_product_config",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"free_product_id": {
+					"name": "free_product_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"promo_codes": {
+					"name": "promo_codes",
+					"type": "jsonb[]",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_rewards_org_id_env": {
+					"name": "idx_rewards_org_id_env",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"coupons_org_id_fkey": {
+					"name": "coupons_org_id_fkey",
+					"tableFrom": "rewards",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.rollovers": {
+			"name": "rollovers",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"cus_ent_id": {
+					"name": "cus_ent_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"balance": {
+					"name": "balance",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"usage": {
+					"name": "usage",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"entities": {
+					"name": "entities",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"idx_rollovers_cus_ent_id": {
+					"name": "idx_rollovers_cus_ent_id",
+					"columns": [
+						{
+							"expression": "cus_ent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_rollovers_cus_ent_expires": {
+					"name": "idx_rollovers_cus_ent_expires",
+					"columns": [
+						{
+							"expression": "cus_ent_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"rollover_cus_ent_id_fkey": {
+					"name": "rollover_cus_ent_id_fkey",
+					"tableFrom": "rollovers",
+					"columnsFrom": ["cus_ent_id"],
+					"tableTo": "customer_entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "cascade",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.phases": {
+			"name": "phases",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"schedule_id": {
+					"name": "schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"starts_at": {
+					"name": "starts_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_product_ids": {
+					"name": "customer_product_ids",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"phases_schedule_id_fkey": {
+					"name": "phases_schedule_id_fkey",
+					"tableFrom": "phases",
+					"columnsFrom": ["schedule_id"],
+					"tableTo": "schedules",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"phases_schedule_id_starts_at_key": {
+					"name": "phases_schedule_id_starts_at_key",
+					"columns": ["schedule_id", "starts_at"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.schedules": {
+			"name": "schedules",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"customer_id": {
+					"name": "customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"entity_id": {
+					"name": "entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"schedules_customer_scope_unique": {
+					"name": "schedules_customer_scope_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"schedules\".\"internal_entity_id\" IS NULL",
+					"concurrently": false
+				},
+				"schedules_entity_scope_unique": {
+					"name": "schedules_entity_scope_unique",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_schedules_internal_customer_id": {
+					"name": "idx_schedules_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_schedules_internal_entity_id": {
+					"name": "idx_schedules_internal_entity_id",
+					"columns": [
+						{
+							"expression": "internal_entity_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"schedules_org_id_fkey": {
+					"name": "schedules_org_id_fkey",
+					"tableFrom": "schedules",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"schedules_internal_customer_id_fkey": {
+					"name": "schedules_internal_customer_id_fkey",
+					"tableFrom": "schedules",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"schedules_internal_entity_id_fkey": {
+					"name": "schedules_internal_entity_id_fkey",
+					"tableFrom": "schedules",
+					"columnsFrom": ["internal_entity_id"],
+					"tableTo": "entities",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "set null"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.session": {
+			"name": "session",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"impersonated_by": {
+					"name": "impersonated_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"active_organization_id": {
+					"name": "active_organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"city": {
+					"name": "city",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"country": {
+					"name": "country",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"session_userId_idx": {
+					"name": "session_userId_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"session_user_id_user_id_fk": {
+					"name": "session_user_id_user_id_fk",
+					"tableFrom": "session",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"leaf.slack_admin_threads": {
+			"name": "slack_admin_threads",
+			"schema": "leaf",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"chat_installation_id": {
+					"name": "chat_installation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"workspace_id": {
+					"name": "workspace_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"channel_id": {
+					"name": "channel_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"org_slug": {
+					"name": "org_slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_identifier": {
+					"name": "target_identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_by_provider_user_id": {
+					"name": "created_by_provider_user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"slack_admin_threads_thread_key": {
+					"name": "slack_admin_threads_thread_key",
+					"columns": ["workspace_id", "channel_id", "thread_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.sso_connection": {
+			"name": "sso_connection",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'pending_domain_verification'"
+				},
+				"activated_at": {
+					"name": "activated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"sso_connection_organization_id_idx": {
+					"name": "sso_connection_organization_id_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"sso_connection_provider_id_sso_provider_provider_id_fk": {
+					"name": "sso_connection_provider_id_sso_provider_provider_id_fk",
+					"tableFrom": "sso_connection",
+					"columnsFrom": ["provider_id"],
+					"tableTo": "sso_provider",
+					"columnsTo": ["provider_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"sso_connection_organization_id_organizations_id_fk": {
+					"name": "sso_connection_organization_id_organizations_id_fk",
+					"tableFrom": "sso_connection",
+					"columnsFrom": ["organization_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"sso_connection_provider_id_unique": {
+					"name": "sso_connection_provider_id_unique",
+					"columns": ["provider_id"],
+					"nullsNotDistinct": false
+				},
+				"sso_connection_organization_id_unique": {
+					"name": "sso_connection_organization_id_unique",
+					"columns": ["organization_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.sso_provider": {
+			"name": "sso_provider",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"issuer": {
+					"name": "issuer",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"domain": {
+					"name": "domain",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"oidc_config": {
+					"name": "oidc_config",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"saml_config": {
+					"name": "saml_config",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_id": {
+					"name": "provider_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"organization_id": {
+					"name": "organization_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"domain_verified": {
+					"name": "domain_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {
+				"sso_provider_user_id_idx": {
+					"name": "sso_provider_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"sso_provider_organization_id_idx": {
+					"name": "sso_provider_organization_id_idx",
+					"columns": [
+						{
+							"expression": "organization_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"sso_provider_domain_idx": {
+					"name": "sso_provider_domain_idx",
+					"columns": [
+						{
+							"expression": "domain",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"sso_provider_user_id_user_id_fk": {
+					"name": "sso_provider_user_id_user_id_fk",
+					"tableFrom": "sso_provider",
+					"columnsFrom": ["user_id"],
+					"tableTo": "user",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"sso_provider_organization_id_organizations_id_fk": {
+					"name": "sso_provider_organization_id_organizations_id_fk",
+					"tableFrom": "sso_provider",
+					"columnsFrom": ["organization_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"sso_provider_domain_unique": {
+					"name": "sso_provider_domain_unique",
+					"columns": ["domain"],
+					"nullsNotDistinct": false
+				},
+				"sso_provider_provider_id_unique": {
+					"name": "sso_provider_provider_id_unique",
+					"columns": ["provider_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.subscriptions": {
+			"name": "subscriptions",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stripe_id": {
+					"name": "stripe_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"stripe_schedule_id": {
+					"name": "stripe_schedule_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'::jsonb"
+				},
+				"usage_features": {
+					"name": "usage_features",
+					"type": "text[]",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'{}'"
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_period_start": {
+					"name": "current_period_start",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_period_end": {
+					"name": "current_period_end",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"billing_cycle_anchor_seconds": {
+					"name": "billing_cycle_anchor_seconds",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"subscriptions_org_id_fkey": {
+					"name": "subscriptions_org_id_fkey",
+					"tableFrom": "subscriptions",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"subscriptions_stripe_id_key": {
+					"name": "subscriptions_stripe_id_key",
+					"columns": ["stripe_id"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.transition_rules": {
+			"name": "transition_rules",
+			"schema": "",
+			"columns": {
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"carry_over_usages": {
+					"name": "carry_over_usages",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"transition_rules_org_id_fkey": {
+					"name": "transition_rules_org_id_fkey",
+					"tableFrom": "transition_rules",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {
+				"transition_rules_pkey": {
+					"name": "transition_rules_pkey",
+					"columns": ["org_id", "env"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.usage_windows": {
+			"name": "usage_windows",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"internal_customer_id": {
+					"name": "internal_customer_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_entity_id": {
+					"name": "internal_entity_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"feature_id": {
+					"name": "feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"internal_feature_id": {
+					"name": "internal_feature_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"filter_key": {
+					"name": "filter_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"anchor_customer_entitlement_id": {
+					"name": "anchor_customer_entitlement_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"window_start_at": {
+					"name": "window_start_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"window_end_at": {
+					"name": "window_end_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"usage": {
+					"name": "usage",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"idx_usage_windows_internal_customer_id": {
+					"name": "idx_usage_windows_internal_customer_id",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				},
+				"idx_usage_windows_internal_customer_id_c": {
+					"name": "idx_usage_windows_internal_customer_id_c",
+					"columns": [
+						{
+							"expression": "\"internal_customer_id\" COLLATE \"C\"",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_uw_internal_feature_id": {
+					"name": "idx_uw_internal_feature_id",
+					"columns": [
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				},
+				"idx_usage_windows_customer_feature_scope": {
+					"name": "idx_usage_windows_customer_feature_scope",
+					"columns": [
+						{
+							"expression": "internal_customer_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "internal_feature_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "COALESCE(\"internal_entity_id\", '')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "COALESCE(\"filter_key\", '')",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"concurrently": true
+				}
+			},
+			"foreignKeys": {
+				"usage_windows_internal_customer_id_fkey": {
+					"name": "usage_windows_internal_customer_id_fkey",
+					"tableFrom": "usage_windows",
+					"columnsFrom": ["internal_customer_id"],
+					"tableTo": "customers",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"usage_windows_internal_entity_id_fkey": {
+					"name": "usage_windows_internal_entity_id_fkey",
+					"tableFrom": "usage_windows",
+					"columnsFrom": ["internal_entity_id"],
+					"tableTo": "entities",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"usage_windows_internal_feature_id_fkey": {
+					"name": "usage_windows_internal_feature_id_fkey",
+					"tableFrom": "usage_windows",
+					"columnsFrom": ["internal_feature_id"],
+					"tableTo": "features",
+					"columnsTo": ["internal_id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				},
+				"usage_windows_anchor_customer_entitlement_id_fkey": {
+					"name": "usage_windows_anchor_customer_entitlement_id_fkey",
+					"tableFrom": "usage_windows",
+					"columnsFrom": ["anchor_customer_entitlement_id"],
+					"tableTo": "customer_entitlements",
+					"columnsTo": ["id"],
+					"onUpdate": "cascade",
+					"onDelete": "set null"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		},
+		"public.user": {
+			"name": "user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"banned": {
+					"name": "banned",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_reason": {
+					"name": "ban_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ban_expires": {
+					"name": "ban_expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_active_at": {
+					"name": "last_active_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"idx_user_name_trgm": {
+					"name": "idx_user_name_trgm",
+					"columns": [
+						{
+							"expression": "\"name\" gin_trgm_ops",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"where": "\"user\".\"name\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_user_email_trgm": {
+					"name": "idx_user_email_trgm",
+					"columns": [
+						{
+							"expression": "\"email\" gin_trgm_ops",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "gin",
+					"where": "\"user\".\"email\" IS NOT NULL",
+					"concurrently": false
+				},
+				"idx_user_created_at_id": {
+					"name": "idx_user_created_at_id",
+					"columns": [
+						{
+							"expression": "\"created_at\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"id\" DESC",
+							"isExpression": true,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"user_created_by_fkey": {
+					"name": "user_created_by_fkey",
+					"tableFrom": "user",
+					"columnsFrom": ["created_by"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"nullsNotDistinct": false
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.vercel_resources": {
+			"name": "vercel_resources",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"org_id": {
+					"name": "org_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"env": {
+					"name": "env",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"installation_id": {
+					"name": "installation_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'{}'::jsonb"
+				}
+			},
+			"indexes": {
+				"vercel_resources_installation_name_unique_idx": {
+					"name": "vercel_resources_installation_name_unique_idx",
+					"columns": [
+						{
+							"expression": "org_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "env",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "installation_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"with": {},
+					"method": "btree",
+					"where": "status <> 'uninstalled'",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {
+				"vercel_resources_org_id_fkey": {
+					"name": "vercel_resources_org_id_fkey",
+					"tableFrom": "vercel_resources",
+					"columnsFrom": ["org_id"],
+					"tableTo": "organizations",
+					"columnsTo": ["id"],
+					"onUpdate": "no action",
+					"onDelete": "cascade"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.verification": {
+			"name": "verification",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"verification_identifier_idx": {
+					"name": "verification_identifier_idx",
+					"columns": [
+						{
+							"expression": "identifier",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"with": {},
+					"method": "btree",
+					"concurrently": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": true
+		}
+	},
+	"enums": {},
+	"schemas": {
+		"leaf": "leaf"
+	},
+	"views": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -1,426 +1,426 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1779096275848,
-			"tag": "0000_bumpy_tinkerer",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1779971507895,
-			"tag": "0001_concerned_ravenous",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1780329256103,
-			"tag": "0002_aromatic_johnny_blaze",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1780423680857,
-			"tag": "0003_short_gargoyle",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1780493543535,
-			"tag": "0004_lucky_electro",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1780582242747,
-			"tag": "0005_fresh_runaways",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1780584591419,
-			"tag": "0006_sad_madrox",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1780655063264,
-			"tag": "0007_cute_ikaris",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1780679328640,
-			"tag": "0008_premium_pet_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1780687569277,
-			"tag": "0009_perpetual_wonder_man",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1780990532501,
-			"tag": "0010_magenta_misty_knight",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1781085888296,
-			"tag": "0011_easy_spot",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1781125150955,
-			"tag": "0012_low_moonstone",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1781165345168,
-			"tag": "0013_third_darkhawk",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1781186995896,
-			"tag": "0014_repair_migrations_archived",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1781188376470,
-			"tag": "0015_reflective_mystique",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1781342244254,
-			"tag": "0016_cynical_morg",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1781689355978,
-			"tag": "0017_colossal_meltdown",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1781696431377,
-			"tag": "0018_modern_jocasta",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1781877264759,
-			"tag": "0019_slack_admin_threads",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1781880506096,
-			"tag": "0020_loud_carnage",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1781886743530,
-			"tag": "0021_wonderful_firedrake",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1781886743531,
-			"tag": "0022_wild_union_jack",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1782294963052,
-			"tag": "0023_flaky_cannonball",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1782294963053,
-			"tag": "0024_rewards_org_env_idx",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1782317599973,
-			"tag": "0025_condemned_madelyne_pryor",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1782328105039,
-			"tag": "0026_panoramic_blob",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1782397854425,
-			"tag": "0027_magical_gargoyle",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1782459162420,
-			"tag": "0028_supreme_karen_page",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1782460700487,
-			"tag": "0029_reflective_miracleman",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1782462848407,
-			"tag": "0030_windy_wolfsbane",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1782573840271,
-			"tag": "0031_absent_adam_destine",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1782760749233,
-			"tag": "0032_white_stone_men",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1782770925277,
-			"tag": "0033_dusty_crystal",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1782836417268,
-			"tag": "0034_ambiguous_wolfsbane",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1782844933101,
-			"tag": "0035_boring_maggott",
-			"breakpoints": true
-		},
-		{
-			"idx": 36,
-			"version": "7",
-			"when": 1782907607380,
-			"tag": "0036_remarkable_spirit",
-			"breakpoints": true
-		},
-		{
-			"idx": 37,
-			"version": "7",
-			"when": 1782981605443,
-			"tag": "0037_match_slack_auth_mode",
-			"breakpoints": true
-		},
-		{
-			"idx": 38,
-			"version": "7",
-			"when": 1783090737295,
-			"tag": "0038_exotic_scarlet_spider",
-			"breakpoints": true
-		},
-		{
-			"idx": 39,
-			"version": "7",
-			"when": 1783200161669,
-			"tag": "0039_unique_molecule_man",
-			"breakpoints": true
-		},
-		{
-			"idx": 40,
-			"version": "7",
-			"when": 1783416274113,
-			"tag": "0040_abnormal_stranger",
-			"breakpoints": true
-		},
-		{
-			"idx": 41,
-			"version": "7",
-			"when": 1783529369844,
-			"tag": "0041_sweet_klaw",
-			"breakpoints": true
-		},
-		{
-			"idx": 42,
-			"version": "7",
-			"when": 1783533774922,
-			"tag": "0042_shocking_sharon_carter",
-			"breakpoints": true
-		},
-		{
-			"idx": 43,
-			"version": "7",
-			"when": 1783954630481,
-			"tag": "0043_motionless_agent_brand",
-			"breakpoints": true
-		},
-		{
-			"idx": 44,
-			"version": "7",
-			"when": 1784112581877,
-			"tag": "0044_large_moonstone",
-			"breakpoints": true
-		},
-		{
-			"idx": 45,
-			"version": "7",
-			"when": 1784124820600,
-			"tag": "0045_omniscient_human_torch",
-			"breakpoints": true
-		},
-		{
-			"idx": 46,
-			"version": "7",
-			"when": 1784127872787,
-			"tag": "0046_swift_warbird",
-			"breakpoints": true
-		},
-		{
-			"idx": 47,
-			"version": "7",
-			"when": 1784903183283,
-			"tag": "0047_dry_the_enforcers",
-			"breakpoints": true
-		},
-		{
-			"idx": 48,
-			"version": "7",
-			"when": 1784909275551,
-			"tag": "0048_lucky_loa",
-			"breakpoints": true
-		},
-		{
-			"idx": 49,
-			"version": "7",
-			"when": 1784987089139,
-			"tag": "0049_round_speed",
-			"breakpoints": true
-		},
-		{
-			"idx": 50,
-			"version": "7",
-			"when": 1784991222817,
-			"tag": "0050_dazzling_blacklash",
-			"breakpoints": true
-		},
-		{
-			"idx": 51,
-			"version": "7",
-			"when": 1785158350408,
-			"tag": "0051_empty_justin_hammer",
-			"breakpoints": true
-		},
-		{
-			"idx": 52,
-			"version": "7",
-			"when": 1785177455125,
-			"tag": "0052_keen_giant_girl",
-			"breakpoints": true
-		},
-		{
-			"idx": 53,
-			"version": "7",
-			"when": 1785236772276,
-			"tag": "0053_true_giant_girl",
-			"breakpoints": true
-		},
-		{
-			"idx": 54,
-			"version": "7",
-			"when": 1785238643793,
-			"tag": "0054_aspiring_squadron_supreme",
-			"breakpoints": true
-		},
-		{
-			"idx": 55,
-			"version": "7",
-			"when": 1785259823613,
-			"tag": "0055_cuddly_firedrake",
-			"breakpoints": true
-		},
-		{
-			"idx": 56,
-			"version": "7",
-			"when": 1785268449447,
-			"tag": "0056_lean_maginty",
-			"breakpoints": true
-		},
-		{
-			"idx": 57,
-			"version": "7",
-			"when": 1785337088338,
-			"tag": "0057_demonic_lionheart",
-			"breakpoints": true
-		},
-		{
-			"idx": 58,
-			"version": "7",
-			"when": 1785704393674,
-			"tag": "0058_black_thundra",
-			"breakpoints": true
-		},
-		{
-			"idx": 59,
-			"version": "7",
-			"when": 1785836622432,
-			"tag": "0059_unstamp_pooled_reset_by_invoice",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1779096275848,
+      "tag": "0000_bumpy_tinkerer",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779971507895,
+      "tag": "0001_concerned_ravenous",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780329256103,
+      "tag": "0002_aromatic_johnny_blaze",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1780423680857,
+      "tag": "0003_short_gargoyle",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1780493543535,
+      "tag": "0004_lucky_electro",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780582242747,
+      "tag": "0005_fresh_runaways",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1780584591419,
+      "tag": "0006_sad_madrox",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1780655063264,
+      "tag": "0007_cute_ikaris",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1780679328640,
+      "tag": "0008_premium_pet_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1780687569277,
+      "tag": "0009_perpetual_wonder_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1780990532501,
+      "tag": "0010_magenta_misty_knight",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1781085888296,
+      "tag": "0011_easy_spot",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1781125150955,
+      "tag": "0012_low_moonstone",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1781165345168,
+      "tag": "0013_third_darkhawk",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1781186995896,
+      "tag": "0014_repair_migrations_archived",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1781188376470,
+      "tag": "0015_reflective_mystique",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1781342244254,
+      "tag": "0016_cynical_morg",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1781689355978,
+      "tag": "0017_colossal_meltdown",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1781696431377,
+      "tag": "0018_modern_jocasta",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1781877264759,
+      "tag": "0019_slack_admin_threads",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1781880506096,
+      "tag": "0020_loud_carnage",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1781886743530,
+      "tag": "0021_wonderful_firedrake",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1781886743531,
+      "tag": "0022_wild_union_jack",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1782294963052,
+      "tag": "0023_flaky_cannonball",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1782294963053,
+      "tag": "0024_rewards_org_env_idx",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1782317599973,
+      "tag": "0025_condemned_madelyne_pryor",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1782328105039,
+      "tag": "0026_panoramic_blob",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1782397854425,
+      "tag": "0027_magical_gargoyle",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1782459162420,
+      "tag": "0028_supreme_karen_page",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1782460700487,
+      "tag": "0029_reflective_miracleman",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1782462848407,
+      "tag": "0030_windy_wolfsbane",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1782573840271,
+      "tag": "0031_absent_adam_destine",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1782760749233,
+      "tag": "0032_white_stone_men",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1782770925277,
+      "tag": "0033_dusty_crystal",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1782836417268,
+      "tag": "0034_ambiguous_wolfsbane",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1782844933101,
+      "tag": "0035_boring_maggott",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1782907607380,
+      "tag": "0036_remarkable_spirit",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1782981605443,
+      "tag": "0037_match_slack_auth_mode",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1783090737295,
+      "tag": "0038_exotic_scarlet_spider",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1783200161669,
+      "tag": "0039_unique_molecule_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1783416274113,
+      "tag": "0040_abnormal_stranger",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1783529369844,
+      "tag": "0041_sweet_klaw",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1783533774922,
+      "tag": "0042_shocking_sharon_carter",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1783954630481,
+      "tag": "0043_motionless_agent_brand",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784112581877,
+      "tag": "0044_large_moonstone",
+      "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1784124820600,
+      "tag": "0045_omniscient_human_torch",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1784127872787,
+      "tag": "0046_swift_warbird",
+      "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1784903183283,
+      "tag": "0047_dry_the_enforcers",
+      "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1784909275551,
+      "tag": "0048_lucky_loa",
+      "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1784987089139,
+      "tag": "0049_round_speed",
+      "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1784991222817,
+      "tag": "0050_dazzling_blacklash",
+      "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1785158350408,
+      "tag": "0051_empty_justin_hammer",
+      "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1785177455125,
+      "tag": "0052_keen_giant_girl",
+      "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1785236772276,
+      "tag": "0053_true_giant_girl",
+      "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1785238643793,
+      "tag": "0054_aspiring_squadron_supreme",
+      "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1785259823613,
+      "tag": "0055_cuddly_firedrake",
+      "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1785268449447,
+      "tag": "0056_lean_maginty",
+      "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1785337088338,
+      "tag": "0057_demonic_lionheart",
+      "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1785704393674,
+      "tag": "0058_black_thundra",
+      "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1785786538657,
+      "tag": "0059_square_captain_cross",
+      "breakpoints": true
+    }
+  ]
 }

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -1,426 +1,426 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1779096275848,
-      "tag": "0000_bumpy_tinkerer",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1779971507895,
-      "tag": "0001_concerned_ravenous",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1780329256103,
-      "tag": "0002_aromatic_johnny_blaze",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1780423680857,
-      "tag": "0003_short_gargoyle",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1780493543535,
-      "tag": "0004_lucky_electro",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1780582242747,
-      "tag": "0005_fresh_runaways",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1780584591419,
-      "tag": "0006_sad_madrox",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1780655063264,
-      "tag": "0007_cute_ikaris",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1780679328640,
-      "tag": "0008_premium_pet_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1780687569277,
-      "tag": "0009_perpetual_wonder_man",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1780990532501,
-      "tag": "0010_magenta_misty_knight",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1781085888296,
-      "tag": "0011_easy_spot",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1781125150955,
-      "tag": "0012_low_moonstone",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1781165345168,
-      "tag": "0013_third_darkhawk",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1781186995896,
-      "tag": "0014_repair_migrations_archived",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1781188376470,
-      "tag": "0015_reflective_mystique",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1781342244254,
-      "tag": "0016_cynical_morg",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1781689355978,
-      "tag": "0017_colossal_meltdown",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1781696431377,
-      "tag": "0018_modern_jocasta",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1781877264759,
-      "tag": "0019_slack_admin_threads",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1781880506096,
-      "tag": "0020_loud_carnage",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1781886743530,
-      "tag": "0021_wonderful_firedrake",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1781886743531,
-      "tag": "0022_wild_union_jack",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1782294963052,
-      "tag": "0023_flaky_cannonball",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1782294963053,
-      "tag": "0024_rewards_org_env_idx",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1782317599973,
-      "tag": "0025_condemned_madelyne_pryor",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1782328105039,
-      "tag": "0026_panoramic_blob",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1782397854425,
-      "tag": "0027_magical_gargoyle",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1782459162420,
-      "tag": "0028_supreme_karen_page",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1782460700487,
-      "tag": "0029_reflective_miracleman",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1782462848407,
-      "tag": "0030_windy_wolfsbane",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1782573840271,
-      "tag": "0031_absent_adam_destine",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1782760749233,
-      "tag": "0032_white_stone_men",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1782770925277,
-      "tag": "0033_dusty_crystal",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1782836417268,
-      "tag": "0034_ambiguous_wolfsbane",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1782844933101,
-      "tag": "0035_boring_maggott",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1782907607380,
-      "tag": "0036_remarkable_spirit",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "7",
-      "when": 1782981605443,
-      "tag": "0037_match_slack_auth_mode",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "7",
-      "when": 1783090737295,
-      "tag": "0038_exotic_scarlet_spider",
-      "breakpoints": true
-    },
-    {
-      "idx": 39,
-      "version": "7",
-      "when": 1783200161669,
-      "tag": "0039_unique_molecule_man",
-      "breakpoints": true
-    },
-    {
-      "idx": 40,
-      "version": "7",
-      "when": 1783416274113,
-      "tag": "0040_abnormal_stranger",
-      "breakpoints": true
-    },
-    {
-      "idx": 41,
-      "version": "7",
-      "when": 1783529369844,
-      "tag": "0041_sweet_klaw",
-      "breakpoints": true
-    },
-    {
-      "idx": 42,
-      "version": "7",
-      "when": 1783533774922,
-      "tag": "0042_shocking_sharon_carter",
-      "breakpoints": true
-    },
-    {
-      "idx": 43,
-      "version": "7",
-      "when": 1783954630481,
-      "tag": "0043_motionless_agent_brand",
-      "breakpoints": true
-    },
-    {
-      "idx": 44,
-      "version": "7",
-      "when": 1784112581877,
-      "tag": "0044_large_moonstone",
-      "breakpoints": true
-    },
-    {
-      "idx": 45,
-      "version": "7",
-      "when": 1784124820600,
-      "tag": "0045_omniscient_human_torch",
-      "breakpoints": true
-    },
-    {
-      "idx": 46,
-      "version": "7",
-      "when": 1784127872787,
-      "tag": "0046_swift_warbird",
-      "breakpoints": true
-    },
-    {
-      "idx": 47,
-      "version": "7",
-      "when": 1784903183283,
-      "tag": "0047_dry_the_enforcers",
-      "breakpoints": true
-    },
-    {
-      "idx": 48,
-      "version": "7",
-      "when": 1784909275551,
-      "tag": "0048_lucky_loa",
-      "breakpoints": true
-    },
-    {
-      "idx": 49,
-      "version": "7",
-      "when": 1784987089139,
-      "tag": "0049_round_speed",
-      "breakpoints": true
-    },
-    {
-      "idx": 50,
-      "version": "7",
-      "when": 1784991222817,
-      "tag": "0050_dazzling_blacklash",
-      "breakpoints": true
-    },
-    {
-      "idx": 51,
-      "version": "7",
-      "when": 1785158350408,
-      "tag": "0051_empty_justin_hammer",
-      "breakpoints": true
-    },
-    {
-      "idx": 52,
-      "version": "7",
-      "when": 1785177455125,
-      "tag": "0052_keen_giant_girl",
-      "breakpoints": true
-    },
-    {
-      "idx": 53,
-      "version": "7",
-      "when": 1785236772276,
-      "tag": "0053_true_giant_girl",
-      "breakpoints": true
-    },
-    {
-      "idx": 54,
-      "version": "7",
-      "when": 1785238643793,
-      "tag": "0054_aspiring_squadron_supreme",
-      "breakpoints": true
-    },
-    {
-      "idx": 55,
-      "version": "7",
-      "when": 1785259823613,
-      "tag": "0055_cuddly_firedrake",
-      "breakpoints": true
-    },
-    {
-      "idx": 56,
-      "version": "7",
-      "when": 1785268449447,
-      "tag": "0056_lean_maginty",
-      "breakpoints": true
-    },
-    {
-      "idx": 57,
-      "version": "7",
-      "when": 1785337088338,
-      "tag": "0057_demonic_lionheart",
-      "breakpoints": true
-    },
-    {
-      "idx": 58,
-      "version": "7",
-      "when": 1785704393674,
-      "tag": "0058_black_thundra",
-      "breakpoints": true
-    },
-    {
-      "idx": 59,
-      "version": "7",
-      "when": 1785786538657,
-      "tag": "0059_square_captain_cross",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1779096275848,
+			"tag": "0000_bumpy_tinkerer",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1779971507895,
+			"tag": "0001_concerned_ravenous",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1780329256103,
+			"tag": "0002_aromatic_johnny_blaze",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1780423680857,
+			"tag": "0003_short_gargoyle",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1780493543535,
+			"tag": "0004_lucky_electro",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1780582242747,
+			"tag": "0005_fresh_runaways",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1780584591419,
+			"tag": "0006_sad_madrox",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1780655063264,
+			"tag": "0007_cute_ikaris",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1780679328640,
+			"tag": "0008_premium_pet_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1780687569277,
+			"tag": "0009_perpetual_wonder_man",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1780990532501,
+			"tag": "0010_magenta_misty_knight",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1781085888296,
+			"tag": "0011_easy_spot",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1781125150955,
+			"tag": "0012_low_moonstone",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1781165345168,
+			"tag": "0013_third_darkhawk",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1781186995896,
+			"tag": "0014_repair_migrations_archived",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1781188376470,
+			"tag": "0015_reflective_mystique",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1781342244254,
+			"tag": "0016_cynical_morg",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1781689355978,
+			"tag": "0017_colossal_meltdown",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1781696431377,
+			"tag": "0018_modern_jocasta",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1781877264759,
+			"tag": "0019_slack_admin_threads",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1781880506096,
+			"tag": "0020_loud_carnage",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1781886743530,
+			"tag": "0021_wonderful_firedrake",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1781886743531,
+			"tag": "0022_wild_union_jack",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1782294963052,
+			"tag": "0023_flaky_cannonball",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1782294963053,
+			"tag": "0024_rewards_org_env_idx",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1782317599973,
+			"tag": "0025_condemned_madelyne_pryor",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1782328105039,
+			"tag": "0026_panoramic_blob",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1782397854425,
+			"tag": "0027_magical_gargoyle",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1782459162420,
+			"tag": "0028_supreme_karen_page",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1782460700487,
+			"tag": "0029_reflective_miracleman",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1782462848407,
+			"tag": "0030_windy_wolfsbane",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1782573840271,
+			"tag": "0031_absent_adam_destine",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1782760749233,
+			"tag": "0032_white_stone_men",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1782770925277,
+			"tag": "0033_dusty_crystal",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1782836417268,
+			"tag": "0034_ambiguous_wolfsbane",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1782844933101,
+			"tag": "0035_boring_maggott",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1782907607380,
+			"tag": "0036_remarkable_spirit",
+			"breakpoints": true
+		},
+		{
+			"idx": 37,
+			"version": "7",
+			"when": 1782981605443,
+			"tag": "0037_match_slack_auth_mode",
+			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1783090737295,
+			"tag": "0038_exotic_scarlet_spider",
+			"breakpoints": true
+		},
+		{
+			"idx": 39,
+			"version": "7",
+			"when": 1783200161669,
+			"tag": "0039_unique_molecule_man",
+			"breakpoints": true
+		},
+		{
+			"idx": 40,
+			"version": "7",
+			"when": 1783416274113,
+			"tag": "0040_abnormal_stranger",
+			"breakpoints": true
+		},
+		{
+			"idx": 41,
+			"version": "7",
+			"when": 1783529369844,
+			"tag": "0041_sweet_klaw",
+			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "7",
+			"when": 1783533774922,
+			"tag": "0042_shocking_sharon_carter",
+			"breakpoints": true
+		},
+		{
+			"idx": 43,
+			"version": "7",
+			"when": 1783954630481,
+			"tag": "0043_motionless_agent_brand",
+			"breakpoints": true
+		},
+		{
+			"idx": 44,
+			"version": "7",
+			"when": 1784112581877,
+			"tag": "0044_large_moonstone",
+			"breakpoints": true
+		},
+		{
+			"idx": 45,
+			"version": "7",
+			"when": 1784124820600,
+			"tag": "0045_omniscient_human_torch",
+			"breakpoints": true
+		},
+		{
+			"idx": 46,
+			"version": "7",
+			"when": 1784127872787,
+			"tag": "0046_swift_warbird",
+			"breakpoints": true
+		},
+		{
+			"idx": 47,
+			"version": "7",
+			"when": 1784903183283,
+			"tag": "0047_dry_the_enforcers",
+			"breakpoints": true
+		},
+		{
+			"idx": 48,
+			"version": "7",
+			"when": 1784909275551,
+			"tag": "0048_lucky_loa",
+			"breakpoints": true
+		},
+		{
+			"idx": 49,
+			"version": "7",
+			"when": 1784987089139,
+			"tag": "0049_round_speed",
+			"breakpoints": true
+		},
+		{
+			"idx": 50,
+			"version": "7",
+			"when": 1784991222817,
+			"tag": "0050_dazzling_blacklash",
+			"breakpoints": true
+		},
+		{
+			"idx": 51,
+			"version": "7",
+			"when": 1785158350408,
+			"tag": "0051_empty_justin_hammer",
+			"breakpoints": true
+		},
+		{
+			"idx": 52,
+			"version": "7",
+			"when": 1785177455125,
+			"tag": "0052_keen_giant_girl",
+			"breakpoints": true
+		},
+		{
+			"idx": 53,
+			"version": "7",
+			"when": 1785236772276,
+			"tag": "0053_true_giant_girl",
+			"breakpoints": true
+		},
+		{
+			"idx": 54,
+			"version": "7",
+			"when": 1785238643793,
+			"tag": "0054_aspiring_squadron_supreme",
+			"breakpoints": true
+		},
+		{
+			"idx": 55,
+			"version": "7",
+			"when": 1785259823613,
+			"tag": "0055_cuddly_firedrake",
+			"breakpoints": true
+		},
+		{
+			"idx": 56,
+			"version": "7",
+			"when": 1785268449447,
+			"tag": "0056_lean_maginty",
+			"breakpoints": true
+		},
+		{
+			"idx": 57,
+			"version": "7",
+			"when": 1785337088338,
+			"tag": "0057_demonic_lionheart",
+			"breakpoints": true
+		},
+		{
+			"idx": 58,
+			"version": "7",
+			"when": 1785704393674,
+			"tag": "0058_black_thundra",
+			"breakpoints": true
+		},
+		{
+			"idx": 59,
+			"version": "7",
+			"when": 1785836622432,
+			"tag": "0059_unstamp_pooled_reset_by_invoice",
+			"breakpoints": true
+		}
+	]
 }


### PR DESCRIPTION
## Summary

**1. Pooled balances reset via the lazy path / crons regardless of `reset_mode`.**
Subscription-mode pools were only reset by their sub's `invoice.created`, so a pool whose reset interval is shorter than the sub's invoice cadence (monthly pool on an annual sub, or a sub with no matching-interval item) never reset. Now the lazy read path, the V1 cron loader, and batch-reset-v2 all handle every non-lifetime pool; `invoice.created` stays as a redundant boundary-aligned fast path (the PL/pgSQL reset CAS makes dual triggers safe). Synthetic pool cusEnts are no longer stamped `reset_by_invoice`; existing stamped rows need a one-off manual backfill (`UPDATE customer_entitlements SET reset_by_invoice = false WHERE is_pooled_balance = true AND reset_by_invoice IS TRUE`) so the batch scan sees them.

**2. Prepaid pooled next-cycle contribution promotion.**
A deferred quantity downgrade (`OnDecrease.NoProrations`) on a pooled prepaid contributor now records `next_cycle_contribution` + `effective_at` (billing period end) on its contribution row via the UpdateQuantity plan. At reset time (any trigger), `promoteDuePooledContributions` runs one CTE that promotes due contributions and recomputes `pooled_balances.granted` from all contributions — drift self-heals on every pool reset, and concurrent resetters get the authoritative granted instead of a stale in-memory copy. Contribution-less pools are left untouched, and the pool write carries a row-version guard (updated_at latest vs statement snapshot) gating the whole statement — a transition committing mid-promotion makes it a no-op instead of stomping the transition's granted (race test: `pooled-promotion-transition-guard.test.ts`). Benchmarked at ~18ms per promotion with 100k contributions, ~100ms at 1M (`server/experiments/benchPooledPromotion.ts`).

**Cache handling:** the lazy path patches granted directly into the cached subject via a new `pooled_granted` field in the `updateSubjectBalances` Lua (no invalidation mid-flow); the webhook path invalidates (condition widened to cover promoted-but-CAS-skipped resets); V1 cron and batch already delete balance-hash fields and rehydrate.

## Tests

- New: `pooled-balance-subscription-lazy-reset.test.ts` (annual-sub monthly pool resets on read + via cron loader), `pooled-prepaid-next-cycle-contribution.test.ts` (deferred downgrade → staggered promotion → drift healing → cache-hit persistence of patched granted).
- Updated: batch-reset-v2 pooled (subscription pool resets like lazy, + lifetime no-action verdict), reset-flow (webhook test on natural timing), `expectPooledBalanceCorrect`, unit filter test.
- Full pooled suite pass: 41 files, all green after the contribution-less-pool guard.

## Notes

- Run the reset_by_invoice un-stamp backfill manually (no migration file by design).
- Known pre-existing gaps (not addressed here): immediate/prorated quantity changes on pooled prepaid don't update contributions; `processPrepaidPricesForInvoiceCreated` has no pooled awareness at renewal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables lazy and cron resets for all non‑lifetime pooled balances and adds next‑cycle contribution promotion for pooled prepaid downgrades, with a concurrency guard and in‑memory refresh to avoid stale grants. `invoice.created` remains a redundant, CAS‑safe fast path; lifetime pools are unchanged.

- **New Features**
  - Lazy read path, V1 cron, and batch reset now handle every non‑lifetime pool; subscription pools reset off cadence as needed.
  - Prepaid pooled downgrades with `OnDecrease.NoProrations` record `next_cycle_contribution` + `effective_at`; any reset promotes due rows and recomputes `pooled_balances.granted` from all contributions (drift self‑heals). Promotion is row‑version guarded; on a guard trip, it no‑ops and refreshes the in‑memory `granted` so refill uses the latest value.
  - Synthetic pool entitlements are never stamped `reset_by_invoice`, so batch scans include them; the lazy path patches `pooled_granted` via Lua, and cron/batch/webhook invalidate when promotion or reset occurs (including promote‑only cases).

- **Migration**
  - No DB migration; run the previous `reset_by_invoice` un‑stamp backfill manually.

<sup>Written for commit 0348f111d06ccdb65f258215ee9afbb150ba3262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands pooled-balance resets to lazy and cron paths and promotes deferred contribution changes at reset boundaries.
- **[Bug fixes, Improvements]** Resets all non-lifetime pools independently of invoice cadence.
- **[Improvements]** Promotes due next-cycle contributions, recomputes authoritative grants, and adds cache propagation for lazy resets.
- **[Bug fixes]** Adds a pool-row version guard to avoid overwriting a transition that commits during promotion.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a skipped lazy reset can leave Redis stale and a transition can still change the pool grant between promotion and the entitlement reset.

Contribution promotion and entitlement reset remain separate operations: an all-skipped entitlement CAS bypasses cache propagation, and the pool-row version guard does not cover a transition that commits after promotion returns but before the entitlement balance is written.

**Files Needing Attention:** server/src/internal/customers/actions/resetCustomerEntitlements/processReset.ts; server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts; server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/pooledBalances/execute/promoteDuePooledContributions.ts | Adds guarded contribution promotion and grant recomputation, but its row-version protection ends before the separate entitlement reset. |
| server/src/internal/customers/actions/resetCustomerEntitlements/processReset.ts | Promotes pooled contributions before computing reset values; the later reset remains able to use a grant superseded by a concurrent transition. |
| server/src/internal/customers/actions/resetCustomerEntitlementsV2/lazyResetSubjectEntitlements.ts | Adds pooled-grant cache patching for applied resets, while all-skipped concurrent resets still bypass cache propagation. |
| server/src/internal/customers/actions/resetCustomerEntitlementsV2/resetSubjectCache.ts | Extends the Redis balance update payload with the authoritative pooled grant when the caller invokes the cache patch. |
| server/src/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPooledContributionUpdate.ts | Computes deferred pooled contribution values and their next-cycle effective time for quantity downgrades. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Read as Lazy read / reset trigger
    participant Promote as Contribution promotion
    participant Pool as pooled_balances
    participant Reset as Entitlement reset CAS
    participant Cache as Redis
    Read->>Promote: Promote due contributions
    Promote->>Pool: Guarded recompute of granted
    Pool-->>Promote: Authoritative grant
    Promote-->>Read: Mutate in-memory pooled grant
    Read->>Reset: Reset entitlement using grant
    alt Reset applied
        Reset-->>Read: applied
        Read->>Cache: Patch reset fields and pooled grant
    else Concurrent reset won
        Reset-->>Read: skipped
        Note over Read,Cache: Current code performs no cache propagation
    end
    Note over Pool,Reset: A transition may update the pool between these separate operations
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(billing): 🐛 refresh in-memory grant..."](https://github.com/useautumn/autumn/commit/0348f111d06ccdb65f258215ee9afbb150ba3262) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50035793)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Pooled Balances](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/pooled-balances.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
</details>

<!-- /greptile_comment -->