### PR TITLE
chore(exports): route customer export reads to the read replica

### DIFF
--- a/server/src/internal/customers/exports/workflows/setup/reconcileUploadedExport.ts
+++ b/server/src/internal/customers/exports/workflows/setup/reconcileUploadedExport.ts
@@ -1,4 +1,5 @@
 import type { DbCustomerExport } from "@autumn/shared";
+import { dbReplica } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { RunCustomerExportPayload } from "@/trigger/exports/customerExportTaskPayload.js";
@@ -33,7 +34,7 @@ export const reconcileUploadedExport = async ({
 	// The exact count died with the failed completion write; recounting the frozen
 	// bounds can drift below the file's rows if customers were deleted since.
 	const { totalCount } = await resolveCustomerExportPopulation({
-		db: ctx.db,
+		db: dbReplica ?? ctx.db,
 		orgId: payload.orgId,
 		env: payload.env,
 		snapshot: customerExport.snapshot,

--- a/server/src/internal/customers/exports/workflows/upload/createCustomerExportRowStream.ts
+++ b/server/src/internal/customers/exports/workflows/upload/createCustomerExportRowStream.ts
@@ -1,5 +1,6 @@
 import { Readable } from "node:stream";
 import type { CustomerExportSnapshot } from "@autumn/shared";
+import { dbReplica } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { CustomerExportRow } from "../../csv/createCustomerExportStringifier.js";
 import {
@@ -24,7 +25,8 @@ export const createCustomerExportRowStream = ({
 	population: CustomerExportPopulation;
 	onPageProcessed: (rowCount: number) => Promise<void> | void;
 }): Readable => {
-	const oneOffProductLookup = createOneOffProductLookup({ db: ctx.db });
+	const readDb = dbReplica ?? ctx.db;
+	const oneOffProductLookup = createOneOffProductLookup({ db: readDb });
 
 	const exportRows = async function* (): AsyncGenerator<CustomerExportRow> {
 		let afterInternalId: string | null = null;
@@ -32,7 +34,7 @@ export const createCustomerExportRowStream = ({
 
 		while (hasMorePages) {
 			const scalars = await getCustomerExportScalars({
-				db: ctx.db,
+				db: readDb,
 				orgId: ctx.org.id,
 				env: ctx.env,
 				snapshot,
@@ -44,7 +46,7 @@ export const createCustomerExportRowStream = ({
 			if (!lastScalar) break;
 
 			const planColumnsByCustomer = await getCustomerExportPlanColumns({
-				db: ctx.db,
+				db: readDb,
 				internalCustomerIds: scalars.map((scalar) => scalar.internal_id),
 				oneOffProductLookup,
 			});

--- a/server/src/internal/customers/exports/workflows/upload/uploadCustomerExportCsv.ts
+++ b/server/src/internal/customers/exports/workflows/upload/uploadCustomerExportCsv.ts
@@ -1,4 +1,5 @@
 import type { DbCustomerExport } from "@autumn/shared";
+import { dbReplica } from "@/db/initDrizzle.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { RunCustomerExportPayload } from "@/trigger/exports/customerExportTaskPayload.js";
@@ -27,9 +28,10 @@ export const uploadCustomerExportCsv = async ({
 	progress?: CustomerExportProgressReporter;
 }): Promise<{ rowCount: number; byteCount: number }> => {
 	const { exportId, orgId, env } = payload;
+	const readDb = dbReplica ?? ctx.db;
 
 	const { population, totalCount } = await resolveCustomerExportPopulation({
-		db: ctx.db,
+		db: readDb,
 		orgId,
 		env,
 		snapshot: customerExport.snapshot,
@@ -42,7 +44,11 @@ export const uploadCustomerExportCsv = async ({
 		s3Key: key,
 	});
 	logger.info("customer-export: started", {
-		data: { exportId, totalCount },
+		data: {
+			exportId,
+			totalCount,
+			readSource: readDb === ctx.db ? "primary" : "replica",
+		},
 	});
 
 	// The reporter is absent for inline runs; retries reset before re-walking.


### PR DESCRIPTION
## Summary

Customer CSV export reads scan whole orgs (population COUNT + upper bound, 2000-row keyset page scans, plan-columns union, one-off product lookup). This routes all of them to the read replica so the export job stops loading the primary.

- Read pool is picked once per run: `dbReplica ?? ctx.db` — replica whenever `DATABASE_REPLICA_URL` is configured, primary otherwise (local/dev/tests keep working unchanged).
- `readDb` threads through `uploadCustomerExportCsv` → `streamCustomerExportCsv` → `createCustomerExportRowStream` and the reconcile recount.
- All writes and export-row reads (`resolveRunnableExport`, `markRunning`/`markFailed`/`markCompleted`, reclaim) stay on the primary — the export row is created moments before the task runs, so it must never be read from a lagging replica.
- The `customer-export: started` log line now includes `readSource: "replica" | "primary"` to confirm routing in Axiom.

## Notes

- No lag gate by design: we are pre-prod with no customers on exports, so reads go to the replica unconditionally.
- The Trigger.dev worker environment needs `DATABASE_REPLICA_URL` set, or exports silently keep using the primary (visible via `readSource`).
- The replica pool carries a 5s `query_timeout` the general pool doesn't; irrelevant at current data sizes.

Supersedes #2616.