### PR TITLE
Add redundant Redis application connections

### DIFF
--- a/server/src/external/redis/initRedis.ts
+++ b/server/src/external/redis/initRedis.ts
@@ -4,6 +4,7 @@ export {
 	createDisabledRedis,
 	createRedisClient,
 	createRedisConnection,
+	createRedisConnectionPair,
 } from "./initUtils/createRedisClient.js";
 export {
 	getRedisAvailability,

--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -4,6 +4,7 @@ import type { RedisV2InstanceName } from "@/internal/misc/redisV2Cache/redisV2Ca
 import { getReachableDragonflyUrl } from "./getReachableDragonflyUrl.js";
 import {
 	createRedisConnection,
+	createRedisConnectionPair,
 	currentRegion,
 	waitForRedisReady,
 } from "./initRedis.js";
@@ -19,7 +20,7 @@ const dragonflyUrl = rawDragonflyUrl
 
 export const hasRedisV2Config = Boolean(dragonflyUrl);
 
-export const redisV2: Redis = createRedisConnection({
+export const redisV2: Redis = createRedisConnectionPair({
 	cacheUrl: dragonflyUrl || "",
 	region: `${currentRegion}:v2`,
 	supportsUpstashShebang: false,

--- a/server/src/external/redis/initUtils/createRedisClient.ts
+++ b/server/src/external/redis/initUtils/createRedisClient.ts
@@ -1,5 +1,6 @@
 import { Redis } from "ioredis";
 import { instrumentRedis } from "../otel/instrumentRedis.js";
+import { createRedisClientPair } from "./redisClientPair.js";
 import { redisDnsLookup } from "./redisDnsLookup.js";
 import { registerRedisCommands } from "./registerRedisCommands.js";
 
@@ -65,6 +66,18 @@ export const createRedisClient = ({
 };
 
 export const createRedisConnection = createRedisClient;
+
+export const createRedisConnectionPair = (
+	options: Parameters<typeof createRedisClient>[0],
+): Redis =>
+	createRedisClientPair({
+		createClient: ({ role }) =>
+			createRedisClient({
+				...options,
+				region:
+					role === "primary" ? options.region : `${options.region}:standby`,
+			}),
+	});
 
 export const createDisabledRedis = (): Redis =>
 	new Proxy(

--- a/server/src/external/redis/initUtils/redisClientPair.ts
+++ b/server/src/external/redis/initUtils/redisClientPair.ts
@@ -1,0 +1,125 @@
+import type { Redis } from "ioredis";
+
+export type RedisClientRole = "primary" | "standby";
+
+type RedisClientPair = {
+	primary: Redis;
+	standby: Redis;
+};
+
+const pairByRouter = new WeakMap<Redis, RedisClientPair>();
+
+const getReadyClientFromPair = ({
+	pair,
+	exclude,
+}: {
+	pair: RedisClientPair;
+	exclude?: Redis;
+}): Redis | null => {
+	if (pair.primary !== exclude && pair.primary.status === "ready") {
+		return pair.primary;
+	}
+	if (pair.standby !== exclude && pair.standby.status === "ready") {
+		return pair.standby;
+	}
+	return null;
+};
+
+export const getReadyRedisClient = ({
+	redisInstance,
+	exclude,
+}: {
+	redisInstance: Redis;
+	exclude?: Redis;
+}): Redis | null => {
+	const pair = pairByRouter.get(redisInstance);
+	if (pair) return getReadyClientFromPair({ pair, exclude });
+	if (redisInstance === exclude || redisInstance.status !== "ready")
+		return null;
+	return redisInstance;
+};
+
+const getRouterStatus = ({ primary, standby }: RedisClientPair): string => {
+	if (primary.status === "ready" || standby.status === "ready") return "ready";
+	if (primary.status !== "end") return primary.status;
+	return standby.status;
+};
+
+const eventMethods = new Set([
+	"on",
+	"once",
+	"off",
+	"removeListener",
+	"removeAllListeners",
+]);
+
+export const createRedisClientPairRouter = ({
+	primary,
+	standby,
+}: RedisClientPair): Redis => {
+	let router: Redis;
+	const pair = { primary, standby };
+
+	router = new Proxy({} as Redis, {
+		get(_target, property) {
+			if (property === "status") return getRouterStatus(pair);
+			if (property === "disconnect") {
+				return (...args: unknown[]) => {
+					Reflect.apply(primary.disconnect, primary, args);
+					Reflect.apply(standby.disconnect, standby, args);
+				};
+			}
+			if (property === "connect") {
+				return (...args: unknown[]) =>
+					Promise.all([
+						Reflect.apply(primary.connect, primary, args),
+						Reflect.apply(standby.connect, standby, args),
+					]).then(() => undefined);
+			}
+			if (property === "quit") {
+				return (...args: unknown[]) =>
+					Promise.all([
+						Reflect.apply(primary.quit, primary, args),
+						Reflect.apply(standby.quit, standby, args),
+					]).then(([result]) => result);
+			}
+			if (property === "duplicate") {
+				return (...args: unknown[]) => {
+					const activeRedis = getReadyClientFromPair({ pair }) ?? pair.primary;
+					return Reflect.apply(activeRedis.duplicate, activeRedis, args);
+				};
+			}
+			if (typeof property === "string" && eventMethods.has(property)) {
+				return (...args: unknown[]) => {
+					const primaryMethod = Reflect.get(primary, property, primary);
+					const standbyMethod = Reflect.get(standby, property, standby);
+					Reflect.apply(primaryMethod, primary, args);
+					Reflect.apply(standbyMethod, standby, args);
+					return router;
+				};
+			}
+
+			const activeRedis = getReadyClientFromPair({ pair }) ?? pair.primary;
+			const value = Reflect.get(activeRedis, property, activeRedis);
+			return typeof value === "function" ? value.bind(activeRedis) : value;
+		},
+		set(_target, property, value) {
+			Reflect.set(primary, property, value, primary);
+			Reflect.set(standby, property, value, standby);
+			return true;
+		},
+	});
+
+	pairByRouter.set(router, pair);
+	return router;
+};
+
+export const createRedisClientPair = ({
+	createClient,
+}: {
+	createClient: ({ role }: { role: RedisClientRole }) => Redis;
+}): Redis => {
+	const primary = createClient({ role: "primary" });
+	const standby = createClient({ role: "standby" });
+	return createRedisClientPairRouter({ primary, standby });
+};

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -1,6 +1,7 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { redis } from "@/external/redis/initRedis.js";
+import { getReadyRedisClient } from "../initUtils/redisClientPair.js";
 import { RedisUnavailableError } from "./errors.js";
 
 const REDIS_WARNING_INTERVAL_MS = 30_000;
@@ -70,25 +71,54 @@ export const runRedisOp = async <T>({
 	source,
 	redisInstance,
 	queueIfNotReady = false,
+	idempotent = false,
 }: {
-	operation: () => Promise<T>;
+	operation: (activeRedis: Redis) => Promise<T>;
 	source: string;
 	redisInstance?: Redis;
 	queueIfNotReady?: boolean;
+	idempotent?: boolean;
 }): Promise<T> => {
 	const targetRedis = redisInstance ?? redis;
+	const readyRedis = getReadyRedisClient({ redisInstance: targetRedis });
 
-	if (!queueIfNotReady && targetRedis.status !== "ready") {
+	if (!queueIfNotReady && !readyRedis) {
 		const reason: UnavailableReason = "not_ready";
 		warnRedisUnavailable({ source, reason });
 		throw new RedisUnavailableError({ source, reason });
 	}
+	const activeRedis = readyRedis ?? targetRedis;
 
 	try {
-		const value = await operation();
+		const value = await operation(activeRedis);
 		return value;
 	} catch (error) {
-		const classified = classifyErrorReason(targetRedis, error);
+		const classified = classifyErrorReason(activeRedis, error);
+		if (idempotent && classified) {
+			const retryRedis = getReadyRedisClient({
+				redisInstance: targetRedis,
+				exclude: activeRedis,
+			});
+			if (retryRedis) {
+				try {
+					return await operation(retryRedis);
+				} catch (retryError) {
+					const retryReason =
+						classifyErrorReason(retryRedis, retryError) ?? "other";
+					warnRedisUnavailable({
+						source,
+						reason: retryReason,
+						error: retryError,
+					});
+					throw new RedisUnavailableError({
+						source,
+						reason: retryReason,
+						cause: retryError,
+					});
+				}
+			}
+		}
+
 		const reason: UnavailableReason = classified ?? "other";
 		warnRedisUnavailable({ source, reason, error });
 		throw new RedisUnavailableError({ source, reason, cause: error });
@@ -115,7 +145,7 @@ export const tryRedisOp = async <T>({
 }): Promise<T | undefined> => {
 	try {
 		return await runRedisOp({
-			operation,
+			operation: () => operation(),
 			source,
 			redisInstance,
 			queueIfNotReady,

--- a/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
@@ -1,7 +1,7 @@
 import {
-    type FullSubject,
-    fullSubjectToFullCustomer,
-    normalizedToFullSubject,
+	type FullSubject,
+	fullSubjectToFullCustomer,
+	normalizedToFullSubject,
 } from "@autumn/shared";
 import { isRedisMigrationCacheStale } from "@/external/redis/customerRedisRouting.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
@@ -17,9 +17,9 @@ import { getCachedFeatureBalancesBatch } from "../balances/getCachedFeatureBalan
 import { buildFullSubjectKey } from "../builders/buildFullSubjectKey.js";
 import { buildFullSubjectViewEpochKey } from "../builders/buildFullSubjectViewEpochKey.js";
 import {
-    type CachedFullSubject,
-    cachedFullSubjectToNormalized,
-    FULL_SUBJECT_CACHE_SCHEMA_VERSION,
+	type CachedFullSubject,
+	cachedFullSubjectToNormalized,
+	FULL_SUBJECT_CACHE_SCHEMA_VERSION,
 } from "../fullSubjectCacheModel.js";
 import { sanitizeCachedFullSubject } from "../sanitize/index.js";
 import { invalidateCachedFullSubject } from "./invalidate/invalidateFullSubject.js";
@@ -38,7 +38,6 @@ export const getCachedFullSubject = async ({
 	source,
 	staleWhileRevalidate = false,
 	runLazyResets = true,
-
 }: {
 	ctx: AutumnContext;
 	customerId: string;
@@ -46,7 +45,6 @@ export const getCachedFullSubject = async ({
 	source?: string;
 	staleWhileRevalidate?: boolean;
 	runLazyResets?: boolean;
-
 }): Promise<GetCachedFullSubjectResult> => {
 	const { org, env, logger, redisV2 } = ctx;
 	const subjectKey = buildFullSubjectKey({
@@ -66,9 +64,11 @@ export const getCachedFullSubject = async ({
 	// Read-only GETs — epoch TTL is refreshed on writes (setCachedFullSubject
 	// Lua) and on invalidations, not on reads, to avoid write amplification.
 	const pipelineResults = await runRedisOp({
-		operation: () => redisV2.pipeline().get(subjectKey).get(epochKey).exec(),
+		operation: (activeRedis) =>
+			activeRedis.pipeline().get(subjectKey).get(epochKey).exec(),
 		source: "getCachedFullSubject:pipeline",
 		redisInstance: redisV2,
+		idempotent: true,
 	});
 
 	const subjectEntry = pipelineResults?.[0];
@@ -276,7 +276,7 @@ export const getCachedFullSubject = async ({
 				fullCustomer: fullSubjectToFullCustomer({ fullSubject }),
 			});
 		}
-		
+
 		return { fullSubject, subjectViewEpoch: currentSubjectViewEpoch };
 	} catch (error) {
 		logger.warn(

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/getOrInitFullSubjectViewEpoch.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/getOrInitFullSubjectViewEpoch.ts
@@ -19,10 +19,11 @@ export const getOrInitFullSubjectViewEpoch = async ({
 
 	// GETEX reads the epoch and refreshes its TTL in one round trip.
 	const currentEpoch = await runRedisOp({
-		operation: () =>
-			redisV2.getex(epochKey, "EX", FULL_SUBJECT_EPOCH_TTL_SECONDS),
+		operation: (activeRedis) =>
+			activeRedis.getex(epochKey, "EX", FULL_SUBJECT_EPOCH_TTL_SECONDS),
 		source: "getOrInitFullSubjectViewEpoch:getex",
 		redisInstance: redisV2,
+		idempotent: true,
 	});
 	if (currentEpoch !== null && currentEpoch !== undefined) {
 		const parsedEpoch = Number.parseInt(currentEpoch, 10);
@@ -30,8 +31,8 @@ export const getOrInitFullSubjectViewEpoch = async ({
 	}
 
 	await runRedisOp({
-		operation: () =>
-			redisV2.set(epochKey, "0", "EX", FULL_SUBJECT_EPOCH_TTL_SECONDS),
+		operation: (activeRedis) =>
+			activeRedis.set(epochKey, "0", "EX", FULL_SUBJECT_EPOCH_TTL_SECONDS),
 		source: "getOrInitFullSubjectViewEpoch:init",
 		redisInstance: redisV2,
 	});

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
@@ -68,9 +68,11 @@ export const getCachedPartialFullSubject = async ({
 	// Read-only GETs — epoch TTL is refreshed on writes (setCachedFullSubject
 	// Lua) and on invalidations, not on reads, to avoid write amplification.
 	const pipelineResults = await runRedisOp({
-		operation: () => redisV2.pipeline().get(subjectKey).get(epochKey).exec(),
+		operation: (activeRedis) =>
+			activeRedis.pipeline().get(subjectKey).get(epochKey).exec(),
 		source: "getCachedPartialFullSubject:pipeline",
 		redisInstance: redisV2,
+		idempotent: true,
 	});
 
 	const subjectEntry = pipelineResults?.[0];

--- a/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
+++ b/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
@@ -3,6 +3,7 @@ import type {
 	SubjectBalance,
 	UsageWindow,
 } from "@autumn/shared";
+import type { Redis } from "ioredis";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildSharedFullSubjectBalanceKey } from "../builders/buildSharedFullSubjectBalanceKey.js";
@@ -49,16 +50,15 @@ export type FeatureBalancesBatchOutcome =
 	| { kind: "missing"; reason: string };
 
 const readFeatureBalancesFromMaster = async ({
-	ctx,
+	redisInstance,
 	balanceKey,
 	customerEntitlementIds,
 }: {
-	ctx: AutumnContext;
+	redisInstance: Redis;
 	balanceKey: string;
 	customerEntitlementIds: string[];
 }): Promise<(string | null)[] | null> => {
-	const { redisV2 } = ctx;
-	const multi = redisV2.multi();
+	const multi = redisInstance.multi();
 	multi.hmget(balanceKey, ...customerEntitlementIds);
 	const multiResults = await multi.exec();
 	const firstResult = multiResults?.[0];
@@ -95,16 +95,17 @@ export const getCachedFeatureBalance = async ({
 	}
 
 	const results = await runRedisOp({
-		operation: () =>
+		operation: (activeRedis) =>
 			readMaster
 				? readFeatureBalancesFromMaster({
-						ctx,
+						redisInstance: activeRedis,
 						balanceKey,
 						customerEntitlementIds,
 					})
-				: redisV2.hmget(balanceKey, ...customerEntitlementIds),
+				: activeRedis.hmget(balanceKey, ...customerEntitlementIds),
 		source: "getCachedFeatureBalance",
 		redisInstance: redisV2,
+		idempotent: true,
 	});
 
 	if (!results) return { kind: "missing", reason: "single_pipeline_null" };
@@ -157,30 +158,32 @@ export const getCachedFeatureBalancesBatch = async ({
 	if (featureIds.length === 0) return { kind: "ok", value: [] };
 
 	const { org, env, redisV2 } = ctx;
-	const pipeline = redisV2.pipeline();
-	for (const featureId of featureIds) {
-		const customerEntitlementIds =
-			customerEntitlementIdsByFeatureId[featureId] ?? [];
-		const fields = [...customerEntitlementIds];
-		if (includeAggregated) fields.push(AGGREGATED_BALANCE_FIELD);
-		if (usageWindowFeatureIds?.has(featureId)) {
-			fields.push(USAGE_WINDOWS_FIELD);
-		}
-		pipeline.hmget(
-			buildSharedFullSubjectBalanceKey({
-				orgId: org.id,
-				env,
-				customerId,
-				featureId,
-			}),
-			...fields,
-		);
-	}
-
 	const results = await runRedisOp({
-		operation: () => pipeline.exec(),
+		operation: (activeRedis) => {
+			const pipeline = activeRedis.pipeline();
+			for (const featureId of featureIds) {
+				const customerEntitlementIds =
+					customerEntitlementIdsByFeatureId[featureId] ?? [];
+				const fields = [...customerEntitlementIds];
+				if (includeAggregated) fields.push(AGGREGATED_BALANCE_FIELD);
+				if (usageWindowFeatureIds?.has(featureId)) {
+					fields.push(USAGE_WINDOWS_FIELD);
+				}
+				pipeline.hmget(
+					buildSharedFullSubjectBalanceKey({
+						orgId: org.id,
+						env,
+						customerId,
+						featureId,
+					}),
+					...fields,
+				);
+			}
+			return pipeline.exec();
+		},
 		source: "getCachedFeatureBalancesBatch",
 		redisInstance: redisV2,
+		idempotent: true,
 	});
 
 	if (!results) return { kind: "missing", reason: "batch_pipeline_null" };

--- a/server/src/internal/migrations/v2/run/migrateCustomer/withMigrationCustomerLock.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/withMigrationCustomerLock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { ErrCode, RecaseError } from "@autumn/shared";
-import { hasRedisConfig, redis } from "@/external/redis/initRedis.js";
+import { hasRedisConfig } from "@/external/redis/initRedis.js";
 import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { timeout } from "@/utils/genUtils.js";
@@ -34,7 +34,8 @@ const releaseMigrationCustomerLock = async ({
 }) =>
 	runRedisOp({
 		source: "migration-customer-lock:release",
-		operation: () => redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, ownerToken),
+		operation: (activeRedis) =>
+			activeRedis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, ownerToken),
 	});
 
 export const withMigrationCustomerLock = async <T>({
@@ -59,8 +60,8 @@ export const withMigrationCustomerLock = async <T>({
 		try {
 			result = await runRedisOp({
 				source: "migration-customer-lock:acquire",
-				operation: () =>
-					redis.set(lockKey, ownerToken, "PX", LOCK_TTL_MS, "NX"),
+				operation: (activeRedis) =>
+					activeRedis.set(lockKey, ownerToken, "PX", LOCK_TTL_MS, "NX"),
 			});
 		} catch (error) {
 			await releaseMigrationCustomerLock({ lockKey, ownerToken }).catch(

--- a/server/src/queue/concurrency/queueCapacityLease.ts
+++ b/server/src/queue/concurrency/queueCapacityLease.ts
@@ -79,8 +79,8 @@ const createPermit = ({
 				await runRedisOp({
 					source: "queue-concurrency:release",
 					redisInstance: redis,
-					operation: () =>
-						redis.eval(RELEASE_PERMIT_SCRIPT, 1, redisKey, token),
+					operation: (activeRedis) =>
+						activeRedis.eval(RELEASE_PERMIT_SCRIPT, 1, redisKey, token),
 				});
 			} catch {
 				// The permit lease expires automatically if Redis cannot release it.
@@ -145,8 +145,8 @@ export const reserveQueueCapacity = async ({
 		const result = await runRedisOp({
 			source: "queue-concurrency:acquire",
 			redisInstance: redis,
-			operation: () =>
-				redis.eval(
+			operation: (activeRedis) =>
+				activeRedis.eval(
 					ACQUIRE_PERMITS_SCRIPT,
 					1,
 					policy.redisKey,

--- a/server/tests/unit/redis/redis-connection-redundancy.test.ts
+++ b/server/tests/unit/redis/redis-connection-redundancy.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "ioredis";
+import {
+	createRedisClientPair,
+	createRedisClientPairRouter,
+} from "@/external/redis/initUtils/redisClientPair.js";
+import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
+
+// A Redis client pair must reroute before dispatch and retry only operations explicitly marked idempotent.
+
+type FakeRedis = {
+	status: string;
+	calls: string[];
+	get: (key: string) => Promise<string | null>;
+	set: (key: string, value: string) => Promise<"OK">;
+	duplicate: () => Redis;
+	disconnect: () => void;
+};
+
+const asRedis = (value: FakeRedis): Redis => value as unknown as Redis;
+
+const createFakeRedis = ({
+	name,
+	status = "ready",
+	getError,
+	setError,
+	duplicateResult,
+}: {
+	name: string;
+	status?: string;
+	getError?: Error;
+	setError?: Error;
+	duplicateResult?: Redis;
+}): FakeRedis => ({
+	status,
+	calls: [],
+	async get(key) {
+		this.calls.push(`get:${key}`);
+		if (getError) throw getError;
+		return `${name}:${key}`;
+	},
+	async set(key, value) {
+		this.calls.push(`set:${key}:${value}`);
+		if (setError) throw setError;
+		return "OK";
+	},
+	duplicate() {
+		this.calls.push("duplicate");
+		return duplicateResult ?? asRedis(this);
+	},
+	disconnect() {
+		this.calls.push("disconnect");
+	},
+});
+
+describe("Redis connection redundancy", () => {
+	test("creates two independent application clients", () => {
+		const primary = createFakeRedis({ name: "primary" });
+		const standby = createFakeRedis({ name: "standby" });
+		const createdRoles: string[] = [];
+
+		const router = createRedisClientPair({
+			createClient: ({ role }) => {
+				createdRoles.push(role);
+				return asRedis(role === "primary" ? primary : standby);
+			},
+		});
+
+		expect(createdRoles).toEqual(["primary", "standby"]);
+		expect(router).not.toBe(asRedis(primary));
+		expect(router).not.toBe(asRedis(standby));
+	});
+
+	test("routes a command to the standby when the primary is not ready", async () => {
+		const primary = createFakeRedis({
+			name: "primary",
+			status: "reconnecting",
+		});
+		const standby = createFakeRedis({ name: "standby" });
+		const router = createRedisClientPairRouter({
+			primary: asRedis(primary),
+			standby: asRedis(standby),
+		});
+
+		expect(router.status).toBe("ready");
+		expect(await router.get("subject")).toBe("standby:subject");
+		expect(primary.calls).toEqual([]);
+		expect(standby.calls).toEqual(["get:subject"]);
+	});
+
+	test("keeps the health probe separate from the pair router", () => {
+		const probe = createFakeRedis({ name: "probe" });
+		const primary = createFakeRedis({
+			name: "primary",
+			duplicateResult: asRedis(probe),
+		});
+		const standby = createFakeRedis({ name: "standby" });
+		const router = createRedisClientPairRouter({
+			primary: asRedis(primary),
+			standby: asRedis(standby),
+		});
+
+		expect(router.duplicate()).toBe(asRedis(probe));
+		expect(router.duplicate()).not.toBe(router);
+		expect(primary.calls).toEqual(["duplicate", "duplicate"]);
+		expect(standby.calls).toEqual([]);
+	});
+
+	test("disconnects both application clients", () => {
+		const primary = createFakeRedis({ name: "primary" });
+		const standby = createFakeRedis({ name: "standby" });
+		const router = createRedisClientPairRouter({
+			primary: asRedis(primary),
+			standby: asRedis(standby),
+		});
+
+		router.disconnect();
+
+		expect(primary.calls).toEqual(["disconnect"]);
+		expect(standby.calls).toEqual(["disconnect"]);
+	});
+
+	test("retries an idempotent operation once on the other ready client", async () => {
+		const primary = createFakeRedis({
+			name: "primary",
+			getError: new Error("Connection is closed"),
+		});
+		const standby = createFakeRedis({ name: "standby" });
+		const router = createRedisClientPairRouter({
+			primary: asRedis(primary),
+			standby: asRedis(standby),
+		});
+
+		const result = await runRedisOp({
+			redisInstance: router,
+			source: "test:idempotent-read",
+			idempotent: true,
+			operation: (activeRedis) => activeRedis.get("subject"),
+		});
+
+		expect(result).toBe("standby:subject");
+		expect(primary.calls).toEqual(["get:subject"]);
+		expect(standby.calls).toEqual(["get:subject"]);
+	});
+
+	test("does not retry a non-idempotent operation after dispatch", async () => {
+		const primary = createFakeRedis({
+			name: "primary",
+			setError: new Error("Connection is closed"),
+		});
+		const standby = createFakeRedis({ name: "standby" });
+		const router = createRedisClientPairRouter({
+			primary: asRedis(primary),
+			standby: asRedis(standby),
+		});
+
+		const operation = runRedisOp({
+			redisInstance: router,
+			source: "test:non-idempotent-write",
+			operation: (activeRedis) => activeRedis.set("balance", "1"),
+		});
+
+		await expect(operation).rejects.toBeInstanceOf(RedisUnavailableError);
+		expect(primary.calls).toEqual(["set:balance:1"]);
+		expect(standby.calls).toEqual([]);
+	});
+
+	test("preserves not-ready failure when neither client is ready", async () => {
+		const primary = createFakeRedis({
+			name: "primary",
+			status: "reconnecting",
+		});
+		const standby = createFakeRedis({ name: "standby", status: "connecting" });
+		const router = createRedisClientPairRouter({
+			primary: asRedis(primary),
+			standby: asRedis(standby),
+		});
+
+		const operation = runRedisOp({
+			redisInstance: router,
+			source: "test:both-not-ready",
+			operation: (activeRedis) => activeRedis.get("subject"),
+		});
+
+		await expect(operation).rejects.toMatchObject({
+			name: "RedisUnavailableError",
+			reason: "not_ready",
+		});
+		expect(primary.calls).toEqual([]);
+		expect(standby.calls).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What
- Create paired primary and standby application connections for shared Redis V2.
- Route operations to a ready connection and allow one alternate-client retry only for explicitly idempotent operations.
- Keep writes single-attempt, preserve the independent health-probe socket, and scope the standby to shared Redis V2 without doubling dedicated-org or ramp connections.

## Why
A process-local Redis connection can enter a not-ready state while Dragonfly remains healthy, causing task-local fail-opens. A separately created standby gives eligible reads another healthy path without blindly replaying writes.

## Verification
- 7 new Redis redundancy contract tests passed.
- 148 Redis, cache, and FullSubject tests passed.
- 22 directly affected tests passed after the final connection-scope refinement.
- Server typecheck passed.
- Scoped Biome checks and git diff checks passed.
- Commit hooks passed Knip and the server typecheck.

## Caveat
A live two-socket Dragonfly integration test was not run because the local Infisical CLI session was logged out; connection-state behavior is covered with focused unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a primary/standby Redis application connection for shared `redisV2` and routes commands to a ready client, with a one-time alternate-client retry for explicitly idempotent reads. Improves read resilience without replaying writes or duplicating non-shared connections.

- **New Features**
  - Introduced `createRedisConnectionPair` with a router that proxies to a ready primary/standby; keeps the health-probe separate via `duplicate`.
  - Updated `runRedisOp` to pass `activeRedis` and support an `idempotent` flag; retries read-only ops once on the other ready client, never retries writes.
  - Switched `redisV2` to the paired connection and updated call sites to use `activeRedis` and mark safe reads (GET/GETEX/HMGET/pipelines) as `idempotent`; no duplication of dedicated-org or ramp connections.
  - Added unit tests for routing, retry behavior, and non-idempotent write handling.

<sup>Written for commit 353dd076d937e0593227c9c334705a9bb0bf6ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds redundant application connections for shared Redis V2 so eligible cache reads can use a healthy standby while writes remain single-attempt.

- **[Improvements]** Creates independent primary and standby Redis application connections behind one router.
- **[Improvements]** Routes each operation to a ready connection and retries explicitly repeatable cache reads once on the alternate connection.
- **[Bug fixes]** Reduces cache fail-opens caused by one process-local Redis connection becoming unavailable while Dragonfly remains healthy.
- **[API changes]** Passes the selected Redis connection into `runRedisOp` callbacks and adds the `idempotent` retry option.
- **[Improvements]** Keeps the health-probe socket independent and avoids duplicating dedicated-org or ramp clients.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The paired router consistently chooses a ready connection, retries only operations explicitly safe to repeat, keeps writes single-attempt, and preserves the independent health-probe path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/redisClientPair.ts | Introduces the primary/standby router, aggregate readiness, paired lifecycle handling, and independent duplication behavior. |
| server/src/external/redis/utils/runRedisOp.ts | Selects a ready physical client and permits one alternate-client retry only for explicitly idempotent operations. |
| server/src/external/redis/initRedisV2.ts | Switches shared Dragonfly-backed Redis V2 from one application connection to the paired router. |
| server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts | Rebuilds its read-only pipeline on the selected connection and opts into alternate retry. |
| server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts | Builds balance reads and pipelines on the selected connection so retries do not reuse commands bound to the first client. |
| server/src/internal/customers/cache/fullSubject/actions/invalidate/getOrInitFullSubjectViewEpoch.ts | Runs epoch reads and initialization against the connection selected by the operation wrapper. |
| server/src/queue/concurrency/queueCapacityLease.ts | Preserves single-attempt lease acquisition and release while using the selected Redis connection. |
| server/src/internal/migrations/v2/run/migrateCustomer/withMigrationCustomerLock.ts | Preserves single-attempt migration-lock operations while using the selected Redis connection. |
| server/tests/unit/redis/redis-connection-redundancy.test.ts | Covers paired creation, ready-client routing, probe duplication, cleanup, eligible retry, write handling, and total unavailability. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Op[Redis operation] --> Ready{Ready application connection?}
    Ready -->|Primary ready| Primary[Primary connection]
    Ready -->|Primary unavailable| Standby[Standby connection]
    Ready -->|Neither ready| Unavailable[RedisUnavailableError or offline queue]
    Primary --> Result{Operation result}
    Standby --> Result
    Result -->|Success| Return[Return result]
    Result -->|Failure and explicitly idempotent| Alternate{Other connection ready?}
    Result -->|Failure and write/non-idempotent| Fail[Return RedisUnavailableError]
    Alternate -->|Yes| Retry[Retry once on alternate]
    Alternate -->|No| Fail
    Retry --> Return
    Retry -->|Failure| Fail
    Probe[Independent health-probe connection] -. monitors .-> Ready
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(redis): add redundant application c..."](https://github.com/useautumn/autumn/commit/353dd076d937e0593227c9c334705a9bb0bf6ff2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50096355)</sub>

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->