### PR TITLE
Release 06/08/2026

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - closed
     branches:
       - main
 
@@ -63,3 +64,37 @@ jobs:
             --header "Content-Type: application/json" \
             --data-binary @"$RUNNER_TEMP/slack-payload.json" \
             "$SLACK_SHIPPED_WEBHOOK_URL"
+
+  notify-merged:
+    name: Reply when merged
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Reply in shipped thread
+        env:
+          DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
+          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [ -z "$DEPLOY_URL" ] || [ -z "$DEPLOY_SECRET" ]; then
+            echo "::error::DEPLOY_URL and DEPLOY_SECRET must be configured"
+            exit 1
+          fi
+
+          export MERGED_AT MERGE_COMMIT_SHA PR_URL
+          node -e 'process.stdout.write(JSON.stringify({ pullRequestUrl: process.env.PR_URL, mergedAt: process.env.MERGED_AT, mergeCommitSha: process.env.MERGE_COMMIT_SHA }))' \
+            > "$RUNNER_TEMP/shipped-merge-payload.json"
+
+          curl --silent --show-error --fail-with-body --retry 3 --retry-all-errors \
+            --request POST \
+            --header "Content-Type: application/json" \
+            --header "x-deploy-secret: $DEPLOY_SECRET" \
+            --data-binary @"$RUNNER_TEMP/shipped-merge-payload.json" \
+            "$DEPLOY_URL/api/shipped/merge"

--- a/shared/models/productV2Models/productItemModels/productItemModels.ts
+++ b/shared/models/productV2Models/productItemModels/productItemModels.ts
@@ -1,17 +1,17 @@
 import { z } from "zod/v4";
 import { ApiFeatureV0Schema } from "../../../api/features/prevVersions/apiFeatureV0.js";
 import {
-    AdditionalCurrencyPriceArraySchema,
-    AdditionalCurrencyTierArraySchema,
+	AdditionalCurrencyPriceArraySchema,
+	AdditionalCurrencyTierArraySchema,
 } from "../../../api/products/components/additionalCurrencies.js";
 import { RolloverExpiryDurationType } from "../../productModels/durationTypes/rolloverExpiryDurationType.js";
 import { ProductItemInterval } from "../../productModels/intervals/productItemInterval.js";
 import { TierBehavior } from "../../productModels/priceModels/priceConfig/usagePriceConfig.js";
 import { Infinite } from "../../productModels/productEnums.js";
 import {
-    AllocatedBillingBehavior,
-    OnDecrease,
-    OnIncrease,
+	AllocatedBillingBehavior,
+	OnDecrease,
+	OnIncrease,
 } from "./productItemEnums.js";
 
 export const TierInfinite = "inf";
@@ -215,6 +215,11 @@ export const ProductItemSchema = z.object({
 	/** One-way Price → ProductItem display context. Never read this back when
 	 * rebuilding a price because an edited item may carry stale Stripe IDs. */
 	price_config: z.any().nullish().meta({
+		internal: true,
+	}),
+	/** Editor-only handle for items with no persisted entitlement/price id yet,
+	 * so two unsaved items for one feature stay individually addressable. */
+	_uid: z.string().nullish().meta({
 		internal: true,
 	}),
 });

--- a/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/generateItemChanges.ts
@@ -23,6 +23,7 @@ const INTERNAL_KEYS = new Set([
 	"price_config", // Internal - backend config
 	"isPrice", // Frontend-only extension
 	"isVariable", // Frontend-only extension
+	"_uid", // Frontend-only editor handle
 ]);
 
 /** Recursively sorts object keys and normalizes undefined to null for consistent comparison */

--- a/vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts
+++ b/vite/src/components/forms/shared/utils/normalizeBillingRequestItems.ts
@@ -1,4 +1,5 @@
 import type { ProductItem } from "@autumn/shared";
+import { stripEditorFields } from "@/utils/product/productItemUtils";
 
 type DraftProductItem = Omit<ProductItem, "price"> & {
 	price?: ProductItem["price"] | "";
@@ -27,5 +28,7 @@ export function normalizeBillingRequestItems({
 		return [itemWithoutDraftPrice as ProductItem];
 	});
 
-	return normalizedItems.length > 0 ? normalizedItems : undefined;
+	return normalizedItems.length > 0
+		? stripEditorFields({ items: normalizedItems })
+		: undefined;
 }

--- a/vite/src/hooks/inline-editor/useItemDraftController.ts
+++ b/vite/src/hooks/inline-editor/useItemDraftController.ts
@@ -40,7 +40,13 @@ export interface ItemDraftController {
 	patchProduct: ({ product }: { product: FrontendProduct }) => void;
 	patchItem: ({ itemId, item }: { itemId: string; item: ProductItem }) => void;
 	startItem: ({ itemId, item }: { itemId: string; item: ProductItem }) => void;
-	updateItem: ({ item }: { item: ProductItem }) => void;
+	updateItem: ({
+		item,
+		itemId,
+	}: {
+		item: ProductItem;
+		itemId?: string;
+	}) => void;
 	discardItem: () => void;
 	commitItem: () => void;
 	clearItemSession: () => void;
@@ -213,7 +219,9 @@ export const useItemDraftController = ({
 	);
 
 	const updateItemDraft = useCallback(
-		({ item }: { item: ProductItem }) => {
+		// `itemId` renames the session when an edit changes the item's derived id,
+		// keeping it addressable by callers that still resolve items by id.
+		({ item, itemId }: { item: ProductItem; itemId?: string }) => {
 			setDraftItemSession((prev) => {
 				if (!prev) return prev;
 				patchPlanItem({
@@ -223,6 +231,7 @@ export const useItemDraftController = ({
 				});
 				return {
 					...prev,
+					itemId: itemId ?? prev.itemId,
 					draftItem: item,
 				};
 			});

--- a/vite/src/utils/product/productItemUtils.ts
+++ b/vite/src/utils/product/productItemUtils.ts
@@ -128,6 +128,9 @@ export const getItemId = ({
 	item: ProductItem;
 	itemIndex: number;
 }) => {
+	// Assigned at creation, so it survives edits that rewrite every other field.
+	if (item._uid) return `uid-${item._uid}`;
+
 	const interval = intervalSuffix(item);
 	if (item.entitlement_id) return `ent-${item.entitlement_id}${interval}`;
 	if (item.price_id) return `price-${item.price_id}${interval}`;
@@ -139,6 +142,14 @@ export const getItemId = ({
 	}
 	return `item-${itemIndex}`;
 };
+
+/** Editor-only fields must not reach the API; strip before building a request. */
+export const stripEditorFields = ({
+	items,
+}: {
+	items: ProductItem[] | undefined;
+}): ProductItem[] | undefined =>
+	items?.map(({ _uid, ...item }) => item as ProductItem);
 
 export const getPrepaidItems = (product: ProductV2 | undefined) => {
 	if (!product) return [];

--- a/vite/src/views/products/plan/ProductSheets.tsx
+++ b/vite/src/views/products/plan/ProductSheets.tsx
@@ -130,7 +130,17 @@ export const ProductSheets = () => {
 			draftItemSession &&
 			draftItemSession.itemId === itemId
 		) {
-			updateItemDraft({ item: updatedItem });
+			// Edits to feature type or interval change the item's derived id, so
+			// resync it or the plan row stops matching and loses its selection.
+			const newItemId = getItemId({
+				item: updatedItem,
+				itemIndex: draftItemSession.itemIndex,
+			});
+			updateItemDraft({ item: updatedItem, itemId: newItemId });
+			if (newItemId !== itemId) {
+				updateItemId(newItemId);
+				lastItemIdRef.current = newItemId;
+			}
 			return;
 		}
 

--- a/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/SelectFeatureSheet.tsx
@@ -54,7 +54,7 @@ export function SelectFeatureSheet({
 	const [selectOpen, setSelectOpen] = useState(false);
 
 	const { features } = useFeaturesQuery();
-	const { product, setProduct, initialProduct } = useProduct();
+	const { product, setProduct } = useProduct();
 	const { setSheet } = useSheet();
 
 	const nonArchivedFeatures = useMemo(
@@ -82,14 +82,7 @@ export function SelectFeatureSheet({
 		const selectedFeature = features.find((f) => f.id === featureId);
 		if (!selectedFeature) return;
 
-		// Check if this feature was previously configured in initialProduct
-		const previousItem = initialProduct?.items?.find(
-			(i) => i.feature_id === featureId,
-		);
-
-		// Use the previous configuration if available, otherwise create a new default item
-		const newItem =
-			previousItem ?? getDefaultItem({ feature: selectedFeature });
+		const newItem = getDefaultItem({ feature: selectedFeature });
 
 		// Add the new item to the product
 		const newItems = [...product.items, newItem];

--- a/vite/src/views/products/plan/utils/getDefaultItem.ts
+++ b/vite/src/views/products/plan/utils/getDefaultItem.ts
@@ -25,6 +25,9 @@ export const getDefaultItem = ({
 
 	// Create a new item with the selected feature
 	const newItem = {
+		// Identity for an item the backend has not assigned ids to yet; two items
+		// for one feature are otherwise indistinguishable until the plan is saved.
+		_uid: crypto.randomUUID(),
 		feature_id: feature.id,
 		feature_type: itemFeatureType,
 		included_usage: null,

--- a/vite/src/views/products/product/utils/updateProduct.ts
+++ b/vite/src/views/products/product/utils/updateProduct.ts
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import type { ZodError } from "zod";
 import { ProductService } from "@/services/products/ProductService";
 import { getBackendErr } from "@/utils/genUtils";
+import { stripEditorFields } from "@/utils/product/productItemUtils";
 import { normalizeItemCurrencies } from "../../plan/utils/currencyUtils";
 import { validateItemsBeforeSave } from "../../plan/utils/validateItemsBeforeSave";
 
@@ -48,7 +49,9 @@ export const updateProduct = async ({
 					normalizeItemCurrencies({ item, orgCurrency }),
 				)
 			: product.items;
-		const sortedItems = sortPlanItems({ items });
+		const sortedItems = stripEditorFields({
+			items: sortPlanItems({ items }),
+		});
 		const { base_id, ...productUpdates } = product;
 		const updateData = UpdateProductV2ParamsSchema.parse({
 			...productUpdates,


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes plan editor row collisions by giving items a stable, editor-only `_uid` and keeping selection stable during edits. Also adds a GitHub Action that replies to shipped threads when `dev` release PRs are merged.

- **Bug Fixes**
  - Assign `_uid` on new items and use it in `getItemId` so unsaved items stay distinct and survive edits.
  - Strip `_uid` before billing/catalog requests and ignore it in item diff generation.
  - Resync the draft session `itemId` when edits change the derived id to keep the row selected.
  - Stop reusing previous item config in “Add Feature” to avoid reinserting an existing entitlement.

- **New Features**
  - Workflow posts a merge reply to shipped threads for `dev` → `main` PRs.
  - Sends merge details to `$DEPLOY_URL/api/shipped/merge` with `DEPLOY_SECRET`.

<sup>Written for commit 78174fcf388a1bf8a55ec6b88ea899cc3f7177fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release improves editor identity handling for unsaved plan items and adds a notification when the dev release PR merges. It also changes feature re-addition behavior, but currently discards the feature's previous billing configuration.
- **[Improvements, Bug fixes]** Give unsaved product items stable editor-only identifiers and remove those identifiers before supported API requests.
- **[Bug fixes]** Keep inline-editor sessions synchronized when an existing item's derived identifier changes.
- **[Improvements]** Notify the shipped-thread service after the dev PR is merged.
- **[API changes]** Extend the shared product-item model with an internal `_uid` field.
- **[Bug fixes]** Always initialize selected features as new items; this currently regresses remove-and-readd behavior for configured features.
</details>

<h3>Confidence Score: 4/5</h3>

The feature re-addition regression should be fixed before merging because it can silently overwrite existing pricing and allowance settings.

Removing and re-adding an existing feature now constructs and saves a default item instead of restoring the configuration that was present when editing began.

**Files Needing Attention:** vite/src/views/products/plan/components/SelectFeatureSheet.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/components/SelectFeatureSheet.tsx | Re-adding a removed feature now replaces its prior pricing and entitlement settings with defaults. |
| vite/src/views/products/plan/utils/getDefaultItem.ts | Assigns a stable editor-only UUID to newly created product items. |
| vite/src/utils/product/productItemUtils.ts | Uses editor UUIDs as stable row identities and provides request-boundary stripping. |
| vite/src/hooks/inline-editor/useItemDraftController.ts | Supports renaming draft sessions when edits change an item's derived identifier. |
| vite/src/views/products/product/utils/updateProduct.ts | Removes editor-only fields before validating and sending product updates. |
| .github/workflows/post-cubic-summary.yml | Adds a merge-only job that reports the merged dev PR to the deployment service. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Select feature] --> B[Create item with stable _uid]
  B --> C[Edit item in plan]
  C --> D[Strip _uid before request]
  D --> E[Save product]
  F[Remove configured feature] --> A
  A --> G[Default billing configuration]
  G --> E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/products/plan/components/SelectFeatureSheet.tsx:85
**Re-addition resets feature configuration**

When a user removes and re-adds an existing feature, `getDefaultItem` replaces its previous pricing, included usage, tiers, interval, billing units, and entity association with defaults, causing those unintended values to be persisted when the plan is saved.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/aeeaa91132be3fb290800c70422f30fc8b464031) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50804515)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->