### PR TITLE
fix: remove the fallback DB budget on customer/entity reads

### DIFF
--- a/server/src/honoMiddlewares/criticalDbMiddleware.ts
+++ b/server/src/honoMiddlewares/criticalDbMiddleware.ts
@@ -25,6 +25,7 @@ const CRITICAL_ROUTES = [
 	{ method: "POST", url: "/balances.check" },
 	{ method: "POST", url: "/balances.track" },
 	{ method: "POST", url: "/balances.finalize" },
+	{ method: "POST", url: "/customers.get" },
 	{ method: "POST", url: "/customers.get_or_create" },
 	{ method: "POST", url: "/entities.get" },
 ];

--- a/server/src/internal/customers/actions/getApiCustomerByRollout.ts
+++ b/server/src/internal/customers/actions/getApiCustomerByRollout.ts
@@ -7,13 +7,7 @@ import {
 } from "@/internal/customers/cache/fullSubject/index.js";
 import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
-import { withTimeout } from "@/utils/withTimeout.js";
 import { getApiCustomerV2 } from "../cusUtils/getApiCustomerV2/index.js";
-
-/** Same deadline as check's DB hydration — a Redis-down fallback can't wait out the 15s pool clocks.
- *  "Query read timeout" keeps the expiry classified transient so shed503 sheds instead of rethrowing. */
-export const FALLBACK_DB_HYDRATION_BUDGET_MS = 2_000;
-export const FALLBACK_DB_HYDRATION_TIMEOUT_MESSAGE = "Query read timeout";
 
 export const getApiCustomerByRollout = async ({
 	ctx,
@@ -78,13 +72,9 @@ export const getApiCustomerByRollout = async ({
 		ctx,
 		source: "get_customer",
 		run: () => lookup({ skipCache: false }),
+		// Bounded by the 15s pool clocks and query_timeout, not an extra budget.
 		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
-			? () =>
-					withTimeout({
-						timeoutMs: FALLBACK_DB_HYDRATION_BUDGET_MS,
-						timeoutMessage: FALLBACK_DB_HYDRATION_TIMEOUT_MESSAGE,
-						fn: () => lookup({ skipCache: true }),
-					})
+			? () => lookup({ skipCache: true })
 			: undefined,
 	});
 

--- a/server/src/internal/entities/actions/getApiEntityByRollout.ts
+++ b/server/src/internal/entities/actions/getApiEntityByRollout.ts
@@ -1,10 +1,6 @@
 import type { ApiEntityV2 } from "@autumn/shared";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import {
-	FALLBACK_DB_HYDRATION_BUDGET_MS,
-	FALLBACK_DB_HYDRATION_TIMEOUT_MESSAGE,
-} from "@/internal/customers/actions/getApiCustomerByRollout.js";
 import { coalescedSubjectRead } from "@/internal/customers/cache/fullSubject/coalesceSubjectRead.js";
 import {
 	buildSubjectReadFlightKey,
@@ -12,7 +8,6 @@ import {
 } from "@/internal/customers/cache/fullSubject/index.js";
 import { isRedisFallbackToDbEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
-import { withTimeout } from "@/utils/withTimeout.js";
 import { getApiEntityV2 } from "../entityUtils/getApiEntityV2/getApiEntityV2.js";
 
 export const getApiEntityByRollout = async ({
@@ -78,13 +73,9 @@ export const getApiEntityByRollout = async ({
 		ctx,
 		source: "entities.get",
 		run: () => lookup({ skipCache: false }),
+		// Bounded by the 15s pool clocks and query_timeout, not an extra budget.
 		fallbackOnRedisUnavailable: isRedisFallbackToDbEnabled()
-			? () =>
-					withTimeout({
-						timeoutMs: FALLBACK_DB_HYDRATION_BUDGET_MS,
-						timeoutMessage: FALLBACK_DB_HYDRATION_TIMEOUT_MESSAGE,
-						fn: () => lookup({ skipCache: true }),
-					})
+			? () => lookup({ skipCache: true })
 			: undefined,
 	});
 


### PR DESCRIPTION
## What

Removes the 2s `withTimeout` budget around the Redis-outage DB fallback (`lookup({ skipCache: true })`) in `getApiCustomerByRollout` and `getApiEntityByRollout`, along with the `FALLBACK_DB_HYDRATION_BUDGET_MS` / `FALLBACK_DB_HYDRATION_TIMEOUT_MESSAGE` constants and now-unused `withTimeout` imports.

## Why

The 2s budget was copied from check's DB hydration deadline, but that symmetry is false. Check fails **open** — when its hydration budget expires, the request degrades but still serves. These read wrappers fail **closed**: when the budget expires, the synthetic "Query read timeout" is classified transient and `shed503OnTransientError` turns the request into a 503. So the budget converts *slow successes* into shed errors.

That's exactly what happened in prod today: during a brief Dragonfly blip, **469 requests were shed with 503s** while the DB sat at ~20% utilization — every one of those fallback queries would have completed successfully, just slower than 2s under the thundering herd.

The fallback is still bounded: the 15s pool clocks and `query_timeout` (the load-test-validated configuration) cap how long a fallback read can hang, and real transient DB errors still shed via `shed503OnTransientError` as before.

Not touched: check's budgets (`getCheckDataV2`, `handleCheck`) — those are fail-open and correct — and `getOrCreateApiCustomerByRollout`, which never had a budget.

## Testing

- `bun ts` clean
- Unit lanes green (116 pass / 0 fail): `tests/unit/full-subject-cache/`, `tests/unit/replica-reads/`, `tests/unit/db/shed503OnTransientError.test.ts`, `tests/unit/rollouts/`
- No tests asserted the removed budget; transient-error shed coverage unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the 2s fallback DB timeout on customer/entity reads and route POST /customers.get to the critical DB pool to match its REST twin. Fallback reads now rely on the DB’s 15s pool clocks and query_timeout, avoiding 503s during Redis outages.

- **Bug Fixes**
  - Removed `withTimeout` budget around fallback reads in `getApiCustomerByRollout` and `getApiEntityByRollout`.
  - Deleted `FALLBACK_DB_HYDRATION_BUDGET_MS`, `FALLBACK_DB_HYDRATION_TIMEOUT_MESSAGE`, and unused `withTimeout` imports.
  - Added POST `/customers.get` to `CRITICAL_ROUTES` in `criticalDbMiddleware` so it runs on the critical pool.

<sup>Written for commit 8cdd4e06df687a1ec64ed01c693cd66fd524984a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents slow customer and entity fallback reads from being converted into premature 503 responses during Redis outages.
- **Bug fixes:** Removes the separate two-second timeout from customer and entity database fallback reads.
- **Improvements:** Routes `customers.get` through the isolated critical database pool, where fallback reads remain bounded by pool-level controls.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/criticalDbMiddleware.ts | Adds `POST /customers.get` to the routes assigned to the critical database pool. |
| server/src/internal/customers/actions/getApiCustomerByRollout.ts | Removes the two-second wrapper from Redis-outage customer fallback reads. |
| server/src/internal/entities/actions/getApiEntityByRollout.ts | Removes the same fallback timeout from entity reads and deletes the now-unused imports. |

<sub>Reviews (2): Last reviewed commit: ["fix: route POST /customers.get to the cr..."](https://github.com/useautumn/autumn/commit/8cdd4e06df687a1ec64ed01c693cd66fd524984a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50489319)</sub>

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->