### PR TITLE
Use fetch transport for edge-config S3 polling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect fix/edge-config-fetch-handler
 
 jobs:
   checks:

--- a/bun.lock
+++ b/bun.lock
@@ -615,6 +615,7 @@
         "@react-email/components": "0.0.42",
         "@sentry/bun": "catalog:",
         "@slack/web-api": "^7.8.0",
+        "@smithy/fetch-http-handler": "^5.6.10",
         "@supabase/supabase-js": "^2.46.2",
         "@tinybirdco/sdk": "^0.0.69",
         "@trigger.dev/build": "4.4.6",

--- a/server/package.json
+++ b/server/package.json
@@ -91,6 +91,7 @@
 		"@react-email/components": "0.0.42",
 		"@sentry/bun": "catalog:",
 		"@slack/web-api": "^7.8.0",
+		"@smithy/fetch-http-handler": "^5.6.10",
 		"@supabase/supabase-js": "^2.46.2",
 		"@tinybirdco/sdk": "^0.0.69",
 		"@trigger.dev/build": "4.4.6",

--- a/server/src/external/aws/s3/initS3.ts
+++ b/server/src/external/aws/s3/initS3.ts
@@ -1,4 +1,5 @@
 import { S3Client } from "@aws-sdk/client-s3";
+import { FetchHttpHandler } from "@smithy/fetch-http-handler";
 import { DEFAULT_AWS_REGION } from "@/external/aws/awsRegionUtils.js";
 
 type S3Credentials = {
@@ -17,15 +18,18 @@ export const getS3Client = ({
 	region = DEFAULT_AWS_REGION,
 	credentials,
 	requestChecksumCalculation,
+	httpTransport = "node",
 }: {
 	region?: string;
 	credentials?: S3Credentials;
 	requestChecksumCalculation?: "WHEN_SUPPORTED" | "WHEN_REQUIRED";
+	httpTransport?: "node" | "fetch";
 }) => {
 	const cacheKey = [
 		region,
 		credentials?.accessKeyId ?? "",
 		requestChecksumCalculation ?? "",
+		httpTransport,
 	].join(":");
 
 	const existingClient = s3ClientsByCacheKey.get(cacheKey);
@@ -35,6 +39,9 @@ export const getS3Client = ({
 		region,
 		...(credentials ? { credentials } : {}),
 		...(requestChecksumCalculation ? { requestChecksumCalculation } : {}),
+		...(httpTransport === "fetch"
+			? { requestHandler: new FetchHttpHandler() }
+			: {}),
 	});
 	s3ClientsByCacheKey.set(cacheKey, s3Client);
 	return s3Client;

--- a/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
@@ -111,7 +111,8 @@ export const createEdgeConfigStore = <T>({
 	const resolveClient = () => {
 		if (injectedS3Client) return injectedS3Client;
 		const { region } = getConfigLocation();
-		return getS3Client({ region });
+		// Keep continuous poll traffic off Bun's node:http compatibility layer.
+		return getS3Client({ region, httpTransport: "fetch" });
 	};
 
 	const readFromSource = async (): Promise<T> => {

--- a/server/tests/unit/external/aws/s3/init-s3.test.ts
+++ b/server/tests/unit/external/aws/s3/init-s3.test.ts
@@ -1,0 +1,50 @@
+/** Fetch-backed S3 clients must bypass node:http and retain separate cache identity. */
+
+import { describe, expect, jest, test } from "bun:test";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { FetchHttpHandler } from "@smithy/fetch-http-handler";
+import { getS3Client } from "@/external/aws/s3/initS3.js";
+
+describe("getS3Client", () => {
+	test("creates and caches a fetch-backed client independently", () => {
+		const region = "eu-west-3";
+		const defaultClient = getS3Client({ region });
+		const fetchClient = getS3Client({ region, httpTransport: "fetch" });
+		const cachedFetchClient = getS3Client({ region, httpTransport: "fetch" });
+
+		expect(fetchClient.config.requestHandler).toBeInstanceOf(FetchHttpHandler);
+		expect(fetchClient).toBe(cachedFetchClient);
+		expect(fetchClient).not.toBe(defaultClient);
+	});
+
+	test("sends signed S3 commands through the fetch transport", async () => {
+		const originalFetch = globalThis.fetch;
+		const fetchMock = jest.fn(
+			async () =>
+				new Response('{"enabled":true}', {
+					headers: { "content-type": "application/json" },
+				}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		try {
+			const client = getS3Client({
+				region: "eu-central-2",
+				credentials: {
+					accessKeyId: "test-access-key",
+					secretAccessKey: "test-secret-key",
+				},
+				httpTransport: "fetch",
+			});
+
+			const response = await client.send(
+				new GetObjectCommand({ Bucket: "test-bucket", Key: "config.json" }),
+			);
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			expect(await response.Body?.transformToString()).toBe('{"enabled":true}');
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+});


### PR DESCRIPTION
## What changed

- add an opt-in `fetch` transport to the cached S3 client factory
- route only edge-config S3 reads and writes through `FetchHttpHandler`; other S3 clients keep the existing Node transport
- keep the transport in the client cache key so fetch-backed and default clients never collide
- add regression coverage for cache isolation and a signed `GetObjectCommand` flowing through `fetch`
- add `fix/edge-config-fetch-handler` to `STAGING_DEPLOY_BRANCH_ALLOWLIST`

## Why

The Autumn server's edge-config stores continuously poll S3. The AWS SDK currently uses `NodeHttpHandler`, and the idle-memory investigation showed request-driven native RSS retention associated with this path. This PR changes only the HTTP transport so staging can test that hypothesis without migrating config storage or changing polling cadence, credentials, retries, keys, parsing, defaults, or write behavior.

This is an experiment: it does not yet claim the production leak is fixed. The intended next step is a matched staging before/after idle soak and RSS comparison.

## Validation

- regression test failed before the implementation because the requested client still used `NodeHttpHandler`
- `CI=1 bun test tests/unit/external/aws/s3/init-s3.test.ts tests/unit/edge-config/edge-config-store.test.ts` — 17 passed
- `cd server && bun ts` — passed
- focused Biome check — passed
- `bun install --frozen-lockfile` — passed
- workflow YAML parse and `git diff --check` — passed

## Staging

The branch is allowlisted for a manual `workflow_dispatch` run with `tag=deploy-staging`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route edge-config S3 polling through a `fetch` transport to bypass Node’s HTTP layer and validate idle RSS in staging. Only edge-config paths use `FetchHttpHandler`; all other S3 clients are unchanged.

- **New Features**
  - Added opt-in `fetch` transport to the S3 client factory and enabled it for edge-config reads/writes.
  - Included transport in the client cache key to isolate fetch-backed and default clients.
  - Added tests for cache isolation and a signed `GetObjectCommand` flowing through `fetch`.
  - Allowlisted `fix/edge-config-fetch-handler` for manual staging deploys.

- **Dependencies**
  - Added `@smithy/fetch-http-handler` (^5.6.10).

<sup>Written for commit c13b123d29f6c74950384cbfebf9e6e3ecaad59d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR opts edge-config S3 traffic into Smithy's fetch transport while preserving the existing Node transport for all other S3 consumers.

- **[Improvements]** Adds a transport option to the cached S3 client factory and includes it in cache identity.
- **[Improvements]** Routes edge-config reads and writes through `FetchHttpHandler` for the staging memory experiment.
- **[Improvements]** Adds fetch-path and cache-isolation regression coverage, though the signed write path remains uncovered.
- **[Improvements]** Allowlists the experiment branch for manual staging deployment.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking caveat that its regression coverage does not exercise fetch-backed edge-config writes.

Transport selection and cache isolation are implemented consistently, and the signed read path is tested; adding a PutObject regression would protect the distinct request-body path used by configuration updates.

**Files Needing Attention:** server/tests/unit/external/aws/s3/init-s3.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/aws/s3/initS3.ts | Adds an opt-in FetchHttpHandler and correctly isolates fetch-backed clients through the transport-aware cache key. |
| server/src/internal/misc/edgeConfig/edgeConfigStore.ts | Routes both edge-config polling reads and configuration writes through the fetch-backed S3 client. |
| server/tests/unit/external/aws/s3/init-s3.test.ts | Verifies cache isolation and signed fetch-backed reads, but does not exercise the newly routed PutObject write body. |
| server/package.json | Adds the Smithy fetch handler as a direct runtime dependency. |
| .github/workflows/build.yml | Adds the experiment branch to the existing manual staging-deployment allowlist. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Edge[Edge-config store] -->|httpTransport: fetch| Factory[getS3Client cache]
  Other[Other S3 consumers] -->|default: node| Factory
  Factory -->|fetch cache key| Fetch[FetchHttpHandler]
  Factory -->|node cache key| Node[Default Node handler]
  Fetch --> S3[(Amazon S3)]
  Node --> S3
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/tests/unit/external/aws/s3/init-s3.test.ts:40-42
**Fetch-backed writes remain untested**

The new transport is used for both edge-config reads and writes, but this regression test exercises only `GetObjectCommand`. Adding a signed `PutObjectCommand` case with a JSON body would cover the distinct request-body path and prevent fetch-backed configuration updates from breaking unnoticed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(edge-config): use fetch transport fo..."](https://github.com/useautumn/autumn/commit/c13b123d29f6c74950384cbfebf9e6e3ecaad59d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50094662)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->