### PR TITLE
release

### DIFF
--- a/vite/src/hooks/useOverflowCount.ts
+++ b/vite/src/hooks/useOverflowCount.ts
@@ -1,0 +1,84 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Measures how many fixed-order children fit on one row, reserving room for a
+ * trailing overflow indicator when not everything fits.
+ *
+ * Render every item into `measureRef` off-screen at natural width, followed by
+ * the indicator template last; the visible row renders only `visibleCount`.
+ */
+export function useOverflowCount({
+	itemCount,
+	gap,
+	enabled = true,
+	hasIndicator = false,
+}: {
+	itemCount: number;
+	gap: number;
+	enabled?: boolean;
+	hasIndicator?: boolean;
+}) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const measureRef = useRef<HTMLDivElement>(null);
+	const [visibleCount, setVisibleCount] = useState(itemCount);
+
+	useLayoutEffect(() => {
+		// Keep the last measured count when disabled — resetting it makes callers
+		// that gate UI on `visibleCount < itemCount` flicker for one render.
+		if (!enabled) return;
+
+		const container = containerRef.current;
+		const measure = measureRef.current;
+		if (!container || !measure) return;
+
+		const recompute = () => {
+			const containerWidth = container.clientWidth;
+			if (!containerWidth) return;
+
+			const children = Array.from(measure.children) as HTMLElement[];
+			const widthOf = (el: HTMLElement) => el.getBoundingClientRect().width;
+			const itemEls = hasIndicator ? children.slice(0, -1) : children;
+			const indicatorWidth =
+				hasIndicator && children.length > 0
+					? widthOf(children[children.length - 1])
+					: 0;
+
+			const fitCount = (reserved: number) => {
+				let running = reserved;
+				let fitted = 0;
+				for (const itemEl of itemEls) {
+					const next = running + (fitted > 0 ? gap : 0) + widthOf(itemEl);
+					if (next > containerWidth) break;
+					running = next;
+					fitted += 1;
+				}
+				return fitted;
+			};
+
+			// Everything fits with no indicator — show it all.
+			if (fitCount(0) === itemEls.length) {
+				setVisibleCount(itemEls.length);
+				return;
+			}
+
+			// Always show at least one item, even if it alone overflows.
+			setVisibleCount(Math.max(fitCount(indicatorWidth + gap), 1));
+		};
+
+		recompute();
+
+		// Only width matters. Observing height too would re-measure on every frame
+		// of a container height animation, thrashing the count mid-transition.
+		let lastWidth = container.clientWidth;
+		const observer = new ResizeObserver(() => {
+			const width = container.clientWidth;
+			if (width === lastWidth) return;
+			lastWidth = width;
+			recompute();
+		});
+		observer.observe(container);
+		return () => observer.disconnect();
+	}, [itemCount, gap, enabled, hasIndicator]);
+
+	return { containerRef, measureRef, visibleCount };
+}

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -24,6 +24,7 @@ import {
 	deduplicateEntitlements,
 	flattenCustomerEntitlements,
 	flattenStandaloneCustomerEntitlements,
+	getAvailableBooleanFeatures,
 	processNonBooleanEntitlements,
 } from "./customerFeatureUsageUtils";
 
@@ -164,8 +165,17 @@ export function CustomerFeatureUsageTable() {
 		[deduplicatedCusEnts],
 	);
 
+	const availableBooleanFeatures = useMemo(
+		() =>
+			getAvailableBooleanFeatures({
+				features: features ?? [],
+				grantedEnts: booleanEnts,
+			}),
+		[features, booleanEnts],
+	);
+
 	const hasMeteredBalances = balanceEnts.length > 0;
-	const hasBooleanFlags = booleanEnts.length > 0;
+	const hasFlagsSection = booleanEnts.length > 0;
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -195,7 +205,7 @@ export function CustomerFeatureUsageTable() {
 							</Button>
 						</Table.Actions>
 					</Table.Toolbar>
-					{hasBooleanFlags && <SectionTag>Balances</SectionTag>}
+					{hasFlagsSection && <SectionTag>Balances</SectionTag>}
 					{hasMeteredBalances ? (
 						<CustomerBalanceTable
 							allEnts={balanceEnts}
@@ -205,14 +215,17 @@ export function CustomerFeatureUsageTable() {
 						/>
 					) : (
 						!isLoading &&
-						!hasBooleanFlags && (
+						!hasFlagsSection && (
 							<EmptyState text="Enable a plan to grant access to features" />
 						)
 					)}
 				</Table.Container>
 			</Table.Provider>
-			{!isLoading && hasBooleanFlags && (
-				<CustomerFlagsSection booleanEnts={booleanEnts} />
+			{!isLoading && hasFlagsSection && (
+				<CustomerFlagsSection
+					booleanEnts={booleanEnts}
+					availableFeatures={availableBooleanFeatures}
+				/>
 			)}
 		</div>
 	);

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
@@ -1,26 +1,161 @@
-import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
-import { SectionTag } from "@autumn/ui";
-import { CheckCircleIcon } from "@phosphor-icons/react";
+import type { Feature, FullCusEntWithFullCusProduct } from "@autumn/shared";
+import { Tabs, TabsList, TabsTrigger } from "@autumn/ui";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { cn } from "@/lib/utils";
+import { flagPillClassName, OVERFLOW_PILL_CLASSNAME } from "./FlagPill";
+import { useFlagsView } from "./useFlagsView";
+
+type FlagsView = "enabled" | "catalog";
+
+const FLAG_VIEWS: { value: FlagsView; label: string }[] = [
+	{ value: "enabled", label: "Flags" },
+	{ value: "catalog", label: "Full Catalog" },
+];
+
+// The primitive's active chip is near-black and its track is bg-muted, a point
+// off interactive-secondary in dark mode — neither separates from the card.
+const TAB_CLASSNAME = cn(
+	"px-2.5 py-0.5 rounded-md text-xs font-medium text-tertiary-foreground",
+	"transition-colors hover:text-foreground",
+	"data-[active]:bg-background data-[active]:text-foreground data-[active]:shadow-sm",
+	"dark:data-[active]:bg-background dark:data-[active]:text-foreground",
+);
+
+const ENTER_TRANSITION = { duration: 0.2, ease: [0.23, 1, 0.32, 1] } as const;
+const EXIT_TRANSITION = { duration: 0.12, ease: "easeOut" } as const;
+// No spring — bouncing the row height would shove everything below it around.
+const HEIGHT_TRANSITION = { duration: 0.25, ease: [0.23, 1, 0.32, 1] } as const;
 
 export function CustomerFlagsSection({
 	booleanEnts,
+	availableFeatures,
 }: {
 	booleanEnts: FullCusEntWithFullCusProduct[];
+	availableFeatures: Feature[];
 }) {
+	const reduceMotion = useReducedMotion() ?? false;
+	const {
+		showingCatalog,
+		expanded,
+		isCollapsed,
+		visibleEnts,
+		hiddenCount,
+		hasOverflow,
+		rowHeight,
+		containerRef,
+		measureRef,
+		rowRef,
+		setShowingCatalog,
+		toggleExpanded,
+	} = useFlagsView({ booleanEnts });
+
+	// Pills keep their slot across views — only trailing ones are added or
+	// removed — so a plain fade reads calmer than layout animation plus scale.
+	const pillMotion = {
+		initial: { opacity: 0 },
+		animate: { opacity: 1 },
+		exit: { opacity: 0, transition: EXIT_TRANSITION },
+		transition: reduceMotion ? { duration: 0 } : ENTER_TRANSITION,
+	};
+
+	// Catalog is an expansion of the customer's flags, never a section on its own.
 	if (booleanEnts.length === 0) return null;
 
 	return (
 		<div className="flex flex-col">
-			<SectionTag>Flags</SectionTag>
-			<div className="flex flex-wrap gap-2">
-				{booleanEnts.map((ent) => (
+			<div className="flex items-center mb-3">
+				<Tabs
+					value={showingCatalog ? "catalog" : "enabled"}
+					onValueChange={(value) => setShowingCatalog(value === "catalog")}
+				>
+					<TabsList className="h-auto gap-0.5 p-0.5 rounded-lg bg-muted dark:bg-muted">
+						{FLAG_VIEWS.map(({ value, label }) =>
+							value === "catalog" && availableFeatures.length === 0 ? null : (
+								<TabsTrigger
+									key={value}
+									value={value}
+									className={TAB_CLASSNAME}
+								>
+									{label}
+								</TabsTrigger>
+							),
+						)}
+					</TabsList>
+				</Tabs>
+			</div>
+
+			<div ref={containerRef} className="relative">
+				{/* Always mounted — gating this on the view would leave the count stale
+				    for a frame when returning to Flags, collapsing to the wrong width. */}
+				<div
+					ref={measureRef}
+					aria-hidden
+					className="absolute -top-[9999px] left-0 flex gap-2 pointer-events-none"
+				>
+					{booleanEnts.map((ent) => (
+						<div
+							key={ent.entitlement.feature.id}
+							className={flagPillClassName(true)}
+						>
+							{ent.entitlement.feature.name}
+						</div>
+					))}
+					<div className={OVERFLOW_PILL_CLASSNAME}>Show less</div>
+				</div>
+
+				<motion.div
+					animate={{ height: rowHeight }}
+					transition={reduceMotion ? { duration: 0 } : HEIGHT_TRANSITION}
+					className="overflow-hidden"
+				>
 					<div
-						key={ent.entitlement.feature.id}
-						className="text-sm text-muted-foreground bg-interactive-secondary border h-10 flex items-center px-4 rounded-lg"
+						ref={rowRef}
+						className={cn(
+							"flex gap-2 flex-wrap",
+							// Clip to one row by height, not nowrap: nowrap lets the row
+							// exceed the container, parking trailing children off-screen
+							// right until the count catches up.
+							isCollapsed && "max-h-10 overflow-hidden",
+						)}
 					>
-						<span>{ent.entitlement.feature.name}</span>
+						<AnimatePresence initial={false}>
+							{visibleEnts.map((ent) => (
+								<motion.div
+									key={ent.entitlement.feature.id}
+									{...pillMotion}
+									className={flagPillClassName(true)}
+								>
+									{ent.entitlement.feature.name}
+								</motion.div>
+							))}
+
+							{showingCatalog &&
+								availableFeatures.map((feature) => (
+									<motion.div
+										key={feature.id}
+										{...pillMotion}
+										className={flagPillClassName(false)}
+									>
+										{feature.name}
+									</motion.div>
+								))}
+						</AnimatePresence>
+
+						{hasOverflow && (
+							<button
+								type="button"
+								onClick={toggleExpanded}
+								className={cn(
+									OVERFLOW_PILL_CLASSNAME,
+									"cursor-pointer transition-colors hover:text-foreground hover:border-solid",
+									"animate-in fade-in-0 duration-500 ease-out",
+								)}
+							>
+								{expanded ? "Show less" : `+${hiddenCount} more`}
+							</button>
+						)}
 					</div>
-				))}
+				</motion.div>
 			</div>
 		</div>
 	);

--- a/vite/src/views/customers2/components/table/customer-feature-usage/FlagPill.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/FlagPill.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+const BASE =
+	"text-sm h-10 flex items-center px-4 rounded-lg border whitespace-nowrap";
+
+export const FLAG_PILL_GAP = 8;
+
+// Fixed width so swapping "+7 more" for "Show less" doesn't resize the pill,
+// which reads as drift while it fades.
+export const OVERFLOW_PILL_CLASSNAME = cn(
+	BASE,
+	"border-dashed text-tertiary-foreground w-28 justify-center",
+);
+
+export function flagPillClassName(granted: boolean) {
+	return cn(
+		BASE,
+		granted
+			? "text-muted-foreground bg-interactive-secondary"
+			: "text-tertiary-foreground border-dashed",
+	);
+}

--- a/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts
@@ -203,6 +203,28 @@ export function processNonBooleanEntitlements({
 }
 
 /**
+ * Boolean features in the org catalog the customer has not been granted.
+ */
+export function getAvailableBooleanFeatures({
+	features,
+	grantedEnts,
+}: {
+	features: Feature[];
+	grantedEnts: FullCusEntWithFullCusProduct[];
+}): Feature[] {
+	const grantedIds = new Set(
+		grantedEnts.map((ent) => ent.entitlement.feature.id),
+	);
+
+	return features.filter(
+		(feature) =>
+			feature.type === FeatureType.Boolean &&
+			!feature.archived &&
+			!grantedIds.has(feature.id),
+	);
+}
+
+/**
  * Filters entitlements to only boolean features
  */
 function filterBooleanEntitlements({

--- a/vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts
@@ -1,0 +1,56 @@
+import type { FullCusEntWithFullCusProduct } from "@autumn/shared";
+import { useState } from "react";
+import { useMeasuredHeight } from "@/hooks/useMeasuredHeight";
+import { useOverflowCount } from "@/hooks/useOverflowCount";
+import { FLAG_PILL_GAP } from "./FlagPill";
+
+type FlagsViewState = { showingCatalog: boolean; expanded: boolean };
+
+export function useFlagsView({
+	booleanEnts,
+}: {
+	booleanEnts: FullCusEntWithFullCusProduct[];
+}) {
+	// Expansion survives a trip through the catalog, so the two axes are
+	// independent rather than one enum.
+	const [state, setState] = useState<FlagsViewState>({
+		showingCatalog: false,
+		expanded: false,
+	});
+	const { showingCatalog, expanded } = state;
+
+	// Measures a hidden layer, so it can always run — the count stays correct
+	// across every view instead of lagging a frame behind a toggle.
+	const { containerRef, measureRef, visibleCount } = useOverflowCount({
+		itemCount: booleanEnts.length,
+		gap: FLAG_PILL_GAP,
+		hasIndicator: true,
+	});
+
+	const { ref: rowRef, height: measuredHeight } =
+		useMeasuredHeight<HTMLDivElement>();
+
+	const isCollapsed = !showingCatalog && !expanded;
+	const visibleEnts = isCollapsed
+		? booleanEnts.slice(0, visibleCount)
+		: booleanEnts;
+
+	return {
+		showingCatalog,
+		expanded,
+		isCollapsed,
+		visibleEnts,
+		hiddenCount: booleanEnts.length - visibleEnts.length,
+		// One condition for both labels — deriving it from `hiddenCount` would drop
+		// to 0 on expand, unmounting the button and replaying its enter animation.
+		hasOverflow: !showingCatalog && visibleCount < booleanEnts.length,
+		rowHeight: measuredHeight ?? "auto",
+		containerRef,
+		measureRef,
+		rowRef,
+		setShowingCatalog: (showingCatalog: boolean) =>
+			setState((prev) => ({ ...prev, showingCatalog })),
+		toggleExpanded: () =>
+			setState((prev) => ({ ...prev, expanded: !prev.expanded })),
+	};
+}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved the Customer Flags section with overflow-aware pills, a Show more/less toggle, and a Full Catalog tab for boolean features. Adds a reusable overflow measurement hook and smooth transitions for a stable, flicker-free layout.

- **New Features**
  - Flags/Catalog tabs using `@autumn/ui` Tabs; Catalog is hidden when there are no ungranted boolean features.
  - Overflow-aware pills with "+N more" and "Show less"; clips to one row and always shows at least one pill.
  - New `useOverflowCount` hook to measure visible items (gap- and indicator-aware) with resize handling.
  - New `useFlagsView` hook for tabs/expand state, visible slice, and measured row height; respects reduced motion and animates height/opacity.
  - Added `FlagPill` styles for granted vs catalog items; fixed-width overflow pill to prevent drift.
  - Added `getAvailableBooleanFeatures` and passed available features from `CustomerFeatureUsageTable`.

<sup>Written for commit 51cea88df3597b5ca47fb17b94832eff19164619. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release improves how customer Boolean flags are displayed and adds a full catalog view.

- **[Improvements]** Adds responsive flag-pill overflow handling with expand and collapse controls.
- **[Improvements]** Adds tabs for switching between granted flags and the full available Boolean-feature catalog.
- **[Improvements]** Filters archived and already-granted features out of the available catalog.
</details>

<h3>Confidence Score: 3/5</h3>

The PR should be fixed before merging because narrow layouts can make hidden flags permanently inaccessible and refreshed catalog data can leave the tabs in an inconsistent state.

The new overflow calculation can place its expand control on a clipped row, while the catalog trigger can disappear without resetting the controlled catalog selection.

**Files Needing Attention:** vite/src/hooks/useOverflowCount.ts, vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx, vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/hooks/useOverflowCount.ts | Adds responsive overflow measurement, but forcing one visible item can clip the only control for revealing hidden flags. |
| vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx | Replaces the simple flag list with tabbed, animated views; conditional tab removal can leave the controlled view state inconsistent. |
| vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts | Coordinates catalog, expansion, overflow, and height state, but does not reset catalog mode when that view becomes unavailable. |
| vite/src/views/customers2/components/table/customer-feature-usage/customerFeatureUsageUtils.ts | Adds a focused filter for active, ungranted Boolean catalog features. |
| vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx | Computes available Boolean features and supplies them to the new flags section. |
| vite/src/views/customers2/components/table/customer-feature-usage/FlagPill.tsx | Centralizes the shared styles and dimensions used by granted, available, and overflow pills. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Customer feature data] --> B[Granted Boolean flags]
  A --> C[Available Boolean catalog features]
  B --> D[Flags view]
  B --> E[Full Catalog view]
  C --> E
  D --> F[Measure available row width]
  F --> G[Visible flag pills]
  F --> H[Overflow control]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/hooks/useOverflowCount.ts:62
**Overflow control gets clipped**

When the first flag and the overflow button do not fit together, forcing `visibleCount` to one places the button on a clipped second row, causing users to lose the only control for revealing the remaining flags.

### Issue 2
vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx:73
**Catalog selection becomes invalid**

When refreshed data leaves no available catalog features, this removes the catalog trigger while `showingCatalog` remains true, causing the tab bar to have no selected trigger and the catalog area to remain empty until the user manually selects Flags.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2634 from useautumn/..."](https://github.com/useautumn/autumn/commit/51cea88df3597b5ca47fb17b94832eff19164619) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50771098)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->