### PR TITLE
fix(licenses): reject pooled items on plans used as licenses

### DIFF
--- a/server/src/internal/licenses/actions/links/validatePooledItemsOnLicensePlan.ts
+++ b/server/src/internal/licenses/actions/links/validatePooledItemsOnLicensePlan.ts
@@ -1,0 +1,33 @@
+import { ErrCode, type ProductItem, RecaseError } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { planLicenseRepo } from "../../repos/planLicenseRepo.js";
+
+/** A plan offered as a license may not carry pooled items. Rejected at the point
+ * the item is added so the parent plans linking to it stay versionable — otherwise
+ * the pooled item only surfaces later, as a failure on an unrelated parent. */
+export const validatePooledItemsOnLicensePlan = async ({
+	db,
+	internalProductId,
+	planId,
+	newItems,
+}: {
+	db: DrizzleCli;
+	internalProductId: string;
+	planId: string;
+	newItems: ProductItem[];
+}) => {
+	if (!newItems.some((item) => item.pooled)) return;
+
+	const parentLinks =
+		await planLicenseRepo.listCatalogByLicenseInternalProductIds({
+			db,
+			licenseInternalProductIds: [internalProductId],
+		});
+	if (parentLinks.length === 0) return;
+
+	throw new RecaseError({
+		message: `Pooled items are not supported for plan licenses (${planId}).`,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/licenses/actions/links/validatePooledItemsOnLicensePlan.ts
+++ b/server/src/internal/licenses/actions/links/validatePooledItemsOnLicensePlan.ts
@@ -2,21 +2,36 @@ import { ErrCode, type ProductItem, RecaseError } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { planLicenseRepo } from "../../repos/planLicenseRepo.js";
 
+const pooledFeatureIds = (items: ProductItem[]) =>
+	new Set(
+		items
+			.filter((item) => item.pooled && item.feature_id)
+			.map((item) => item.feature_id as string),
+	);
+
 /** A plan offered as a license may not carry pooled items. Rejected at the point
  * the item is added so the parent plans linking to it stay versionable — otherwise
- * the pooled item only surfaces later, as a failure on an unrelated parent. */
+ * the pooled item only surfaces later, as a failure on an unrelated parent.
+ * Only newly added pooled features are rejected: plans already in this state
+ * predate the check and must stay editable. */
 export const validatePooledItemsOnLicensePlan = async ({
 	db,
 	internalProductId,
 	planId,
 	newItems,
+	currentItems,
 }: {
 	db: DrizzleCli;
 	internalProductId: string;
 	planId: string;
 	newItems: ProductItem[];
+	currentItems: ProductItem[];
 }) => {
-	if (!newItems.some((item) => item.pooled)) return;
+	const currentPooled = pooledFeatureIds(currentItems);
+	const addedPooled = [...pooledFeatureIds(newItems)].filter(
+		(featureId) => !currentPooled.has(featureId),
+	);
+	if (addedPooled.length === 0) return;
 
 	const parentLinks =
 		await planLicenseRepo.listCatalogByLicenseInternalProductIds({

--- a/server/src/internal/product/actions/updateProduct.ts
+++ b/server/src/internal/product/actions/updateProduct.ts
@@ -363,6 +363,7 @@ export const updateProduct = async ({
 		internalProductId: fullProduct.internal_id,
 		planId: fullProduct.id,
 		newItems: newProductV2.items,
+		currentItems: curProductV2.items,
 	});
 	const preparedLicenseSync = await prepareProductLicenseSync({
 		ctx,

--- a/server/src/internal/product/actions/updateProduct.ts
+++ b/server/src/internal/product/actions/updateProduct.ts
@@ -18,6 +18,7 @@ import {
 	applyPreparedPlanLicenseSync,
 	validatePlanLicenseUpdate,
 } from "@/internal/licenses/actions/links/syncPlanLicenses.js";
+import { validatePooledItemsOnLicensePlan } from "@/internal/licenses/actions/links/validatePooledItemsOnLicensePlan.js";
 import { applyLicenseParentPropagation } from "@/internal/licenses/actions/propagation/applyLicenseParentPropagation.js";
 import { prepareLicenseParentPropagation } from "@/internal/licenses/actions/propagation/prepareLicenseParentPropagation.js";
 import { updateVariants } from "@/internal/product/actions/updateVariants/updateVariants.js";
@@ -357,6 +358,12 @@ export const updateProduct = async ({
 	const productWillVersion = productVersioningEligible && productChanged;
 	const willVersion =
 		force_version || billingControlsWillVersion || productWillVersion;
+	await validatePooledItemsOnLicensePlan({
+		db,
+		internalProductId: fullProduct.internal_id,
+		planId: fullProduct.id,
+		newItems: newProductV2.items,
+	});
 	const preparedLicenseSync = await prepareProductLicenseSync({
 		ctx,
 		fromInternalProductId: fullProduct.internal_id,

--- a/server/tests/integration/licenses/catalog-update/license-version-pooled-regression.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-version-pooled-regression.test.ts
@@ -1,0 +1,121 @@
+// Contract: a plan used as a license rejects pooled items at the point they are added,
+// so parents linking to it stay versionable instead of failing on an unrelated edit.
+
+import { expect, test } from "bun:test";
+import { type ApiPlanV1, ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: adding a pooled item to a linked license plan rejects, leaving the parent versionable")}`,
+	async () => {
+		const parent = products.base({
+			id: "pooled-version-regression-parent",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const license = products.base({
+			id: "pooled-version-regression-child",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId: "license-version-pooled-regression",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+				s.billing.attach({ productId: parent.id }),
+			],
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "Pooled items are not supported for plan licenses",
+			func: () =>
+				autumnV2_2.post("/plans.update", {
+					plan_id: license.id,
+					force_version: true,
+					items: [
+						{
+							...itemsV2.monthlyCredits({ included: 100 }),
+							pooled: true,
+						},
+					],
+				}),
+		});
+
+		const licenseAfter = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: license.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(licenseAfter.version).toBe(1);
+		expect(
+			licenseAfter.entitlements.some((entitlement) => entitlement.pooled),
+		).toBe(false);
+
+		await autumnV2_2.post(`/products/${parent.id}`, {
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+
+		const parentV2 = (await autumnV2_2.post("/plans.get", {
+			plan_id: parent.id,
+		})) as ApiPlanV1;
+		expect(parentV2.version).toBe(2);
+		expect(parentV2.licenses ?? []).toHaveLength(1);
+		expect((parentV2.licenses ?? [])[0]).toMatchObject({
+			license_plan_id: license.id,
+			included: 1,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: linking a license whose pinned version is pooled still rejects")}`,
+	async () => {
+		const parent = products.base({
+			id: "pooled-version-still-rejects-parent",
+			items: [items.dashboard()],
+		});
+		const pooledLicense = products.base({
+			id: "pooled-version-still-rejects-child",
+			items: [
+				{
+					...items.monthlyCredits({ includedUsage: 100 }),
+					pooled: true,
+				},
+			],
+		});
+
+		const { autumnV2_2 } = await initScenario({
+			customerId: "license-version-pooled-still-rejects",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, pooledLicense] }),
+			],
+			actions: [],
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "Pooled items are not supported for plan licenses",
+			func: () =>
+				autumnV2_2.post("/plans.update", {
+					plan_id: parent.id,
+					licenses: [{ license_plan_id: pooledLicense.id, included: 1 }],
+				}),
+		});
+	},
+);

--- a/server/tests/integration/licenses/catalog-update/license-version-pooled-regression.test.ts
+++ b/server/tests/integration/licenses/catalog-update/license-version-pooled-regression.test.ts
@@ -2,13 +2,14 @@
 // so parents linking to it stay versionable instead of failing on an unrelated edit.
 
 import { expect, test } from "bun:test";
-import { type ApiPlanV1, ErrCode } from "@autumn/shared";
+import { type ApiPlanV1, ErrCode, entitlements } from "@autumn/shared";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
 import { products } from "@tests/utils/fixtures/products.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { eq } from "drizzle-orm";
 import { ProductService } from "@/internal/products/ProductService.js";
 
 test.concurrent(
@@ -78,6 +79,69 @@ test.concurrent(
 		expect((parentV2.licenses ?? [])[0]).toMatchObject({
 			license_plan_id: license.id,
 			included: 1,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("licenses: a linked license plan already carrying a pooled item stays editable")}`,
+	async () => {
+		const parent = products.base({
+			id: "pooled-legacy-editable-parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "pooled-legacy-editable-child",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId: "license-legacy-pooled-editable",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+			],
+		});
+
+		// Legacy state: pooled + linked, which the guards now prevent via the API.
+		const licenseBefore = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: license.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		await ctx.db
+			.update(entitlements)
+			.set({ pooled: true })
+			.where(eq(entitlements.internal_product_id, licenseBefore.internal_id));
+
+		await autumnV2_2.post("/plans.update", {
+			plan_id: license.id,
+			name: "Renamed legacy license",
+		});
+
+		const renamed = (await autumnV2_2.post("/plans.get", {
+			plan_id: license.id,
+		})) as ApiPlanV1;
+		expect(renamed.name).toBe("Renamed legacy license");
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			errMessage: "Pooled items are not supported for plan licenses",
+			func: () =>
+				autumnV2_2.post("/plans.update", {
+					plan_id: license.id,
+					items: [
+						{ ...itemsV2.monthlyCredits({ included: 100 }), pooled: true },
+					],
+				}),
 		});
 	},
 );

--- a/shared/utils/productV2Utils/productItemUtils/mapToItem.ts
+++ b/shared/utils/productV2Utils/productItemUtils/mapToItem.ts
@@ -51,6 +51,7 @@ export const toFeatureItem = ({ ent }: { ent: EntitlementWithFeature }) => {
 		return {
 			feature_id: ent.feature.id,
 			entity_feature_id: ent.entity_feature_id,
+			pooled: ent.pooled ?? false,
 			entitlement_id: ent.id,
 		};
 	}


### PR DESCRIPTION
## Problem

Reported in Slack: adding a feature to an existing plan failed with

> Pooled items are not supported for plan licenses (team_seat).

The user wasn't using pooled balances, and `team_seat` wasn't the plan they were editing.

Not a frontend bug — the dashboard only writes `pooled` from one explicit checkbox (`PooledBalanceConfig.tsx:15`); nothing sets it implicitly.

## Root cause

Adding a pooled item to a plan that is **linked as a license** succeeds silently. `validateLicenseLink` has three call sites and all three are on the *parent* side, so nothing checks a plan's **inbound** links when its own items change.

The license then versions, and a fresh catalog `plan_license` row is created pointing at the new version carrying the pooled item. From then on the parent is permanently unversionable: `validateCopiedPlanLicenses` re-validates the carried-forward link and throws — naming a plan the user never touched.

Confirmed against the DB in a repro: the pooled item persisted on license v2, and the catalog link row was created 300ms after it, pointing at v2.

## Fix

Validate inbound license links at the point the pooled item is added. Placed before the version/in-place fork in `updateProduct`, since `force_version` returns early and would bypass a check inside `updateProductItems`.

Second, unrelated-but-adjacent bug: `toFeatureItem` dropped `pooled` for boolean features on read while `itemToPriceAndEnt` writes it unconditionally. A boolean item saved with `pooled: true` read back without it, so the checkbox rendered unchecked while validation rejected the stored `true`.

## Testing

`license-version-pooled-regression.test.ts` — verified red/green by stashing the fix and restarting the server:

- without the fix: the pooled item is accepted, test fails
- with the fix: rejected, parent stays versionable

Full `licenses/catalog-update/` suite: **64 pass, 0 fail** across 31 files. `bun ts` clean.

## Note

The error message is unchanged, so it still names the license plan rather than the plan being edited. Now that it fires at the point of the actual edit that's much less confusing, but wording it as "this plan is used as a license by X" would be clearer if you want a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject newly added pooled items on plans used as licenses at the moment they’re added to stop silent acceptance that later blocks parent plan versioning. Also ensure boolean feature items round-trip the `pooled` flag so the dashboard reflects the stored value.

- **Bug Fixes**
  - Add `validatePooledItemsOnLicensePlan` in `updateProduct`, run before version/in-place forks, and return 400 when a license-linked plan gains pooled items.
  - Diff new vs current items and reject only newly added or flipped-to-pooled features; legacy pooled state remains editable.
  - Preserve `pooled` on boolean feature items in `toFeatureItem` to keep reads/writes and the checkbox in sync.

<sup>Written for commit 919fae50e65115a9e209d3ecdcc57cefdabf62f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents plans used as licenses from acquiring pooled items and preserves the pooled flag when boolean feature items are read.

- **Bug fixes:** Validate inbound license links before updating or versioning a plan, rejecting newly pooled features that would make linked parent plans unversionable.
- **Bug fixes:** Preserve the `pooled` value when converting boolean entitlements into API product items.
- **Improvements:** Add integration coverage for rejection, legacy-plan editability, parent versioning, and linking an already-pooled license.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/licenses/actions/links/validatePooledItemsOnLicensePlan.ts | Adds an inbound-link guard that rejects newly pooled features on plans currently identified as licenses. |
| server/src/internal/product/actions/updateProduct.ts | Runs the new guard before the versioning and in-place update branches so both update modes are covered. |
| shared/utils/productV2Utils/productItemUtils/mapToItem.ts | Restores the persisted pooled flag when mapping boolean entitlements to product items. |
| server/tests/integration/licenses/catalog-update/license-version-pooled-regression.test.ts | Covers pooled-item rejection, retained parent versionability, legacy-state editing, and rejection when linking an already-pooled plan. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Plan update request] --> B{Adds a pooled feature?}
  B -- No --> E[Continue update]
  B -- Yes --> C{Plan has inbound license links?}
  C -- Yes --> D[Reject with invalid request]
  C -- No --> E
  E --> F{Version or update in place}
  F --> G[Persist product items]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(licenses): only reject newly added p..."](https://github.com/useautumn/autumn/commit/919fae50e65115a9e209d3ecdcc57cefdabf62f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50820305)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->