### PR TITLE
fix: reuse still-valid cached credentials when a refresh attempt fails

### DIFF
--- a/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
+++ b/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
@@ -49,30 +49,39 @@ const resolveContainerCredentials =
 		const authToken =
 			process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN ??
 			(tokenFile ? (await Bun.file(tokenFile).text()).trim() : undefined);
-		// A stalled metadata endpoint must not hang boot: polling start is awaited.
-		const response = await fetch(url, {
-			signal: AbortSignal.timeout(5_000),
-			...(authToken ? { headers: { Authorization: authToken } } : {}),
-		});
-		if (!response.ok) {
-			throw new Error(
-				`Container credentials endpoint returned ${response.status}`,
-			);
+		try {
+			// A stalled metadata endpoint must not hang boot: polling start is awaited.
+			const response = await fetch(url, {
+				signal: AbortSignal.timeout(5_000),
+				...(authToken ? { headers: { Authorization: authToken } } : {}),
+			});
+			if (!response.ok) {
+				throw new Error(
+					`Container credentials endpoint returned ${response.status}`,
+				);
+			}
+			const raw = (await response.json()) as {
+				AccessKeyId: string;
+				SecretAccessKey: string;
+				Token: string;
+				Expiration: string;
+			};
+			containerCredentials = {
+				accessKeyId: raw.AccessKeyId,
+				secretAccessKey: raw.SecretAccessKey,
+				sessionToken: raw.Token,
+				expiresAt: Date.parse(raw.Expiration),
+			};
+			bunClientCache.clear();
+			return containerCredentials;
+		} catch (error) {
+			// A metadata blip inside the refresh margin must not wipe live config:
+			// reuse cached credentials while they remain genuinely valid.
+			const stillValid =
+				containerCredentials && Date.now() < containerCredentials.expiresAt;
+			if (stillValid) return containerCredentials;
+			throw error;
 		}
-		const raw = (await response.json()) as {
-			AccessKeyId: string;
-			SecretAccessKey: string;
-			Token: string;
-			Expiration: string;
-		};
-		containerCredentials = {
-			accessKeyId: raw.AccessKeyId,
-			secretAccessKey: raw.SecretAccessKey,
-			sessionToken: raw.Token,
-			expiresAt: Date.parse(raw.Expiration),
-		};
-		bunClientCache.clear();
-		return containerCredentials;
 	};
 
 const getBunClient = async ({

--- a/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
+++ b/server/src/external/aws/s3/bunS3EdgeConfigClient.ts
@@ -46,10 +46,10 @@ const resolveContainerCredentials =
 			? `http://169.254.170.2${relativeUri}`
 			: (fullUri as string);
 		const tokenFile = process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE;
-		const authToken =
-			process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN ??
-			(tokenFile ? (await Bun.file(tokenFile).text()).trim() : undefined);
 		try {
+			const authToken =
+				process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN ??
+				(tokenFile ? (await Bun.file(tokenFile).text()).trim() : undefined);
 			// A stalled metadata endpoint must not hang boot: polling start is awaited.
 			const response = await fetch(url, {
 				signal: AbortSignal.timeout(5_000),


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse still-valid cached AWS container credentials when a refresh fails, so the S3 edge config client keeps working and avoids wiping live config during transient metadata or token-file errors.

- **Bug Fixes**
  - Wrap authorization token read and metadata fetch in one try/catch; on failure, return cached `containerCredentials` if `expiresAt` is still in the future.
  - Clear `bunClientCache` only after a successful refresh, keeping working clients during brief outages.

<sup>Written for commit ddb972a8a9e85a91f5475f6cf019488b969a9c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR completes the cached-credential fallback so transient AWS metadata failures do not interrupt edge-config access while existing credentials remain valid.

- **[Bug fixes]** Moves authorization-token file reads inside the guarded refresh path, fixing the previously reported case where an unreadable token file bypassed cached credentials.
- **[Improvements]** Preserves cached S3 clients after failed refreshes and clears them only after obtaining replacement credentials.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported token-file failure now enters the cached-credential fallback, and no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/aws/s3/bunS3EdgeConfigClient.ts | The refresh handler now covers token-file reads and metadata requests, safely reusing unexpired credentials and retaining matching cached clients when refresh fails. |

<sub>Reviews (2): Last reviewed commit: ["fix: read the auth token inside the cred..."](https://github.com/useautumn/autumn/commit/ddb972a8a9e85a91f5475f6cf019488b969a9c94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50398960)</sub>

<!-- /greptile_comment -->