### PR TITLE
fix: preserve nested property rollup fallback

### DIFF
--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -462,6 +462,7 @@ export const aggregate = async ({
 			hasCustomerId: Boolean(customerId),
 			hasEntityId: Boolean(params.entity_id),
 			hasPropertyFilters: Object.keys(filterParams).length > 0,
+			propertyKey,
 			skipPropertyRollup: false,
 		});
 		const useDailyRollup = shouldUsePropertyDailyRollup({

--- a/server/src/internal/analytics/actions/dailyRollupRouting.ts
+++ b/server/src/internal/analytics/actions/dailyRollupRouting.ts
@@ -18,18 +18,21 @@ export const shouldUseOrgPropertyRollup = ({
 	hasCustomerId,
 	hasEntityId,
 	hasPropertyFilters,
+	propertyKey,
 	skipPropertyRollup,
 }: {
 	groupColumn: GroupableColumn;
 	hasCustomerId: boolean;
 	hasEntityId: boolean;
 	hasPropertyFilters: boolean;
+	propertyKey: string;
 	skipPropertyRollup: boolean;
 }): boolean =>
 	groupColumn === "property" &&
 	!hasCustomerId &&
 	!hasEntityId &&
 	!hasPropertyFilters &&
+	!propertyKey.includes(".") &&
 	!skipPropertyRollup;
 
 const parseUtcTimestamp = ({ value }: { value: string }): number => {

--- a/server/tests/unit/analytics/daily-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-routing.test.ts
@@ -17,10 +17,13 @@ test("org property rollup: routes only unfiltered aggregate-all property groups"
 		hasCustomerId: false,
 		hasEntityId: false,
 		hasPropertyFilters: false,
+		propertyKey: "email_type",
 		skipPropertyRollup: false,
 	};
+	const nestedProperty = { ...base, propertyKey: "metadata.region" };
 
 	expect(shouldUseOrgPropertyRollup(base)).toBe(true);
+	expect(shouldUseOrgPropertyRollup(nestedProperty)).toBe(false);
 	expect(shouldUseOrgPropertyRollup({ ...base, hasCustomerId: true })).toBe(
 		false,
 	);


### PR DESCRIPTION
## Summary

- keep nested property group-bys on the existing ungated Tinybird path
- preserve the new org-property rollup for eligible top-level property keys
- add regression coverage for top-level versus nested routing

## Root cause

The org-property materializations index only top-level JSON keys, while the API accepts dotted nested paths. Routing a nested path such as `properties.metadata.region` to the org rollup produced empty grouped and coverage results, which suppressed the existing ungated fallback.

## Validation

- `bun ts`
- `bun test tests/unit/analytics/daily-rollup-routing.test.ts tests/unit/analytics/property-rollup-completeness.test.ts` — 23 passed
- focused Biome check on the three changed files
- repository commit hook, including server typecheck

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix routing for nested property group-bys by keeping them on the existing Tinybird path to avoid empty results. Top-level property keys still use the org-property rollup when eligible.

- **Bug Fixes**
  - Gate org property rollup to top-level keys only by passing `propertyKey` to the routing check and rejecting dotted paths.
  - Preserve fallback for nested properties to ensure correct grouped and coverage results.
  - Add unit tests for top-level vs nested routing to prevent regression.

<sup>Written for commit 428f06c0c7b6ef1415d614adf75db072455b8448. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This fix prevents nested property group-bys from using an org-level rollup that only indexes top-level keys.
- **Bug fixes:** Route dotted nested property paths through the existing Tinybird fallback while retaining the org-property rollup for eligible top-level keys.
- **Improvements:** Add regression coverage confirming that top-level and nested property keys select different routes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed routing behavior.

The new condition narrowly prevents nested property paths from entering a rollup that only supports top-level keys, while the caller supplies a definite normalized key and tests cover both routing outcomes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/aggregate.ts | Passes the normalized property key into the org-rollup routing decision. |
| server/src/internal/analytics/actions/dailyRollupRouting.ts | Excludes dotted nested property paths from the top-level-only org-property rollup. |
| server/tests/unit/analytics/daily-rollup-routing.test.ts | Adds regression coverage for top-level versus nested property routing. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Property group-by request] --> B{Property key contains a dot?}
  B -- No --> C{Eligible for org rollup?}
  C -- Yes --> D[Use org-property rollup]
  C -- No --> E[Use existing Tinybird path]
  B -- Yes --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve nested property rollup fal..."](https://github.com/useautumn/autumn/commit/428f06c0c7b6ef1415d614adf75db072455b8448) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50780141)</sub>

<!-- /greptile_comment -->