### PR TITLE
fix(billing): resolve a price to its entitlement across product versions

### DIFF
--- a/server/tests/integration/billing/cross-product-entitlements/cross-product-entitlement-ops.test.ts
+++ b/server/tests/integration/billing/cross-product-entitlements/cross-product-entitlement-ops.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Contract: a customer product may carry entitlement rows owned by a DIFFERENT
+ * product than the one it points at — grandfathered rows survive a plan version
+ * bump, and a regenerated custom price is stamped with the customer product's
+ * own `internal_product_id`. Every billing operation must still resolve the
+ * price → entitlement pair and leave Stripe consistent with Autumn.
+ *
+ * Shape reproduced here (from a reported production customer):
+ *  - a custom customer product on the current plan,
+ *  - a pay-per-use in-arrear item whose price AND entitlement are both owned by
+ *    a superseded plan (they agree with each other; only the customer product
+ *    has moved on),
+ *  - a fixed monthly price owned by the current plan.
+ *
+ * Before the `priceToEnt` fix, `update` 404'd with
+ * `createStripeInArrearPrice: feature not found for price pr_...`. These cases
+ * cover the other operations that walk the same resolution path.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { queryRows } from "@tests/integration/balances/utils/usage-limit-utils/usageWindowDbTestUtils";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect/expectStripeSubscriptionCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { addMonths } from "date-fns";
+import { sql } from "drizzle-orm";
+
+const CREDITS_PRICE_PER_UNIT = 0.01;
+const BASE_PRICE = 20;
+
+const creditsItem = ({ price }: { price: number }) =>
+	items.consumable({
+		featureId: TestFeature.Credits,
+		includedUsage: 0,
+		price,
+	});
+
+/** Pay-per-use credits + a fixed base price — the priced pair that has to
+ * resolve across the product boundary. */
+const planItems = () => [
+	creditsItem({ price: CREDITS_PRICE_PER_UNIT }),
+	items.monthlyPrice({ price: BASE_PRICE }),
+];
+
+const buildPlans = ({ suffix }: { suffix: string }) => ({
+	plan: products.base({ id: `plan-${suffix}`, items: planItems() }),
+	// Stands in for the superseded version that still owns the grandfathered rows.
+	supersededPlan: products.base({
+		id: `superseded-${suffix}`,
+		items: [items.monthlyCredits({ includedUsage: 10_000 })],
+	}),
+	upgradePlan: products.base({
+		id: `upgrade-${suffix}`,
+		items: [
+			creditsItem({ price: CREDITS_PRICE_PER_UNIT }),
+			items.monthlyPrice({ price: 150 }),
+		],
+	}),
+});
+
+const internalProductId = async ({
+	ctx,
+	productId,
+}: {
+	ctx: TestContext;
+	productId: string;
+}) =>
+	queryRows(
+		await ctx.db.execute(sql`
+			SELECT internal_id FROM products
+			WHERE id = ${productId} AND org_id = ${ctx.org.id} AND env = ${ctx.env}
+			LIMIT 1
+		`),
+	)[0]?.internal_id as string | undefined;
+
+const activeCreditsRow = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}) =>
+	queryRows(
+		await ctx.db.execute(sql`
+			SELECT
+				customer_product.internal_product_id AS customer_product_internal_product_id,
+				entitlement.id AS entitlement_id,
+				entitlement.internal_product_id AS entitlement_internal_product_id,
+				price.id AS price_id
+			FROM customer_entitlements customer_entitlement
+			JOIN customer_products customer_product
+				ON customer_product.id = customer_entitlement.customer_product_id
+			JOIN customers customer
+				ON customer.internal_id = customer_product.internal_customer_id
+			JOIN entitlements entitlement
+				ON entitlement.id = customer_entitlement.entitlement_id
+			LEFT JOIN prices price
+				ON price.entitlement_id = entitlement.id
+			WHERE customer.id = ${customerId}
+				AND customer.org_id = ${ctx.org.id}
+				AND customer.env = ${ctx.env}
+				AND customer_product.status = 'active'
+				AND entitlement.feature_id = ${TestFeature.Credits}
+			LIMIT 1
+		`),
+	)[0];
+
+/**
+ * Attach the plan as a custom subscription, then hand its priced credits pair
+ * over to the superseded plan so the customer product straddles two products —
+ * the reported production shape.
+ *
+ * `initScenario` prefixes product ids in place, so `plan.id` and friends are
+ * already fully qualified once it resolves.
+ */
+const initCrossProductScenario = async ({
+	customerId,
+	suffix,
+}: {
+	customerId: string;
+	suffix: string;
+}) => {
+	const { plan, supersededPlan, upgradePlan } = buildPlans({ suffix });
+
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [plan, supersededPlan, upgradePlan] }),
+		],
+		actions: [s.billing.attach({ productId: plan.id, items: planItems() })],
+	});
+
+	const { ctx } = scenario;
+
+	const supersededInternalId = await internalProductId({
+		ctx,
+		productId: supersededPlan.id,
+	});
+	expect(supersededInternalId).toBeTruthy();
+
+	const creditsRow = await activeCreditsRow({ ctx, customerId });
+	expect(creditsRow?.entitlement_id).toBeTruthy();
+	expect(creditsRow?.price_id).toBeTruthy();
+
+	await ctx.db.execute(sql`
+		UPDATE entitlements SET internal_product_id = ${supersededInternalId}
+		WHERE id = ${creditsRow.entitlement_id}
+	`);
+	await ctx.db.execute(sql`
+		UPDATE prices SET internal_product_id = ${supersededInternalId}
+		WHERE id = ${creditsRow.price_id}
+	`);
+
+	// The straddle is real before any operation runs.
+	const straddled = await activeCreditsRow({ ctx, customerId });
+	expect(straddled.entitlement_internal_product_id).toBe(supersededInternalId);
+	expect(straddled.entitlement_internal_product_id).not.toBe(
+		straddled.customer_product_internal_product_id,
+	);
+
+	return { ...scenario, plan, supersededPlan, upgradePlan, creditsRow };
+};
+
+/** Runs the production `/billing.verify` action: every Stripe subscription must
+ * match the state derived from the customer's products. The strongest
+ * "no billing errors" signal available. */
+const expectBillingConsistent = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+}) => await expectStripeSubscriptionCorrect({ ctx, customerId });
+
+test.concurrent(
+	`${chalk.yellowBright("cross-product ents: update reprices the straddled usage item")}`,
+	async () => {
+		const customerId = "xprod-update";
+		const { autumnV1, ctx, plan, creditsRow } = await initCrossProductScenario({
+			customerId,
+			suffix: "update",
+		});
+
+		// Repricing the usage item is what regenerates its custom price; the
+		// unchanged entitlement is carried over still owned by the superseded plan.
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: plan.id,
+			items: [
+				{
+					...creditsItem({ price: CREDITS_PRICE_PER_UNIT * 2 }),
+					entitlement_id: creditsRow.entitlement_id,
+					price_id: creditsRow.price_id,
+				},
+				items.monthlyPrice({ price: 150 }),
+			],
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerInvoiceCorrect({ customer, count: 2 });
+		await expectBillingConsistent({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("cross-product ents: attach a different plan over it")}`,
+	async () => {
+		const customerId = "xprod-attach";
+		const { autumnV2_2, autumnV1, ctx, upgradePlan } =
+			await initCrossProductScenario({
+				customerId,
+				suffix: "attach",
+			});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: upgradePlan.id,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(
+			customer.products?.some((product) => product.id === upgradePlan.id),
+		).toBe(true);
+		await expectBillingConsistent({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("cross-product ents: cancel end-of-cycle then uncancel")}`,
+	async () => {
+		const customerId = "xprod-cancel";
+		const { autumnV1, ctx, plan } = await initCrossProductScenario({
+			customerId,
+			suffix: "cancel",
+		});
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: plan.id,
+			cancel_action: "cancel_end_of_cycle",
+		});
+
+		const canceling = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(
+			canceling.products?.find((product) => product.id === plan.id)
+				?.canceled_at,
+		).toBeTruthy();
+		await expectBillingConsistent({ ctx, customerId });
+
+		await autumnV1.subscriptions.update({
+			customer_id: customerId,
+			product_id: plan.id,
+			cancel_action: "uncancel",
+		});
+
+		const uncanceled = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(
+			uncanceled.products?.find((product) => product.id === plan.id)
+				?.canceled_at,
+		).toBeFalsy();
+		await expectBillingConsistent({ ctx, customerId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("cross-product ents: createSchedule phases the plan forward")}`,
+	async () => {
+		const customerId = "xprod-schedule";
+		const { autumnV1, plan, upgradePlan, advancedTo } =
+			await initCrossProductScenario({
+				customerId,
+				suffix: "schedule",
+			});
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			phases: [
+				{
+					starts_at: advancedTo,
+					plans: [{ plan_id: plan.id }],
+				},
+				{
+					starts_at: addMonths(new Date(advancedTo), 1).getTime(),
+					plans: [{ plan_id: upgradePlan.id }],
+				},
+			],
+		});
+
+		// Deliberately not asserting expectStripeSubscriptionCorrect here: this
+		// flow reports an `unexpected_schedule` mismatch even with no cross-product
+		// rows at all (verified against a plain plan), so it would assert a
+		// pre-existing gap rather than anything this contract covers.
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(
+			customer.products?.some((product) => product.id === upgradePlan.id),
+		).toBe(true);
+	},
+);

--- a/server/tests/integration/billing/update-subscription/custom-plan/update-cross-version-entitlement.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan/update-cross-version-entitlement.test.ts
@@ -1,0 +1,172 @@
+/**
+ * TDD test for: a custom `billing.update` 404s with `feature_not_found` when the
+ * customer product carries a usage entitlement row owned by a DIFFERENT product
+ * than the customer product itself (grandfathered / migrated rows).
+ *
+ * Reported by mintlify: updating a subscription to $150/mo returned
+ * `createStripeInArrearPrice: feature not found for price pr_...` on every retry
+ * (a different price id each time, because the id is minted fresh and never
+ * persisted). 1890 mintlify customer products are in this shape.
+ *
+ * Red-failure mode (current behavior):
+ *  - `itemToPriceAndEnt` always mints a fresh custom price stamped with the
+ *    customer product's own `internal_product_id`, while an unchanged
+ *    entitlement is carried over as `sameEnt` and keeps the OTHER product's
+ *    `internal_product_id` (`entsAreSame` does not compare it).
+ *  - `priceToEnt` matches on `entitlement_id` AND `internal_product_id`, so it
+ *    fails to resolve an entitlement that is sitting right there in the array,
+ *    and `createStripeInArrearPrice` throws a 404 `feature_not_found`.
+ *
+ * Green-success criteria (after fix):
+ *  - `priceToEnt` resolves by entitlement id alone — ids are globally unique
+ *    KSUIDs, and its customer-product-scoped sibling
+ *    `customerPriceToCustomerEntitlement` already matches this way — so the
+ *    update succeeds and the new base price is applied.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { queryRows } from "@tests/integration/balances/utils/usage-limit-utils/usageWindowDbTestUtils";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { sql } from "drizzle-orm";
+
+/** The customer product's live price/entitlement ids, as the dashboard reads
+ * them back before echoing them into `billing.update`. */
+const getLiveItemIds = async ({
+	ctx,
+	customerId,
+	featureId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	featureId: string;
+}) =>
+	queryRows(
+		await ctx.db.execute(sql`
+			SELECT
+				customer_entitlement.entitlement_id,
+				entitlement.internal_product_id AS entitlement_internal_product_id,
+				customer_product.internal_product_id AS customer_product_internal_product_id,
+				price.id AS price_id
+			FROM customer_entitlements customer_entitlement
+			JOIN customer_products customer_product
+				ON customer_product.id = customer_entitlement.customer_product_id
+			JOIN customers customer
+				ON customer.internal_id = customer_product.internal_customer_id
+			JOIN entitlements entitlement
+				ON entitlement.id = customer_entitlement.entitlement_id
+			LEFT JOIN prices price
+				ON price.entitlement_id = entitlement.id
+			WHERE customer.id = ${customerId}
+				AND customer.org_id = ${ctx.org.id}
+				AND customer.env = ${ctx.env}
+				AND customer_product.status = 'active'
+				AND entitlement.feature_id = ${featureId}
+			LIMIT 1
+		`),
+	)[0];
+
+test.concurrent(
+	`${chalk.yellowBright("p2p: custom update when the usage entitlement belongs to another product")}`,
+	async () => {
+		const customerId = "p2p-cross-version-ent";
+		const messagesItem = items.consumableMessages({
+			includedUsage: 0,
+			price: 0.01,
+		});
+		const priceItem = items.monthlyPrice({ price: 20 });
+
+		const pro = products.base({
+			id: "pro-cross-version",
+			items: [messagesItem, priceItem],
+		});
+		// Stands in for the older plan version the grandfathered entitlement row
+		// still belongs to after a migration.
+		const legacy = products.base({
+			id: "legacy-cross-version",
+			items: [items.monthlyWords({ includedUsage: 1 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, legacy] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		const before = await getLiveItemIds({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(before?.entitlement_id).toBeTruthy();
+		expect(before?.price_id).toBeTruthy();
+
+		// Reproduce the grandfathered pair: the customer product still points at
+		// `pro`, but its usage price AND entitlement are both owned by the older
+		// plan. They agree with each other — only the customer product has moved
+		// on — which is what makes the regenerated custom price straddle them.
+		const legacyInternalId = sql`(
+			SELECT internal_id FROM products
+			WHERE id = ${legacy.id}
+				AND org_id = ${ctx.org.id}
+				AND env = ${ctx.env}
+			LIMIT 1
+		)`;
+		await ctx.db.execute(sql`
+			UPDATE entitlements SET internal_product_id = ${legacyInternalId}
+			WHERE id = ${before.entitlement_id}
+		`);
+		await ctx.db.execute(sql`
+			UPDATE prices SET internal_product_id = ${legacyInternalId}
+			WHERE id = ${before.price_id}
+		`);
+
+		const after = await getLiveItemIds({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(after.entitlement_internal_product_id).not.toBe(
+			after.customer_product_internal_product_id,
+		);
+
+		// The dashboard echoes the customer product's live item ids back on update.
+		// Repricing the usage item (and only it) is what forces `itemToPriceAndEnt`
+		// down the `updatedPrice` branch: the entitlement is unchanged so it is
+		// carried over as `sameEnt` keeping the older product, while the price is
+		// regenerated and stamped with the customer product's product.
+		const updateParams = {
+			customer_id: customerId,
+			product_id: pro.id,
+			items: [
+				{
+					...items.consumableMessages({ includedUsage: 0, price: 0.02 }),
+					entitlement_id: before.entitlement_id,
+					price_id: before.price_id,
+				},
+				items.monthlyPrice({ price: 150 }),
+			],
+		};
+
+		await autumnV1.subscriptions.update(updateParams);
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			includedUsage: 0,
+			balance: 0,
+			usage: 0,
+		});
+	},
+);

--- a/server/tests/unit/catalog/priceToEnt.test.ts
+++ b/server/tests/unit/catalog/priceToEnt.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "bun:test";
+import type { EntitlementWithFeature, Price } from "@autumn/shared";
+import { priceToEnt } from "@autumn/shared";
+
+/**
+ * A customer product can legitimately carry entitlement rows owned by another
+ * product — grandfathered / migrated rows survive a version bump, and
+ * `handleNewProductItems` re-stamps a regenerated custom price with the
+ * customer product's own `internal_product_id` while carrying the unchanged
+ * entitlement over untouched (`entsAreSame` ignores `internal_product_id`).
+ *
+ * Matching on `internal_product_id` therefore drops an entitlement that is
+ * sitting right there in the array, which surfaced as a 404
+ * `createStripeInArrearPrice: feature not found for price pr_...` on
+ * `billing.update`. Ids are globally unique KSUIDs, so the id alone identifies
+ * the entitlement — the same rule its customer-product-scoped sibling
+ * `customerPriceToCustomerEntitlement` already follows.
+ */
+
+const entitlement = ({
+	id,
+	internalProductId,
+}: {
+	id: string;
+	internalProductId: string;
+}) =>
+	({
+		id,
+		internal_product_id: internalProductId,
+		feature_id: "AI_CREDITS",
+		feature: { id: "AI_CREDITS", name: "AI Credits" },
+	}) as unknown as EntitlementWithFeature;
+
+const price = ({
+	entitlementId,
+	internalProductId,
+}: {
+	entitlementId: string;
+	internalProductId: string;
+}) =>
+	({
+		id: "pr_regenerated",
+		entitlement_id: entitlementId,
+		internal_product_id: internalProductId,
+	}) as unknown as Price;
+
+test("priceToEnt resolves an entitlement owned by another product", () => {
+	const ent = entitlement({ id: "ent_1", internalProductId: "prod_v3" });
+
+	const resolved = priceToEnt({
+		price: price({ entitlementId: "ent_1", internalProductId: "prod_v6" }),
+		entitlements: [ent],
+	});
+
+	expect(resolved).toBe(ent);
+});
+
+test("priceToEnt still resolves when price and entitlement share a product", () => {
+	const ent = entitlement({ id: "ent_1", internalProductId: "prod_v6" });
+
+	const resolved = priceToEnt({
+		price: price({ entitlementId: "ent_1", internalProductId: "prod_v6" }),
+		entitlements: [ent],
+	});
+
+	expect(resolved).toBe(ent);
+});
+
+test("priceToEnt returns undefined when no entitlement id matches", () => {
+	const resolved = priceToEnt({
+		price: price({
+			entitlementId: "ent_missing",
+			internalProductId: "prod_v6",
+		}),
+		entitlements: [entitlement({ id: "ent_1", internalProductId: "prod_v6" })],
+	});
+
+	expect(resolved).toBeUndefined();
+});

--- a/shared/utils/productUtils/convertProductUtils.ts
+++ b/shared/utils/productUtils/convertProductUtils.ts
@@ -62,11 +62,21 @@ export function priceToEnt({
 	entitlements: EntitlementWithFeature[];
 	errorOnNotFound?: boolean;
 }): EntitlementWithFeature | undefined {
-	const entitlement = entitlements.find(
-		(ent) =>
-			ent.id === price.entitlement_id &&
-			ent.internal_product_id === price.internal_product_id,
+	// Prefer the entitlement that also shares the price's product — the original,
+	// strict match, so nothing changes for a well-formed product. Only fall back
+	// to id alone, because a customer product can carry entitlement rows owned by
+	// another product (grandfathered rows that survive a version bump) while a
+	// regenerated custom price is stamped with the customer product's own
+	// internal_product_id. Entitlement ids are globally unique, so the fallback
+	// cannot resolve to a different entitlement than the strict match would have.
+	// Mirrors the scoped sibling customerPriceToCustomerEntitlement.
+	const idMatches = entitlements.filter(
+		(ent) => ent.id === price.entitlement_id,
 	);
+	const entitlement =
+		idMatches.find(
+			(ent) => ent.internal_product_id === price.internal_product_id,
+		) ?? idMatches[0];
 
 	if (!entitlement && errorOnNotFound) {
 		throw new InternalError({


### PR DESCRIPTION
## Problem

A customer reported that every attempt to update their subscription failed:

```
createStripeInArrearPrice: feature not found for price pr_3HSnqvNXQufR1Tk60VgqNAM4J6w
```

A different `pr_` id each time, because the price is minted fresh per attempt and never persisted. Nine retries in one day, plus earlier occurrences.

## Root cause

The customer product is a custom plan on `pro` v6, but it carries rows grandfathered from older versions — its pay-per-use usage price **and** its entitlement are both owned by `pro` v3. They agree with each other; only the customer product has moved on.

On `billing.update`:

1. `setupUpdateSubscriptionProductContext` builds `fullProduct = cusProductToProduct(cusProduct)`, so `product.internal_id` is v6 while the carried entitlements keep their own `internal_product_id` (v3).
2. `entsAreSame` does not compare `internal_product_id`, so the unchanged entitlement is carried over as `sameEnt`, still owned by v3.
3. `itemToPriceAndEnt` regenerates the custom price and stamps it with v6.
4. `priceToEnt` required **both** `id` and `internal_product_id` to match — so it failed to resolve an entitlement that was sitting right there in the array.

The same guard also made `stripePriceMatchesAutumnPrice` (which passes `errorOnNotFound: true`) throw `Entitlement not found for price pr_...` — the second live error on this account.

**Scale:** 1,890 customer products on one org (plus 3 on another) hold a usage price whose entitlement belongs to a different product than the customer product. Persisted price → entitlement pairs are otherwise consistent (0 bad rows), so this needs no data repair — only the resolution rule.

## Fix

`priceToEnt` now prefers the entitlement that also shares the price's product — the original, strict match, so behaviour is unchanged for a well-formed product — and only falls back to matching on id alone.

Entitlement ids are globally unique and every one of the 18 call sites passes a single product's entitlement array, so the fallback can never resolve to a different entitlement than the strict match would have. This mirrors the scoped sibling `customerPriceToCustomerEntitlement`, which already matches on entitlement id alone.

### Caller audit

The only possible behaviour change is `undefined → resolved`:

| Behaviour before | Sites | Now |
|---|---|---|
| **Threw** `Entitlement not found for price` | `stripePriceMatchesAutumnPrice`, `setupFeatureQuantitiesContext`, `priceToStripeCreatePriceParams` | resolves |
| Silently skipped (`continue` / warn) | `findProductLevelMatchForStripeItem`, `subscriptionToFeatureOptions`, `buildIncrementalSyncParams`, `buildFeatureQuantities`, `convertStripeCheckoutSession` | resolves |
| Produced wrong data | `createNewCustomer` (undefined `feature_id`), `stripeItemToFeatureOptionsQuantity` (allowance treated as 0), `mapToProductV2` (emitted a duplicate price-only item) | correct |
| Took a wrong branch | `createStripePrepaidPriceV2` (reused the V1 price, ignoring allowance), `priceIsTieredOneOff` (never tiered), `getPriceStripeReuseLevel` (`"none"` → a new Stripe price every time) | correct |

`getPriceStripeReuseLevel` actually gets *stricter*: its `if (!newEnt && !candidateEnt) return "full"` branch was reusing Stripe ids for usage prices without ever comparing entitlements when both sides failed to resolve.

## Tests

**`update-cross-version-entitlement.test.ts`** — the reproduction. Verified as a real red by stashing the fix:

```
error: createStripeInArrearPrice: feature not found for price pr_3HT0zhsvUc4JKpKTh4RBG7Lybn4
       code: "feature_not_found"
```

Two details are load-bearing: the price *and* entitlement must both move to the older plan (that is what makes `getPriceStripeReuseLevel` return `"none"`, skip Stripe-price reuse, and actually reach `createStripeInArrearPrice`), and the usage item must be repriced (otherwise `itemToPriceAndEnt` takes the `samePrice` branch and never regenerates a price).

**`cross-product-entitlement-ops.test.ts`** — the same shape run through `update`, `attach`, `cancel` → `uncancel`, and `createSchedule`. Three assert `expectStripeSubscriptionCorrect`, which runs the production `/billing.verify` action.

**`tests/unit/catalog/priceToEnt.test.ts`** — cross-product resolve, same-product resolve, and genuine miss → `undefined`.

## Known gap, not introduced here

The `createSchedule` case reports `unexpected_schedule` ("Stripe schedule phases not in Autumn"). I checked this against a plain plan with no cross-product rows at all and it fails identically, so it is pre-existing and unrelated. That case asserts the scheduled plan landed instead, with a comment explaining why.

## Verification

- `update-cross-version-entitlement.test.ts` — 1 pass
- `cross-product-entitlement-ops.test.ts` — 4 pass
- `tests/unit/catalog` + `tests/unit/billing` — 879 pass
- `bun ts` and biome clean on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes price→entitlement matching when a customer product carries grandfathered entitlements from another product version. Prevents `feature_not_found` and entitlement-mismatch errors during `billing.update`, attach/cancel, and schedule flows.

- **Bug Fixes**
  - Updated `priceToEnt` to prefer a strict match (entitlement id + product) and fall back to id-only; mirrors `customerPriceToCustomerEntitlement` and keeps behavior unchanged for well-formed products.
  - Added targeted unit and integration tests that cover cross-product updates, attach, cancel/uncancel, and schedules, including verification via `/billing.verify`.

<sup>Written for commit e0fb777d95082209ace5fa4577fdb6cfa27a4e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes billing operations for customer products carrying entitlements from an older product version.
- **[Bug fixes]** Resolves a price by its entitlement ID when the price and entitlement belong to different product versions, while preserving the existing same-product preference.
- **[Improvements]** Adds unit coverage for strict matches, cross-product matches, and missing entitlements.
- **[Improvements]** Adds integration coverage for subscription updates, plan attachment, cancellation and restoration, and scheduled plan changes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the lookup change preserving existing strict matches and correctly handling cross-version entitlement ownership.

Entitlement IDs are globally unique, callers provide product-scoped entitlement arrays, and the added unit and integration tests cover both the repaired billing path and unchanged lookup behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productUtils/convertProductUtils.ts | Preserves same-product entitlement resolution as the first choice and adds an ID-only fallback for valid cross-version rows. |
| server/tests/unit/catalog/priceToEnt.test.ts | Covers cross-product resolution, unchanged strict resolution, and genuine missing-entitlement behavior. |
| server/tests/integration/billing/update-subscription/custom-plan/update-cross-version-entitlement.test.ts | Reproduces the reported custom subscription update failure with a grandfathered price and entitlement pair. |
| server/tests/integration/billing/cross-product-entitlements/cross-product-entitlement-ops.test.ts | Exercises the cross-version entitlement shape across update, attach, cancellation restoration, and schedule operations. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    P[Price requiring entitlement] --> S{Matching ID and product?}
    S -->|Yes| E[Use strict same-product match]
    S -->|No| I{Matching entitlement ID?}
    I -->|Yes| F[Use cross-version entitlement]
    I -->|No| N[Return undefined or throw when requested]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(billing): resolve a price to its ent..."](https://github.com/useautumn/autumn/commit/e0fb777d95082209ace5fa4577fdb6cfa27a4e84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50224337)</sub>

<!-- /greptile_comment -->