### PR TITLE
chore: make CSV Exports use read replica

### DIFF
--- a/server/src/internal/customers/exports/CustomerExportService.ts
+++ b/server/src/internal/customers/exports/CustomerExportService.ts
@@ -247,6 +247,37 @@ export const CustomerExportService = {
 		return updated.length > 0;
 	},
 
+	/**
+	 * Guarded like `markCompleted` so a finished or already-reclaimed export is
+	 * never re-failed; returns whether this call was the one that failed it.
+	 */
+	markFailedIfActive: async ({
+		db,
+		id,
+		errorMessage,
+	}: {
+		db: DrizzleCli;
+		id: string;
+		errorMessage: string;
+	}): Promise<boolean> => {
+		const updated = await db
+			.update(customerExports)
+			.set({
+				status: CustomerExportStatus.Failed,
+				error_message: errorMessage,
+				completed_at: Date.now(),
+			})
+			.where(
+				and(
+					eq(customerExports.id, id),
+					inArray(customerExports.status, [...ACTIVE_CUSTOMER_EXPORT_STATUSES]),
+				),
+			)
+			.returning({ id: customerExports.id });
+
+		return updated.length > 0;
+	},
+
 	markFailed: async ({
 		db,
 		id,

--- a/server/src/internal/customers/exports/getCustomerExportReadDb.ts
+++ b/server/src/internal/customers/exports/getCustomerExportReadDb.ts
@@ -1,0 +1,9 @@
+import { type DrizzleCli, dbReplica } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+/** Export reads scan whole orgs; the replica absorbs that instead of the primary. */
+export const getCustomerExportReadDb = ({
+	ctx,
+}: {
+	ctx: AutumnContext;
+}): DrizzleCli => dbReplica ?? ctx.db;

--- a/server/src/internal/customers/exports/workflows/complete/failCustomerExportRun.ts
+++ b/server/src/internal/customers/exports/workflows/complete/failCustomerExportRun.ts
@@ -1,0 +1,72 @@
+import { ms } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { RunCustomerExportPayloadSchema } from "@/trigger/exports/customerExportTaskPayload.js";
+import { retryAsync } from "@/utils/retryAsync.js";
+import { CustomerExportService } from "../../CustomerExportService.js";
+
+// Shorter than the completion retry: the run has already failed and lifecycle
+// hooks are a poor place to sit, whereas a lost write is reclaimable.
+const MARK_FAILED_ATTEMPTS = 3;
+const MARK_FAILED_RETRY_DELAY_MS = ms.seconds(1);
+
+/** The row's message is a dashboard tooltip, so the raw cause only goes to logs. */
+const RUN_FAILED_MESSAGE = "Export job failed unexpectedly";
+
+const describeError = (error: unknown) =>
+	error instanceof Error ? error.message : String(error);
+
+/**
+ * Terminal write for a run that threw outside the upload. Trigger skips its
+ * failure hook on timeout, cancellation and OOM, which stay reclaim-only.
+ */
+export const failCustomerExportRun = async ({
+	db,
+	logger,
+	rawPayload,
+	error,
+}: {
+	db: DrizzleCli;
+	logger: Logger;
+	rawPayload: unknown;
+	error: unknown;
+}): Promise<void> => {
+	const cause = describeError(error);
+
+	// No exportId means no row to fail; the stale reclaim path is the only recovery.
+	const parsed = RunCustomerExportPayloadSchema.safeParse(rawPayload);
+	if (!parsed.success) {
+		logger.error("customer-export: run failed with an unreadable payload", {
+			data: { cause, payloadError: parsed.error.message },
+		});
+		return;
+	}
+
+	const { exportId } = parsed.data;
+
+	try {
+		const failed = await retryAsync({
+			attempts: MARK_FAILED_ATTEMPTS,
+			delayMs: MARK_FAILED_RETRY_DELAY_MS,
+			onRetry: ({ attempt, error: retryError }) =>
+				logger.warn("customer-export: retrying markFailedIfActive", {
+					data: { exportId, attempt, error: describeError(retryError) },
+				}),
+			run: () =>
+				CustomerExportService.markFailedIfActive({
+					db,
+					id: exportId,
+					errorMessage: RUN_FAILED_MESSAGE,
+				}),
+		});
+
+		logger.error("customer-export: run failed", {
+			data: { exportId, cause, markedFailed: failed },
+		});
+	} catch (writeError) {
+		// Rethrowing would only replace the real cause; the row is reclaimable.
+		logger.error("customer-export: could not record the failed run", {
+			data: { exportId, cause, error: describeError(writeError) },
+		});
+	}
+};

--- a/server/src/internal/customers/exports/workflows/setup/reconcileUploadedExport.ts
+++ b/server/src/internal/customers/exports/workflows/setup/reconcileUploadedExport.ts
@@ -3,6 +3,7 @@ import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { RunCustomerExportPayload } from "@/trigger/exports/customerExportTaskPayload.js";
 import { findPublishedExportObject } from "../../findPublishedExportObject.js";
+import { getCustomerExportReadDb } from "../../getCustomerExportReadDb.js";
 import { resolveCustomerExportPopulation } from "../../queries/getCustomerExportScalars.js";
 import { markCompletedWithRetry } from "../complete/markCompletedWithRetry.js";
 
@@ -33,7 +34,7 @@ export const reconcileUploadedExport = async ({
 	// The exact count died with the failed completion write; recounting the frozen
 	// bounds can drift below the file's rows if customers were deleted since.
 	const { totalCount } = await resolveCustomerExportPopulation({
-		db: ctx.db,
+		db: getCustomerExportReadDb({ ctx }),
 		orgId: payload.orgId,
 		env: payload.env,
 		snapshot: customerExport.snapshot,

--- a/server/src/internal/customers/exports/workflows/upload/createCustomerExportRowStream.ts
+++ b/server/src/internal/customers/exports/workflows/upload/createCustomerExportRowStream.ts
@@ -1,5 +1,6 @@
 import { Readable } from "node:stream";
 import type { CustomerExportSnapshot } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { CustomerExportRow } from "../../csv/createCustomerExportStringifier.js";
 import {
@@ -15,16 +16,18 @@ import { createOneOffProductLookup } from "../../queries/getOneOffProductLookup.
 
 export const createCustomerExportRowStream = ({
 	ctx,
+	readDb,
 	snapshot,
 	population,
 	onPageProcessed,
 }: {
 	ctx: AutumnContext;
+	readDb: DrizzleCli;
 	snapshot: CustomerExportSnapshot;
 	population: CustomerExportPopulation;
 	onPageProcessed: (rowCount: number) => Promise<void> | void;
 }): Readable => {
-	const oneOffProductLookup = createOneOffProductLookup({ db: ctx.db });
+	const oneOffProductLookup = createOneOffProductLookup({ db: readDb });
 
 	const exportRows = async function* (): AsyncGenerator<CustomerExportRow> {
 		let afterInternalId: string | null = null;
@@ -32,7 +35,7 @@ export const createCustomerExportRowStream = ({
 
 		while (hasMorePages) {
 			const scalars = await getCustomerExportScalars({
-				db: ctx.db,
+				db: readDb,
 				orgId: ctx.org.id,
 				env: ctx.env,
 				snapshot,
@@ -44,7 +47,7 @@ export const createCustomerExportRowStream = ({
 			if (!lastScalar) break;
 
 			const planColumnsByCustomer = await getCustomerExportPlanColumns({
-				db: ctx.db,
+				db: readDb,
 				internalCustomerIds: scalars.map((scalar) => scalar.internal_id),
 				oneOffProductLookup,
 			});

--- a/server/src/internal/customers/exports/workflows/upload/streamCustomerExportCsv.ts
+++ b/server/src/internal/customers/exports/workflows/upload/streamCustomerExportCsv.ts
@@ -1,4 +1,5 @@
 import type { DbCustomerExport } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { CustomerExportDestination } from "@/external/aws/s3/customerExportsS3Config.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { CustomerExportPopulation } from "../../queries/getCustomerExportScalars.js";
@@ -7,12 +8,14 @@ import { uploadCustomerExportCsvStream } from "./uploadCustomerExportCsvStream.j
 
 export const streamCustomerExportCsv = async ({
 	ctx,
+	readDb,
 	customerExport,
 	population,
 	destination,
 	onRowsProcessed,
 }: {
 	ctx: AutumnContext;
+	readDb: DrizzleCli;
 	customerExport: DbCustomerExport;
 	population: CustomerExportPopulation;
 	destination: CustomerExportDestination;
@@ -23,6 +26,7 @@ export const streamCustomerExportCsv = async ({
 
 	const rows = createCustomerExportRowStream({
 		ctx,
+		readDb,
 		snapshot,
 		population,
 		onPageProcessed: async (pageRowCount) => {

--- a/server/src/internal/customers/exports/workflows/upload/uploadCustomerExportCsv.ts
+++ b/server/src/internal/customers/exports/workflows/upload/uploadCustomerExportCsv.ts
@@ -3,6 +3,7 @@ import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { RunCustomerExportPayload } from "@/trigger/exports/customerExportTaskPayload.js";
 import { CustomerExportService } from "../../CustomerExportService.js";
+import { getCustomerExportReadDb } from "../../getCustomerExportReadDb.js";
 import { resolveCustomerExportPopulation } from "../../queries/getCustomerExportScalars.js";
 import type { CustomerExportProgressReporter } from "../customerExportProgressReporter.js";
 import { streamCustomerExportCsv } from "./streamCustomerExportCsv.js";
@@ -27,9 +28,10 @@ export const uploadCustomerExportCsv = async ({
 	progress?: CustomerExportProgressReporter;
 }): Promise<{ rowCount: number; byteCount: number }> => {
 	const { exportId, orgId, env } = payload;
+	const readDb = getCustomerExportReadDb({ ctx });
 
 	const { population, totalCount } = await resolveCustomerExportPopulation({
-		db: ctx.db,
+		db: readDb,
 		orgId,
 		env,
 		snapshot: customerExport.snapshot,
@@ -42,7 +44,11 @@ export const uploadCustomerExportCsv = async ({
 		s3Key: key,
 	});
 	logger.info("customer-export: started", {
-		data: { exportId, totalCount },
+		data: {
+			exportId,
+			totalCount,
+			readSource: readDb === ctx.db ? "primary" : "replica",
+		},
 	});
 
 	// The reporter is absent for inline runs; retries reset before re-walking.
@@ -51,6 +57,7 @@ export const uploadCustomerExportCsv = async ({
 
 	return await streamCustomerExportCsv({
 		ctx,
+		readDb,
 		customerExport,
 		population,
 		destination: { bucket, region, key },

--- a/server/src/trigger/exports/customerExportTask.ts
+++ b/server/src/trigger/exports/customerExportTask.ts
@@ -3,6 +3,9 @@ import {
 	CUSTOMER_EXPORT_TOTAL_ROWS_KEY,
 } from "@autumn/shared";
 import { metadata, task } from "@trigger.dev/sdk/v3";
+import { db } from "@/db/initDrizzle.js";
+import { createDualLogger } from "@/external/logtail/logtailUtils.js";
+import { failCustomerExportRun } from "@/internal/customers/exports/workflows/complete/failCustomerExportRun.js";
 import { executeCustomerExport } from "@/internal/customers/exports/workflows/executeCustomerExport.js";
 import {
 	CUSTOMER_EXPORT_MAX_DURATION_SECONDS,
@@ -11,6 +14,7 @@ import {
 } from "@/trigger/exports/customerExportQueue.js";
 import { RunCustomerExportPayloadSchema } from "@/trigger/exports/customerExportTaskPayload.js";
 import { createTriggerContext } from "@/trigger/utils/createTriggerContext.js";
+import { addTriggerToLogs } from "@/utils/logging/addContextToLogs.js";
 
 export const customerExportTask = task({
 	id: "customer-export",
@@ -46,6 +50,24 @@ export const customerExportTask = task({
 					);
 				},
 			},
+		});
+	},
+
+	// Runs once retries are exhausted. Deliberately avoids createTriggerContext,
+	// which is itself a way `run` fails, and writes through the raw pool instead.
+	onFailure: async ({ payload, error, ctx: triggerCtx }) => {
+		await failCustomerExportRun({
+			db,
+			logger: addTriggerToLogs({
+				logger: createDualLogger(),
+				triggerContext: {
+					run_id: triggerCtx.run.id,
+					task_id: triggerCtx.task.id,
+					attempt_number: triggerCtx.attempt.number,
+				},
+			}),
+			rawPayload: payload,
+			error,
 		});
 	},
 });

--- a/server/tests/unit/customers/exports/fail-customer-export-run.test.ts
+++ b/server/tests/unit/customers/exports/fail-customer-export-run.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+
+type MarkFailedArgs = { id: string; errorMessage: string };
+
+const markFailedCalls: MarkFailedArgs[] = [];
+
+const mockState: { markFailedIfActive: () => Promise<boolean> } = {
+	markFailedIfActive: async () => true,
+};
+
+const actualService = await import(
+	"@/internal/customers/exports/CustomerExportService.js"
+);
+
+// Bun module mocks are process-global; spread the real module so later test
+// files importing the other service methods still load.
+mock.module("@/internal/customers/exports/CustomerExportService.js", () => ({
+	...actualService,
+	CustomerExportService: {
+		...actualService.CustomerExportService,
+		markFailedIfActive: (args: MarkFailedArgs) => {
+			markFailedCalls.push({ id: args.id, errorMessage: args.errorMessage });
+			return mockState.markFailedIfActive();
+		},
+	},
+}));
+
+const { failCustomerExportRun } = await import(
+	"@/internal/customers/exports/workflows/complete/failCustomerExportRun.js"
+);
+
+const errors: string[] = [];
+const stubLogger = {
+	warn: () => {},
+	error: (message: string) => errors.push(message),
+	info: () => {},
+	debug: () => {},
+} as unknown as Logger;
+
+const db = {} as DrizzleCli;
+const payload = { exportId: "cusexp_123", orgId: "org_1", env: "sandbox" };
+
+describe("failCustomerExportRun", () => {
+	beforeEach(() => {
+		markFailedCalls.length = 0;
+		errors.length = 0;
+		mockState.markFailedIfActive = async () => true;
+	});
+
+	it("fails the export a crashed run left behind", async () => {
+		await failCustomerExportRun({
+			db,
+			logger: stubLogger,
+			rawPayload: payload,
+			error: new Error("failed to build context"),
+		});
+
+		expect(markFailedCalls).toHaveLength(1);
+		expect(markFailedCalls[0].id).toBe("cusexp_123");
+		expect(markFailedCalls[0].errorMessage).not.toContain("build context");
+	});
+
+	it("keeps the raw cause out of the row but in the logs", async () => {
+		await failCustomerExportRun({
+			db,
+			logger: stubLogger,
+			rawPayload: payload,
+			error: new Error("createTriggerContext: org=90LN env=sandbox"),
+		});
+
+		expect(markFailedCalls[0].errorMessage).not.toContain("90LN");
+		expect(errors).toContain("customer-export: run failed");
+	});
+
+	it("leaves a row that already reached a terminal state alone", async () => {
+		mockState.markFailedIfActive = async () => false;
+
+		await failCustomerExportRun({
+			db,
+			logger: stubLogger,
+			rawPayload: payload,
+			error: new Error("boom"),
+		});
+
+		expect(markFailedCalls).toHaveLength(1);
+		expect(errors).toContain("customer-export: run failed");
+	});
+
+	it("cannot fail a row it cannot identify", async () => {
+		await failCustomerExportRun({
+			db,
+			logger: stubLogger,
+			rawPayload: { orgId: "org_1" },
+			error: new Error("boom"),
+		});
+
+		expect(markFailedCalls).toHaveLength(0);
+		expect(errors).toContain(
+			"customer-export: run failed with an unreadable payload",
+		);
+	});
+
+	it("does not rethrow when the status write keeps failing", async () => {
+		mockState.markFailedIfActive = async () => {
+			throw new Error("connection timeout");
+		};
+
+		await failCustomerExportRun({
+			db,
+			logger: stubLogger,
+			rawPayload: payload,
+			error: new Error("boom"),
+		});
+
+		expect(markFailedCalls).toHaveLength(3);
+		expect(errors).toContain(
+			"customer-export: could not record the failed run",
+		);
+	}, 10_000);
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route CSV export reads to the read replica to reduce load on the primary and keep exports responsive. Also guard-fail export rows when a run crashes before upload so queued jobs don't get stuck.

- **Refactors**
  - Added `getCustomerExportReadDb` to prefer `dbReplica` for export reads; falls back to `ctx.db`.
  - Routed population counting and row streaming to the read DB; logs read source as "primary"/"replica".

- **Bug Fixes**
  - Added `CustomerExportService.markFailedIfActive` to fail active rows with a short message and completion timestamp.
  - Implemented `failCustomerExportRun` and wired `customerExportTask.onFailure` to use the raw `db`; retries 3x with 1s delay and logs the raw cause.
  - Skips failing on unreadable payloads or terminal rows; does not rethrow on write errors.
  - Note: `onFailure` is not invoked on max-duration kills, cancellation, or OOM in `@trigger.dev/sdk`; those remain covered by the stale reclaim path.

<sup>Written for commit a414e101f8a21722852bbf15baf749d20f13091c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

