### PR TITLE
Fix negative carry-over balance recalculation

### DIFF
--- a/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
@@ -9,6 +9,7 @@ import {
 	type RecalculateBalanceParamsV0,
 	RecaseError,
 } from "@autumn/shared";
+import { Decimal } from "decimal.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { deductFromCusEntsTypescript } from "@/internal/balances/track/deductUtils/deductFromCusEntsTypescript";
 import { CusService } from "@/internal/customers/CusService";
@@ -20,9 +21,11 @@ const resetCusEntInPlace = ({
 }: {
 	cusEnt: FullCusEntWithFullCusProduct;
 }): void => {
+	const startingBalance = cusEntToStartingBalance({ cusEnt });
 	const resetUpdate = getResetBalancesUpdate({
 		cusEnt,
-		allowance: cusEntToStartingBalance({ cusEnt }) ?? undefined,
+		allowance:
+			startingBalance === undefined ? undefined : Math.max(0, startingBalance),
 	});
 	if ("entities" in resetUpdate) {
 		cusEnt.entities = resetUpdate.entities;
@@ -31,6 +34,20 @@ const resetCusEntInPlace = ({
 		cusEnt.additional_balance = resetUpdate.additional_balance;
 	}
 	cusEnt.adjustment = 0;
+};
+
+const cusEntsToRecalculateUsage = ({
+	cusEnts,
+	entityId,
+}: {
+	cusEnts: FullCusEntWithFullCusProduct[];
+	entityId?: string;
+}): number => {
+	let usage = new Decimal(cusEntsToUsage({ cusEnts, entityId }));
+	for (const cusEnt of cusEnts) {
+		usage = usage.sub(Math.min(0, cusEntToStartingBalance({ cusEnt }) ?? 0));
+	}
+	return usage.toNumber();
 };
 
 /**
@@ -74,7 +91,7 @@ export const computeRecalculateBalance = async ({
 		});
 	}
 	const entityId = fullCustomer.entity?.id ?? undefined;
-	const totalUsage = cusEntsToUsage({ cusEnts: before, entityId });
+	const totalUsage = cusEntsToRecalculateUsage({ cusEnts: before, entityId });
 	const after = before.map((cusEnt) => structuredClone(cusEnt));
 	const recalculableScopes = getRecalculableScopeKeys({
 		cusEnts: after,
@@ -94,7 +111,10 @@ export const computeRecalculateBalance = async ({
 		if (!recalculableScopes.has(key)) {
 			continue;
 		}
-		const scopeUsage = cusEntsToUsage({ cusEnts: group, entityId });
+		const scopeUsage = cusEntsToRecalculateUsage({
+			cusEnts: group,
+			entityId,
+		});
 		for (const cusEnt of group) {
 			resetCusEntInPlace({ cusEnt });
 		}

--- a/server/tests/integration/balances/recalculate/recalculate-balance.test.ts
+++ b/server/tests/integration/balances/recalculate/recalculate-balance.test.ts
@@ -3,8 +3,12 @@ import type {
 	CheckResponseV2,
 	RecalculateBalancePreview,
 } from "@autumn/shared";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
+import { waitForPostgresBalance } from "@tests/integration/cron/batch-reset-v2/batchResetV2TestUtils.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 
@@ -504,7 +508,7 @@ test.concurrent(
 			customerId: "recalc-9",
 			setup: [
 				s.customer({ testClock: false }),
-				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.entities({ count: 1, featureId: TestFeature.Admin }),
 			],
 			actions: [],
 		});
@@ -649,5 +653,79 @@ test.concurrent(
 			skip_cache: true,
 		});
 		expect(breakdownById(after)).toEqual(breakdownById(before));
+	},
+);
+
+// RECALCULATE-11: Negative carry-over debt must be reapplied to the new grant;
+// previously it was counted as a negative grant, making recalculation a no-op.
+test.concurrent(
+	`${chalk.yellowBright("recalculate-11: absorbs negative carry-over into the new plan")}`,
+	async () => {
+		const pro = products.pro({
+			id: "recalc-negative-carry-over-pro",
+			items: [items.consumableMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "recalc-negative-carry-over-premium",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+		const { customerId, autumnV2, autumnV2_1, autumnV2_2, ctx } =
+			await initScenario({
+				customerId: "recalc-negative-carry-over",
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [pro, premium] }),
+				],
+				actions: [s.attach({ productId: pro.id, timeout: 4000 })],
+			});
+
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 120,
+		});
+		const cusEnt = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		await waitForPostgresBalance({
+			db: ctx.db,
+			customerEntitlementId: cusEnt!.id,
+			expectedBalance: -20,
+		});
+
+		await autumnV2_2.billing.attach({
+			customer_id: customerId,
+			plan_id: premium.id,
+			carry_over_balances: { enabled: true },
+		});
+
+		const preview = await autumnV2.balances.previewRecalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		expect(preview.total_usage).toBe(20);
+		expect(sumBefore(preview)).toBe(480);
+		expect(sumAfter(preview)).toBe(480);
+		expect(
+			preview.entitlements.some(
+				(entry) => entry.before_remaining !== entry.after_remaining,
+			),
+		).toBe(true);
+
+		await autumnV2.balances.recalculate({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+		});
+		const check = await autumnV2.check<CheckResponseV2>({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			skip_cache: true,
+		});
+		expect(check.balance?.current_balance).toBe(480);
+		for (const entry of check.balance?.breakdown ?? []) {
+			expect(entry.current_balance).toBeGreaterThanOrEqual(0);
+		}
 	},
 );

--- a/server/tests/scenarios/attach/carry-over-negative-balance-scenario.test.ts
+++ b/server/tests/scenarios/attach/carry-over-negative-balance-scenario.test.ts
@@ -1,5 +1,5 @@
-/** Leaves a Pro customer at -20 with Premium available for a manual carry-over attach.
- * Attach Premium with carry_over_balances enabled; the resulting balance should be 480. */
+/** Leaves a Premium customer with -20 carried debt ready for dashboard recalculation.
+ * Recalculation should absorb the debt and reduce displayed remaining from 500 to 480. */
 
 import { test } from "bun:test";
 import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement";
@@ -10,7 +10,7 @@ import { products } from "@tests/utils/fixtures/products";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 
-test(`${chalk.yellowBright("scenario: negative balance ready for carry-over attach")}`, async () => {
+test(`${chalk.yellowBright("scenario: negative carry-over ready for recalculation")}`, async () => {
 	const customerId = "carry-over-negative-balance-repro";
 	const pro = products.pro({
 		id: "pro",
@@ -21,7 +21,7 @@ test(`${chalk.yellowBright("scenario: negative balance ready for carry-over atta
 		items: [items.monthlyMessages({ includedUsage: 500 })],
 	});
 
-	const { autumnV2_1, ctx } = await initScenario({
+	const { autumnV2, autumnV2_1, autumnV2_2, ctx } = await initScenario({
 		customerId,
 		setup: [
 			s.customer({ paymentMethod: "success" }),
@@ -47,12 +47,22 @@ test(`${chalk.yellowBright("scenario: negative balance ready for carry-over atta
 		customerEntitlementId: cusEnt.id,
 		expectedBalance: -20,
 	});
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: premium.id,
+		carry_over_balances: { enabled: true },
+	});
+	const preview = await autumnV2.balances.previewRecalculate({
+		customer_id: customerId,
+		feature_id: TestFeature.Messages,
+	});
 
 	console.log(
 		chalk.cyanBright(
 			`\nCustomer ${customerId} is ready.\n` +
-				`Current plan: ${pro.id}; messages balance: -20.\n` +
-				`Attach ${premium.id} with carry over balances enabled; expect 480.\n`,
+				`Current plan: ${premium.id}; carried debt: -20.\n` +
+				`Recalculate messages in the dashboard; remaining should become 480.\n`,
 		),
+		preview,
 	);
 });


### PR DESCRIPTION
## Summary

- count negative starting grants as debt during balance recalculation
- reset negative carry-over grants to zero before redistributing usage
- add integration coverage for carry-over followed by preview and recalculation
- add a dashboard QA scenario that stops before recalculation
- use an available non-consumable fixture feature for the entity-scope recalculation case

## Verification

- bunx tsgo --build --noEmit
- Biome check on changed files
- full recalculation integration suite: 11 passes, 0 failures
- negative carry-over dashboard scenario: 1 pass, 0 failures

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up fixes recalculation of balances containing negative carry-over grants and expands coverage for the corrected flow.
- **Bug fixes:** Counts a negative carried grant as prior usage, resets it to zero, and redistributes that usage across the active grants.
- **Improvements:** Adds integration coverage for carry-over, preview, recalculation, and entity-scoped behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts | Corrects negative carry-over recalculation by converting negative starting grants into usage before resetting and redistributing balances. |
| server/tests/integration/balances/recalculate/recalculate-balance.test.ts | Adds end-to-end coverage confirming that a carried debt of 20 reduces a new grant of 500 to 480 after recalculation. |
| server/tests/scenarios/attach/carry-over-negative-balance-scenario.test.ts | Updates the manual scenario to attach the replacement plan, preview recalculation, and expose the negative carry-over state. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Negative carry-over grant] --> B[Count grant magnitude as usage]
  B --> C[Reset negative grant to zero]
  C --> D[Redistribute usage across recalculable grants]
  D --> E[Return corrected remaining balance]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: 🐛 recalculate negative carry-over ..."](https://github.com/useautumn/autumn/commit/4f2a90506ce24329b23c9e4ca19bfe5caf376a58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50439994)</sub>

<!-- /greptile_comment -->