### PR TITLE
Release

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -16,7 +16,6 @@ jobs:
   notify-shipped:
     name: Notify shipped
     if: >-
-      github.event.pull_request.head.ref == 'dev' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.body || '', '<!-- This is an auto-generated description by cubic. -->') &&
       (github.event.action == 'opened' ||
@@ -53,7 +52,7 @@ jobs:
             -e 's/&/\&amp;/g' \
             -e 's/</\&lt;/g' \
             -e 's/>/\&gt;/g')
-          printf -v SLACK_MESSAGE '*dev2main* :rocket:\n<%s|PR #%s>\n\n%s' \
+          printf -v SLACK_MESSAGE '*→ main* :rocket:\n<%s|PR #%s>\n\n%s' \
             "$PR_URL" "$PR_NUMBER" "$slack_summary"
           export SLACK_MESSAGE
 
@@ -70,7 +69,6 @@ jobs:
     if: >-
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'dev' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 

--- a/server/src/external/redis/initUtils/createStandbyRedisRouter.ts
+++ b/server/src/external/redis/initUtils/createStandbyRedisRouter.ts
@@ -15,6 +15,9 @@ type StandbyConnections = {
 export type StandbyRedisRouter = {
 	/** Preferred connection first, then the alternate. Never empty. */
 	ordered: () => [Redis, Redis];
+	/** Ready and past its failure penalty. `status` alone says only that the
+	 *  socket is up, not that the router still trusts the connection. */
+	isUsable: (connection: Redis) => boolean;
 	recordOutcome: (args: { connection: Redis; error?: unknown }) => void;
 };
 
@@ -107,7 +110,7 @@ export const createStandbyRedisRouter = ({
 		entry.consecutiveFailures = 0;
 	};
 
-	const router: StandbyRedisRouter = { ordered, recordOutcome };
+	const router: StandbyRedisRouter = { ordered, isUsable, recordOutcome };
 
 	const observeOutcome = ({
 		result,

--- a/server/src/external/redis/utils/redisOpTimeouts.ts
+++ b/server/src/external/redis/utils/redisOpTimeouts.ts
@@ -16,8 +16,10 @@ export const REDIS_OP_TIMEOUT_MS = {
 	secretKeyGet: 200,
 	/** p99.9 208ms — 200 would clip real traffic. */
 	orgFeaturesGet: 300,
-	/** p99.9 297ms on shared V2; this site also serves the dedicated cluster. */
-	featureBalances: 400,
+	/** p99.9 297ms on shared V2; this site also serves the dedicated cluster.
+	 *  The only standby-retry caller the wrapper actually bounds, so 500 rather
+	 *  than 400: the reserve has to come out of headroom, not out of the tail. */
+	featureBalances: 500,
 	/** p99.9 643-938ms; latency scales with the customer's feature count.
 	 *  V2's 1s `commandTimeout` binds before this does. */
 	featureBalancesBatch: 1200,

--- a/server/src/external/redis/utils/redisOpTimeouts.ts
+++ b/server/src/external/redis/utils/redisOpTimeouts.ts
@@ -5,6 +5,11 @@
  * Only reads with a working non-Redis path belong here. A timed-out write is
  * ambiguous — `withTimeout` abandons the promise but the command still lands.
  * Values are sized above each op's measured production p99.9.
+ *
+ * A value above the client's `commandTimeout` is inert: ioredis arms that timer
+ * per command at dispatch (offline-queued commands and pipeline members
+ * included), so on V2 the 1s ceiling ends the attempt first and the p99.9
+ * figures below are measured against an already-truncated tail.
  */
 export const REDIS_OP_TIMEOUT_MS = {
 	/** p99.9 137ms. Falls through to Postgres via verifyKey. */
@@ -13,8 +18,10 @@ export const REDIS_OP_TIMEOUT_MS = {
 	orgFeaturesGet: 300,
 	/** p99.9 297ms on shared V2; this site also serves the dedicated cluster. */
 	featureBalances: 400,
-	/** p99.9 643-938ms; latency scales with the customer's feature count. */
+	/** p99.9 643-938ms; latency scales with the customer's feature count.
+	 *  V2's 1s `commandTimeout` binds before this does. */
 	featureBalancesBatch: 1200,
-	/** p99.9 849ms across the pipe[get,get] pool. */
+	/** p99.9 849ms across the pipe[get,get] pool.
+	 *  V2's 1s `commandTimeout` binds before this does. */
 	subjectPipeline: 1200,
 } as const;

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -136,10 +136,12 @@ export const runRedisOp = async <T>({
 		if (!router) return await runAttempt(targetRedis, timeoutMs);
 
 		const [preferred, alternate] = router.ordered();
-		const preferredAttemptBudgetMs =
-			alternate.status === "ready"
-				? getPreferredAttemptBudgetMs({ timeoutMs })
-				: timeoutMs;
+		// Only shorten the preferred attempt for an alternate worth retrying on.
+		// `canRetry` below stays broader on purpose: once the preferred has failed,
+		// a penalized alternate still beats falling open to the non-Redis path.
+		const preferredAttemptBudgetMs = router.isUsable(alternate)
+			? getPreferredAttemptBudgetMs({ timeoutMs })
+			: timeoutMs;
 		try {
 			const value = await runAttempt(preferred, preferredAttemptBudgetMs);
 			router.recordOutcome({ connection: preferred });

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -12,7 +12,7 @@ const STANDBY_RETRY_RESERVE_RATIO = 0.25;
 const MAX_STANDBY_RETRY_RESERVE_MS = 250;
 const lastRedisWarningAtBySource = new Map<string, number>();
 
-const getPreferredAttemptBudgetMs = ({
+export const getPreferredAttemptBudgetMs = ({
 	timeoutMs,
 }: {
 	timeoutMs?: number;

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -136,7 +136,10 @@ export const runRedisOp = async <T>({
 		if (!router) return await runAttempt(targetRedis, timeoutMs);
 
 		const [preferred, alternate] = router.ordered();
-		const preferredAttemptBudgetMs = getPreferredAttemptBudgetMs({ timeoutMs });
+		const preferredAttemptBudgetMs =
+			alternate.status === "ready"
+				? getPreferredAttemptBudgetMs({ timeoutMs })
+				: timeoutMs;
 		try {
 			const value = await runAttempt(preferred, preferredAttemptBudgetMs);
 			router.recordOutcome({ connection: preferred });

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -8,7 +8,25 @@ import { isConnectionLevelRedisError } from "./isTransientRedisError.js";
 const REDIS_WARNING_INTERVAL_MS = 30_000;
 /** Below this a retry cannot finish, so spend the budget on the fallback. */
 const MIN_RETRY_BUDGET_MS = 50;
+const STANDBY_RETRY_RESERVE_RATIO = 0.25;
+const MAX_STANDBY_RETRY_RESERVE_MS = 250;
 const lastRedisWarningAtBySource = new Map<string, number>();
+
+const getPreferredAttemptBudgetMs = ({
+	timeoutMs,
+}: {
+	timeoutMs?: number;
+}): number | undefined => {
+	if (timeoutMs === undefined) return undefined;
+
+	const retryReserveMs = Math.min(
+		Math.floor(timeoutMs * STANDBY_RETRY_RESERVE_RATIO),
+		MAX_STANDBY_RETRY_RESERVE_MS,
+	);
+	return retryReserveMs >= MIN_RETRY_BUDGET_MS
+		? timeoutMs - retryReserveMs
+		: timeoutMs;
+};
 
 const classifyErrorReason = (
 	targetRedis: Redis,
@@ -118,8 +136,9 @@ export const runRedisOp = async <T>({
 		if (!router) return await runAttempt(targetRedis, timeoutMs);
 
 		const [preferred, alternate] = router.ordered();
+		const preferredAttemptBudgetMs = getPreferredAttemptBudgetMs({ timeoutMs });
 		try {
-			const value = await runAttempt(preferred, timeoutMs);
+			const value = await runAttempt(preferred, preferredAttemptBudgetMs);
 			router.recordOutcome({ connection: preferred });
 			return value;
 		} catch (firstError) {

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -6,7 +6,11 @@ import {
 } from "@/external/redis/initUtils/createStandbyRedisRouter.js";
 import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
 import { throwOnPipelineConnectionError } from "@/external/redis/utils/pipelineErrors.js";
-import { runRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { REDIS_OP_TIMEOUT_MS } from "@/external/redis/utils/redisOpTimeouts.js";
+import {
+	getPreferredAttemptBudgetMs,
+	runRedisOp,
+} from "@/external/redis/utils/runRedisOp.js";
 
 type Listener = (...args: unknown[]) => void;
 
@@ -439,6 +443,17 @@ describe("runRedisOp standby failover", () => {
 		expect(primary.calls).toEqual(["get:subject"]);
 		expect(standby.calls).toEqual(["get:subject"]);
 		expect(Date.now() - startedAt).toBeLessThan(390);
+	});
+
+	// The reserve has to fit inside the headroom each deadline was sized with,
+	// not eat into the tail it was sized to cover. Feature balances measure a
+	// p99.9 of 297ms, so the preferred attempt must stay clear of that.
+	test("leaves the feature-balance read its measured tail", () => {
+		expect(
+			getPreferredAttemptBudgetMs({
+				timeoutMs: REDIS_OP_TIMEOUT_MS.featureBalances,
+			}),
+		).toBe(375);
 	});
 
 	test("keeps the full deadline when the alternate is penalized", async () => {

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -387,6 +387,23 @@ describe("runRedisOp standby failover", () => {
 		expect(standby.calls).toEqual([]);
 	});
 
+	test("keeps the full deadline when the alternate is not ready", async () => {
+		const { primary, standby, redis } = createPair({ standbyStatus: "end" });
+		primary.hangGetForMs = 175;
+
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "standby-test",
+			retryOnStandby: true,
+			timeoutMs: 200,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("primary");
+		expect(primary.calls).toEqual(["get:subject"]);
+		expect(standby.calls).toEqual([]);
+	});
+
 	test("surfaces the retry failure when both connections fail", async () => {
 		const { primary, standby, redis } = createPair();
 		primary.failGetWith = connectionError();

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -441,6 +441,40 @@ describe("runRedisOp standby failover", () => {
 		expect(Date.now() - startedAt).toBeLessThan(390);
 	});
 
+	test("keeps the full deadline when the alternate is penalized", async () => {
+		const { primary, standby, redis } = createPair({
+			primaryStatus: "reconnecting",
+		});
+
+		// Fail the standby out of rotation while it is the only usable connection,
+		// then restore the primary: the pair ends up ready but distrusted.
+		standby.failGetWith = connectionError();
+		for (let attempt = 0; attempt < 3; attempt++) {
+			await runRedisOp({
+				redisInstance: redis,
+				source: "standby-test",
+				retryOnStandby: true,
+				operation: (connection) => connection.get("subject"),
+			}).catch(() => undefined);
+		}
+		standby.failGetWith = undefined;
+		primary.status = "ready";
+		const standbyCallsBefore = standby.calls.length;
+
+		primary.hangGetForMs = 520;
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "standby-test",
+			retryOnStandby: true,
+			timeoutMs: 600,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("primary");
+		expect(primary.calls).toEqual(["get:subject"]);
+		expect(standby.calls.length).toBe(standbyCallsBefore);
+	});
+
 	test("shares one timeout budget across both attempts", async () => {
 		const { primary, standby, redis } = createPair();
 		// Primary burns most of the budget, then fails; standby never answers.

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -405,6 +405,25 @@ describe("runRedisOp standby failover", () => {
 		expect(standby.calls).toEqual(["get:subject"]);
 	});
 
+	test("reserves part of the deadline for a standby retry", async () => {
+		const { primary, standby, redis } = createPair();
+		primary.hangGetForMs = 5_000;
+
+		const startedAt = Date.now();
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "standby-test",
+			retryOnStandby: true,
+			timeoutMs: 400,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("standby");
+		expect(primary.calls).toEqual(["get:subject"]);
+		expect(standby.calls).toEqual(["get:subject"]);
+		expect(Date.now() - startedAt).toBeLessThan(390);
+	});
+
 	test("shares one timeout budget across both attempts", async () => {
 		const { primary, standby, redis } = createPair();
 		// Primary burns most of the budget, then fails; standby never answers.


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve part of the Redis deadline for standby retries when the alternate is usable, keeping the full deadline otherwise; increased `featureBalances` to 500ms so the reserve comes from headroom. Shipped Slack notifications now fire for any PR merged to `main`.

- **Bug Fixes**
  - `runRedisOp` reserves up to 25% (max 250ms) of `timeoutMs` for a standby retry when `router.isUsable(alternate)` is true; otherwise the preferred attempt gets the full deadline.
  - Added `isUsable` to the standby router to gate retry budgeting on router trust, not just socket `status`.
  - Raised `REDIS_OP_TIMEOUT_MS.featureBalances` to 500ms to keep the preferred attempt clear of the measured p99.9 tail while reserving retry headroom.
  - Documented that `ioredis` `commandTimeout` can bind before per-op deadlines.
  - Added unit tests for budget reservation, penalized/unready alternates, shared timeout behavior, and preserving the feature-balance tail.

- **New Features**
  - GitHub Actions: post shipped summaries for any PR to `main` and update Slack label to `*→ main*`.

<sup>Written for commit bef3cc35e47416edffc4d7243845c8195ae0bf40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adjusts Redis standby retry budgeting and broadens shipped notifications to all internally merged pull requests targeting `main`.

- **Bug fixes:** Raises the feature-balance Redis deadline and reserves retry time only when the router considers the alternate usable.
- **Improvements:** Exposes router usability, documents interaction with ioredis command timeouts, and adds standby-budget tests.
- **Improvements:** Updates the shipped Slack workflow to cover any internal pull request merged into `main` and labels notifications accordingly.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a preferred Redis response can still be discarded despite arriving within the configured operation deadline.

The new 500 ms feature-balance timeout is reduced to 375 ms for the preferred attempt, and the timeout wrapper cannot recover a preferred response that arrives during the remaining 125 ms; if standby also fails, the request receives RedisUnavailableError.

**Files Needing Attention:** server/src/external/redis/utils/runRedisOp.ts, server/src/external/redis/utils/redisOpTimeouts.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/utils/runRedisOp.ts | Adds conditional standby reservation, but the shortened preferred timer still discards responses that complete within the full operation deadline. |
| server/src/external/redis/utils/redisOpTimeouts.ts | Raises the feature-balance timeout to preserve measured latency headroom, which shifts rather than eliminates the preferred-response discard window. |
| server/src/external/redis/initUtils/createStandbyRedisRouter.ts | Exposes the existing router usability predicate so retry budgeting can account for readiness and failure penalties. |
| server/tests/unit/redis/standby-redis-routing.test.ts | Adds coverage for reservation and unusable alternates but does not verify that a preferred result arriving during the reserved interval remains usable. |
| .github/workflows/post-cubic-summary.yml | Broadens shipped notifications to internal pull requests merged into main and updates the Slack heading. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Wrapper as runRedisOp
  participant Preferred as Preferred Redis
  participant Standby as Standby Redis
  Caller->>Wrapper: read(timeout 500ms)
  Wrapper->>Preferred: attempt(timeout 375ms)
  Preferred-->>Wrapper: timeout at 375ms
  Wrapper->>Standby: retry with remaining time
  Preferred-->>Wrapper: valid response at 400ms (discarded)
  Standby-->>Wrapper: failure or timeout
  Wrapper-->>Caller: RedisUnavailableError
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/external/redis/utils/runRedisOp.ts:142-147
**Preferred response still discarded**

When a standby-enabled feature-balance read gets a preferred Redis response between 375 ms and the configured 500 ms deadline, the shortened attempt abandons that response. If the standby does not complete successfully, `runRedisOp` throws `RedisUnavailableError` even though the preferred connection answered within the operation's deadline.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: size the feature-balance deadline s..."](https://github.com/useautumn/autumn/commit/bef3cc35e47416edffc4d7243845c8195ae0bf40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50836103)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->