### PR TITLE
feat: blanket 3s fail-open on check + admin toggle for redisFallbackToDb

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: stack/check-fail-open main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect
 
 jobs:
   checks:

--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -111,6 +111,28 @@ type VersionedHandlerMap<
  * });
  * ```
  */
+/** Race `run` against a blanket fail-open timer. When the timer wins, the
+ *  losing execution keeps running detached — locks release when it settles. */
+export const raceFailOpen = async ({
+	run,
+	timeoutMs,
+	respond,
+}: {
+	run: () => Promise<Response>;
+	timeoutMs: number;
+	respond: () => Response | Promise<Response>;
+}): Promise<Response> => {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const failOpen = new Promise<Response>((resolve) => {
+		timer = setTimeout(() => resolve(Promise.resolve(respond())), timeoutMs);
+	});
+	try {
+		return await Promise.race([run(), failOpen]);
+	} finally {
+		clearTimeout(timer);
+	}
+};
+
 export function createRoute<
 	Body extends ZodType | undefined = undefined,
 	Query extends ZodType | undefined = undefined,
@@ -160,6 +182,14 @@ export function createRoute<
 	/** Coarse route grouping (per-group org config, e.g. idempotency TTLs).
 	 *  Resolvable from middleware via getRouteGroup(c). */
 	routeGroup?: RouteGroup;
+	/** Blanket fail-open: if the handler exceeds timeoutMs, respond() is sent
+	 *  and the in-flight execution is abandoned (locks TTL out). */
+	failOpen?: {
+		timeoutMs: number;
+		respond: (
+			c: ValidatedContext<HonoEnv, Body, Query, Params>,
+		) => Response | Promise<Response>;
+	};
 }): [H, ...H[]] {
 	const middlewares: H[] = [];
 
@@ -289,6 +319,18 @@ export function createRoute<
 	};
 
 	const wrappedHandler = async (
+		c: ValidatedContext<HonoEnv, Body, Query, Params>,
+	) => {
+		const { failOpen } = opts;
+		if (!failOpen) return executeRoute(c);
+		return raceFailOpen({
+			run: () => executeRoute(c),
+			timeoutMs: failOpen.timeoutMs,
+			respond: () => failOpen.respond(c),
+		});
+	};
+
+	const executeRoute = async (
 		c: ValidatedContext<HonoEnv, Body, Query, Params>,
 	) => {
 		c.set("validated", true);

--- a/server/src/internal/api/check/handleCheck.ts
+++ b/server/src/internal/api/check/handleCheck.ts
@@ -12,12 +12,36 @@ import {
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { runCheckWithRollout } from "@/internal/balances/check/index.js";
 import { parseCheckParamsForLock } from "@/internal/balances/utils/lock/parseCheckParamsForLock.js";
+import { getCheckFailOpenFallback } from "./checkUtils/getCheckFailOpenFallback.js";
 import { getCheckPreview } from "./getCheckPreview.js";
 import { handleProductCheck } from "./handlers/handleProductCheck.js";
 
 const DEFAULT_REQUIRED_BALANCE = 1;
+// check is the hottest-path route: past this budget we answer allowed rather
+// than make the caller wait, no matter what work (locks included) is in flight.
+const CHECK_FAIL_OPEN_TIMEOUT_MS = 3_000;
+
 export const handleCheck = createRoute({
 	scopes: [Scopes.Balances.Read],
+	failOpen: {
+		timeoutMs: CHECK_FAIL_OPEN_TIMEOUT_MS,
+		respond: (c) => {
+			const ctx = c.get("ctx");
+			const body = parseCheckParamsForLock({ params: c.req.valid("json") });
+			const response = getCheckFailOpenFallback({
+				ctx,
+				body,
+				requiredBalance:
+					body.required_balance ??
+					body.required_quantity ??
+					DEFAULT_REQUIRED_BALANCE,
+				error: new Error(
+					`check exceeded the ${CHECK_FAIL_OPEN_TIMEOUT_MS}ms blanket fail-open timeout`,
+				),
+			});
+			return c.json(response, 202);
+		},
+	},
 	routeGroup: RouteGroup.Balances,
 	versionedQuery: {
 		latest: CheckQuerySchema,

--- a/server/tests/unit/middleware/raceFailOpen.test.ts
+++ b/server/tests/unit/middleware/raceFailOpen.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { raceFailOpen } from "@/honoMiddlewares/routeHandler.js";
+
+const response = (label: string) => new Response(label);
+
+describe("raceFailOpen", () => {
+	it("returns the handler response when it beats the timer", async () => {
+		const result = await raceFailOpen({
+			run: async () => response("handler"),
+			timeoutMs: 1_000,
+			respond: () => response("fail-open"),
+		});
+
+		expect(await result.text()).toBe("handler");
+	});
+
+	it("returns the fail-open response when the handler is too slow", async () => {
+		const result = await raceFailOpen({
+			run: async () => {
+				await Bun.sleep(200);
+				return response("handler");
+			},
+			timeoutMs: 20,
+			respond: () => response("fail-open"),
+		});
+
+		expect(await result.text()).toBe("fail-open");
+	});
+
+	it("a slow handler that later rejects does not crash the process", async () => {
+		let settled = false;
+		const result = await raceFailOpen({
+			run: async () => {
+				await Bun.sleep(50);
+				settled = true;
+				throw new Error("late failure after fail-open already responded");
+			},
+			timeoutMs: 10,
+			respond: () => response("fail-open"),
+		});
+
+		expect(await result.text()).toBe("fail-open");
+		// Let the abandoned run settle; an unhandled rejection would fail the suite.
+		await Bun.sleep(80);
+		expect(settled).toBe(true);
+	});
+
+	it("a fast rejection propagates instead of failing open", async () => {
+		await expect(
+			raceFailOpen({
+				run: async () => {
+					throw new Error("real error");
+				},
+				timeoutMs: 1_000,
+				respond: () => response("fail-open"),
+			}),
+		).rejects.toThrow("real error");
+	});
+});

--- a/vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx
+++ b/vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx
@@ -69,6 +69,7 @@ export const MiscellaneousEdgeConfigForm = ({
 					parsed.subjectLookupDbOnly ?? prev.subjectLookupDbOnly,
 				idempotencyDynamoRead:
 					parsed.idempotencyDynamoRead ?? prev.idempotencyDynamoRead,
+				redisFallbackToDb: parsed.redisFallbackToDb ?? prev.redisFallbackToDb,
 			}));
 			setJsonError(null);
 		} catch {
@@ -203,6 +204,17 @@ export const MiscellaneousEdgeConfigForm = ({
 							onCheckedChange={(subjectLookupDbOnly) => {
 								setSyncSource("form");
 								setConfig((prev) => ({ ...prev, subjectLookupDbOnly }));
+							}}
+						/>
+
+						<MiscellaneousEdgeConfigSwitch
+							title="Redis outage: fall back to Postgres"
+							hint="When Redis is unavailable, subject reads are served from Postgres (admission gate + replicas) instead of returning 503s. Arm only after the primary and replica bouncer pools are sized for outage load."
+							ariaLabel="Enable Redis-outage fallback to Postgres"
+							checked={config.redisFallbackToDb}
+							onCheckedChange={(redisFallbackToDb) => {
+								setSyncSource("form");
+								setConfig((prev) => ({ ...prev, redisFallbackToDb }));
 							}}
 						/>
 

--- a/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts
+++ b/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts
@@ -3,6 +3,7 @@ export type MiscellaneousEdgeConfig = {
 	syncCoalesce: boolean;
 	subjectLookupDbOnly: boolean;
 	idempotencyDynamoRead: boolean;
+	redisFallbackToDb: boolean;
 	configHealthy: boolean;
 	configConfigured: boolean;
 	lastSuccessAt: string | null;
@@ -14,6 +15,7 @@ export const MISCELLANEOUS_DEFAULT_CONFIG: MiscellaneousEdgeConfig = {
 	syncCoalesce: false,
 	subjectLookupDbOnly: false,
 	idempotencyDynamoRead: false,
+	redisFallbackToDb: false,
 	configHealthy: false,
 	configConfigured: false,
 	lastSuccessAt: null,


### PR DESCRIPTION
createRoute gains a generic failOpen option: race the handler against a
timer, respond with the route-supplied fail-open body, abandon the losing
execution (locks TTL out). Only check opts in, reusing its versioned
fail-open fallback at 202. The admin edge-config UI gains the
redisFallbackToDb switch with an arming warning.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a generic fail-open to `createRoute` and enable a 3s fail-open for the Check API that responds with 202 instead of waiting. Also adds an admin Edge Config toggle `redisFallbackToDb` to serve reads from Postgres during Redis outages; includes a temporary staging deploy allowlist entry for validation.

- **New Features**
  - Added `raceFailOpen` and a `failOpen` option to `createRoute`; races the handler against a timeout and returns immediately while slow work finishes detached. Unit tests cover fast/slow paths and error propagation.
  - Enabled a 3s fail-open for `handleCheck` using `getCheckFailOpenFallback`; returns a versioned 202 fallback when the timer wins.
  - Added an admin UI switch for `redisFallbackToDb` with an arming warning; default is false and wired through the form and types.

<sup>Written for commit e45828368c5614551e6e259309bef223293ae61d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a generic route timeout fallback, enables it for check requests after three seconds, and exposes the Redis-to-Postgres fallback setting in the admin UI.
- **[API changes, Improvements]** Race check handlers against a three-second timer and return an allowed 202 fallback when the timer wins.
- **[Improvements]** Add an admin switch for serving subject reads from Postgres during Redis outages.
- **[Improvements]** Add unit coverage for the generic timeout race and detached handler failures.
- **[Improvements]** Allow the feature branch to deploy to staging.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because timed-out legacy check requests can still receive a response in the wrong API version.

When a request names a feature absent from the organization catalog, the timeout fallback returns its raw V3 body, while older clients expect their version-specific shape; this leaves the previously reported parsing and incorrect-field behavior unresolved.

**Files Needing Attention:** server/src/internal/api/check/handleCheck.ts; server/src/internal/api/check/checkUtils/buildCheckFallbackResponse.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/routeHandler.ts | Adds the generic timer race used to return a route-specific fallback while the original handler continues. |
| server/src/internal/api/check/handleCheck.ts | Enables the three-second check fallback, but the previously reported legacy response-version defect remains. |
| server/tests/unit/middleware/raceFailOpen.test.ts | Covers fast and slow completion as well as handler rejection behavior for the generic race helper. |
| vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx | Adds the Redis-outage Postgres fallback switch and operational warning. |
| vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts | Adds the new edge-config field and its disabled default. |
| .github/workflows/build.yml | Adds the feature branch to the staging deployment allowlist. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Route as createRoute
  participant Check as Check handler
  participant Timer as 3s timer
  Client->>Route: Check request
  Route->>Check: Start handler
  Route->>Timer: Start timeout
  alt Handler finishes first
    Check-->>Route: Versioned check response
    Route-->>Client: Handler response
  else Timer finishes first
    Timer-->>Route: Fail-open fallback
    Route-->>Client: 202 allowed response
    Note over Check: Handler continues detached
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: temporary staging-deploy allowlis..."](https://github.com/useautumn/autumn/commit/4529cd6067ad6422d9d4b0f0db4bd546bd316555) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50073025)</sub>

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)

<!-- /greptile_comment -->