### PR TITLE
Reply to shipped threads for release lifecycle

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - closed
     branches:
       - main
 
@@ -63,3 +64,37 @@ jobs:
             --header "Content-Type: application/json" \
             --data-binary @"$RUNNER_TEMP/slack-payload.json" \
             "$SLACK_SHIPPED_WEBHOOK_URL"
+
+  notify-merged:
+    name: Reply when merged
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Reply in shipped thread
+        env:
+          DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
+          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [ -z "$DEPLOY_URL" ] || [ -z "$DEPLOY_SECRET" ]; then
+            echo "::error::DEPLOY_URL and DEPLOY_SECRET must be configured"
+            exit 1
+          fi
+
+          export MERGED_AT MERGE_COMMIT_SHA PR_URL
+          node -e 'process.stdout.write(JSON.stringify({ pullRequestUrl: process.env.PR_URL, mergedAt: process.env.MERGED_AT, mergeCommitSha: process.env.MERGE_COMMIT_SHA }))' \
+            > "$RUNNER_TEMP/shipped-merge-payload.json"
+
+          curl --silent --show-error --fail-with-body --retry 3 --retry-all-errors \
+            --request POST \
+            --header "Content-Type: application/json" \
+            --header "x-deploy-secret: $DEPLOY_SECRET" \
+            --data-binary @"$RUNNER_TEMP/shipped-merge-payload.json" \
+            "$DEPLOY_URL/api/shipped/merge"


### PR DESCRIPTION
Replies to each dev-to-main shipped summary when the PR is merged. The corresponding infra change also replies when the production blue/green swap is triggered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a reply to the shipped release thread when a dev-to-main PR is merged. Also supports lifecycle replies from infra when the production blue/green swap happens.

- **New Features**
  - Listen for `closed` events and trigger only when the PR is merged, from `dev`, and within the same repo.
  - Send a merge payload (PR URL, mergedAt, mergeCommitSha) to `$DEPLOY_URL/api/shipped/merge` using the `x-deploy-secret` header.
  - Fail fast if `DEPLOY_URL` or `DEPLOY_SECRET` is missing.

<sup>Written for commit 884ea543e1401fda86dfdc7356eea1352faf1ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The workflow now reports when a dev-to-main release PR is merged, allowing the release lifecycle to reply to its shipped thread.

- **Improvements:** Listen for closed pull-request events and run a dedicated job only for merged, same-repository dev-to-main PRs.
- **Improvements:** Send the pull-request URL, merge timestamp, and merge commit SHA to the deployment service’s shipped-merge endpoint.
- **Improvements:** Validate deployment credentials and retry failed HTTP requests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The existing summary job remains excluded from closed events, while the new job is restricted to successfully merged, same-repository dev-to-main pull requests and safely serializes event fields into its request payload.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/post-cubic-summary.yml | Adds a tightly guarded merge notification job while preserving the existing shipped-summary job’s opened/edited-only behavior. |

<sub>Reviews (1): Last reviewed commit: ["Reply to shipped threads for release lif..."](https://github.com/useautumn/autumn/commit/884ea543e1401fda86dfdc7356eea1352faf1ed8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50801939)</sub>

<!-- /greptile_comment -->