### PR TITLE
fix(migrations): restore redis.call in migration lock release script

### DIFF
--- a/server/src/internal/migrations/v2/run/migrateCustomer/withMigrationCustomerLock.ts
+++ b/server/src/internal/migrations/v2/run/migrateCustomer/withMigrationCustomerLock.ts
@@ -11,8 +11,8 @@ const RETRY_MIN_MS = 75;
 const RETRY_JITTER_MS = 50;
 
 const RELEASE_LOCK_SCRIPT = `
-if miscRedis.call("GET", KEYS[1]) == ARGV[1] then
-	return miscRedis.call("DEL", KEYS[1])
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("DEL", KEYS[1])
 end
 return 0
 `;


### PR DESCRIPTION
## Problem

The redis-cloud migration refactor (4c3039760) renamed the redis client variable, and the find-replace leaked into the Lua template string in `withMigrationCustomerLock.ts`:

```lua
if miscRedis.call("GET", KEYS[1]) == ARGV[1] then
	return miscRedis.call("DEL", KEYS[1])
```

Lua scripts only expose the `redis` global, so every eval of `RELEASE_LOCK_SCRIPT` threw "attempted to access nonexistent global variable". The error is swallowed (caught/warn-logged), so nothing crashed — but migration customer locks were never released early and always sat until their 15-minute TTL. A second migration for the same customer inside that window spins on retry up to the 10-minute wait deadline, then fails with a 423.

## Fix

Rename `miscRedis.call` back to `redis.call` inside the Lua string (the TS-level `miscRedis.eval(...)` caller is untouched — that rename was correct).

## Verification

Swept the rest of the repo for the same class of mangling: all 31 `.lua` files under `server/src/_luaScriptsV2/` (64 call sites) and every inline Lua template string in TS (`redisUtils.ts`, `queueCapacityLease.ts`, `checkoutSessionLock.ts`) correctly use `redis.call`. This was the only instance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `redis.call` in the migration lock release Lua script so customer migration locks are released immediately instead of waiting for the 15‑minute TTL. This prevents follow‑up migrations from failing with 423s.

- **Bug Fixes**
  - Replace `miscRedis.call` with `redis.call` in `RELEASE_LOCK_SCRIPT` to stop eval errors and enable early lock release.

<sup>Written for commit 38e6157da16a1537770b1c3afa5025f557c4cf81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

