### PR TITLE
fix: give plan editor items a stable identity

### DIFF
--- a/shared/models/productV2Models/productItemModels/productItemModels.ts
+++ b/shared/models/productV2Models/productItemModels/productItemModels.ts
@@ -1,17 +1,17 @@
 import { z } from "zod/v4";
 import { ApiFeatureV0Schema } from "../../../api/features/prevVersions/apiFeatureV0.js";
 import {
-    AdditionalCurrencyPriceArraySchema,
-    AdditionalCurrencyTierArraySchema,
+	AdditionalCurrencyPriceArraySchema,
+	AdditionalCurrencyTierArraySchema,
 } from "../../../api/products/components/additionalCurrencies.js";
 import { RolloverExpiryDurationType } from "../../productModels/durationTypes/rolloverExpiryDurationType.js";
 import { ProductItemInterval } from "../../productModels/intervals/productItemInterval.js";
 import { TierBehavior } from "../../productModels/priceModels/priceConfig/usagePriceConfig.js";
 import { Infinite } from "../../productModels/productEnums.js";
 import {
-    AllocatedBillingBehavior,
-    OnDecrease,
-    OnIncrease,
+	AllocatedBillingBehavior,
+	OnDecrease,
+	OnIncrease,
 } from "./productItemEnums.js";
 
 export const TierInfinite = "inf";
@@ -215,6 +215,11 @@ export const ProductItemSchema = z.object({
 	/** One-way Price → ProductItem display context. Never read this back when
 	 * rebuilding a price because an edited item may carry stale Stripe IDs. */
 	price_config: z.any().nullish().meta({
+		internal: true,
+	}),
+	/** Editor-only handle for items with no persisted entitlement/price id yet,
+	 * so two unsaved items for one feature stay individually addressable. */
+	_uid: z.string().nullish().meta({
 		internal: true,
 	}),
 });

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -23,6 +23,7 @@ const INTERNAL_KEYS = new Set([
 	"price_config", // Internal - backend config
 	"isPrice", // Frontend-only extension
 	"isVariable", // Frontend-only extension
+	"_uid", // Frontend-only editor handle
 ]);
 
 /** Recursively sorts object keys and normalizes undefined to null for consistent comparison */

--- a/vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts
+++ b/vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts
@@ -1,4 +1,5 @@
 import type { ProductItem } from "@autumn/shared";
+import { stripEditorFields } from "@/utils/product/productItemUtils";
 
 type DraftProductItem = Omit<ProductItem, "price"> & {
 	price?: ProductItem["price"] | "";
@@ -27,5 +28,7 @@ export function normalizeBillingRequestItems({
 		return [itemWithoutDraftPrice as ProductItem];
 	});
 
-	return normalizedItems.length > 0 ? normalizedItems : undefined;
+	return normalizedItems.length > 0
+		? stripEditorFields({ items: normalizedItems })
+		: undefined;
 }

--- a/vite/src/hooks/inline-editor/useItemDraftController.ts
+++ b/vite/src/hooks/inline-editor/useItemDraftController.ts
@@ -40,7 +40,13 @@ export interface ItemDraftController {
 	patchProduct: ({ product }: { product: FrontendProduct }) => void;
 	patchItem: ({ itemId, item }: { itemId: string; item: ProductItem }) => void;
 	startItem: ({ itemId, item }: { itemId: string; item: ProductItem }) => void;
-	updateItem: ({ item }: { item: ProductItem }) => void;
+	updateItem: ({
+		item,
+		itemId,
+	}: {
+		item: ProductItem;
+		itemId?: string;
+	}) => void;
 	discardItem: () => void;
 	commitItem: () => void;
 	clearItemSession: () => void;
@@ -213,7 +219,9 @@ export const useItemDraftController = ({
 	);
 
 	const updateItemDraft = useCallback(
-		({ item }: { item: ProductItem }) => {
+		// `itemId` renames the session when an edit changes the item's derived id,
+		// keeping it addressable by callers that still resolve items by id.
+		({ item, itemId }: { item: ProductItem; itemId?: string }) => {
 			setDraftItemSession((prev) => {
 				if (!prev) return prev;
 				patchPlanItem({
@@ -223,6 +231,7 @@ export const useItemDraftController = ({
 				});
 				return {
 					...prev,
+					itemId: itemId ?? prev.itemId,
 					draftItem: item,
 				};
 			});

--- a/vite/src/utils/product/productItemUtils.ts
+++ b/vite/src/utils/product/productItemUtils.ts
@@ -128,6 +128,9 @@ export const getItemId = ({
 	item: ProductItem;
 	itemIndex: number;
 }) => {
+	// Assigned at creation, so it survives edits that rewrite every other field.
+	if (item._uid) return `uid-${item._uid}`;
+
 	const interval = intervalSuffix(item);
 	if (item.entitlement_id) return `ent-${item.entitlement_id}${interval}`;
 	if (item.price_id) return `price-${item.price_id}${interval}`;
@@ -139,6 +142,14 @@ export const getItemId = ({
 	}
 	return `item-${itemIndex}`;
 };
+
+/** Editor-only fields must not reach the API; strip before building a request. */
+export const stripEditorFields = ({
+	items,
+}: {
+	items: ProductItem[] | undefined;
+}): ProductItem[] | undefined =>
+	items?.map(({ _uid, ...item }) => item as ProductItem);
 
 export const getPrepaidItems = (product: ProductV2 | undefined) => {
 	if (!product) return [];

--- a/vite/src/views/products/plan/ProductSheets.tsx
+++ b/vite/src/views/products/plan/ProductSheets.tsx
@@ -130,7 +130,17 @@ export const ProductSheets = () => {
 			draftItemSession &&
 			draftItemSession.itemId === itemId
 		) {
-			updateItemDraft({ item: updatedItem });
+			// Edits to feature type or interval change the item's derived id, so
+			// resync it or the plan row stops matching and loses its selection.
+			const newItemId = getItemId({
+				item: updatedItem,
+				itemIndex: draftItemSession.itemIndex,
+			});
+			updateItemDraft({ item: updatedItem, itemId: newItemId });
+			if (newItemId !== itemId) {
+				updateItemId(newItemId);
+				lastItemIdRef.current = newItemId;
+			}
 			return;
 		}
 

--- a/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
@@ -54,7 +54,7 @@ export function SelectFeatureSheet({
 	const [selectOpen, setSelectOpen] = useState(false);
 
 	const { features } = useFeaturesQuery();
-	const { product, setProduct, initialProduct } = useProduct();
+	const { product, setProduct } = useProduct();
 	const { setSheet } = useSheet();
 
 	const nonArchivedFeatures = useMemo(
@@ -82,14 +82,7 @@ export function SelectFeatureSheet({
 		const selectedFeature = features.find((f) => f.id === featureId);
 		if (!selectedFeature) return;
 
-		// Check if this feature was previously configured in initialProduct
-		const previousItem = initialProduct?.items?.find(
-			(i) => i.feature_id === featureId,
-		);
-
-		// Use the previous configuration if available, otherwise create a new default item
-		const newItem =
-			previousItem ?? getDefaultItem({ feature: selectedFeature });
+		const newItem = getDefaultItem({ feature: selectedFeature });
 
 		// Add the new item to the product
 		const newItems = [...product.items, newItem];

--- a/vite/src/views/products/plan/utils/getDefaultItem.ts
+++ b/vite/src/views/products/plan/utils/getDefaultItem.ts
@@ -25,6 +25,9 @@ export const getDefaultItem = ({
 
 	// Create a new item with the selected feature
 	const newItem = {
+		// Identity for an item the backend has not assigned ids to yet; two items
+		// for one feature are otherwise indistinguishable until the plan is saved.
+		_uid: crypto.randomUUID(),
 		feature_id: feature.id,
 		feature_type: itemFeatureType,
 		included_usage: null,

--- a/vite/src/views/products/product/utils/updateProduct.ts
+++ b/vite/src/views/products/product/utils/updateProduct.ts
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import type { ZodError } from "zod";
 import { ProductService } from "@/services/products/ProductService";
 import { getBackendErr } from "@/utils/genUtils";
+import { stripEditorFields } from "@/utils/product/productItemUtils";
 import { normalizeItemCurrencies } from "../../plan/utils/currencyUtils";
 import { validateItemsBeforeSave } from "../../plan/utils/validateItemsBeforeSave";
 
@@ -48,7 +49,9 @@ export const updateProduct = async ({
 					normalizeItemCurrencies({ item, orgCurrency }),
 				)
 			: product.items;
-		const sortedItems = sortPlanItems({ items });
+		const sortedItems = stripEditorFields({
+			items: sortPlanItems({ items }),
+		});
 		const { base_id, ...productUpdates } = product;
 		const updateData = UpdateProductV2ParamsSchema.parse({
 			...productUpdates,


### PR DESCRIPTION
## Problem

Plan items were identified by hashing their **contents** — feature id, entitlement/price id, interval. Two items for the same feature could therefore produce the same id, and the editor could not tell them apart:

```
included  5,000,000 AI Tokens per month          -> "ent-ent_abc-month"
priced    5M then £7 per 1,000,000 per month     -> "ent-ent_abc-month"   <- same id
```

Both rows highlighted at once, and the Configure sheet always retargeted whichever came first in the list, so clicking one row could open and edit the other.

Reproduced on a customer custom plan, and again on an unsaved plan with two rows for one feature.

## Root causes

1. **"Add Feature" reinserted an existing row.** It looked up a previous config in `initialProduct` by `feature_id` alone and pushed that same object back into `items`, producing two rows sharing one `entitlement_id`. The behaviour it existed for (restore settings after deleting and re-adding a feature within one session) was incidental, not deliberate, and is dropped.
2. **Identity was derived from mutable content.** Unsaved rows have no entitlement/price id yet, so two of them for one feature always collided. And any edit that changed an id-affecting field renamed the row mid-edit, which every holder of that id then had to resync by hand.

## Changes

- `_uid` assigned at item creation (`getDefaultItem`, the single place rows are born) and `getItemId` keys off it. Identity now survives edits and unsaved rows stay distinct.
- `_uid` stripped at the billing and catalog request boundaries. Migrations already drop it via the `productItemToPlanItemV1` whitelist mapper.
- `_uid` added to `INTERNAL_KEYS` so it doesn't register as an edit. Other comparison paths (`featureItemsAreSame`) check an explicit field whitelist and are unaffected.
- "Add Feature" always creates a fresh row.
- `itemId` resynced on the draft-session path, which previously returned early and left the id stale — a row lost its selection whenever an edit changed its derived id. This was already reachable by changing an interval.

Fixes both the normal plan editor and the inline custom-plan editor; they share `ProductSheets` / `PlanFeatureRow`, so the fix is in one place.

## Testing

- Customer custom plan with an included and a priced row for one feature: each row selects independently and opens its own config.
- Priced ↔ Included toggle: selection holds.
- Two rows for one feature on an unsaved plan: no longer collide.
- `tsc --noEmit` clean in vite; `server bun ts` unchanged (its one error reproduces on a clean tree).
- Biome warnings identical to baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give plan editor items a stable identity so rows don’t collide when multiple entries share a feature. Fixes row selection and Configure sheet targeting in both the plan editor and inline custom-plan editor.

- **Bug Fixes**
  - Add `_uid` to `ProductItem` at creation (`getDefaultItem`); `getItemId` prefers it so identity survives edits and unsaved rows stay distinct.
  - Strip `_uid` before API requests and ignore it in comparisons (`INTERNAL_KEYS`, `stripEditorFields`), applied in billing and product update paths.
  - "Add Feature" always creates a new row instead of reinserting a previous config.
  - Resync `itemId` during draft sessions when edits change the derived id, keeping the row selected.

<sup>Written for commit f3a990d8d69e855d3c723e050a7abfc62375b90c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces editor-only UUIDs intended to keep plan rows stable across edits and removes those UUIDs at API boundaries. Existing plans are not hydrated with UUIDs, so the reported collision remains reachable after a plan is reloaded.
- **[Bug fixes]** Assigns stable identities to newly created plan items and uses them for row selection.
- **[Bug fixes]** Always creates a fresh item when adding a feature instead of restoring an earlier object.
- **[Improvements]** Keeps draft-session selection synchronized when an item's identifier changes.
- **[API changes]** Strips editor-only identity metadata from billing and catalog requests.
</details>

<h3>Confidence Score: 4/5</h3>

The existing-plan collision must be fixed before merging because reloaded rows with the same entitlement and interval can still open and edit the wrong item.

Newly created rows receive stable UUIDs, but existing backend-loaded rows do not, leaving them on the same first-match content-derived identity path this change is intended to eliminate.

**Files Needing Attention:** vite/src/utils/product/productItemUtils.ts, vite/src/views/products/plan/utils/getDefaultItem.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/utils/product/productItemUtils.ts | Prefers `_uid` for identity but retains a colliding fallback for all existing items that are never hydrated with one. |
| vite/src/views/products/plan/utils/getDefaultItem.ts | Correctly gives newly created items a UUID, but this creation-only assignment does not cover loaded plans. |
| vite/src/views/products/plan/ProductSheets.tsx | Resynchronizes draft identifiers correctly, but first-match lookup still misroutes existing rows with duplicate fallback identities. |
| vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts | Removes editor-only metadata from normalized billing requests. |
| vite/src/views/products/product/utils/updateProduct.ts | Removes editor-only metadata before validating and sending product updates. |
| vite/src/views/products/plan/components/SelectFeatureSheet.tsx | Creates a fresh default item when adding a feature instead of reusing an earlier persisted object. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create new plan item] --> B[Assign unique _uid]
  B --> C[getItemId uses _uid]
  D[Load existing plan item] --> E[No _uid assigned]
  E --> F[getItemId uses entitlement and interval]
  F --> G{Sibling has same values?}
  G -- Yes --> H[Both rows resolve to first match]
  G -- No --> I[Rows remain distinct]
  C --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/utils/product/productItemUtils.ts:132
**Loaded rows retain colliding identities**

When an existing plan has an included row and a priced row with the same entitlement and billing interval, neither loaded item has `_uid`, so both still receive the same fallback ID and `findIndex` opens the first row when the second is selected.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: give plan editor items a stable ide..."](https://github.com/useautumn/autumn/commit/f3a990d8d69e855d3c723e050a7abfc62375b90c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50801450)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->