### PR TITLE
fix: keep readMaster balance reads off the standby retry path

### DIFF
--- a/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
+++ b/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
@@ -107,7 +107,9 @@ export const getCachedFeatureBalance = async ({
 				: redis.hmget(balanceKey, ...customerEntitlementIds),
 		source: "getCachedFeatureBalance",
 		redisInstance: redisV2,
-		retryOnStandby: true,
+		// readMaster demands same-socket ordering: a standby retry could land
+		// before an in-flight write on the dying primary socket.
+		retryOnStandby: !readMaster,
 		timeoutMs: REDIS_OP_TIMEOUT_MS.featureBalances,
 	});
 


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable standby retries for `readMaster` balance reads to prevent stale reads and preserve same-socket write/read ordering. Avoids hitting a standby before an in-flight write completes on the primary.

- **Bug Fixes**
  - Set `retryOnStandby` to `!readMaster` in `getCachedFeatureBalance` to keep master reads off the standby retry path.

<sup>Written for commit 7d1b0891cc387692766c4b3896067d72be33efb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prepares master-ordered balance reads to avoid potentially stale standby retries during Redis failover.
- **[Bug fixes]** Sets `retryOnStandby` to false for `readMaster` balance reads, preserving same-socket ordering when a primary connection fails.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete currently reachable failures identified.

The changed condition preserves existing retry behavior for all current callers because none pass `readMaster: true`; when that mode is enabled, avoiding standby retry matches the documented ordering requirement.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts | Conditionally disables standby retries for master-ordered balance reads; no current caller enables the affected `readMaster` branch. |

<sub>Reviews (1): Last reviewed commit: ["fix: keep readMaster balance reads off t..."](https://github.com/useautumn/autumn/commit/7d1b0891cc387692766c4b3896067d72be33efb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50567245)</sub>

<!-- /greptile_comment -->