### PR TITLE
fix: reserve timeout budget for Redis standby

### DIFF
--- a/server/src/external/redis/initUtils/createStandbyRedisRouter.ts
+++ b/server/src/external/redis/initUtils/createStandbyRedisRouter.ts
@@ -15,6 +15,9 @@ type StandbyConnections = {
 export type StandbyRedisRouter = {
 	/** Preferred connection first, then the alternate. Never empty. */
 	ordered: () => [Redis, Redis];
+	/** Ready and past its failure penalty. `status` alone says only that the
+	 *  socket is up, not that the router still trusts the connection. */
+	isUsable: (connection: Redis) => boolean;
 	recordOutcome: (args: { connection: Redis; error?: unknown }) => void;
 };
 
@@ -107,7 +110,7 @@ export const createStandbyRedisRouter = ({
 		entry.consecutiveFailures = 0;
 	};
 
-	const router: StandbyRedisRouter = { ordered, recordOutcome };
+	const router: StandbyRedisRouter = { ordered, isUsable, recordOutcome };
 
 	const observeOutcome = ({
 		result,

--- a/server/src/external/redis/utils/redisOpTimeouts.ts
+++ b/server/src/external/redis/utils/redisOpTimeouts.ts
@@ -5,6 +5,11 @@
  * Only reads with a working non-Redis path belong here. A timed-out write is
  * ambiguous — `withTimeout` abandons the promise but the command still lands.
  * Values are sized above each op's measured production p99.9.
+ *
+ * A value above the client's `commandTimeout` is inert: ioredis arms that timer
+ * per command at dispatch (offline-queued commands and pipeline members
+ * included), so on V2 the 1s ceiling ends the attempt first and the p99.9
+ * figures below are measured against an already-truncated tail.
  */
 export const REDIS_OP_TIMEOUT_MS = {
 	/** p99.9 137ms. Falls through to Postgres via verifyKey. */
@@ -13,8 +18,10 @@ export const REDIS_OP_TIMEOUT_MS = {
 	orgFeaturesGet: 300,
 	/** p99.9 297ms on shared V2; this site also serves the dedicated cluster. */
 	featureBalances: 400,
-	/** p99.9 643-938ms; latency scales with the customer's feature count. */
+	/** p99.9 643-938ms; latency scales with the customer's feature count.
+	 *  V2's 1s `commandTimeout` binds before this does. */
 	featureBalancesBatch: 1200,
-	/** p99.9 849ms across the pipe[get,get] pool. */
+	/** p99.9 849ms across the pipe[get,get] pool.
+	 *  V2's 1s `commandTimeout` binds before this does. */
 	subjectPipeline: 1200,
 } as const;

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -136,10 +136,12 @@ export const runRedisOp = async <T>({
 		if (!router) return await runAttempt(targetRedis, timeoutMs);
 
 		const [preferred, alternate] = router.ordered();
-		const preferredAttemptBudgetMs =
-			alternate.status === "ready"
-				? getPreferredAttemptBudgetMs({ timeoutMs })
-				: timeoutMs;
+		// Only shorten the preferred attempt for an alternate worth retrying on.
+		// `canRetry` below stays broader on purpose: once the preferred has failed,
+		// a penalized alternate still beats falling open to the non-Redis path.
+		const preferredAttemptBudgetMs = router.isUsable(alternate)
+			? getPreferredAttemptBudgetMs({ timeoutMs })
+			: timeoutMs;
 		try {
 			const value = await runAttempt(preferred, preferredAttemptBudgetMs);
 			router.recordOutcome({ connection: preferred });

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -136,7 +136,10 @@ export const runRedisOp = async <T>({
 		if (!router) return await runAttempt(targetRedis, timeoutMs);
 
 		const [preferred, alternate] = router.ordered();
-		const preferredAttemptBudgetMs = getPreferredAttemptBudgetMs({ timeoutMs });
+		const preferredAttemptBudgetMs =
+			alternate.status === "ready"
+				? getPreferredAttemptBudgetMs({ timeoutMs })
+				: timeoutMs;
 		try {
 			const value = await runAttempt(preferred, preferredAttemptBudgetMs);
 			router.recordOutcome({ connection: preferred });

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -8,7 +8,25 @@ import { isConnectionLevelRedisError } from "./isTransientRedisError.js";
 const REDIS_WARNING_INTERVAL_MS = 30_000;
 /** Below this a retry cannot finish, so spend the budget on the fallback. */
 const MIN_RETRY_BUDGET_MS = 50;
+const STANDBY_RETRY_RESERVE_RATIO = 0.25;
+const MAX_STANDBY_RETRY_RESERVE_MS = 250;
 const lastRedisWarningAtBySource = new Map<string, number>();
+
+const getPreferredAttemptBudgetMs = ({
+	timeoutMs,
+}: {
+	timeoutMs?: number;
+}): number | undefined => {
+	if (timeoutMs === undefined) return undefined;
+
+	const retryReserveMs = Math.min(
+		Math.floor(timeoutMs * STANDBY_RETRY_RESERVE_RATIO),
+		MAX_STANDBY_RETRY_RESERVE_MS,
+	);
+	return retryReserveMs >= MIN_RETRY_BUDGET_MS
+		? timeoutMs - retryReserveMs
+		: timeoutMs;
+};
 
 const classifyErrorReason = (
 	targetRedis: Redis,
@@ -118,8 +136,9 @@ export const runRedisOp = async <T>({
 		if (!router) return await runAttempt(targetRedis, timeoutMs);
 
 		const [preferred, alternate] = router.ordered();
+		const preferredAttemptBudgetMs = getPreferredAttemptBudgetMs({ timeoutMs });
 		try {
-			const value = await runAttempt(preferred, timeoutMs);
+			const value = await runAttempt(preferred, preferredAttemptBudgetMs);
 			router.recordOutcome({ connection: preferred });
 			return value;
 		} catch (firstError) {

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -387,6 +387,23 @@ describe("runRedisOp standby failover", () => {
 		expect(standby.calls).toEqual([]);
 	});
 
+	test("keeps the full deadline when the alternate is not ready", async () => {
+		const { primary, standby, redis } = createPair({ standbyStatus: "end" });
+		primary.hangGetForMs = 175;
+
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "standby-test",
+			retryOnStandby: true,
+			timeoutMs: 200,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("primary");
+		expect(primary.calls).toEqual(["get:subject"]);
+		expect(standby.calls).toEqual([]);
+	});
+
 	test("surfaces the retry failure when both connections fail", async () => {
 		const { primary, standby, redis } = createPair();
 		primary.failGetWith = connectionError();

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -441,6 +441,40 @@ describe("runRedisOp standby failover", () => {
 		expect(Date.now() - startedAt).toBeLessThan(390);
 	});
 
+	test("keeps the full deadline when the alternate is penalized", async () => {
+		const { primary, standby, redis } = createPair({
+			primaryStatus: "reconnecting",
+		});
+
+		// Fail the standby out of rotation while it is the only usable connection,
+		// then restore the primary: the pair ends up ready but distrusted.
+		standby.failGetWith = connectionError();
+		for (let attempt = 0; attempt < 3; attempt++) {
+			await runRedisOp({
+				redisInstance: redis,
+				source: "standby-test",
+				retryOnStandby: true,
+				operation: (connection) => connection.get("subject"),
+			}).catch(() => undefined);
+		}
+		standby.failGetWith = undefined;
+		primary.status = "ready";
+		const standbyCallsBefore = standby.calls.length;
+
+		primary.hangGetForMs = 520;
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "standby-test",
+			retryOnStandby: true,
+			timeoutMs: 600,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("primary");
+		expect(primary.calls).toEqual(["get:subject"]);
+		expect(standby.calls.length).toBe(standbyCallsBefore);
+	});
+
 	test("shares one timeout budget across both attempts", async () => {
 		const { primary, standby, redis } = createPair();
 		// Primary burns most of the budget, then fails; standby never answers.

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -405,6 +405,25 @@ describe("runRedisOp standby failover", () => {
 		expect(standby.calls).toEqual(["get:subject"]);
 	});
 
+	test("reserves part of the deadline for a standby retry", async () => {
+		const { primary, standby, redis } = createPair();
+		primary.hangGetForMs = 5_000;
+
+		const startedAt = Date.now();
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "standby-test",
+			retryOnStandby: true,
+			timeoutMs: 400,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("standby");
+		expect(primary.calls).toEqual(["get:subject"]);
+		expect(standby.calls).toEqual(["get:subject"]);
+		expect(Date.now() - startedAt).toBeLessThan(390);
+	});
+
 	test("shares one timeout budget across both attempts", async () => {
 		const { primary, standby, redis } = createPair();
 		// Primary burns most of the budget, then fails; standby never answers.


### PR DESCRIPTION
## Summary

- reserve 25% of a retry-enabled Redis read deadline for the alternate connection, capped at 250ms
- keep the existing 50ms minimum retry budget and the same total operation deadline
- leave writes, non-retry operations, and calls without an explicit timeout unchanged
- document in `redisOpTimeouts.ts` that a per-op bound above the client's `commandTimeout` cannot bind

## Why

The standby retry shares one deadline across both attempts, and nothing bounded the first attempt, so in principle the preferred connection could consume the whole caller budget and leave the standby under the 50ms floor.

In production that is currently prevented by a second mechanism rather than by this code. V2 clients are built with `commandTimeout` 1000ms, applied to both sides of the router, and ioredis arms that timer per command at dispatch, covering offline-queued commands and pipeline members. Both existing `retryOnStandby` call sites pass 1200ms deadlines, so the preferred attempt already fails at ~1000ms with "Command timed out", which the connection-level classifier matches, leaving ~200ms for the standby.

So for the two callers that exist today this moves the preferred bound from 1000ms to 950ms and the standby's share from ~200ms to 250ms. The reason to land it is the case the 1s ceiling does not cover: a future `retryOnStandby` caller with a deadline at or below `commandTimeout`, where the per-op wrapper is the only bound and the standby would genuinely get nothing.

This improves failures isolated to the preferred Redis connection. It does not address whole-process or host stalls where both Redis pools pause together, as seen in the Resend case.

## Validation

- `bun test tests/unit/redis/standby-redis-routing.test.ts` - 32 pass
- `cd server && bun ts`
- scoped Biome check on the changed files
- commit hooks: knip and `@autumn/server` typecheck passed

The unit test setup emitted the existing local Infisical login warning, but the focused suite ran and passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserves 25% of a retry-enabled Redis read timeout (capped at 250ms) for a standby retry when the standby is usable, so the primary can’t consume the whole deadline and failover stays reliable. Documents that on V2 `ioredis` the 1s `commandTimeout` can preempt per-op limits.

- **Bug Fixes**
  - Applies only to read ops with `retryOnStandby`; writes and non-retry calls unchanged.
  - Gates the reserve on router usability (past penalty), not merely socket “ready”; keeps the full deadline when the alternate is unready or penalized.
  - Maintains a single shared deadline across primary and standby attempts.
  - Adds unit tests for reserved-budget, not-ready alternate, and penalized-standby paths; does not address whole-process stalls where both pools pause.

<sup>Written for commit b4e870ea7ddcdce90d4d7c9cf0e356a4a990fa77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reserves part of a retry-enabled Redis read deadline for a healthy standby connection while preserving the existing total deadline and behavior for writes, non-retry operations, and unavailable standbys.

- **[Bug fixes]** Limits the preferred Redis attempt so a usable standby retains up to 250ms for failover.
- **[Improvements]** Exposes the router’s existing usability check so timeout allocation respects connection penalties rather than socket status alone.
- **[Improvements]** Documents how the Redis client’s command timeout interacts with per-operation limits.
- **[Improvements]** Adds focused coverage for healthy, unavailable, and penalized standby states.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/createStandbyRedisRouter.ts | Exposes the router’s existing readiness-and-penalty usability predicate for timeout allocation. |
| server/src/external/redis/utils/redisOpTimeouts.ts | Documents that the client command timeout can preempt larger per-operation bounds. |
| server/src/external/redis/utils/runRedisOp.ts | Reserves part of the shared deadline for standby retries only when the alternate is currently usable. |
| server/tests/unit/redis/standby-redis-routing.test.ts | Covers reserved-budget behavior and preservation of the full preferred deadline when the standby is unavailable or penalized. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Router
  participant Preferred as Preferred Redis
  participant Standby as Standby Redis
  Caller->>Router: Read with retry and explicit deadline
  Router->>Router: Check whether standby is usable
  alt Standby usable
    Router->>Preferred: Attempt with reduced budget
    alt Preferred succeeds
      Preferred-->>Caller: Read result
    else Preferred has connection-level failure
      Router->>Standby: Retry with reserved shared-deadline budget
      Standby-->>Caller: Read result or final error
    end
  else Standby unavailable or penalized
    Router->>Preferred: Attempt with full deadline
    Preferred-->>Caller: Read result or error
  end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: gate the standby reserve on router ..."](https://github.com/useautumn/autumn/commit/b4e870ea7ddcdce90d4d7c9cf0e356a4a990fa77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50815975)</sub>

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->