### PR TITLE
fix: sweep floating garbage before memory sampling

### DIFF
--- a/server/src/utils/memory/inFlightRequests.ts
+++ b/server/src/utils/memory/inFlightRequests.ts
@@ -65,3 +65,5 @@ export const listInFlightRequests = ({
 export const clearInFlightRequests = () => {
 	inFlightRequests.clear();
 };
+
+export const countInFlightRequests = () => inFlightRequests.size;

--- a/server/src/utils/memoryMonitor.ts
+++ b/server/src/utils/memoryMonitor.ts
@@ -31,6 +31,9 @@ function logMemoryUsage(label: string) {
 		return;
 	}
 
+	// Sweep floating garbage first: JSC defers collection until memory pressure,
+	// so unswept transients otherwise read as a leak in rss/heapUsed.
+	Bun.gc(true);
 	const mem = process.memoryUsage();
 
 	const lagMeanMs = Math.round((lagHistogram.mean / 1e6) * 10) / 10;

--- a/server/src/utils/memoryMonitor.ts
+++ b/server/src/utils/memoryMonitor.ts
@@ -20,8 +20,11 @@ export function getEventLoopLagMs(): number {
 }
 
 const DEFAULT_INTERVAL_MS = 60_000; // 1 minute
+const SWEEP_INTERVAL_TICKS = 10;
 
 let intervalHandle: ReturnType<typeof setInterval> | null = null;
+// Start eligible so the first idle tick sweeps.
+let ticksSinceSweep = SWEEP_INTERVAL_TICKS;
 
 function toMB(bytes: number): number {
 	return Math.round((bytes / 1024 / 1024) * 10) / 10;
@@ -33,9 +36,14 @@ function logMemoryUsage(label: string) {
 	}
 
 	// JSC defers GC until memory pressure, so unswept transients read as a leak.
-	// Sync GC blocks the event loop; only force it while no requests are in flight.
-	if (countInFlightRequests() === 0) {
+	// Sync GC blocks the event loop: sweep at most every 10 min, and only idle.
+	let swept = false;
+	if (ticksSinceSweep >= SWEEP_INTERVAL_TICKS && countInFlightRequests() === 0) {
 		Bun.gc(true);
+		ticksSinceSweep = 0;
+		swept = true;
+	} else {
+		ticksSinceSweep++;
 	}
 	const mem = process.memoryUsage();
 
@@ -50,6 +58,7 @@ function logMemoryUsage(label: string) {
 			type: "memory_log",
 			data: {
 				label,
+				swept,
 				pid: process.pid,
 				rssMB: toMB(mem.rss),
 				heapUsedMB: toMB(mem.heapUsed),

--- a/server/src/utils/memoryMonitor.ts
+++ b/server/src/utils/memoryMonitor.ts
@@ -7,6 +7,7 @@
 
 import { monitorEventLoopDelay } from "node:perf_hooks";
 import { logger } from "../external/logtail/logtailUtils.js";
+import { countInFlightRequests } from "./memory/inFlightRequests.js";
 
 // Event loop lag histogram — samples at 100ms resolution at the C++ level.
 // No JS callbacks involved, negligible overhead.
@@ -31,9 +32,11 @@ function logMemoryUsage(label: string) {
 		return;
 	}
 
-	// Sweep floating garbage first: JSC defers collection until memory pressure,
-	// so unswept transients otherwise read as a leak in rss/heapUsed.
-	Bun.gc(true);
+	// JSC defers GC until memory pressure, so unswept transients read as a leak.
+	// Sync GC blocks the event loop; only force it while no requests are in flight.
+	if (countInFlightRequests() === 0) {
+		Bun.gc(true);
+	}
 	const mem = process.memoryUsage();
 
 	const lagMeanMs = Math.round((lagHistogram.mean / 1e6) * 10) / 10;


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR avoids forcing synchronous garbage collection while tracked HTTP requests are active, making production memory samples less likely to disrupt request handling.
- **[Bug fixes]** Check the number of tracked in-flight HTTP requests before forcing a garbage-collection sweep.
- **[Improvements]** Export a lightweight request-count helper for memory-monitoring decisions.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge based on the eligible follow-up review findings.

No blocking failure remains in the eligible review scope.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/memory/inFlightRequests.ts | Exports the tracked request count so the memory monitor can avoid collecting during active HTTP requests. |
| server/src/utils/memoryMonitor.ts | Forces garbage collection before production memory sampling only when no tracked HTTP requests are active. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Timer[Memory monitor interval] --> Env{Development?}
  Env -->|Yes| Skip[Skip memory sample]
  Env -->|No| Count[Count tracked HTTP requests]
  Count -->|Zero| GC[Force synchronous GC]
  Count -->|One or more| Sample[Sample memory without forced GC]
  GC --> Sample
  Sample --> Log[Log memory and event-loop metrics]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: only force GC sweep while no reques..."](https://github.com/useautumn/autumn/commit/259ee84222493d395d82176ffc719749a9c68711) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50106426)</sub>

<!-- /greptile_comment -->