### PR TITLE
feat(redis): dual-write + read-both for lock and cross-request misc keys during ramps

### DIFF
--- a/.plans/redis-cloud-migration/PLAN.md
+++ b/.plans/redis-cloud-migration/PLAN.md
@@ -58,7 +58,9 @@ Design locked with John: key classification is read-through caches (rampable by 
 
 ### PR 3 — the sweep + ramp wiring (todo)
 
-ctx.miscRedis threading, Proxy deletion, runRedisOp `operation(redis)` API, pinned call sites; then ramp the 5 rampable cache modules onto `resolveMiscRedis`/`forEachMiscRedisTarget` + admin UI. Pre-flip checklist: verify `checkout:*` and `oauth_state:*` miss behavior (or flip at low traffic).
+Proxy deletion + pinned call sites; then ramp the 5 rampable cache modules onto `resolveMiscRedis`/`forEachMiscRedisTarget` + admin UI. Pre-flip checklist: verify `checkout:*` and `oauth_state:*` miss behavior (or flip at low traffic).
+
+DESCOPED (John, 2026-08-04): no `ctx.miscRedis` threading — call sites call `getMiscRedis()` / `resolveMiscRedis({ requestId: ctx.id })` directly (ctx is already in scope where it matters). The `runRedisOp`/`tryRedisOp` `operation(redis)` callback API change is deferred — keep the current shape for now. John handles the cloud-repo fixes (incl. `initOrgUtils.ts` `redis` import) and runs integration tests himself.
 
 
 | # | Unit | Scope |
@@ -67,12 +69,13 @@ ctx.miscRedis threading, Proxy deletion, runRedisOp `operation(redis)` API, pinn
 | 9 | Misc-redis migration edge config | Extend `mainRedisCacheSchemas` with `cacheV2Ramp`-shaped destination: encrypted `connectionString`, `url`, `migrationPercent`/`previousMigrationPercent`/`migrationChangedAt`. Copy patterns from `cacheV2RampClient.ts` (lazy hot-swappable destination client, disconnect on change) and `cacheV2RampStore.ts` (refuse conn edits while percent > 0). Destination reads `CACHE_MISC_DRAGONFLY_URL` as the default/bootstrap URL. Admin routes + `EdgeConfigView.tsx` section; register S3 key in `adminS3Config.ts`. |
 | 10 | Per-request routing + dual invalidation | `ctx.miscRedis` threaded like `ctx.redisV2` (worker equivalents: `createWorkerContext.ts`, `createAutumnContext.ts`). Bucket by requestId decides old vs new instance for cache wrappers. `getMiscRedisTargets()` (analog of `getRedisTargetsForCustomer`, `customerRedisRouting.ts:104`) fans every DEL/invalidate out to both instances while ramp active. |
 | 11 | Coordination keys pinned | Locks (`redisUtils`, billing/checkout/entity/migration/stripe-sub locks), rate limiters, stripe webhook idempotency, OAuth replay guard, auto-topup suppression, queue capacity leases call `getMiscRedis()` directly — resolves from `activeInstance` only, ignores the bucket. |
+| 12 | Lock dual-write + read-both (DONE, branch `feat/redis-lock-dual-write`) | While a ramp exists, locks survive a flip/rollback: NX decision stays on the active instance, won locks mirror fire-and-forget to the ramp target (`void mirrorSetOnMiscRedisRampTarget` — never throws), release/refresh fan to all targets (`clearLock`/`refreshLockLease` via `forEachMiscRedisTarget`). Dual-written cross-request stores (`checkoutSessionLock`, `stripeSubscriptionLock`, `expiredCustomerProductsCache`) write through `setOnMiscRedisTargets` and read active-first-then-others via `getFromMiscRedisTargets` (covers values written before the ramp existed). Excluded (documented): `queueCapacityLease` (Lua semaphore — mirroring needs a force-add script; flip worst case = over-admission bounded by leaseMs), idempotency claim (Dynamo authoritative; Redis leg rollback-only), `oauthRefreshReplay` (30s TTL), `saveLockReceipt` (cross-request state class, not a lock). |
 
 ## Phase 4 — Cutover (ops)
 
-- Verify Dragonfly compat: `SCRIPT LOAD`/`EVALSHA` (hono-rate-limiter store), inline `eval` lock scripts, `JSON.SET` (`saveLockReceipt.ts:41` — last RedisJSON user after unit 2), `{orgId}` hash tags (`products_full:{orgId}`).
+- ~~Verify Dragonfly compat~~ VERIFIED 2026-08-04 (empirically, on both the local Dragonfly and the dev Dragonfly Cloud backup `u4477txx8.dragonflydb.cloud:6385`, both df-v1.38.1): SCRIPT LOAD/EVALSHA + NOSCRIPT retry surface (hono-rate-limiter scripts verbatim), owner-token lock scripts, queue-permit semaphore scripts, JSON.SET/JSON.GET (saveLockReceipt), `{orgId}` hash-tag SET/GET/SCAN/DEL — all pass. Script: scratchpad `dragonflyCompatCheck.ts` (rerunnable with `CACHE_V2_DRAGONFLY_URL=<url>`).
 - Ramp 1 → 10 → 50 → 100 over days (TTLs are short: org 60s, keys 1h, products 24h — new instance warms fast).
-- Flip `activeInstance` to the Dragonfly URL — coordination keys cut over here; lock TTLs ≤ 300s bound the drain window; brief idempotency/rate-limit amnesia is acceptable.
+- Flip `activeInstance` to the Dragonfly URL — coordination keys cut over here; with lock dual-write (unit 12) in-flight locks already exist on the target. `setActiveMiscRedisInstance` clears the ramp, which stops mirroring — so immediately `startMiscRedisRamp({ percent: 0 })` back toward the old instance as the rollback soak (keeps mirroring + invalidation fan-out); clear it once rollback is off the table.
 - Decommission Redis Cloud; remove `CACHE_URL` region naming; remove ramp state.
 - Dashboards: `create-redis-dashboard` skill has the canonical Axiom template.
 

--- a/server/src/external/redis/actions/checkoutSessionLock/checkoutSessionLock.ts
+++ b/server/src/external/redis/actions/checkoutSessionLock/checkoutSessionLock.ts
@@ -1,6 +1,6 @@
-import { getMiscRedis } from "@/external/redis/initRedis";
+import { getFromMiscRedisTargets } from "@/external/redis/miscCache/getFromMiscRedisTargets.js";
+import { setOnMiscRedisTargets } from "@/external/redis/miscCache/setOnMiscRedisTargets.js";
 import { clearLock } from "@/external/redis/utils/lockUtils/clearLock.js";
-import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import { expireStripeCheckoutSession } from "@/external/stripe/checkoutSessions/operations/expireStripeCheckoutSession.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
@@ -30,13 +30,9 @@ const get = async ({
 	ctx: AutumnContext;
 	customerId: string;
 }): Promise<CheckoutSessionLockData | null> => {
-	const miscRedis = getMiscRedis();
-	const lockKey = buildCheckoutSessionLockKey({ ctx, customerId });
-
-	const value = await tryRedisOp({
-		operation: () => miscRedis.get(lockKey),
+	const value = await getFromMiscRedisTargets({
+		key: buildCheckoutSessionLockKey({ ctx, customerId }),
 		source: "checkout-session-lock:get",
-		redisInstance: miscRedis,
 	});
 	if (!value) return null;
 
@@ -52,22 +48,16 @@ const set = async ({
 	customerId: string;
 	data: CheckoutSessionLockData;
 }): Promise<void> => {
-	const miscRedis = getMiscRedis();
 	const lockKey = buildCheckoutSessionLockKey({ ctx, customerId });
 	const ttlSeconds = data.expiresAt
 		? Math.max(1, Math.ceil((data.expiresAt - Date.now()) / 1000))
 		: FALLBACK_CHECKOUT_LOCK_TTL_SECONDS;
 
-	await tryRedisOp({
-		operation: () =>
-			miscRedis.set(
-				lockKey,
-				JSON.stringify({ ...data, token: data.checkoutSessionId }),
-				"EX",
-				ttlSeconds,
-			),
+	await setOnMiscRedisTargets({
+		key: lockKey,
+		value: JSON.stringify({ ...data, token: data.checkoutSessionId }),
+		ttlMs: ttlSeconds * 1000,
 		source: "checkout-session-lock:set",
-		redisInstance: miscRedis,
 	});
 };
 

--- a/server/src/external/redis/actions/expiredCustomerProductsCache/expiredCustomerProductsCache.ts
+++ b/server/src/external/redis/actions/expiredCustomerProductsCache/expiredCustomerProductsCache.ts
@@ -1,9 +1,9 @@
 import type { FullCusProduct } from "@autumn/shared";
-import { getMiscRedis } from "@/external/redis/initRedis.js";
-import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { getFromMiscRedisTargets } from "@/external/redis/miscCache/getFromMiscRedisTargets.js";
+import { setOnMiscRedisTargets } from "@/external/redis/miscCache/setOnMiscRedisTargets.js";
 
-/** Pinned: written by subscription.deleted and read by invoice.created — two
- *  different requests, so ramp routing would break the handoff. */
+/** Cross-request handoff (subscription.deleted writes, invoice.created reads),
+ *  so it dual-writes and reads from every live instance during a ramp. */
 const EXPIRED_CUSTOMER_PRODUCTS_TTL_SECONDS = 300;
 
 export const buildExpiredCustomerProductsCacheKey = (
@@ -15,13 +15,9 @@ export const getCachedExpiredCustomerProducts = async ({
 }: {
 	stripeSubscriptionId: string;
 }): Promise<FullCusProduct[] | null> => {
-	const miscRedis = getMiscRedis();
-	const cacheKey = buildExpiredCustomerProductsCacheKey(stripeSubscriptionId);
-
-	const cached = await tryRedisOp({
-		operation: () => miscRedis.get(cacheKey),
+	const cached = await getFromMiscRedisTargets({
+		key: buildExpiredCustomerProductsCacheKey(stripeSubscriptionId),
 		source: "expired-cus-products-cache:get",
-		redisInstance: miscRedis,
 	});
 	if (!cached) return null;
 
@@ -35,18 +31,10 @@ export const setCachedExpiredCustomerProducts = async ({
 	stripeSubscriptionId: string;
 	customerProducts: FullCusProduct[];
 }): Promise<void> => {
-	const miscRedis = getMiscRedis();
-	const cacheKey = buildExpiredCustomerProductsCacheKey(stripeSubscriptionId);
-
-	await tryRedisOp({
-		operation: () =>
-			miscRedis.set(
-				cacheKey,
-				JSON.stringify(customerProducts),
-				"EX",
-				EXPIRED_CUSTOMER_PRODUCTS_TTL_SECONDS,
-			),
+	await setOnMiscRedisTargets({
+		key: buildExpiredCustomerProductsCacheKey(stripeSubscriptionId),
+		value: JSON.stringify(customerProducts),
+		ttlMs: EXPIRED_CUSTOMER_PRODUCTS_TTL_SECONDS * 1000,
 		source: "expired-cus-products-cache:set",
-		redisInstance: miscRedis,
 	});
 };

--- a/server/src/external/redis/actions/stripeSubscriptionLock/stripeSubscriptionLock.ts
+++ b/server/src/external/redis/actions/stripeSubscriptionLock/stripeSubscriptionLock.ts
@@ -1,5 +1,5 @@
-import { getMiscRedis } from "@/external/redis/initRedis";
-import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { getFromMiscRedisTargets } from "@/external/redis/miscCache/getFromMiscRedisTargets.js";
+import { setOnMiscRedisTargets } from "@/external/redis/miscCache/setOnMiscRedisTargets.js";
 
 const STRIPE_SUBSCRIPTION_LOCK_TTL_SECONDS =
 	process.env.NODE_ENV === "production" ? 60 : 3;
@@ -18,19 +18,13 @@ export const setStripeSubscriptionLock = async ({
 	stripeSubscriptionId: string;
 	lockedAtMs: number;
 }) => {
-	const miscRedis = getMiscRedis();
 	const lockKey = buildStripeSubscriptionLockKey(stripeSubscriptionId);
 
-	await tryRedisOp({
-		operation: () =>
-			miscRedis.set(
-				lockKey,
-				JSON.stringify({ lockedAtMs }),
-				"EX",
-				STRIPE_SUBSCRIPTION_LOCK_TTL_SECONDS,
-			),
+	await setOnMiscRedisTargets({
+		key: lockKey,
+		value: JSON.stringify({ lockedAtMs }),
+		ttlMs: STRIPE_SUBSCRIPTION_LOCK_TTL_SECONDS * 1000,
 		source: "stripe-subscription-lock:set",
-		redisInstance: miscRedis,
 	});
 };
 
@@ -39,13 +33,9 @@ export const getStripeSubscriptionLock = async ({
 }: {
 	stripeSubscriptionId: string;
 }): Promise<StripeSubscriptionLock | null> => {
-	const miscRedis = getMiscRedis();
-	const lockKey = buildStripeSubscriptionLockKey(stripeSubscriptionId);
-
-	const value = await tryRedisOp({
-		operation: () => miscRedis.get(lockKey),
+	const value = await getFromMiscRedisTargets({
+		key: buildStripeSubscriptionLockKey(stripeSubscriptionId),
 		source: "stripe-subscription-lock:get",
-		redisInstance: miscRedis,
 	});
 	if (!value) return null;
 

--- a/server/src/external/redis/availabilityMonitor/createRedisAvailability.ts
+++ b/server/src/external/redis/availabilityMonitor/createRedisAvailability.ts
@@ -61,7 +61,9 @@ export const createRedisAvailability = ({
 }) => {
 	let probeRedis: Redis | null = null;
 	let probeSourceRedis: Redis | null = null;
-	let redisAvailabilityState: RedisAvailabilityState = "degraded";
+	// Optimistic start: a boot-time gate check must not read as an outage. A real
+	// outage degrades after failuresToDegrade probes; per-op timeouts bound the gap.
+	let redisAvailabilityState: RedisAvailabilityState = "healthy";
 	let redisMonitorInterval: ReturnType<typeof setInterval> | null = null;
 	let redisTickInFlight = false;
 	let lastAvailabilityLogAt = 0;
@@ -266,19 +268,14 @@ export const createRedisAvailability = ({
 			const activeProbeRedis = getOrCreateProbeRedis();
 			const readinessPromises: Promise<void>[] = [];
 
-			if (
-				mainRedis.status === "connecting" ||
-				mainRedis.status === "reconnecting"
-			) {
+			// Any non-ready status (wait/connecting/connect/reconnecting) means the
+			// handshake is still in flight — probing now would misread boot as an outage.
+			if (mainRedis.status !== "ready") {
 				readinessPromises.push(
 					waitForRedisReady(mainRedis, logPrefix).catch(() => undefined),
 				);
 			}
-			if (
-				activeProbeRedis !== mainRedis &&
-				(activeProbeRedis.status === "connecting" ||
-					activeProbeRedis.status === "reconnecting")
-			) {
+			if (activeProbeRedis !== mainRedis && activeProbeRedis.status !== "ready") {
 				readinessPromises.push(
 					waitForRedisReady(activeProbeRedis, `${logPrefix}Probe`).catch(
 						() => undefined,

--- a/server/src/external/redis/miscCache/getFromMiscRedisTargets.ts
+++ b/server/src/external/redis/miscCache/getFromMiscRedisTargets.ts
@@ -1,0 +1,22 @@
+import { tryRedisOp } from "../utils/runRedisOp.js";
+import { getMiscRedisTargets } from "./resolveMiscRedis.js";
+
+/** Read a cross-request key from the active instance first, then any other
+ *  live target — a flip mid-handoff can leave the value on either side. */
+export const getFromMiscRedisTargets = async ({
+	key,
+	source,
+}: {
+	key: string;
+	source: string;
+}): Promise<string | null> => {
+	for (const { redis } of getMiscRedisTargets()) {
+		const value = await tryRedisOp({
+			operation: () => redis.get(key),
+			source,
+			redisInstance: redis,
+		});
+		if (value) return value;
+	}
+	return null;
+};

--- a/server/src/external/redis/miscCache/setOnMiscRedisTargets.ts
+++ b/server/src/external/redis/miscCache/setOnMiscRedisTargets.ts
@@ -1,0 +1,68 @@
+import type { Redis } from "ioredis";
+import { getActiveMiscRedisInstanceName } from "@/internal/misc/miscRedisConfig/miscRedisConfigStore.js";
+import { tryRedisOp } from "../utils/runRedisOp.js";
+import { getMiscRedisTargets } from "./resolveMiscRedis.js";
+
+const setOnTarget = ({
+	redis,
+	key,
+	value,
+	ttlMs,
+	source,
+}: {
+	redis: Redis;
+	key: string;
+	value: string;
+	ttlMs: number;
+	source: string;
+}) =>
+	tryRedisOp({
+		operation: () => redis.set(key, value, "PX", ttlMs),
+		source,
+		redisInstance: redis,
+	});
+
+/** Write-through for coordination keys (locks/reservations): the same SET
+ *  lands on every live instance, so a cutover or rollback never drops the key. */
+export const setOnMiscRedisTargets = async ({
+	key,
+	value,
+	ttlMs,
+	source,
+}: {
+	key: string;
+	value: string;
+	ttlMs: number;
+	source: string;
+}): Promise<void> => {
+	await Promise.all(
+		getMiscRedisTargets().map(({ redis }) =>
+			setOnTarget({ redis, key, value, ttlMs, source }),
+		),
+	);
+};
+
+/** Best-effort, never-throws copy of a won lock to the ramp target — safe to
+ *  `void`. The NX decision stays with the active instance; a mirror never votes. */
+export const mirrorSetOnMiscRedisRampTarget = async ({
+	key,
+	value,
+	ttlMs,
+	source,
+}: {
+	key: string;
+	value: string;
+	ttlMs: number;
+	source: string;
+}): Promise<void> => {
+	try {
+		const activeInstance = getActiveMiscRedisInstanceName();
+		await Promise.all(
+			getMiscRedisTargets()
+				.filter((target) => target.instanceName !== activeInstance)
+				.map(({ redis }) => setOnTarget({ redis, key, value, ttlMs, source })),
+		);
+	} catch {
+		// Fail open — a missed mirror is bounded by the lock TTL.
+	}
+};

--- a/server/src/external/redis/utils/lockUtils/acquireLock.ts
+++ b/server/src/external/redis/utils/lockUtils/acquireLock.ts
@@ -1,5 +1,6 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { getMiscRedis } from "@/external/redis/initRedis.js";
+import { mirrorSetOnMiscRedisRampTarget } from "@/external/redis/miscCache/setOnMiscRedisTargets.js";
 
 export interface LockData {
 	errorMessage: string;
@@ -55,9 +56,10 @@ export const acquireLock = async ({
 	let conflict = false;
 	try {
 		const lockData: LockData = { errorMessage, token };
+		const serializedLockData = JSON.stringify(lockData);
 		const result = await redis.set(
 			lockKey,
-			JSON.stringify(lockData),
+			serializedLockData,
 			"PX",
 			ttlMs,
 			"NX",
@@ -73,6 +75,13 @@ export const acquireLock = async ({
 
 			throw lockConflictError(parsed?.errorMessage || errorMessage);
 		}
+
+		void mirrorSetOnMiscRedisRampTarget({
+			key: lockKey,
+			value: serializedLockData,
+			ttlMs,
+			source: "lock:mirror",
+		});
 
 		return true;
 	} catch (error) {

--- a/server/src/external/redis/utils/lockUtils/clearLock.ts
+++ b/server/src/external/redis/utils/lockUtils/clearLock.ts
@@ -1,6 +1,7 @@
-import { getMiscRedis } from "@/external/redis/initRedis.js";
+import { forEachMiscRedisTarget } from "@/external/redis/miscCache/resolveMiscRedis.js";
 
-/** Best-effort: with `token`, deletes only if this holder still owns the lock; never throws (TTL reaps). */
+/** Best-effort: with `token`, deletes only if this holder still owns the lock.
+ *  Releases on every live instance during a ramp; never throws (TTL reaps). */
 export const clearLock = async ({
 	lockKey,
 	token,
@@ -9,14 +10,17 @@ export const clearLock = async ({
 	token?: string;
 }) => {
 	try {
-		const redis = getMiscRedis();
-		if (redis.status !== "ready") return;
+		await forEachMiscRedisTarget({
+			operation: async ({ redis }) => {
+				if (redis.status !== "ready") return;
 
-		if (token) {
-			await redis.deleteOwnedLock(lockKey, token);
-		} else {
-			await redis.del(lockKey);
-		}
+				if (token) {
+					await redis.deleteOwnedLock(lockKey, token);
+				} else {
+					await redis.del(lockKey);
+				}
+			},
+		});
 	} catch {
 		// Release is best-effort — an uncleared lock expires by TTL.
 	}

--- a/server/src/external/redis/utils/lockUtils/refreshLockLease.ts
+++ b/server/src/external/redis/utils/lockUtils/refreshLockLease.ts
@@ -1,6 +1,7 @@
-import { getMiscRedis } from "@/external/redis/initRedis.js";
+import { forEachMiscRedisTarget } from "@/external/redis/miscCache/resolveMiscRedis.js";
 
-/** Best-effort one-shot lease extension for a still-owned lock. */
+/** Best-effort one-shot lease extension for a still-owned lock, applied to
+ *  every live instance during a ramp. */
 export const refreshLockLease = async ({
 	lockKey,
 	token,
@@ -11,9 +12,12 @@ export const refreshLockLease = async ({
 	ttlMs: number;
 }) => {
 	try {
-		const redis = getMiscRedis();
-		if (redis.status !== "ready") return;
-		await redis.refreshOwnedLock(lockKey, token, ttlMs.toString());
+		await forEachMiscRedisTarget({
+			operation: async ({ redis }) => {
+				if (redis.status !== "ready") return;
+				await redis.refreshOwnedLock(lockKey, token, ttlMs.toString());
+			},
+		});
 	} catch {
 		// Refresh is best-effort — worst case the original lease stands.
 	}

--- a/server/tests/unit/redis/lock-dual-write.test.ts
+++ b/server/tests/unit/redis/lock-dual-write.test.ts
@@ -1,0 +1,232 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import type { Redis } from "ioredis";
+
+type FakeRedis = {
+	status: string;
+	calls: string[];
+	setResult: string | null;
+	setShouldThrow: boolean;
+	getResult: string | null;
+	set: (...args: (string | number)[]) => Promise<string | null>;
+	get: (key: string) => Promise<string | null>;
+	del: (key: string) => Promise<number>;
+	deleteOwnedLock: (key: string, token: string) => Promise<number>;
+	refreshOwnedLock: (
+		key: string,
+		token: string,
+		ttl: string,
+	) => Promise<number>;
+};
+
+const fakeRedis = (): FakeRedis => ({
+	status: "ready",
+	calls: [],
+	setResult: "OK",
+	setShouldThrow: false,
+	getResult: null,
+	async set(...args) {
+		if (this.setShouldThrow) throw new Error("set failed");
+		this.calls.push(`set:${args.join(":")}`);
+		return this.setResult;
+	},
+	async get(key) {
+		this.calls.push(`get:${key}`);
+		return this.getResult;
+	},
+	async del(key) {
+		this.calls.push(`del:${key}`);
+		return 1;
+	},
+	async deleteOwnedLock(key, token) {
+		this.calls.push(`deleteOwnedLock:${key}:${token}`);
+		return 1;
+	},
+	async refreshOwnedLock(key, token, ttl) {
+		this.calls.push(`refreshOwnedLock:${key}:${token}:${ttl}`);
+		return 1;
+	},
+});
+
+let main = fakeRedis();
+let backup = fakeRedis();
+
+// Capture the real module before mocking so afterAll can restore it —
+// bun's mock.module leaks across test files otherwise.
+const realInstances = {
+	...(await import("@/external/redis/miscCache/miscRedisInstances.js")),
+};
+
+mock.module("@/external/redis/miscCache/miscRedisInstances.js", () => ({
+	getMiscMainRedis: () => main as unknown as Redis,
+	getMiscBackupRedis: () => backup as unknown as Redis,
+}));
+
+import { getFromMiscRedisTargets } from "@/external/redis/miscCache/getFromMiscRedisTargets.js";
+import { setOnMiscRedisTargets } from "@/external/redis/miscCache/setOnMiscRedisTargets.js";
+import { acquireLock } from "@/external/redis/utils/lockUtils/acquireLock.js";
+import { clearLock } from "@/external/redis/utils/lockUtils/clearLock.js";
+import { refreshLockLease } from "@/external/redis/utils/lockUtils/refreshLockLease.js";
+import { _setMiscRedisConfigForTesting } from "@/internal/misc/miscRedisConfig/miscRedisConfigStore.js";
+
+const withRamp = () => {
+	_setMiscRedisConfigForTesting({
+		activeInstance: "main",
+		ramp: { percent: 0, previousPercent: 0, changedAt: 0 },
+	});
+};
+
+afterEach(() => {
+	main = fakeRedis();
+	backup = fakeRedis();
+	_setMiscRedisConfigForTesting({});
+});
+
+afterAll(() => {
+	mock.module(
+		"@/external/redis/miscCache/miscRedisInstances.js",
+		() => realInstances,
+	);
+});
+
+describe("acquireLock dual-write", () => {
+	test("mirrors a won lock to the ramp target as a plain SET (no NX)", async () => {
+		withRamp();
+
+		await acquireLock({ lockKey: "lock:x", ttlMs: 5000, token: "t1" });
+
+		expect(main.calls[0]).toStartWith("set:lock:x:");
+		expect(main.calls[0]).toEndWith(":PX:5000:NX");
+		expect(backup.calls).toHaveLength(1);
+		expect(backup.calls[0]).toEndWith(":PX:5000");
+		expect(backup.calls[0]).not.toInclude(":NX");
+	});
+
+	test("writes only to the active instance when no ramp exists", async () => {
+		await acquireLock({ lockKey: "lock:x", ttlMs: 5000, token: "t1" });
+
+		expect(main.calls).toHaveLength(1);
+		expect(backup.calls).toHaveLength(0);
+	});
+
+	test("does not mirror on conflict", async () => {
+		withRamp();
+		main.setResult = null;
+
+		await expect(
+			acquireLock({ lockKey: "lock:x", ttlMs: 5000, token: "t1" }),
+		).rejects.toThrow();
+		expect(backup.calls).toHaveLength(0);
+	});
+
+	test("a failed mirror write does not fail acquisition", async () => {
+		withRamp();
+		backup.setShouldThrow = true;
+
+		const acquired = await acquireLock({
+			lockKey: "lock:x",
+			ttlMs: 5000,
+			token: "t1",
+		});
+		expect(acquired).toBe(true);
+	});
+});
+
+describe("clearLock dual-write", () => {
+	test("releases the owned lock on every live target", async () => {
+		withRamp();
+
+		await clearLock({ lockKey: "lock:x", token: "t1" });
+
+		expect(main.calls).toEqual(["deleteOwnedLock:lock:x:t1"]);
+		expect(backup.calls).toEqual(["deleteOwnedLock:lock:x:t1"]);
+	});
+
+	test("skips targets that are not ready", async () => {
+		withRamp();
+		backup.status = "connecting";
+
+		await clearLock({ lockKey: "lock:x" });
+
+		expect(main.calls).toEqual(["del:lock:x"]);
+		expect(backup.calls).toHaveLength(0);
+	});
+});
+
+describe("refreshLockLease dual-write", () => {
+	test("extends the lease on every live target", async () => {
+		withRamp();
+
+		await refreshLockLease({ lockKey: "lock:x", token: "t1", ttlMs: 9000 });
+
+		expect(main.calls).toEqual(["refreshOwnedLock:lock:x:t1:9000"]);
+		expect(backup.calls).toEqual(["refreshOwnedLock:lock:x:t1:9000"]);
+	});
+});
+
+describe("setOnMiscRedisTargets", () => {
+	test("write-through lands on every live target during a ramp", async () => {
+		withRamp();
+
+		await setOnMiscRedisTargets({
+			key: "sub:x",
+			value: "v",
+			ttlMs: 60000,
+			source: "test:set",
+		});
+
+		expect(main.calls).toEqual(["set:sub:x:v:PX:60000"]);
+		expect(backup.calls).toEqual(["set:sub:x:v:PX:60000"]);
+	});
+
+	test("writes only to the active instance when no ramp exists", async () => {
+		await setOnMiscRedisTargets({
+			key: "sub:x",
+			value: "v",
+			ttlMs: 60000,
+			source: "test:set",
+		});
+
+		expect(main.calls).toEqual(["set:sub:x:v:PX:60000"]);
+		expect(backup.calls).toHaveLength(0);
+	});
+});
+
+describe("getFromMiscRedisTargets", () => {
+	test("returns the active instance's value without querying the ramp target", async () => {
+		withRamp();
+		main.getResult = "from-main";
+
+		const value = await getFromMiscRedisTargets({
+			key: "sub:x",
+			source: "test:get",
+		});
+
+		expect(value).toBe("from-main");
+		expect(backup.calls).toHaveLength(0);
+	});
+
+	test("falls back to the ramp target when the active instance misses", async () => {
+		withRamp();
+		backup.getResult = "from-backup";
+
+		const value = await getFromMiscRedisTargets({
+			key: "sub:x",
+			source: "test:get",
+		});
+
+		expect(value).toBe("from-backup");
+		expect(main.calls).toEqual(["get:sub:x"]);
+		expect(backup.calls).toEqual(["get:sub:x"]);
+	});
+
+	test("returns null when no live target has the value", async () => {
+		withRamp();
+
+		const value = await getFromMiscRedisTargets({
+			key: "sub:x",
+			source: "test:get",
+		});
+
+		expect(value).toBeNull();
+	});
+});

--- a/server/tests/unit/redis/with-redis-fail-open-gate-rejection.test.ts
+++ b/server/tests/unit/redis/with-redis-fail-open-gate-rejection.test.ts
@@ -4,7 +4,9 @@ import { ApiVersionClass, LATEST_VERSION, RecaseError } from "@autumn/shared";
 // Capture real modules BEFORE mocking — mock.module leaks across test files
 // (mock.restore does not undo it), so afterAll re-mocks with the real exports.
 const realRedisV2Availability = {
-	...(await import("@/external/redis/availabilityMonitor/redisV2Availability.js")),
+	...(await import(
+		"@/external/redis/availabilityMonitor/redisV2Availability.js"
+	)),
 };
 const realRunCheckV2 = {
 	...(await import("@/internal/balances/check/runCheckV2.js")),
@@ -14,9 +16,12 @@ const realRunTrackV3 = {
 };
 const realQueueUtils = { ...(await import("@/queue/queueUtils.js")) };
 
-mock.module("@/external/redis/availabilityMonitor/redisV2Availability.js", () => ({
-	shouldUseRedisV2: () => true,
-}));
+mock.module(
+	"@/external/redis/availabilityMonitor/redisV2Availability.js",
+	() => ({
+		shouldUseRedisV2: () => true,
+	}),
+);
 
 const gateRejection = () =>
 	new RecaseError({
@@ -92,11 +97,21 @@ const { runTrackWithRollout } = await import(
 );
 const { ParsedCheckParamsSchema } = await import("@autumn/shared");
 
+// queueTrack prefers TRACK_ASYNC_SQS_QUEUE_URL — stub both so a real URL from
+// local env can't leak in and route the mocked enqueue at actual SQS.
 const originalTrackQueueUrl = process.env.TRACK_SQS_QUEUE_URL;
+const originalTrackAsyncQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
 process.env.TRACK_SQS_QUEUE_URL = "https://sqs.test/queue";
+process.env.TRACK_ASYNC_SQS_QUEUE_URL = "https://sqs.test/queue";
+
+const restoreEnv = (key: string, value: string | undefined) => {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+};
 
 afterAll(() => {
-	process.env.TRACK_SQS_QUEUE_URL = originalTrackQueueUrl;
+	restoreEnv("TRACK_SQS_QUEUE_URL", originalTrackQueueUrl);
+	restoreEnv("TRACK_ASYNC_SQS_QUEUE_URL", originalTrackAsyncQueueUrl);
 	mock.module(
 		"@/external/redis/availabilityMonitor/redisV2Availability.js",
 		() => realRedisV2Availability,


### PR DESCRIPTION
Part of the Redis Cloud → Dragonfly misc-cache migration. Stacked on #2600 (CacheManager removal).

## Dual-write + read-both

While a ramp exists, locks and cross-request handoff keys survive a flip/rollback in either direction:

```
acquire:  SET NX on ACTIVE ──decides──> won? ─→ void mirror SET to ramp target (copy, never a vote)
release/refresh:  token-checked op on EVERY live target
set (reservations/handoffs):  same SET on EVERY live target
get:  ACTIVE first, fall through to other targets on miss
```

- `miscCache/setOnMiscRedisTargets.ts` (new): `setOnMiscRedisTargets` (write-through) + `mirrorSetOnMiscRedisRampTarget` (never-throws, fire-and-forget from `acquireLock`).
- `miscCache/getFromMiscRedisTargets.ts` (new): active-first read fall-through — covers values written before the ramp existed.
- `lockUtils`: `acquireLock` mirrors wins; `clearLock`/`refreshLockLease` fan owner-token ops across targets.
- Converted stores: `checkoutSessionLock`, `stripeSubscriptionLock`, `expiredCustomerProductsCache` (the `subscription.deleted` → `invoice.created` handoff).
- No ramp configured → exactly one instance touched, zero overhead.
- Excluded by design (see PLAN.md unit 12): `queueCapacityLease`, idempotency claims, `oauthRefreshReplay`, `saveLockReceipt`.

## Availability monitors no longer boot as degraded

`prime()` only awaited readiness on `connecting`/`reconnecting`, but ioredis reports `connect` mid-handshake — boot probes misread that as an outage ("Unavailable, skipping Redis-backed features" 5ms before ready). Prime now waits on any non-ready status, and the initial state is optimistic `healthy` (a real outage still degrades after 5 failed probes). Covers both misc and V2 monitors via `createRedisAvailability`.

## Test fix

`with-redis-fail-open-gate-rejection` failed on every dev machine: it stubbed deprecated `TRACK_SQS_QUEUE_URL`, but `queueTrack` prefers `TRACK_ASYNC_SQS_QUEUE_URL` — the real env URL leaked in and the mocked enqueue attempted actual SQS. Both vars are stubbed and restored now.

## Testing
- `tests/unit/redis/`: 86/86 pass (12 new dual-write tests; the long-standing local flake above is fixed, not skipped).
- `bun ts` + pinned Biome on touched files.
- Dragonfly compat verified empirically against local + dev Dragonfly Cloud (df-v1.38.1): EVALSHA/NOSCRIPT, owner-token lock scripts, queue-permit semaphore, JSON.SET, `{orgId}` hash tags — all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dual-write for misc Redis locks and cross-request keys during ramps with active-first reads, so state survives flips and rollbacks. Also fixes availability monitor boot behavior and stabilizes a flaky test.

- **New Features**
  - Locks: `acquireLock` keeps `NX` on the active instance and mirrors a plain `SET` to the ramp target; `clearLock`/`refreshLockLease` apply owner-token ops to all live targets.
  - Cross-request keys: write-through to all targets and read active-first with fallback via `setOnMiscRedisTargets` and `getFromMiscRedisTargets`.
  - Converted: `checkoutSessionLock`, `stripeSubscriptionLock`, `expiredCustomerProductsCache`.
  - No ramp → only the active instance is touched. Excluded: `queueCapacityLease`, idempotency claim, `oauthRefreshReplay`, `saveLockReceipt`.

- **Bug Fixes**
  - Availability monitors start healthy and `prime()` waits on any non-ready status before probing.
  - Test: stub both `TRACK_SQS_QUEUE_URL` and `TRACK_ASYNC_SQS_QUEUE_URL` to prevent accidental real SQS calls.

<sup>Written for commit 58d0c5238a3fd73c550b1b20289535af36094460. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds migration-aware Redis handling for distributed locks and cross-request handoff keys, and adjusts Redis availability initialization and a queue-related test.
- **[API changes, Improvements]** Adds active-first reads and writes across all live misc-Redis targets during a ramp.
- **[API changes, Improvements]** Mirrors acquired locks and fans lock release and lease refresh operations across ramp targets.
- **[Bug fixes, Improvements]** Treats Redis availability as healthy during startup while clients finish connecting.
- **[Bug fixes]** Stubs and restores both track-queue environment variables in the fail-open test.
</details>

<h3>Confidence Score: 4/5</h3>

This PR is not safe to merge until lock mirroring preserves mutual exclusion across target flips and is ordered safely against release.

The mirror still performs an unconditional discarded write, so it can overwrite live ownership or recreate a released lock; it also resolves the active instance after acquisition, allowing a cutover to exclude the instance that now needs the mirrored lock and permitting two workers to enter the same protected operation.

**Files Needing Attention:** server/src/external/redis/miscCache/setOnMiscRedisTargets.ts, server/src/external/redis/utils/lockUtils/acquireLock.ts, server/src/external/redis/utils/lockUtils/clearLock.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/miscCache/setOnMiscRedisTargets.ts | Adds write-through and lock-mirroring helpers, but mirror target selection and unconditional writes leave lock ownership unsafe across flips. |
| server/src/external/redis/utils/lockUtils/acquireLock.ts | Mirrors successful acquisitions asynchronously; the discarded operation can race cutover, release, and another owner. |
| server/src/external/redis/utils/lockUtils/clearLock.ts | Expands owner-checked release to every live target, though it cannot order itself after the discarded acquisition mirror. |
| server/src/external/redis/utils/lockUtils/refreshLockLease.ts | Expands owner-checked lease refresh to every live target. |
| server/src/external/redis/miscCache/getFromMiscRedisTargets.ts | Adds active-first reads with fallback to other live migration targets. |
| server/src/external/redis/availabilityMonitor/createRedisAvailability.ts | Starts optimistically healthy and waits for every non-ready Redis status before probing. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W1 as Worker 1
    participant A as Redis A
    participant Config as Active config
    participant B as Redis B
    participant W2 as Worker 2
    W1->>Config: "Resolve active = A"
    W1->>A: SET lock NX
    A-->>W1: OK
    Config->>Config: Flip active to B
    W1->>Config: "Mirror resolves active again = B"
    Note over W1,B: Mirror filters out B
    W2->>Config: "Resolve active = B"
    W2->>B: SET same lock NX
    B-->>W2: OK
    Note over W1,W2: Both workers enter protected work
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/external/redis/miscCache/setOnMiscRedisTargets.ts:59-63
**Cutover skips the new active target**

When the active Redis instance flips after the NX write succeeds but before this asynchronous mirror resolves its targets, the mirror treats the new active instance as the source and filters it out. The lock remains only on the old instance, so another worker can acquire the same lock on the new active instance and both workers execute the protected operation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tests): stub TRACK\_ASYNC\_SQS\_QUEUE\_U..."](https://github.com/useautumn/autumn/commit/58d0c5238a3fd73c550b1b20289535af36094460) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50365126)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->