### PR TITLE
fix(redis): per-key DEL in clearOrgWithFeaturesCache to avoid CROSSSLOT

### DIFF
--- a/server/src/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.ts
+++ b/server/src/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.ts
@@ -5,7 +5,7 @@ import {
 	resolveMiscRedis,
 } from "@/external/redis/miscCache/resolveMiscRedis.js";
 import { REDIS_OP_TIMEOUT_MS } from "@/external/redis/utils/redisOpTimeouts.js";
-import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { runRedisOp, tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 
 /** Short by design: org config changes are also pushed through clearOrgCache, so
  *  this only has to bound the staleness window for anything that misses that. */
@@ -82,12 +82,18 @@ export const clearOrgWithFeaturesCache = async ({
 	);
 
 	await forEachMiscRedisTarget({
+		// One DEL per key: these keys have no hash tag, so a multi-key DEL is
+		// rejected with CROSSSLOT on a clustered instance and nothing is deleted.
 		operation: ({ redis }) =>
-			tryRedisOp({
-				operation: () => redis.del(...cacheKeys),
-				source: "org-features-cache:clear",
-				redisInstance: redis,
-			}),
+			Promise.all(
+				cacheKeys.map((cacheKey) =>
+					runRedisOp({
+						operation: () => redis.del(cacheKey),
+						source: "org-features-cache:clear",
+						redisInstance: redis,
+					}),
+				),
+			),
 		onError: ({ target }) => {
 			logger.warn(
 				`[orgWithFeaturesCache] clear failed on "${target.instanceName}" (org: ${orgId})`,


### PR DESCRIPTION
## Problem

The rampable-actions refactor (9820127fc, shipped to prod this morning) collapsed the both-env `clearOrgWithFeaturesCache` into a single multi-key `DEL liveKey sandboxKey`. `org_with_features:<orgId>:<env>` keys carry no hash tag, so the clustered misc primary rejects the command with `CROSSSLOT` — atomically, so **neither** env's cache entry is deleted.

Every both-env clear (the `env`-omitted variant used by `clearOrgCache`) has been silently no-oping since ~10:00 UTC today (~40–70 failures per 15 min in OTel spans, zero in the 46h before). Impact is bounded by the 60s TTL, but it breaks the invariant the misc-redis ramp relies on: ramped readers must never see stale org config.

It was invisible at the `forEachMiscRedisTarget` layer because `tryRedisOp` swallows the error before the `onError` warn can fire — only the rate-limited `[redis] operation unavailable` warn and error spans recorded it.

## Fix

- One `DEL` per key — single-key commands are always slot-safe; no key-format change, so nothing gets orphaned.
- `runRedisOp` (throwing) instead of `tryRedisOp` inside the fan-out, so a failed clear reaches `forEachMiscRedisTarget`'s per-target catch and its `clear failed` warn actually fires. Fail-open per instance is preserved.

`productsCache` has the same multi-key DEL shape but is safe — its keys embed a `{orgId}` hash tag.

## Verification

- `bun ts` clean, Biome clean
- `tests/unit/redis/misc-redis-keys.test.ts`: 13 pass
- CROSSSLOT can't reproduce locally (non-clustered Redis); post-deploy, the `redis.del` error spans on `misc-primary` should drop to zero

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes org features cache invalidation in clustered Redis by deleting keys individually and surfacing failures to logging, avoiding CROSSSLOT and silent no-ops. Both-env clears now reliably remove each env’s entry and restore the ramp invariant.

- **Bug Fixes**
  - Use one `DEL` per `org_with_features:<orgId>:<env>` key (no hash tag) to make clears slot-safe.
  - Call `runRedisOp` in the fan-out so failures reach `forEachMiscRedisTarget` and its `onError` warn; fail-open per instance preserved.

<sup>Written for commit 5c5a9d3fb149879f3924669340d2c34782af0fe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes organization cache invalidation on clustered Redis and improves failure visibility.
- **Bug fixes:** Replaces the cross-slot multi-key deletion with one slot-safe deletion per cache key.
- **Improvements:** Allows deletion failures to reach the existing per-target warning handler while preserving fail-open behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the clustered Redis deletion failure corrected and existing fail-open behavior preserved.

Each cache key is now deleted with a slot-safe command, while the target fan-out still catches Redis failures and reports them through the configured warning callback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.ts | Splits organization cache invalidation into per-key Redis deletions and propagates failures to the existing target-level handler without allowing them to escape callers. |

<sub>Reviews (1): Last reviewed commit: ["fix(redis): per-key DEL in clearOrgWithF..."](https://github.com/useautumn/autumn/commit/5c5a9d3fb149879f3924669340d2c34782af0fe3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50453944)</sub>

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->