### PR TITLE
Post shipped summaries for any PR to main

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -16,7 +16,6 @@ jobs:
   notify-shipped:
     name: Notify shipped
     if: >-
-      github.event.pull_request.head.ref == 'dev' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.body || '', '<!-- This is an auto-generated description by cubic. -->') &&
       (github.event.action == 'opened' ||
@@ -53,7 +52,7 @@ jobs:
             -e 's/&/\&amp;/g' \
             -e 's/</\&lt;/g' \
             -e 's/>/\&gt;/g')
-          printf -v SLACK_MESSAGE '*dev2main* :rocket:\n<%s|PR #%s>\n\n%s' \
+          printf -v SLACK_MESSAGE '*→ main* :rocket:\n<%s|PR #%s>\n\n%s' \
             "$PR_URL" "$PR_NUMBER" "$slack_summary"
           export SLACK_MESSAGE
 
@@ -70,7 +69,6 @@ jobs:
     if: >-
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'dev' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Posts Cubic summaries and lifecycle updates for any same-repository PR targeting main, using a generic → main label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts `cubic` summaries and lifecycle updates for any same-repo PR targeting main. Removes the dev-branch restriction and updates the Slack header label to "*→ main*".

<sup>Written for commit 7ed2cec108dd6a4d2737dd6e4f57423bf5fae2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands shipped notifications and lifecycle updates from dev-only pull requests to all same-repository pull requests targeting main.

- **Improvements:** Removes the source-branch restriction while retaining the workflow-level main target and same-repository checks.
- **Improvements:** Replaces the dev-specific Slack heading with the generic “→ main” label.
- **Improvements:** Sends lifecycle updates whenever an eligible pull request is merged into main.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the existing event-level filter still limits execution to pull requests targeting main.

The workflow consistently broadens source-branch eligibility while preserving the main target and same-repository restrictions, and its outgoing payloads do not rely on a dev source branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/post-cubic-summary.yml | Broadens both notification jobs to any same-repository PR targeting main and updates the Slack label accordingly; no actionable defect was identified. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PR[Same-repository pull request] --> Main{Targets main?}
  Main -- No --> Skip[Workflow does not run]
  Main -- Yes --> Action{Pull request action}
  Action -- Opened or edited with Cubic summary --> Slack[Post generic → main summary]
  Action -- Merged --> Lifecycle[Post lifecycle update]
  Action -- Otherwise --> NoOp[No notification]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["post shipped summaries for any PR to mai..."](https://github.com/useautumn/autumn/commit/7ed2cec108dd6a4d2737dd6e4f57423bf5fae2e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50811363)</sub>

<!-- /greptile_comment -->