### PR TITLE
fix(catalog): match entToPrice and priceToEnt across product versions

### DIFF
--- a/shared/utils/productUtils/convertProductUtils.ts
+++ b/shared/utils/productUtils/convertProductUtils.ts
@@ -14,6 +14,8 @@ import type {
 import type { EntitlementPrice } from "./entitlementPriceUtils/entitlementPriceTypes.js";
 import { isFixedPrice } from "./priceUtils/classifyPriceUtils.js";
 
+// Must stay symmetric with priceToEnt: if one direction resolves a pair across
+// products and the other does not, mapToProductItems silently drops the price.
 export const entToPrice = ({
 	ent,
 	prices,
@@ -21,10 +23,12 @@ export const entToPrice = ({
 	ent: Entitlement;
 	prices: Price[];
 }) => {
-	return prices.find(
-		(price) =>
-			price.entitlement_id === ent.id &&
-			price.internal_product_id === ent.internal_product_id,
+	const idMatches = prices.filter((price) => price.entitlement_id === ent.id);
+
+	return (
+		idMatches.find(
+			(price) => price.internal_product_id === ent.internal_product_id,
+		) ?? idMatches[0]
 	);
 };
 
@@ -62,14 +66,8 @@ export function priceToEnt({
 	entitlements: EntitlementWithFeature[];
 	errorOnNotFound?: boolean;
 }): EntitlementWithFeature | undefined {
-	// Prefer the entitlement that also shares the price's product — the original,
-	// strict match, so nothing changes for a well-formed product. Only fall back
-	// to id alone, because a customer product can carry entitlement rows owned by
-	// another product (grandfathered rows that survive a version bump) while a
-	// regenerated custom price is stamped with the customer product's own
-	// internal_product_id. Entitlement ids are globally unique, so the fallback
-	// cannot resolve to a different entitlement than the strict match would have.
-	// Mirrors the scoped sibling customerPriceToCustomerEntitlement.
+	// A customer product can carry grandfathered entitlements owned by an older
+	// product version while its regenerated custom price is stamped with its own.
 	const idMatches = entitlements.filter(
 		(ent) => ent.id === price.entitlement_id,
 	);

--- a/shared/utils/productV2Utils/mapToProductV2.test.ts
+++ b/shared/utils/productV2Utils/mapToProductV2.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import type { EntitlementWithFeature, Feature, Price } from "../../index.js";
 import { mapToProductItems } from "./mapToProductV2.js";
 
 // Legacy/customized products may omit relational arrays; mapping must remain total.
@@ -10,4 +11,66 @@ test("mapToProductItems normalizes missing product relations", () => {
 			features: [],
 		}),
 	).toEqual([]);
+});
+
+const creditsFeature = {
+	id: "AI_CREDITS",
+	name: "AI Credits",
+	config: { usage_type: "single_use" },
+} as unknown as Feature;
+
+// An entitlement grandfathered from an older version, paired with a custom price
+// the customer product re-stamped with its own internal_product_id.
+const crossVersionPair = () => {
+	const entitlement = {
+		id: "ent_credits",
+		internal_product_id: "prod_v3",
+		allowance: 0,
+		feature_id: "AI_CREDITS",
+		feature: creditsFeature,
+	} as unknown as EntitlementWithFeature;
+
+	const price = {
+		id: "pr_credits",
+		entitlement_id: "ent_credits",
+		internal_product_id: "prod_v6",
+		config: {
+			type: "usage",
+			feature_id: "AI_CREDITS",
+			interval: "month",
+			billing_units: 1,
+			bill_when: "end_of_period",
+			usage_tiers: [{ to: "inf", amount: 0.01 }],
+		},
+	} as unknown as Price;
+
+	return { entitlement, price };
+};
+
+test("mapToProductItems keeps the usage price when it and its entitlement span product versions", () => {
+	const { entitlement, price } = crossVersionPair();
+
+	const items = mapToProductItems({
+		prices: [price],
+		entitlements: [entitlement],
+		features: [creditsFeature],
+	});
+
+	expect(items).toHaveLength(1);
+	expect(items[0].tiers).toEqual([{ amount: 0.01, to: "inf" }]);
+	expect(items[0].included_usage).toBe(0);
+});
+
+test("mapToProductItems emits one item per price when products match", () => {
+	const { entitlement, price } = crossVersionPair();
+	entitlement.internal_product_id = "prod_v6";
+
+	const items = mapToProductItems({
+		prices: [price],
+		entitlements: [entitlement],
+		features: [creditsFeature],
+	});
+
+	expect(items).toHaveLength(1);
+	expect(items[0].tiers).toEqual([{ amount: 0.01, to: "inf" }]);
 });


### PR DESCRIPTION
## Problem

Usage prices stopped rendering on customer products whose price and entitlement sit on different product versions. The plan shows the included allowance but no overage price — the `$0.01/credit` line is simply absent.

#2602 gave `priceToEnt` a cross-product fallback. Its mirror, `entToPrice`, kept requiring both the id **and** `internal_product_id`. `mapToProductItems` calls both, and a price only becomes its own item when `priceToEnt` returns nothing:

```
shared/utils/productV2Utils/mapToProductV2.ts:59-73

for (ent of entitlements):
    price = entToPrice(ent)      <- strict: id AND internal_product_id
    push(item{ent, price})            -> price = undefined, ent-only item

for (price of prices):
    ent = priceToEnt(price)      <- loose since #2602
    if (!ent) push(item{price})       -> resolves, so nothing is pushed
                                         ^^^ the price is dropped here
```

Before #2602 both directions were strict, so `priceToEnt` returned `undefined` and the price fell through to a price-only item. #2602's caller audit listed this as `mapToProductV2` "emitted a duplicate price-only item → correct". For a well-formed product that is right. For a cross-version product that price-only item was the *only* representation of the price, and suppressing it loses the price entirely.

## Why the shape exists

`itemToPriceAndEnt` stamps a regenerated custom price with the customer product's own `internal_product_id`, while `entsAreSame` carries an unchanged entitlement over untouched — keeping whatever product owned it before the version bump. A `billing.update` on a custom plan is enough to produce the mismatch. #2602 measured 1,890 customer products on a single org already holding this shape.

## Blast radius

Billing is unaffected: the `customer_prices` row survives and the Stripe subscription keeps its metered item, so nothing was under-billed.

The live hazard was the round trip. `useSubscriptionStore.ts:49` and `useCusProductCache.tsx:94` both build the dashboard's editable state from `mapToProductV2`, and an update re-sends that item array — so saving any change on an affected customer would have deleted the usage price for real.

## Fix

`entToPrice` gets the same prefer-strict-then-fall-back rule as `priceToEnt`, so the two directions can no longer disagree about whether a price is spoken for. The entitlement item now carries its price (`included_usage: 0` plus the tiers), and `priceToEnt` still resolves, so there is no duplicate item.

Well-formed products are unaffected — the strict match is still tried first and still wins.

### Caller audit

Six call sites. The only behaviour change is `undefined → resolved`, and resolving is correct in each:

| Call site | Before, on a cross-version product | After |
|---|---|---|
| `mapToProductV2:27,60` | price dropped from the rendered items | ent item carries its price |
| `balanceResolver:31` | pay-per-use line reported `"included"` | `"usage_based"` |
| `initCustomerEntitlementUsageAllowed:21` | overage-allowed `false` | `true` |
| `initCustomerEntitlementBalance:40` | starting balance computed without the price | uses it |
| `initCustomerEntitlementFields:55` | separate-interval check saw no price | sees it |
| `productToEntitlementPrices` → `computeEntitlementPriceTransitions` | price looked deleted in the diff | pairs correctly |

Every caller passes a single product's price array, and a well-formed product has at most one price per entitlement, so the fallback cannot resolve to a different price than the strict match would have.

## Tests

`mapToProductV2.test.ts` — two cases asserting the rendered item keeps its tiers, one cross-version and one same-product. Verified as a real red by stashing the fix:

```
expect(items[0].tiers).toEqual([{ amount: 0.01, to: "inf" }])
- [ { "amount": 0.01, "to": "inf" } ]
+ undefined
(fail) mapToProductItems keeps the usage price when it and its entitlement span product versions
```

- `shared/utils/productV2Utils` + `shared/utils/productUtils` — 29 pass
- `server/tests/unit/catalog` + `server/tests/unit/billing` — 905 pass
- `bun ts` and biome clean on touched files

## Follow-up, not in this PR

This restores the display for every affected customer without touching data. It does not address why the mismatch is created in the first place — `itemToPriceAndEnt` re-stamping a regenerated price while its entitlement keeps the old owner. Worth deciding separately whether the two should be kept consistent at write time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `entToPrice` with `priceToEnt` by adding a strict-then-fallback match, restoring usage price rendering when a price and its entitlement are on different product versions. Prevents the dashboard from dropping usage prices and accidentally removing them on save.

- **Bug Fixes**
  - Update `entToPrice` to match by `entitlement_id` + `internal_product_id`, then fall back to `entitlement_id` only; `mapToProductItems` no longer drops prices when versions differ.
  - Add tests in `mapToProductV2.test.ts` for cross-version and same-product cases to ensure tiers are preserved and only one item is emitted.

<sup>Written for commit 705fe16e4a0c091bbdedc52f430a6e4e3ccb7c45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores usage-price rendering when a price and its entitlement belong to different product versions.
- **Bug fixes:** Makes entitlement-to-price matching symmetric with price-to-entitlement matching by preferring an exact product match and falling back to the shared entitlement ID.
- **Improvements:** Adds regression coverage for cross-version and same-version price pairing.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with focused regression tests covering the corrected cross-version pairing behavior.

The changed matcher preserves exact product matches while restoring prices that were previously dropped when an entitlement survived from an older product version, and no concrete blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productUtils/convertProductUtils.ts | Adds a strict-first, entitlement-ID fallback so cross-version prices remain paired with their entitlements. |
| shared/utils/productV2Utils/mapToProductV2.test.ts | Verifies that usage tiers and included usage survive cross-version pairing without creating duplicate items. |

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): match entToPrice and price..."](https://github.com/useautumn/autumn/commit/705fe16e4a0c091bbdedc52f430a6e4e3ccb7c45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50605855)</sub>

<!-- /greptile_comment -->