### PR TITLE
perf: fetch edge configs via Bun's native S3 client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: stack/cleanups stack/check-fail-open main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect perf/edge-config-bun-s3-client
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: stack/cleanups stack/check-fail-open main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect
 
 jobs:
   checks:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   #   staging repo (autumn-staging) -> us-east-1
   # Branches allowed to deploy to staging via workflow_dispatch with tag=deploy-staging.
   # Add short-lived PR branches here when you need staging without merging to dev.
-  STAGING_DEPLOY_BRANCH_ALLOWLIST: stack/cleanups stack/check-fail-open main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect
+  STAGING_DEPLOY_BRANCH_ALLOWLIST: stack/cleanups stack/check-fail-open main dev feat/past-due-cancel-immediate-void feat/gate-cluster-wide feat/redis-monitor-fix feat/firelens-log-transport-v2 fix/dragonfly-resize-reconnect perf/edge-config-bun-s3-client
 
 jobs:
   checks:

--- a/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
+++ b/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
@@ -33,7 +33,8 @@ const bunClientCache = new Map<string, InstanceType<typeof Bun.S3Client>>();
 const resolveContainerCredentials =
 	async (): Promise<ContainerCredentials | null> => {
 		const relativeUri = process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
-		if (!relativeUri) return null;
+		const fullUri = process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
+		if (!relativeUri && !fullUri) return null;
 
 		const fresh =
 			containerCredentials &&
@@ -41,7 +42,15 @@ const resolveContainerCredentials =
 				containerCredentials.expiresAt - CREDENTIALS_REFRESH_MARGIN_MS;
 		if (fresh) return containerCredentials;
 
-		const response = await fetch(`http://169.254.170.2${relativeUri}`);
+		const url = relativeUri
+			? `http://169.254.170.2${relativeUri}`
+			: (fullUri as string);
+		const authToken = process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN;
+		// A stalled metadata endpoint must not hang boot: polling start is awaited.
+		const response = await fetch(url, {
+			signal: AbortSignal.timeout(5_000),
+			...(authToken ? { headers: { Authorization: authToken } } : {}),
+		});
 		if (!response.ok) {
 			throw new Error(
 				`Container credentials endpoint returned ${response.status}`,

--- a/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
+++ b/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
@@ -45,7 +45,10 @@ const resolveContainerCredentials =
 		const url = relativeUri
 			? `http://169.254.170.2${relativeUri}`
 			: (fullUri as string);
-		const authToken = process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN;
+		const tokenFile = process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE;
+		const authToken =
+			process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN ??
+			(tokenFile ? (await Bun.file(tokenFile).text()).trim() : undefined);
 		// A stalled metadata endpoint must not hang boot: polling start is awaited.
 		const response = await fetch(url, {
 			signal: AbortSignal.timeout(5_000),

--- a/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
+++ b/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
@@ -1,0 +1,130 @@
+// Bun-native S3 client shaped like the SDK's `send()` for edge-config use:
+// avoids the SDK middleware churn that dominated idle allocation.
+import type { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+
+type EdgeConfigS3CommandInput = {
+	Bucket?: string;
+	Key?: string;
+	Body?: string;
+	ContentType?: string;
+};
+
+// Command-union typing keeps real SDK clients injectable in tests and scripts.
+export type EdgeConfigS3Client = {
+	send: (command: GetObjectCommand | PutObjectCommand) => Promise<{
+		Body?: { transformToString: (encoding?: string) => Promise<string> };
+	}>;
+};
+
+type ContainerCredentials = {
+	accessKeyId: string;
+	secretAccessKey: string;
+	sessionToken: string;
+	expiresAt: number;
+};
+
+const CREDENTIALS_REFRESH_MARGIN_MS = 5 * 60_000;
+
+let containerCredentials: ContainerCredentials | null = null;
+const bunClientCache = new Map<string, InstanceType<typeof Bun.S3Client>>();
+
+// Bun.S3Client only reads env/static credentials, so Fargate task-role
+// credentials must be fetched from the ECS container endpoint ourselves.
+const resolveContainerCredentials =
+	async (): Promise<ContainerCredentials | null> => {
+		const relativeUri = process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
+		if (!relativeUri) return null;
+
+		const fresh =
+			containerCredentials &&
+			Date.now() <
+				containerCredentials.expiresAt - CREDENTIALS_REFRESH_MARGIN_MS;
+		if (fresh) return containerCredentials;
+
+		const response = await fetch(`http://169.254.170.2${relativeUri}`);
+		if (!response.ok) {
+			throw new Error(
+				`Container credentials endpoint returned ${response.status}`,
+			);
+		}
+		const raw = (await response.json()) as {
+			AccessKeyId: string;
+			SecretAccessKey: string;
+			Token: string;
+			Expiration: string;
+		};
+		containerCredentials = {
+			accessKeyId: raw.AccessKeyId,
+			secretAccessKey: raw.SecretAccessKey,
+			sessionToken: raw.Token,
+			expiresAt: Date.parse(raw.Expiration),
+		};
+		bunClientCache.clear();
+		return containerCredentials;
+	};
+
+const getBunClient = async ({
+	bucket,
+	region,
+}: {
+	bucket: string;
+	region: string;
+}) => {
+	const credentials = await resolveContainerCredentials();
+	const cacheKey = `${bucket}:${region}:${credentials?.expiresAt ?? "env"}`;
+	const cached = bunClientCache.get(cacheKey);
+	if (cached) return cached;
+
+	const client = new Bun.S3Client({
+		bucket,
+		region,
+		...(credentials
+			? {
+					accessKeyId: credentials.accessKeyId,
+					secretAccessKey: credentials.secretAccessKey,
+					sessionToken: credentials.sessionToken,
+				}
+			: {}),
+	});
+	bunClientCache.set(cacheKey, client);
+	return client;
+};
+
+// Callers branch on `error.name === "NoSuchKey"`; Bun reports it via `code`.
+const normalizeNoSuchKey = (error: unknown): unknown => {
+	const code = (error as { code?: string } | null)?.code;
+	if (code !== "NoSuchKey") return error;
+	const normalized = new Error("The specified key does not exist.");
+	normalized.name = "NoSuchKey";
+	return normalized;
+};
+
+export const createBunS3EdgeConfigClient = ({
+	region,
+}: {
+	region: string;
+}): EdgeConfigS3Client => ({
+	send: async (command) => {
+		const { Bucket, Key, Body, ContentType } =
+			command.input as EdgeConfigS3CommandInput;
+		if (!Bucket || !Key) {
+			throw new Error("Edge config S3 command requires Bucket and Key");
+		}
+		const client = await getBunClient({ bucket: Bucket, region });
+
+		if (Body === undefined) {
+			let text: string;
+			try {
+				text = await client.file(Key).text();
+			} catch (error) {
+				throw normalizeNoSuchKey(error);
+			}
+			return { Body: { transformToString: async () => text } };
+		}
+
+		await client
+			.file(Key)
+			.write(Body, ContentType ? { type: ContentType } : undefined);
+		return {};
+	},
+});

--- a/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigStore.ts
@@ -1,9 +1,11 @@
 import { ErrCode, ms } from "@autumn/shared";
-import type { S3Client } from "@aws-sdk/client-s3";
 import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import type { z } from "zod/v4";
 import { getAdminS3Config } from "@/external/aws/s3/adminS3Config.js";
-import { getS3Client } from "@/external/aws/s3/initS3.js";
+import {
+	createBunS3EdgeConfigClient,
+	type EdgeConfigS3Client,
+} from "@/external/aws/s3/bunS3EdgeConfigClient.js";
 import { getS3BodyAsString } from "@/external/aws/s3/s3Utils.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import RecaseError from "@/utils/errorUtils.js";
@@ -71,7 +73,7 @@ export const createEdgeConfigStore = <T>({
 	defaultValue: () => T;
 	retainOnError?: boolean;
 	pollIntervalMs?: number;
-	s3Client?: S3Client;
+	s3Client?: EdgeConfigS3Client;
 }) => {
 	let runtimeConfig: T = defaultValue();
 	let runtimeStatus: EdgeConfigStatus = {
@@ -112,7 +114,7 @@ export const createEdgeConfigStore = <T>({
 	const resolveClient = () => {
 		if (injectedS3Client) return injectedS3Client;
 		const { region } = getConfigLocation();
-		return getS3Client({ region });
+		return createBunS3EdgeConfigClient({ region });
 	};
 
 	const readFromSource = async (): Promise<T> => {

--- a/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
+++ b/server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts
@@ -1,23 +1,25 @@
 import { randomUUID } from "node:crypto";
-import type { S3Client } from "@aws-sdk/client-s3";
 import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import {
 	ADMIN_EDGE_CONFIG_TIMESTAMP_KEY,
 	getAdminS3Config,
 } from "@/external/aws/s3/adminS3Config.js";
-import { getS3Client } from "@/external/aws/s3/initS3.js";
+import {
+	createBunS3EdgeConfigClient,
+	type EdgeConfigS3Client,
+} from "@/external/aws/s3/bunS3EdgeConfigClient.js";
 import { getS3BodyAsString } from "@/external/aws/s3/s3Utils.js";
 
-const getClient = (s3Client?: S3Client) => {
+const getClient = (s3Client?: EdgeConfigS3Client) => {
 	if (s3Client) return s3Client;
 	const { region } = getAdminS3Config();
-	return getS3Client({ region });
+	return createBunS3EdgeConfigClient({ region });
 };
 
 export const readEdgeConfigTimestamp = async ({
 	s3Client,
 }: {
-	s3Client?: S3Client;
+	s3Client?: EdgeConfigS3Client;
 } = {}): Promise<string | null> => {
 	const { bucket } = getAdminS3Config();
 
@@ -55,7 +57,7 @@ const WRITE_RETRY_DELAY_MS = 50;
 export const writeEdgeConfigTimestamp = async ({
 	s3Client,
 }: {
-	s3Client?: S3Client;
+	s3Client?: EdgeConfigS3Client;
 } = {}): Promise<string> => {
 	const { bucket } = getAdminS3Config();
 	const client = getClient(s3Client);


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch edge-config reads/writes to Bun’s native S3 client to cut SDK middleware overhead and reduce idle allocations. Also hardens container-credentials fetching to avoid stalls.

- **Refactors**
  - Added `createBunS3EdgeConfigClient` with a minimal `send()` compatible with `GetObjectCommand`/`PutObjectCommand` from `@aws-sdk/client-s3`.
  - ECS task-role creds: support `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, `AWS_CONTAINER_CREDENTIALS_FULL_URI` (with `AWS_CONTAINER_AUTHORIZATION_TOKEN` or `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`), bound fetch with a 5s timeout, cache clients per bucket/region/expiry, and normalize `NoSuchKey` errors.
  - `edgeConfigStore` and `edgeConfigTimestamp` now default to the new client and accept `EdgeConfigS3Client` for DI.

- **CI**
  - Removed temporary staging-deploy allowlist for `perf/edge-config-bun-s3-client`.

<sup>Written for commit 0ecf53969dbf2acf81f81e40dab9920dec79be4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces AWS SDK middleware on the edge-config path with Bun’s native S3 client while retaining the existing command-based interface.
- **[Improvements]** Adds a cached Bun S3 adapter for reading and writing edge configuration objects.
- **[Improvements] [Bug fixes]** Fetches ECS task-role credentials with bounded requests, authorization-token support, and expiration-aware refresh.
- **[API changes]** Changes edge-config dependency injection from the concrete AWS SDK client type to a minimal client interface.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/aws/s3/bunS3EdgeConfigClient.ts | Introduces the Bun-native S3 adapter, ECS credential resolution, client caching, and missing-key normalization. |
| server/src/internal/misc/edgeConfig/edgeConfigStore.ts | Makes the Bun adapter the default edge-config client and changes dependency injection to the minimal client interface. |
| server/src/internal/misc/edgeConfig/edgeConfigTimestamp.ts | Uses the Bun adapter by default for reading and writing edge-config change markers. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Store as Edge config store
    participant Adapter as Bun S3 adapter
    participant ECS as ECS credential endpoint
    participant S3 as Amazon S3
    Store->>Adapter: send(GetObjectCommand / PutObjectCommand)
    Adapter->>Adapter: Check cached credentials and client
    alt Credentials require refresh
        Adapter->>ECS: Fetch task-role credentials (5s timeout)
        ECS-->>Adapter: Temporary credentials and expiration
    end
    Adapter->>S3: Read or write object with Bun.S3Client
    S3-->>Adapter: Object body or completion
    Adapter-->>Store: SDK-compatible response
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: read the container authorization to..."](https://github.com/useautumn/autumn/commit/0ecf53969dbf2acf81f81e40dab9920dec79be4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50145164)</sub>

<!-- /greptile_comment -->