### PR TITLE
ci: post Cubic summaries to shipped

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -1,0 +1,60 @@
+name: Post Cubic Summary to Slack
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  notify-shipped:
+    name: Notify shipped
+    if: >-
+      github.event.pull_request.head.ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.body || '', '<!-- This is an auto-generated description by cubic. -->') &&
+      (github.event.action == 'opened' ||
+      !contains(github.event.changes.body.from || '', '<!-- This is an auto-generated description by cubic. -->'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post summary to shipped
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          SLACK_SHIPPED_WEBHOOK_URL: ${{ secrets.SLACK_SHIPPED_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_SHIPPED_WEBHOOK_URL" ]; then
+            echo "::error::SLACK_SHIPPED_WEBHOOK_URL is not configured"
+            exit 1
+          fi
+
+          start_marker="## Summary by cubic"
+          end_marker="<sup>"
+          summary="${PR_BODY#*"$start_marker"}"
+
+          if [ "$summary" = "$PR_BODY" ]; then
+            echo "::error::Cubic summary heading was not found"
+            exit 1
+          fi
+
+          summary="${summary%%"$end_marker"*}"
+          summary="$start_marker$summary"
+          escaped_summary=$(printf '%s' "$summary" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+          printf -v SLACK_MESSAGE '*dev2main* :rocket:\n<%s|PR #%s>\n\n%s' \
+            "$PR_URL" "$PR_NUMBER" "$escaped_summary"
+          export SLACK_MESSAGE
+
+          node -e 'process.stdout.write(JSON.stringify({ text: process.env.SLACK_MESSAGE }))' \
+            > "$RUNNER_TEMP/slack-payload.json"
+
+          curl --silent --show-error --fail-with-body --retry 3 --retry-all-errors \
+            --header "Content-Type: application/json" \
+            --data-binary @"$RUNNER_TEMP/slack-payload.json" \
+            "$SLACK_SHIPPED_WEBHOOK_URL"


### PR DESCRIPTION
## Summary

- post Cubic's generated PR summary to Slack when a same-repository `dev` → `main` PR first receives it
- deliver to the channel-specific webhook stored in `SLACK_SHIPPED_WEBHOOK_URL`
- prevent duplicate posts from later Cubic summary refreshes and reject fork branches named `dev`

## Validation

- parsed the workflow YAML and checked the embedded shell with `bash -n`
- exercised five opened/edited, duplicate, wrong-branch, and fork trigger cases
- verified Cubic summary extraction and ran `git diff --check`

## Rollout

The workflow must reach `main` once before it can observe future `dev` → `main` PR events. The bootstrap PR itself will not post retroactively.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Post the first Cubic-generated PR summary to Slack for same-repo dev → main PRs. Prevents duplicates on later summary refreshes and ignores forks.

- **New Features**
  - Triggers on PR opened or when Cubic first adds its summary.
  - Sends the summary to the `SLACK_SHIPPED_WEBHOOK_URL` webhook.
  - Restricts to same-repo `dev` → `main` PRs; skips forks and misnamed branches.

- **Migration**
  - Set the `SLACK_SHIPPED_WEBHOOK_URL` repo secret.
  - The workflow must be merged to `main` before it can observe future `dev` → `main` PRs; the bootstrap PR will not post retroactively.

<sup>Written for commit 7270b1b14eec72b2af47b26df05ad0b992630fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a workflow that forwards the first Cubic summary on same-repository dev-to-main pull requests to Slack, but its edited-event guard can repost an existing summary after unrelated edits.

- **Improvements:** Adds channel-specific Slack delivery with escaped, JSON-encoded message content and webhook error handling.
- **Improvements:** Restricts delivery to same-repository `dev` branches targeting `main`.
- **Bug fixes:** Attempts to suppress later Cubic summary refreshes, though unrelated PR edits currently bypass that suppression.
</details>

<h3>Confidence Score: 4/5</h3>

This PR should not merge until unrelated edited events are prevented from reposting an existing Cubic summary.

The workflow interprets a missing previous-body field as an empty previous body, so a title-only edit after the initial notification reaches the webhook and creates a duplicate Slack message.

**Files Needing Attention:** .github/workflows/post-cubic-summary.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/post-cubic-summary.yml | Adds the Slack notification workflow, but title-only or other non-body edits can bypass its duplicate-post guard. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant GH as GitHub PR Event
  participant WF as Notification Workflow
  participant Slack as Shipped Slack Webhook
  GH->>WF: opened or edited event
  WF->>WF: Validate dev-to-main, same repository, Cubic marker
  WF->>WF: Check whether old body had marker
  alt Condition passes
    WF->>WF: Extract and encode summary
    WF->>Slack: POST summary
  else Condition fails
    WF-->>GH: Skip notification
  end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/post-cubic-summary.yml:21-22
**Absent body change bypasses deduplication**

When a qualifying PR receives a title-only edit after its Cubic summary was posted, `changes.body` is absent and the empty-string fallback passes this guard, causing the same summary to be posted to Slack again.

```suggestion
      (github.event.action == 'opened' ||
      (github.event.changes.body &&
      !contains(github.event.changes.body.from || '', '<!-- This is an auto-generated description by cubic. -->')))
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: post Cubic summaries to shipped"](https://github.com/useautumn/autumn/commit/7270b1b14eec72b2af47b26df05ad0b992630fc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50548211)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->