### PR TITLE
feat: recycle HTTP cluster forks at an RSS threshold

### DIFF
--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -72,7 +72,10 @@ import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 checkEnvVars();
 
 let shuttingDown = false;
-const drainState = { draining: false };
+const drainState: {
+	draining: boolean;
+	getActiveConnectionCount: () => number;
+} = { draining: false, getActiveConnectionCount: () => 0 };
 
 const init = async ({
 	startupStartedAt,
@@ -111,6 +114,17 @@ const init = async ({
 		if (drainState.draining) res.setHeader("connection", "close");
 		requestListener(req, res);
 	});
+
+	// Streamed responses outlive the request middleware (the body keeps writing
+	// after the handler returns), so drain-extension counts sockets: during a
+	// drain the idle sweeps evict keep-alives, leaving only genuinely active
+	// connections — streams included.
+	const openSockets = new Set<import("node:net").Socket>();
+	server.on("connection", (socket) => {
+		openSockets.add(socket);
+		socket.on("close", () => openSockets.delete(socket));
+	});
+	drainState.getActiveConnectionCount = () => openSockets.size;
 
 	server.keepAliveTimeout = 120000;
 	server.headersTimeout = 120000;
@@ -172,7 +186,10 @@ if (process.env.NODE_ENV === "development") {
 		startWorkerForkRecycling({
 			server,
 			getActiveRequestCount: () =>
-				listInFlightRequests({ now: Date.now() }).length,
+				Math.max(
+					listInFlightRequests({ now: Date.now() }).length,
+					drainState.getActiveConnectionCount(),
+				),
 			onDrainStart: () => {
 				drainState.draining = true;
 			},

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -62,6 +62,7 @@ import {
 	attachPrimaryForkRecycling,
 	startWorkerForkRecycling,
 } from "./utils/memory/forkRecycling/attachForkRecycling.js";
+import { listInFlightRequests } from "./utils/memory/inFlightRequests.js";
 import {
 	startMemorySpikeProbe,
 	stopMemorySpikeProbe,
@@ -170,6 +171,8 @@ if (process.env.NODE_ENV === "development") {
 		const server = await init({ startupStartedAt: Date.now() });
 		startWorkerForkRecycling({
 			server,
+			getActiveRequestCount: () =>
+				listInFlightRequests({ now: Date.now() }).length,
 			onDrainStart: () => {
 				drainState.draining = true;
 			},

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -171,8 +171,9 @@ if (process.env.NODE_ENV === "development") {
 			// True = a coordinated recycle finished; the replacement is already
 			// serving and the coordinator respawns crashes itself.
 			if (forkRecycling.handleExit(worker)) return;
-			// Intentional SIGTERM exits during shutdown are not crashes.
-			if (shuttingDown) return;
+			// Intentional exits during shutdown are not crashes — but a genuine
+			// crash in the shutdown window still deserves its log line.
+			if (shuttingDown && (signal === "SIGTERM" || code === 0)) return;
 			logger.error("WORKER DIED", {
 				pid: worker.process.pid,
 				code,

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -42,22 +42,26 @@ import "./internal/misc/asyncTrack/asyncTrackStore.js";
 // Side-effect: configures trigger.dev SDK to use TRIGGER_SERVER_SECRET_KEY.
 import "./trigger/configureTrigger.js";
 import { closeStripeSyncEngine } from "@autumn/stripe-sync";
-import {
-	startRedisMonitor,
-	stopRedisMonitor,
-	warmupRegionalRedis,
-} from "./external/redis/initRedis.js";
 import { primeRedisMonitor } from "./external/redis/availabilityMonitor/redisAvailability.js";
 import {
 	primeRedisV2Monitor,
 	startRedisV2Monitor,
 	stopRedisV2Monitor,
 } from "./external/redis/availabilityMonitor/redisV2Availability.js";
+import {
+	startRedisMonitor,
+	stopRedisMonitor,
+	warmupRegionalRedis,
+} from "./external/redis/initRedis.js";
 import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
 import { shutdownSqsSendBatchers } from "./queue/queueUtils.js";
 import { checkEnvVars } from "./utils/initUtils.js";
+import {
+	attachPrimaryForkRecycling,
+	startWorkerForkRecycling,
+} from "./utils/memory/forkRecycling/attachForkRecycling.js";
 import {
 	startMemorySpikeProbe,
 	stopMemorySpikeProbe,
@@ -68,7 +72,11 @@ checkEnvVars();
 
 let shuttingDown = false;
 
-const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
+const init = async ({
+	startupStartedAt,
+}: {
+	startupStartedAt: number;
+}): Promise<http.Server> => {
 	logger.info(getRedactedDatabaseUrls(), "DB URLs");
 
 	const app = createHonoApp();
@@ -111,6 +119,8 @@ const init = async ({ startupStartedAt }: { startupStartedAt: number }) => {
 			resolve();
 		});
 	});
+
+	return server;
 };
 
 if (process.env.NODE_ENV === "development") {
@@ -130,21 +140,38 @@ if (process.env.NODE_ENV === "development") {
 			cluster.fork();
 		}
 
+		const forkRecycling = attachPrimaryForkRecycling({
+			clusterModule: cluster,
+			shouldRespawn: () => !shuttingDown,
+			logger,
+		});
+
 		cluster.on("exit", (worker, code, signal) => {
+			// True = a coordinated recycle finished; the replacement is already
+			// serving and the coordinator respawns crashes itself.
+			if (forkRecycling.handleExit(worker)) return;
 			logger.error("WORKER DIED", {
 				pid: worker.process.pid,
 				code,
 				signal,
 				exitedAfterDisconnect: worker.exitedAfterDisconnect,
 			});
-			if (shuttingDown) return;
-			cluster.fork();
 		});
 
 		registerShutdownHandlers();
 	} else {
 		registerFatalErrorHandlers();
-		await init({ startupStartedAt: Date.now() });
+		const server = await init({ startupStartedAt: Date.now() });
+		startWorkerForkRecycling({
+			server,
+			exitGracefully: () => {
+				// Backstop: a hung flush must not strand a drained fork.
+				const forceExit = setTimeout(() => process.exit(0), 5_000);
+				forceExit.unref?.();
+				void gracefulShutdown();
+			},
+			logger,
+		});
 		registerShutdownHandlers();
 	}
 }

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -171,6 +171,8 @@ if (process.env.NODE_ENV === "development") {
 			// True = a coordinated recycle finished; the replacement is already
 			// serving and the coordinator respawns crashes itself.
 			if (forkRecycling.handleExit(worker)) return;
+			// Intentional SIGTERM exits during shutdown are not crashes.
+			if (shuttingDown) return;
 			logger.error("WORKER DIED", {
 				pid: worker.process.pid,
 				code,

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -71,6 +71,7 @@ import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 checkEnvVars();
 
 let shuttingDown = false;
+const drainState = { draining: false };
 
 const init = async ({
 	startupStartedAt,
@@ -103,7 +104,12 @@ const init = async ({
 		: 8080;
 
 	const requestListener = getRequestListener(app.fetch);
-	const server = http.createServer(requestListener);
+	const server = http.createServer((req, res) => {
+		// While draining for a fork recycle, tell pooled clients to retire the
+		// socket after this response instead of racing the idle eviction.
+		if (drainState.draining) res.setHeader("connection", "close");
+		requestListener(req, res);
+	});
 
 	server.keepAliveTimeout = 120000;
 	server.headersTimeout = 120000;
@@ -164,6 +170,9 @@ if (process.env.NODE_ENV === "development") {
 		const server = await init({ startupStartedAt: Date.now() });
 		startWorkerForkRecycling({
 			server,
+			onDrainStart: () => {
+				drainState.draining = true;
+			},
 			exitGracefully: () => {
 				// Backstop: a hung flush must not strand a drained fork.
 				const forceExit = setTimeout(() => process.exit(0), 5_000);

--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -68,11 +68,13 @@ export const attachPrimaryForkRecycling = ({
 export const startWorkerForkRecycling = ({
 	server,
 	exitGracefully,
+	onDrainStart,
 	logger,
 }: {
 	server: Parameters<typeof createWorkerDrainer>[0]["server"];
 	/** Runs the worker's normal shutdown (flushes, pool close, process.exit). */
 	exitGracefully: () => void;
+	onDrainStart?: () => void;
 	logger: Logger;
 }) => {
 	const config = getForkRecycleConfig();
@@ -85,6 +87,7 @@ export const startWorkerForkRecycling = ({
 		server,
 		exit: () => exitGracefully(),
 		drainTimeoutMs: config.drainTimeoutMs,
+		onDrainStart,
 		log: (message) => logger.info(message),
 	});
 

--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -1,0 +1,129 @@
+import type cluster from "node:cluster";
+import type { Worker } from "node:cluster";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { createRecycleCoordinator } from "./recycleCoordinator.js";
+import { getForkRecycleConfig, shouldRequestRecycle } from "./recyclePolicy.js";
+import { createWorkerDrainer } from "./workerDrainer.js";
+
+const RECYCLE_REQUEST = "fork-recycle:request";
+const RECYCLE_DRAIN = "fork-recycle:drain";
+
+type RecycleMessage = { type?: string };
+
+export type PrimaryForkRecycling = {
+	/** True when this exit completed a recycle — caller must not respawn. */
+	handleExit: (worker: Worker) => boolean;
+};
+
+export const attachPrimaryForkRecycling = ({
+	clusterModule,
+	shouldRespawn,
+	logger,
+}: {
+	clusterModule: typeof cluster;
+	shouldRespawn: () => boolean;
+	logger: Logger;
+}): PrimaryForkRecycling => {
+	const workerIds = new Map<string, Worker>();
+
+	const coordinator = createRecycleCoordinator({
+		forkReplacement: () => {
+			const worker = clusterModule.fork();
+			workerIds.set(String(worker.id), worker);
+			return String(worker.id);
+		},
+		sendDrain: (workerId) => {
+			workerIds.get(workerId)?.send({ type: RECYCLE_DRAIN });
+		},
+		respawn: () => {
+			if (!shouldRespawn()) return;
+			const worker = clusterModule.fork();
+			workerIds.set(String(worker.id), worker);
+		},
+		log: (message) => logger.info(message),
+	});
+
+	clusterModule.on("listening", (worker) => {
+		workerIds.set(String(worker.id), worker);
+		coordinator.handleWorkerListening({ workerId: String(worker.id) });
+	});
+
+	clusterModule.on("message", (worker, message: RecycleMessage) => {
+		if (message?.type !== RECYCLE_REQUEST) return;
+		coordinator.handleRecycleRequest({ workerId: String(worker.id) });
+	});
+
+	return {
+		handleExit: (worker) => {
+			const workerId = String(worker.id);
+			workerIds.delete(workerId);
+			return coordinator.handleWorkerExit({ workerId });
+		},
+	};
+};
+
+/** Coordinator owns respawns for every exit it sees, so the caller's exit
+ *  handler must fork only when this returns false AND it wants crash respawn —
+ *  see handleExit. Worker side below. */
+export const startWorkerForkRecycling = ({
+	server,
+	exitGracefully,
+	logger,
+}: {
+	server: Parameters<typeof createWorkerDrainer>[0]["server"];
+	/** Runs the worker's normal shutdown (flushes, pool close, process.exit). */
+	exitGracefully: () => void;
+	logger: Logger;
+}) => {
+	const config = getForkRecycleConfig();
+	if (!config.enabled) return;
+
+	const startedAt = Date.now();
+	let requested = false;
+
+	const drainer = createWorkerDrainer({
+		server,
+		exit: () => exitGracefully(),
+		drainTimeoutMs: config.drainTimeoutMs,
+		log: (message) => logger.info(message),
+	});
+
+	process.on("message", (message: RecycleMessage) => {
+		if (message?.type !== RECYCLE_DRAIN) return;
+		drainer.drain();
+	});
+
+	const check = () => {
+		if (requested) return;
+		const rssBytes = process.memoryUsage.rss();
+		if (
+			!shouldRequestRecycle({
+				rssBytes,
+				thresholdBytes: config.rssThresholdBytes,
+				ageMs: Date.now() - startedAt,
+				minAgeMs: config.minAgeMs,
+			})
+		) {
+			return;
+		}
+
+		requested = true;
+		logger.info(
+			`[ForkRecycle] Worker ${process.pid} requesting recycle at rss=${Math.round(rssBytes / 1024 / 1024)}MB after ${Math.round((Date.now() - startedAt) / 60_000)}min`,
+			{
+				type: "fork_recycle_request",
+				data: {
+					pid: process.pid,
+					rssMB: Math.round(rssBytes / 1024 / 1024),
+					ageMinutes: Math.round((Date.now() - startedAt) / 60_000),
+				},
+			},
+		);
+		process.send?.({ type: RECYCLE_REQUEST });
+	};
+
+	// Jitter so same-boot forks never check in sync.
+	const interval = config.checkIntervalMs * (0.9 + Math.random() * 0.2);
+	const timer = setInterval(check, interval);
+	timer.unref?.();
+};

--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -55,9 +55,10 @@ export const attachPrimaryForkRecycling = ({
 			}
 		},
 		respawn: () => {
-			if (!shouldRespawn()) return;
+			if (!shouldRespawn()) return undefined;
 			const worker = clusterModule.fork();
 			workerIds.set(String(worker.id), worker);
+			return String(worker.id);
 		},
 		log: (message) => logger.info(message),
 	});
@@ -87,12 +88,15 @@ export const attachPrimaryForkRecycling = ({
 export const startWorkerForkRecycling = ({
 	server,
 	exitGracefully,
+	getActiveRequestCount,
 	onDrainStart,
 	logger,
 }: {
 	server: Parameters<typeof createWorkerDrainer>[0]["server"];
 	/** Runs the worker's normal shutdown (flushes, pool close, process.exit). */
 	exitGracefully: () => void;
+	/** Long-running requests (streams) extend the drain instead of being cut. */
+	getActiveRequestCount?: () => number;
 	onDrainStart?: () => void;
 	logger: Logger;
 }) => {
@@ -106,6 +110,7 @@ export const startWorkerForkRecycling = ({
 		server,
 		exit: () => exitGracefully(),
 		drainTimeoutMs: config.drainTimeoutMs,
+		getActiveRequestCount,
 		onDrainStart,
 		log: (message) => logger.info(message),
 	});

--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -27,17 +27,32 @@ export const attachPrimaryForkRecycling = ({
 }): PrimaryForkRecycling => {
 	const workerIds = new Map<string, Worker>();
 
+	// A worker whose IPC channel just closed makes `send` raise; the exit
+	// handler reconciles that case, so the failed write must not crash us.
+	const sendSafely = (workerId: string, type: string) => {
+		try {
+			workerIds.get(workerId)?.send({ type }, (error) => {
+				if (error) logger.warn(`[ForkRecycle] ${type} -> ${workerId} failed`);
+			});
+		} catch {
+			logger.warn(`[ForkRecycle] ${type} -> ${workerId} failed`);
+		}
+	};
+
 	const coordinator = createRecycleCoordinator({
 		forkReplacement: () => {
 			const worker = clusterModule.fork();
 			workerIds.set(String(worker.id), worker);
 			return String(worker.id);
 		},
-		sendDrain: (workerId) => {
-			workerIds.get(workerId)?.send({ type: RECYCLE_DRAIN });
-		},
-		sendAbort: (workerId) => {
-			workerIds.get(workerId)?.send({ type: RECYCLE_ABORT });
+		sendDrain: (workerId) => sendSafely(workerId, RECYCLE_DRAIN),
+		sendAbort: (workerId) => sendSafely(workerId, RECYCLE_ABORT),
+		killWorker: (workerId) => {
+			try {
+				workerIds.get(workerId)?.kill();
+			} catch {
+				logger.warn(`[ForkRecycle] kill -> ${workerId} failed`);
+			}
 		},
 		respawn: () => {
 			if (!shouldRespawn()) return;

--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -7,6 +7,7 @@ import { createWorkerDrainer } from "./workerDrainer.js";
 
 const RECYCLE_REQUEST = "fork-recycle:request";
 const RECYCLE_DRAIN = "fork-recycle:drain";
+const RECYCLE_ABORT = "fork-recycle:abort";
 
 type RecycleMessage = { type?: string };
 
@@ -34,6 +35,9 @@ export const attachPrimaryForkRecycling = ({
 		},
 		sendDrain: (workerId) => {
 			workerIds.get(workerId)?.send({ type: RECYCLE_DRAIN });
+		},
+		sendAbort: (workerId) => {
+			workerIds.get(workerId)?.send({ type: RECYCLE_ABORT });
 		},
 		respawn: () => {
 			if (!shouldRespawn()) return;
@@ -92,8 +96,17 @@ export const startWorkerForkRecycling = ({
 	});
 
 	process.on("message", (message: RecycleMessage) => {
-		if (message?.type !== RECYCLE_DRAIN) return;
-		drainer.drain();
+		if (message?.type === RECYCLE_DRAIN) {
+			drainer.drain();
+			return;
+		}
+		if (message?.type === RECYCLE_ABORT) {
+			// Replacement failed to boot; re-arm so a later check can ask again.
+			requested = false;
+			logger.info(
+				`[ForkRecycle] Worker ${process.pid} recycle aborted; will re-request if still over threshold`,
+			);
+		}
 	});
 
 	const check = () => {

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -2,36 +2,49 @@ type RecycleCycle = {
 	oldWorkerId: string;
 	replacementId: string;
 	drainSent: boolean;
+	/** Old worker crashed before drain; the booting replacement is adopted as
+	 *  its respawn, so the cycle completes on `listening` without a drain. */
+	oldExited: boolean;
 };
 
 export type RecycleCoordinator = {
 	handleRecycleRequest: (args: { workerId: string }) => void;
 	handleWorkerListening: (args: { workerId: string }) => void;
 	/** Returns true when the exit was an expected recycle completion (caller
-	 *  must not respawn); crashes are respawned via the injected callback. */
+	 *  must not treat it as a crash); the coordinator owns all respawns. */
 	handleWorkerExit: (args: { workerId: string }) => boolean;
 };
 
-/** One recycle in flight at a time: the replacement must be listening before
- *  the old fork is told to drain, so task capacity never drops below N forks. */
+/** One recycle in flight at a time, and an invariant every path must hold:
+ *  the serving fork count returns to N — no surplus, no deficit. */
 export const createRecycleCoordinator = ({
 	forkReplacement,
 	sendDrain,
+	sendAbort,
 	respawn,
 	log,
 }: {
 	forkReplacement: () => string;
 	sendDrain: (workerId: string) => void;
+	/** Tells a still-serving worker its cycle was aborted so it may request
+	 *  again later (clears the worker-side request latch). */
+	sendAbort: (workerId: string) => void;
 	respawn: (workerId: string) => void;
 	log: (message: string) => void;
 }): RecycleCoordinator => {
 	let activeCycle: RecycleCycle | null = null;
 	const pendingWorkerIds: string[] = [];
 	const requestedWorkerIds = new Set<string>();
+	const expectedExitWorkerIds = new Set<string>();
 
 	const startCycle = (oldWorkerId: string) => {
 		const replacementId = forkReplacement();
-		activeCycle = { oldWorkerId, replacementId, drainSent: false };
+		activeCycle = {
+			oldWorkerId,
+			replacementId,
+			drainSent: false,
+			oldExited: false,
+		};
 		log(
 			`[ForkRecycle] Replacing worker ${oldWorkerId}; replacement ${replacementId} booting`,
 		);
@@ -59,7 +72,18 @@ export const createRecycleCoordinator = ({
 			if (!activeCycle || activeCycle.replacementId !== workerId) return;
 			if (activeCycle.drainSent) return;
 
+			if (activeCycle.oldExited) {
+				// The worker this replacement was for already crashed; the
+				// replacement simply takes its slot.
+				log(
+					`[ForkRecycle] Replacement ${workerId} listening; adopted for crashed worker ${activeCycle.oldWorkerId}`,
+				);
+				startNextPendingCycle();
+				return;
+			}
+
 			activeCycle.drainSent = true;
+			expectedExitWorkerIds.add(activeCycle.oldWorkerId);
 			log(
 				`[ForkRecycle] Replacement ${workerId} listening; draining ${activeCycle.oldWorkerId}`,
 			);
@@ -67,28 +91,50 @@ export const createRecycleCoordinator = ({
 		},
 
 		handleWorkerExit: ({ workerId }) => {
-			if (activeCycle?.oldWorkerId === workerId) {
-				const wasExpected = activeCycle.drainSent;
+			if (expectedExitWorkerIds.has(workerId)) {
+				expectedExitWorkerIds.delete(workerId);
 				requestedWorkerIds.delete(workerId);
-				startNextPendingCycle();
-				if (wasExpected) {
-					log(`[ForkRecycle] Worker ${workerId} recycled`);
-					return true;
-				}
-				// Died before its drain was ever sent — a plain crash.
-				respawn(workerId);
+				if (activeCycle?.oldWorkerId === workerId) startNextPendingCycle();
+				log(`[ForkRecycle] Worker ${workerId} recycled`);
+				return true;
+			}
+
+			if (activeCycle?.oldWorkerId === workerId) {
+				// Crashed before its drain: the already-booting replacement is its
+				// respawn, so forking again here would leave a surplus worker.
+				requestedWorkerIds.delete(workerId);
+				activeCycle.oldExited = true;
+				log(
+					`[ForkRecycle] Worker ${workerId} died mid-recycle; replacement ${activeCycle.replacementId} adopts its slot`,
+				);
 				return false;
 			}
 
 			if (activeCycle?.replacementId === workerId) {
-				// Replacement crashed during boot: abort so the old fork keeps
-				// serving, and let the standard crash path replace the replacement.
+				const { oldWorkerId, drainSent } = activeCycle;
+				if (drainSent) {
+					// Old worker is already draining and stays an expected exit; the
+					// dead replacement's slot is the one that needs refilling.
+					log(
+						`[ForkRecycle] Replacement ${workerId} died after listening; respawning while ${oldWorkerId} finishes draining`,
+					);
+					startNextPendingCycle();
+					respawn(workerId);
+					return false;
+				}
+				// Died while booting. If the old worker still serves, no capacity was
+				// lost — abort and let it ask again later. If the old worker had
+				// crashed too, this replacement WAS its slot: refill it.
 				log(
-					`[ForkRecycle] Replacement ${workerId} died before listening; aborting recycle of ${activeCycle.oldWorkerId}`,
+					`[ForkRecycle] Replacement ${workerId} died before listening; aborting recycle of ${oldWorkerId}`,
 				);
-				requestedWorkerIds.delete(activeCycle.oldWorkerId);
+				requestedWorkerIds.delete(oldWorkerId);
+				if (activeCycle.oldExited) {
+					respawn(workerId);
+				} else {
+					sendAbort(oldWorkerId);
+				}
 				startNextPendingCycle();
-				respawn(workerId);
 				return false;
 			}
 

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -2,6 +2,9 @@ type RecycleCycle = {
 	oldWorkerId: string;
 	replacementId: string;
 	drainSent: boolean;
+	/** Replacement is listening but the drain waits for crash respawns to
+	 *  finish booting, so capacity never dips below N mid-recycle. */
+	drainDeferred: boolean;
 	/** Old worker crashed before drain; the booting replacement is adopted as
 	 *  its respawn, so the cycle completes on `listening` without a drain. */
 	oldExited: boolean;
@@ -35,7 +38,9 @@ export const createRecycleCoordinator = ({
 	sendAbort: (workerId: string) => void;
 	/** Force-kills a replacement that never reached `listening`. */
 	killWorker: (workerId: string) => void;
-	respawn: (workerId: string) => void;
+	/** Forks a crash replacement; returns its worker id (undefined when the
+	 *  caller is shutting down and skipped the fork). */
+	respawn: (workerId: string) => string | undefined;
 	replacementBootTimeoutMs?: number;
 	log: (message: string) => void;
 }): RecycleCoordinator => {
@@ -46,6 +51,31 @@ export const createRecycleCoordinator = ({
 	const expectedExitWorkerIds = new Set<string>();
 	// Replacements killed for hanging: their eventual exit needs no respawn.
 	const discardedWorkerIds = new Set<string>();
+	// Crash respawns still booting: drains wait for these so a recycle never
+	// stacks on top of reduced capacity.
+	const bootingRespawnIds = new Set<string>();
+
+	const respawnTracked = (workerId: string) => {
+		const newWorkerId = respawn(workerId);
+		if (newWorkerId !== undefined) bootingRespawnIds.add(newWorkerId);
+	};
+
+	const sendDrainNow = (cycle: RecycleCycle) => {
+		cycle.drainSent = true;
+		cycle.drainDeferred = false;
+		expectedExitWorkerIds.add(cycle.oldWorkerId);
+		log(
+			`[ForkRecycle] Replacement ${cycle.replacementId} listening; draining ${cycle.oldWorkerId}`,
+		);
+		sendDrain(cycle.oldWorkerId);
+	};
+
+	const releaseDeferredDrainIfClear = () => {
+		if (bootingRespawnIds.size > 0) return;
+		if (activeCycle?.drainDeferred && !activeCycle.drainSent) {
+			sendDrainNow(activeCycle);
+		}
+	};
 
 	const clearBootDeadline = () => {
 		if (bootDeadline) clearTimeout(bootDeadline);
@@ -58,6 +88,7 @@ export const createRecycleCoordinator = ({
 			oldWorkerId,
 			replacementId,
 			drainSent: false,
+			drainDeferred: false,
 			oldExited: false,
 		};
 		log(
@@ -75,7 +106,7 @@ export const createRecycleCoordinator = ({
 			const { oldExited } = activeCycle;
 			requestedWorkerIds.delete(oldWorkerId);
 			if (oldExited) {
-				respawn(replacementId);
+				respawnTracked(replacementId);
 			} else {
 				sendAbort(oldWorkerId);
 			}
@@ -105,6 +136,11 @@ export const createRecycleCoordinator = ({
 		},
 
 		handleWorkerListening: ({ workerId }) => {
+			if (bootingRespawnIds.delete(workerId)) {
+				releaseDeferredDrainIfClear();
+				return;
+			}
+
 			if (!activeCycle || activeCycle.replacementId !== workerId) return;
 			if (activeCycle.drainSent) return;
 
@@ -119,74 +155,85 @@ export const createRecycleCoordinator = ({
 			}
 
 			clearBootDeadline();
-			activeCycle.drainSent = true;
-			expectedExitWorkerIds.add(activeCycle.oldWorkerId);
-			log(
-				`[ForkRecycle] Replacement ${workerId} listening; draining ${activeCycle.oldWorkerId}`,
-			);
-			sendDrain(activeCycle.oldWorkerId);
+			if (bootingRespawnIds.size > 0) {
+				// A crash respawn is still booting; draining now would dip below N.
+				activeCycle.drainDeferred = true;
+				log(
+					`[ForkRecycle] Replacement ${workerId} listening; deferring drain of ${activeCycle.oldWorkerId} until ${bootingRespawnIds.size} crash respawn(s) boot`,
+				);
+				return;
+			}
+			sendDrainNow(activeCycle);
 		},
 
 		handleWorkerExit: ({ workerId }) => {
-			if (discardedWorkerIds.has(workerId)) {
-				// A hung replacement we already killed and accounted for.
-				discardedWorkerIds.delete(workerId);
-				requestedWorkerIds.delete(workerId);
-				return true;
-			}
+			// A crash respawn dying while booting falls through to the plain-crash
+			// branch below (which respawns again); the deferred-drain release runs
+			// only after that branch has tracked the new respawn.
+			const wasBootingRespawn = bootingRespawnIds.delete(workerId);
+			const wasExpected = (() => {
+				if (discardedWorkerIds.has(workerId)) {
+					// A hung replacement we already killed and accounted for.
+					discardedWorkerIds.delete(workerId);
+					requestedWorkerIds.delete(workerId);
+					return true;
+				}
 
-			if (expectedExitWorkerIds.has(workerId)) {
-				expectedExitWorkerIds.delete(workerId);
-				requestedWorkerIds.delete(workerId);
-				if (activeCycle?.oldWorkerId === workerId) startNextPendingCycle();
-				log(`[ForkRecycle] Worker ${workerId} recycled`);
-				return true;
-			}
+				if (expectedExitWorkerIds.has(workerId)) {
+					expectedExitWorkerIds.delete(workerId);
+					requestedWorkerIds.delete(workerId);
+					if (activeCycle?.oldWorkerId === workerId) startNextPendingCycle();
+					log(`[ForkRecycle] Worker ${workerId} recycled`);
+					return true;
+				}
 
-			if (activeCycle?.oldWorkerId === workerId) {
-				// Crashed before its drain: the already-booting replacement is its
-				// respawn, so forking again here would leave a surplus worker.
-				requestedWorkerIds.delete(workerId);
-				activeCycle.oldExited = true;
-				log(
-					`[ForkRecycle] Worker ${workerId} died mid-recycle; replacement ${activeCycle.replacementId} adopts its slot`,
-				);
-				return false;
-			}
-
-			if (activeCycle?.replacementId === workerId) {
-				const { oldWorkerId, drainSent } = activeCycle;
-				if (drainSent) {
-					// Old worker is already draining and stays an expected exit; the
-					// dead replacement's slot is the one that needs refilling.
+				if (activeCycle?.oldWorkerId === workerId) {
+					// Crashed before its drain: the already-booting replacement is its
+					// respawn, so forking again here would leave a surplus worker.
+					requestedWorkerIds.delete(workerId);
+					activeCycle.oldExited = true;
 					log(
-						`[ForkRecycle] Replacement ${workerId} died after listening; respawning while ${oldWorkerId} finishes draining`,
+						`[ForkRecycle] Worker ${workerId} died mid-recycle; replacement ${activeCycle.replacementId} adopts its slot`,
 					);
-					startNextPendingCycle();
-					respawn(workerId);
 					return false;
 				}
-				// Died while booting. If the old worker still serves, no capacity was
-				// lost — abort and let it ask again later. If the old worker had
-				// crashed too, this replacement WAS its slot: refill it.
-				log(
-					`[ForkRecycle] Replacement ${workerId} died before listening; aborting recycle of ${oldWorkerId}`,
-				);
-				requestedWorkerIds.delete(oldWorkerId);
-				if (activeCycle.oldExited) {
-					respawn(workerId);
-				} else {
-					sendAbort(oldWorkerId);
-				}
-				startNextPendingCycle();
-				return false;
-			}
 
-			requestedWorkerIds.delete(workerId);
-			const pendingIndex = pendingWorkerIds.indexOf(workerId);
-			if (pendingIndex !== -1) pendingWorkerIds.splice(pendingIndex, 1);
-			respawn(workerId);
-			return false;
+				if (activeCycle?.replacementId === workerId) {
+					const { oldWorkerId, drainSent } = activeCycle;
+					if (drainSent) {
+						// Old worker is already draining and stays an expected exit; the
+						// dead replacement's slot is the one that needs refilling.
+						log(
+							`[ForkRecycle] Replacement ${workerId} died after listening; respawning while ${oldWorkerId} finishes draining`,
+						);
+						startNextPendingCycle();
+						respawnTracked(workerId);
+						return false;
+					}
+					// Died while booting. If the old worker still serves, no capacity was
+					// lost — abort and let it ask again later. If the old worker had
+					// crashed too, this replacement WAS its slot: refill it.
+					log(
+						`[ForkRecycle] Replacement ${workerId} died before listening; aborting recycle of ${oldWorkerId}`,
+					);
+					requestedWorkerIds.delete(oldWorkerId);
+					if (activeCycle.oldExited) {
+						respawnTracked(workerId);
+					} else {
+						sendAbort(oldWorkerId);
+					}
+					startNextPendingCycle();
+					return false;
+				}
+
+				requestedWorkerIds.delete(workerId);
+				const pendingIndex = pendingWorkerIds.indexOf(workerId);
+				if (pendingIndex !== -1) pendingWorkerIds.splice(pendingIndex, 1);
+				respawnTracked(workerId);
+				return false;
+			})();
+			if (wasBootingRespawn) releaseDeferredDrainIfClear();
+			return wasExpected;
 		},
 	};
 };

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -55,9 +55,32 @@ export const createRecycleCoordinator = ({
 	// stacks on top of reduced capacity.
 	const bootingRespawnIds = new Set<string>();
 
+	const respawnBootDeadlines = new Map<string, ReturnType<typeof setTimeout>>();
+
+	const untrackBootingRespawn = (workerId: string): boolean => {
+		const deadline = respawnBootDeadlines.get(workerId);
+		if (deadline) clearTimeout(deadline);
+		respawnBootDeadlines.delete(workerId);
+		return bootingRespawnIds.delete(workerId);
+	};
+
 	const respawnTracked = (workerId: string) => {
 		const newWorkerId = respawn(workerId);
-		if (newWorkerId !== undefined) bootingRespawnIds.add(newWorkerId);
+		if (newWorkerId === undefined) return;
+		bootingRespawnIds.add(newWorkerId);
+		// A respawn that hangs before `listening` would defer drains forever.
+		const deadline = setTimeout(() => {
+			if (!untrackBootingRespawn(newWorkerId)) return;
+			log(
+				`[ForkRecycle] Crash respawn ${newWorkerId} not listening after ${replacementBootTimeoutMs}ms; killing and replacing it`,
+			);
+			discardedWorkerIds.add(newWorkerId);
+			killWorker(newWorkerId);
+			respawnTracked(newWorkerId);
+			releaseDeferredDrainIfClear();
+		}, replacementBootTimeoutMs);
+		deadline.unref?.();
+		respawnBootDeadlines.set(newWorkerId, deadline);
 	};
 
 	const sendDrainNow = (cycle: RecycleCycle) => {
@@ -136,7 +159,7 @@ export const createRecycleCoordinator = ({
 		},
 
 		handleWorkerListening: ({ workerId }) => {
-			if (bootingRespawnIds.delete(workerId)) {
+			if (untrackBootingRespawn(workerId)) {
 				releaseDeferredDrainIfClear();
 				return;
 			}
@@ -170,7 +193,7 @@ export const createRecycleCoordinator = ({
 			// A crash respawn dying while booting falls through to the plain-crash
 			// branch below (which respawns again); the deferred-drain release runs
 			// only after that branch has tracked the new respawn.
-			const wasBootingRespawn = bootingRespawnIds.delete(workerId);
+			const wasBootingRespawn = untrackBootingRespawn(workerId);
 			const wasExpected = (() => {
 				if (discardedWorkerIds.has(workerId)) {
 					// A hung replacement we already killed and accounted for.

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -188,9 +188,19 @@ export const createRecycleCoordinator = ({
 				}
 
 				if (activeCycle?.oldWorkerId === workerId) {
+					requestedWorkerIds.delete(workerId);
+					if (activeCycle.drainDeferred) {
+						// Replacement is already listening (drain deferred): the crash
+						// completes the cycle outright — a deferred drain to a dead
+						// worker would wait forever on an exit that already happened.
+						log(
+							`[ForkRecycle] Worker ${workerId} died with drain deferred; replacement ${activeCycle.replacementId} adopts its slot`,
+						);
+						startNextPendingCycle();
+						return false;
+					}
 					// Crashed before its drain: the already-booting replacement is its
 					// respawn, so forking again here would leave a surplus worker.
-					requestedWorkerIds.delete(workerId);
 					activeCycle.oldExited = true;
 					log(
 						`[ForkRecycle] Worker ${workerId} died mid-recycle; replacement ${activeCycle.replacementId} adopts its slot`,

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -15,13 +15,17 @@ export type RecycleCoordinator = {
 	handleWorkerExit: (args: { workerId: string }) => boolean;
 };
 
+export const DEFAULT_REPLACEMENT_BOOT_TIMEOUT_MS = 120_000;
+
 /** One recycle in flight at a time, and an invariant every path must hold:
  *  the serving fork count returns to N — no surplus, no deficit. */
 export const createRecycleCoordinator = ({
 	forkReplacement,
 	sendDrain,
 	sendAbort,
+	killWorker,
 	respawn,
+	replacementBootTimeoutMs = DEFAULT_REPLACEMENT_BOOT_TIMEOUT_MS,
 	log,
 }: {
 	forkReplacement: () => string;
@@ -29,13 +33,24 @@ export const createRecycleCoordinator = ({
 	/** Tells a still-serving worker its cycle was aborted so it may request
 	 *  again later (clears the worker-side request latch). */
 	sendAbort: (workerId: string) => void;
+	/** Force-kills a replacement that never reached `listening`. */
+	killWorker: (workerId: string) => void;
 	respawn: (workerId: string) => void;
+	replacementBootTimeoutMs?: number;
 	log: (message: string) => void;
 }): RecycleCoordinator => {
 	let activeCycle: RecycleCycle | null = null;
+	let bootDeadline: ReturnType<typeof setTimeout> | null = null;
 	const pendingWorkerIds: string[] = [];
 	const requestedWorkerIds = new Set<string>();
 	const expectedExitWorkerIds = new Set<string>();
+	// Replacements killed for hanging: their eventual exit needs no respawn.
+	const discardedWorkerIds = new Set<string>();
+
+	const clearBootDeadline = () => {
+		if (bootDeadline) clearTimeout(bootDeadline);
+		bootDeadline = null;
+	};
 
 	const startCycle = (oldWorkerId: string) => {
 		const replacementId = forkReplacement();
@@ -48,9 +63,30 @@ export const createRecycleCoordinator = ({
 		log(
 			`[ForkRecycle] Replacing worker ${oldWorkerId}; replacement ${replacementId} booting`,
 		);
+		bootDeadline = setTimeout(() => {
+			if (!activeCycle || activeCycle.replacementId !== replacementId) return;
+			if (activeCycle.drainSent) return;
+			// Alive but never listening (hung init): without this deadline the
+			// cycle would hold the recycle queue forever.
+			log(
+				`[ForkRecycle] Replacement ${replacementId} not listening after ${replacementBootTimeoutMs}ms; killing and aborting recycle of ${oldWorkerId}`,
+			);
+			discardedWorkerIds.add(replacementId);
+			const { oldExited } = activeCycle;
+			requestedWorkerIds.delete(oldWorkerId);
+			if (oldExited) {
+				respawn(replacementId);
+			} else {
+				sendAbort(oldWorkerId);
+			}
+			killWorker(replacementId);
+			startNextPendingCycle();
+		}, replacementBootTimeoutMs);
+		bootDeadline.unref?.();
 	};
 
 	const startNextPendingCycle = () => {
+		clearBootDeadline();
 		activeCycle = null;
 		const next = pendingWorkerIds.shift();
 		if (next !== undefined) startCycle(next);
@@ -82,6 +118,7 @@ export const createRecycleCoordinator = ({
 				return;
 			}
 
+			clearBootDeadline();
 			activeCycle.drainSent = true;
 			expectedExitWorkerIds.add(activeCycle.oldWorkerId);
 			log(
@@ -91,6 +128,13 @@ export const createRecycleCoordinator = ({
 		},
 
 		handleWorkerExit: ({ workerId }) => {
+			if (discardedWorkerIds.has(workerId)) {
+				// A hung replacement we already killed and accounted for.
+				discardedWorkerIds.delete(workerId);
+				requestedWorkerIds.delete(workerId);
+				return true;
+			}
+
 			if (expectedExitWorkerIds.has(workerId)) {
 				expectedExitWorkerIds.delete(workerId);
 				requestedWorkerIds.delete(workerId);

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -1,0 +1,102 @@
+type RecycleCycle = {
+	oldWorkerId: string;
+	replacementId: string;
+	drainSent: boolean;
+};
+
+export type RecycleCoordinator = {
+	handleRecycleRequest: (args: { workerId: string }) => void;
+	handleWorkerListening: (args: { workerId: string }) => void;
+	/** Returns true when the exit was an expected recycle completion (caller
+	 *  must not respawn); crashes are respawned via the injected callback. */
+	handleWorkerExit: (args: { workerId: string }) => boolean;
+};
+
+/** One recycle in flight at a time: the replacement must be listening before
+ *  the old fork is told to drain, so task capacity never drops below N forks. */
+export const createRecycleCoordinator = ({
+	forkReplacement,
+	sendDrain,
+	respawn,
+	log,
+}: {
+	forkReplacement: () => string;
+	sendDrain: (workerId: string) => void;
+	respawn: (workerId: string) => void;
+	log: (message: string) => void;
+}): RecycleCoordinator => {
+	let activeCycle: RecycleCycle | null = null;
+	const pendingWorkerIds: string[] = [];
+	const requestedWorkerIds = new Set<string>();
+
+	const startCycle = (oldWorkerId: string) => {
+		const replacementId = forkReplacement();
+		activeCycle = { oldWorkerId, replacementId, drainSent: false };
+		log(
+			`[ForkRecycle] Replacing worker ${oldWorkerId}; replacement ${replacementId} booting`,
+		);
+	};
+
+	const startNextPendingCycle = () => {
+		activeCycle = null;
+		const next = pendingWorkerIds.shift();
+		if (next !== undefined) startCycle(next);
+	};
+
+	return {
+		handleRecycleRequest: ({ workerId }) => {
+			if (requestedWorkerIds.has(workerId)) return;
+			requestedWorkerIds.add(workerId);
+
+			if (activeCycle) {
+				pendingWorkerIds.push(workerId);
+				return;
+			}
+			startCycle(workerId);
+		},
+
+		handleWorkerListening: ({ workerId }) => {
+			if (!activeCycle || activeCycle.replacementId !== workerId) return;
+			if (activeCycle.drainSent) return;
+
+			activeCycle.drainSent = true;
+			log(
+				`[ForkRecycle] Replacement ${workerId} listening; draining ${activeCycle.oldWorkerId}`,
+			);
+			sendDrain(activeCycle.oldWorkerId);
+		},
+
+		handleWorkerExit: ({ workerId }) => {
+			if (activeCycle?.oldWorkerId === workerId) {
+				const wasExpected = activeCycle.drainSent;
+				requestedWorkerIds.delete(workerId);
+				startNextPendingCycle();
+				if (wasExpected) {
+					log(`[ForkRecycle] Worker ${workerId} recycled`);
+					return true;
+				}
+				// Died before its drain was ever sent — a plain crash.
+				respawn(workerId);
+				return false;
+			}
+
+			if (activeCycle?.replacementId === workerId) {
+				// Replacement crashed during boot: abort so the old fork keeps
+				// serving, and let the standard crash path replace the replacement.
+				log(
+					`[ForkRecycle] Replacement ${workerId} died before listening; aborting recycle of ${activeCycle.oldWorkerId}`,
+				);
+				requestedWorkerIds.delete(activeCycle.oldWorkerId);
+				startNextPendingCycle();
+				respawn(workerId);
+				return false;
+			}
+
+			requestedWorkerIds.delete(workerId);
+			const pendingIndex = pendingWorkerIds.indexOf(workerId);
+			if (pendingIndex !== -1) pendingWorkerIds.splice(pendingIndex, 1);
+			respawn(workerId);
+			return false;
+		},
+	};
+};

--- a/server/src/utils/memory/forkRecycling/recyclePolicy.ts
+++ b/server/src/utils/memory/forkRecycling/recyclePolicy.ts
@@ -1,0 +1,45 @@
+const MB = 1024 * 1024;
+
+/** JSC never returns allocator-retained pages, so forks only shed memory by
+ *  dying; recycling above this RSS is the bound the engine cannot provide. */
+export const FORK_RECYCLE_DEFAULTS = {
+	rssThresholdBytes: 3072 * MB,
+	minAgeMs: 30 * 60_000,
+	checkIntervalMs: 30_000,
+	drainTimeoutMs: 30_000,
+} as const;
+
+export const shouldRequestRecycle = ({
+	rssBytes,
+	thresholdBytes,
+	ageMs,
+	minAgeMs,
+}: {
+	rssBytes: number;
+	thresholdBytes: number;
+	ageMs: number;
+	minAgeMs: number;
+}): boolean => rssBytes >= thresholdBytes && ageMs >= minAgeMs;
+
+export const getForkRecycleConfig = () => {
+	const thresholdMb = Number(process.env.FORK_RECYCLE_RSS_MB);
+	const minAgeMs = Number(process.env.FORK_RECYCLE_MIN_AGE_MS);
+	const checkIntervalMs = Number(process.env.FORK_RECYCLE_CHECK_INTERVAL_MS);
+	const drainTimeoutMs = Number(process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS);
+
+	return {
+		enabled: process.env.FORK_RECYCLE_DISABLED !== "true",
+		rssThresholdBytes: Number.isFinite(thresholdMb)
+			? thresholdMb * MB
+			: FORK_RECYCLE_DEFAULTS.rssThresholdBytes,
+		minAgeMs: Number.isFinite(minAgeMs)
+			? minAgeMs
+			: FORK_RECYCLE_DEFAULTS.minAgeMs,
+		checkIntervalMs: Number.isFinite(checkIntervalMs)
+			? checkIntervalMs
+			: FORK_RECYCLE_DEFAULTS.checkIntervalMs,
+		drainTimeoutMs: Number.isFinite(drainTimeoutMs)
+			? drainTimeoutMs
+			: FORK_RECYCLE_DEFAULTS.drainTimeoutMs,
+	};
+};

--- a/server/src/utils/memory/forkRecycling/recyclePolicy.ts
+++ b/server/src/utils/memory/forkRecycling/recyclePolicy.ts
@@ -21,25 +21,31 @@ export const shouldRequestRecycle = ({
 	minAgeMs: number;
 }): boolean => rssBytes >= thresholdBytes && ageMs >= minAgeMs;
 
-export const getForkRecycleConfig = () => {
-	const thresholdMb = Number(process.env.FORK_RECYCLE_RSS_MB);
-	const minAgeMs = Number(process.env.FORK_RECYCLE_MIN_AGE_MS);
-	const checkIntervalMs = Number(process.env.FORK_RECYCLE_CHECK_INTERVAL_MS);
-	const drainTimeoutMs = Number(process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS);
+// Zero/negative timings would hot-loop checks or defeat the drain bounds.
+const positiveOr = (raw: string | undefined, fallback: number): number => {
+	const value = Number(raw);
+	return Number.isFinite(value) && value > 0 ? value : fallback;
+};
 
+export const getForkRecycleConfig = () => {
 	return {
 		enabled: process.env.FORK_RECYCLE_DISABLED !== "true",
-		rssThresholdBytes: Number.isFinite(thresholdMb)
-			? thresholdMb * MB
-			: FORK_RECYCLE_DEFAULTS.rssThresholdBytes,
-		minAgeMs: Number.isFinite(minAgeMs)
-			? minAgeMs
-			: FORK_RECYCLE_DEFAULTS.minAgeMs,
-		checkIntervalMs: Number.isFinite(checkIntervalMs)
-			? checkIntervalMs
-			: FORK_RECYCLE_DEFAULTS.checkIntervalMs,
-		drainTimeoutMs: Number.isFinite(drainTimeoutMs)
-			? drainTimeoutMs
-			: FORK_RECYCLE_DEFAULTS.drainTimeoutMs,
+		rssThresholdBytes:
+			positiveOr(
+				process.env.FORK_RECYCLE_RSS_MB,
+				FORK_RECYCLE_DEFAULTS.rssThresholdBytes / MB,
+			) * MB,
+		minAgeMs: positiveOr(
+			process.env.FORK_RECYCLE_MIN_AGE_MS,
+			FORK_RECYCLE_DEFAULTS.minAgeMs,
+		),
+		checkIntervalMs: positiveOr(
+			process.env.FORK_RECYCLE_CHECK_INTERVAL_MS,
+			FORK_RECYCLE_DEFAULTS.checkIntervalMs,
+		),
+		drainTimeoutMs: positiveOr(
+			process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS,
+			FORK_RECYCLE_DEFAULTS.drainTimeoutMs,
+		),
 	};
 };

--- a/server/src/utils/memory/forkRecycling/workerDrainer.ts
+++ b/server/src/utils/memory/forkRecycling/workerDrainer.ts
@@ -14,12 +14,17 @@ export const createWorkerDrainer = ({
 	exit,
 	drainTimeoutMs,
 	idleSweepIntervalMs = 1_000,
+	onDrainStart,
 	log,
 }: {
 	server: DrainableServer;
 	exit: (code: number) => void;
 	drainTimeoutMs: number;
 	idleSweepIntervalMs?: number;
+	/** Runs before the server closes — lets the request path start sending
+	 *  `Connection: close` so pooled clients retire sockets instead of racing
+	 *  the idle-connection eviction. */
+	onDrainStart?: () => void;
 	log: (message: string) => void;
 }): WorkerDrainer => {
 	let draining = false;
@@ -28,6 +33,7 @@ export const createWorkerDrainer = ({
 		drain: () => {
 			if (draining) return;
 			draining = true;
+			onDrainStart?.();
 
 			let exited = false;
 			const exitOnce = (reason: string) => {
@@ -40,9 +46,11 @@ export const createWorkerDrainer = ({
 			};
 
 			log(`[ForkRecycle] Worker ${process.pid} draining`);
-			server.closeIdleConnections?.();
 			server.close(() => exitOnce("drained"));
 
+			// First sweep only after a full interval: gives in-flight responses a
+			// beat to carry `Connection: close` so pooled sockets retire themselves
+			// instead of being evicted out from under the client.
 			const idleSweep = setInterval(
 				() => server.closeIdleConnections?.(),
 				idleSweepIntervalMs,

--- a/server/src/utils/memory/forkRecycling/workerDrainer.ts
+++ b/server/src/utils/memory/forkRecycling/workerDrainer.ts
@@ -82,7 +82,14 @@ export const createWorkerDrainer = ({
 			};
 
 			const armDeadline = () => {
-				deadline = setTimeout(onDeadline, drainTimeoutMs);
+				// Cap each arm at the remaining max-drain budget so the hard bound
+				// cannot be overshot by an oversized interval.
+				const remainingMs = maxDrainMs - (Date.now() - drainStartedAt);
+				const intervalMs = Math.max(
+					1,
+					Math.min(drainTimeoutMs, Math.max(remainingMs, 1)),
+				);
+				deadline = setTimeout(onDeadline, intervalMs);
 				deadline.unref?.();
 			};
 			armDeadline();

--- a/server/src/utils/memory/forkRecycling/workerDrainer.ts
+++ b/server/src/utils/memory/forkRecycling/workerDrainer.ts
@@ -9,18 +9,27 @@ export type WorkerDrainer = {
 	drain: () => void;
 };
 
+export const DEFAULT_MAX_DRAIN_MS = 10 * 60_000;
+
 export const createWorkerDrainer = ({
 	server,
 	exit,
 	drainTimeoutMs,
+	maxDrainMs = DEFAULT_MAX_DRAIN_MS,
 	idleSweepIntervalMs = 1_000,
+	getActiveRequestCount,
 	onDrainStart,
 	log,
 }: {
 	server: DrainableServer;
 	exit: (code: number) => void;
 	drainTimeoutMs: number;
+	/** Hard bound for a fork that never goes idle (a truly hung request). */
+	maxDrainMs?: number;
 	idleSweepIntervalMs?: number;
+	/** While this reports active requests (long streams, big imports), the
+	 *  drain deadline extends instead of cutting them mid-response. */
+	getActiveRequestCount?: () => number;
 	/** Runs before the server closes — lets the request path start sending
 	 *  `Connection: close` so pooled clients retire sockets instead of racing
 	 *  the idle-connection eviction. */
@@ -35,12 +44,14 @@ export const createWorkerDrainer = ({
 			draining = true;
 			onDrainStart?.();
 
+			const drainStartedAt = Date.now();
 			let exited = false;
+			let deadline: ReturnType<typeof setTimeout> | null = null;
 			const exitOnce = (reason: string) => {
 				if (exited) return;
 				exited = true;
 				clearInterval(idleSweep);
-				clearTimeout(deadline);
+				if (deadline) clearTimeout(deadline);
 				log(`[ForkRecycle] Worker ${process.pid} exiting (${reason})`);
 				exit(0);
 			};
@@ -57,11 +68,24 @@ export const createWorkerDrainer = ({
 			);
 			idleSweep.unref?.();
 
-			const deadline = setTimeout(
-				() => exitOnce("drain timeout"),
-				drainTimeoutMs,
-			);
-			deadline.unref?.();
+			const onDeadline = () => {
+				const activeRequests = getActiveRequestCount?.() ?? 0;
+				const elapsedMs = Date.now() - drainStartedAt;
+				if (activeRequests > 0 && elapsedMs < maxDrainMs) {
+					log(
+						`[ForkRecycle] Worker ${process.pid} still serving ${activeRequests} request(s) after ${Math.round(elapsedMs / 1000)}s; extending drain`,
+					);
+					armDeadline();
+					return;
+				}
+				exitOnce(activeRequests > 0 ? "max drain exceeded" : "drain timeout");
+			};
+
+			const armDeadline = () => {
+				deadline = setTimeout(onDeadline, drainTimeoutMs);
+				deadline.unref?.();
+			};
+			armDeadline();
 		},
 	};
 };

--- a/server/src/utils/memory/forkRecycling/workerDrainer.ts
+++ b/server/src/utils/memory/forkRecycling/workerDrainer.ts
@@ -1,0 +1,59 @@
+type DrainableServer = {
+	close: (callback: () => void) => void;
+	/** Keep-alive sockets with no active request block `close` forever; the
+	 *  periodic sweep evicts them so drain completes between requests. */
+	closeIdleConnections?: () => void;
+};
+
+export type WorkerDrainer = {
+	drain: () => void;
+};
+
+export const createWorkerDrainer = ({
+	server,
+	exit,
+	drainTimeoutMs,
+	idleSweepIntervalMs = 1_000,
+	log,
+}: {
+	server: DrainableServer;
+	exit: (code: number) => void;
+	drainTimeoutMs: number;
+	idleSweepIntervalMs?: number;
+	log: (message: string) => void;
+}): WorkerDrainer => {
+	let draining = false;
+
+	return {
+		drain: () => {
+			if (draining) return;
+			draining = true;
+
+			let exited = false;
+			const exitOnce = (reason: string) => {
+				if (exited) return;
+				exited = true;
+				clearInterval(idleSweep);
+				clearTimeout(deadline);
+				log(`[ForkRecycle] Worker ${process.pid} exiting (${reason})`);
+				exit(0);
+			};
+
+			log(`[ForkRecycle] Worker ${process.pid} draining`);
+			server.closeIdleConnections?.();
+			server.close(() => exitOnce("drained"));
+
+			const idleSweep = setInterval(
+				() => server.closeIdleConnections?.(),
+				idleSweepIntervalMs,
+			);
+			idleSweep.unref?.();
+
+			const deadline = setTimeout(
+				() => exitOnce("drain timeout"),
+				drainTimeoutMs,
+			);
+			deadline.unref?.();
+		},
+	};
+};

--- a/server/tests/unit/memory/fixtures/recycleClusterFixture.ts
+++ b/server/tests/unit/memory/fixtures/recycleClusterFixture.ts
@@ -31,10 +31,11 @@ if (cluster.isPrimary) {
 		console.log(`WORKER_DIED ${worker.process.pid}`);
 	});
 } else {
+	const drainState = { draining: false };
 	const server = http.createServer((_req, res) => {
 		// In-flight window so a hard kill mid-request would surface as a failure.
 		setTimeout(() => {
-			res.setHeader("connection", "keep-alive");
+			res.setHeader("connection", drainState.draining ? "close" : "keep-alive");
 			res.end(`ok:${process.pid}`);
 		}, 20);
 	});
@@ -42,6 +43,9 @@ if (cluster.isPrimary) {
 	server.listen(PORT, "127.0.0.1", () => {
 		startWorkerForkRecycling({
 			server,
+			onDrainStart: () => {
+				drainState.draining = true;
+			},
 			exitGracefully: () => process.exit(0),
 			logger: fixtureLogger,
 		});

--- a/server/tests/unit/memory/fixtures/recycleClusterFixture.ts
+++ b/server/tests/unit/memory/fixtures/recycleClusterFixture.ts
@@ -1,0 +1,49 @@
+// Minimal cluster exercising the real recycling modules without the app:
+// two HTTP forks that recycle constantly under FORK_RECYCLE_* test settings.
+import cluster from "node:cluster";
+import http from "node:http";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import {
+	attachPrimaryForkRecycling,
+	startWorkerForkRecycling,
+} from "@/utils/memory/forkRecycling/attachForkRecycling.js";
+
+const PORT = Number(process.env.FIXTURE_PORT);
+const log = (message: string) => console.log(message);
+const fixtureLogger = { info: log, error: log, warn: log } as unknown as Logger;
+
+if (cluster.isPrimary) {
+	cluster.fork();
+	cluster.fork();
+
+	const forkRecycling = attachPrimaryForkRecycling({
+		clusterModule: cluster,
+		shouldRespawn: () => true,
+		logger: fixtureLogger,
+	});
+
+	cluster.on("listening", (worker) => {
+		console.log(`WORKER_UP ${worker.process.pid}`);
+	});
+
+	cluster.on("exit", (worker) => {
+		if (forkRecycling.handleExit(worker)) return;
+		console.log(`WORKER_DIED ${worker.process.pid}`);
+	});
+} else {
+	const server = http.createServer((_req, res) => {
+		// In-flight window so a hard kill mid-request would surface as a failure.
+		setTimeout(() => {
+			res.setHeader("connection", "keep-alive");
+			res.end(`ok:${process.pid}`);
+		}, 20);
+	});
+
+	server.listen(PORT, "127.0.0.1", () => {
+		startWorkerForkRecycling({
+			server,
+			exitGracefully: () => process.exit(0),
+			logger: fixtureLogger,
+		});
+	});
+}

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	createRecycleCoordinator,
+	type RecycleCoordinator,
+} from "@/utils/memory/forkRecycling/recycleCoordinator.js";
+import { shouldRequestRecycle } from "@/utils/memory/forkRecycling/recyclePolicy.js";
+import { createWorkerDrainer } from "@/utils/memory/forkRecycling/workerDrainer.js";
+
+const MB = 1024 * 1024;
+
+describe("shouldRequestRecycle", () => {
+	const base = {
+		rssBytes: 4096 * MB,
+		thresholdBytes: 3072 * MB,
+		ageMs: 60 * 60_000,
+		minAgeMs: 30 * 60_000,
+	};
+
+	test("fires when rss is over threshold and the fork is old enough", () => {
+		expect(shouldRequestRecycle(base)).toBe(true);
+	});
+
+	test("stays quiet under the threshold", () => {
+		expect(shouldRequestRecycle({ ...base, rssBytes: 2048 * MB })).toBe(false);
+	});
+
+	test("never recycles a young fork regardless of rss", () => {
+		expect(shouldRequestRecycle({ ...base, ageMs: 5 * 60_000 })).toBe(false);
+	});
+});
+
+type CoordinatorHarness = {
+	coordinator: RecycleCoordinator;
+	forked: string[];
+	drained: string[];
+	respawned: string[];
+	listening: Map<string, () => void>;
+};
+
+/** Coordinator with capture-everything callbacks. Replacement forks report
+ *  listening only when the test releases them via `listening`. */
+const createHarness = (): CoordinatorHarness => {
+	const forked: string[] = [];
+	const drained: string[] = [];
+	const respawned: string[] = [];
+	const listening = new Map<string, () => void>();
+	let nextForkId = 100;
+
+	const coordinator = createRecycleCoordinator({
+		forkReplacement: () => {
+			const id = `fork-${nextForkId++}`;
+			forked.push(id);
+			return id;
+		},
+		sendDrain: (workerId) => {
+			drained.push(workerId);
+		},
+		respawn: (workerId) => {
+			respawned.push(workerId);
+		},
+		log: () => {},
+	});
+
+	return { coordinator, forked, drained, respawned, listening };
+};
+
+describe("createRecycleCoordinator", () => {
+	test("request forks a replacement before any drain is sent", () => {
+		const { coordinator, forked, drained } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+
+		expect(forked).toHaveLength(1);
+		expect(drained).toHaveLength(0);
+	});
+
+	test("drains the old worker only once its replacement is listening", () => {
+		const { coordinator, forked, drained } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+
+		expect(drained).toEqual(["w1"]);
+	});
+
+	test("an unrelated worker coming up never triggers a drain", () => {
+		const { coordinator, drained } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: "boot-time-fork" });
+
+		expect(drained).toHaveLength(0);
+	});
+
+	test("serializes concurrent requests: second starts after first completes", () => {
+		const { coordinator, forked, drained } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleRecycleRequest({ workerId: "w2" });
+
+		// Only one replacement forked so far.
+		expect(forked).toHaveLength(1);
+
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toEqual(["w1"]);
+
+		// w1's exit completes the cycle and releases w2's.
+		coordinator.handleWorkerExit({ workerId: "w1" });
+		expect(forked).toHaveLength(2);
+
+		coordinator.handleWorkerListening({ workerId: forked[1] });
+		expect(drained).toEqual(["w1", "w2"]);
+	});
+
+	test("duplicate requests from the same worker are idempotent", () => {
+		const { coordinator, forked } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+
+		expect(forked).toHaveLength(1);
+	});
+
+	test("expected exit of a draining worker is not respawned", () => {
+		const { coordinator, forked, respawned } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		coordinator.handleWorkerExit({ workerId: "w1" });
+
+		expect(respawned).toHaveLength(0);
+	});
+
+	test("a crash (unexpected exit) is respawned as before", () => {
+		const { coordinator, respawned } = createHarness();
+
+		coordinator.handleWorkerExit({ workerId: "w-crashed" });
+
+		expect(respawned).toEqual(["w-crashed"]);
+	});
+
+	test("a crash of the worker awaiting drain releases the lock", () => {
+		const { coordinator, forked, drained, respawned } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleRecycleRequest({ workerId: "w2" });
+		// w1 dies before its replacement reports listening.
+		coordinator.handleWorkerExit({ workerId: "w1" });
+
+		// w1 died on its own, so the standard crash respawn applies…
+		expect(respawned).toEqual(["w1"]);
+		// …and w2's cycle proceeds with a second replacement.
+		expect(forked).toHaveLength(2);
+		coordinator.handleWorkerListening({ workerId: forked[1] });
+		expect(drained).toEqual(["w2"]);
+	});
+
+	test("a crash of a replacement fork before listening aborts the cycle", () => {
+		const { coordinator, forked, drained, respawned } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+
+		// The dead replacement is respawn-eligible like any crash…
+		expect(respawned).toEqual([forked[0]]);
+		// …and w1 is never drained (it keeps serving).
+		expect(drained).toHaveLength(0);
+	});
+});
+
+describe("createWorkerDrainer", () => {
+	type FakeServer = {
+		close: (callback: () => void) => void;
+		closeIdleConnections?: () => void;
+	};
+
+	const exits: number[] = [];
+	afterEach(() => {
+		exits.length = 0;
+	});
+
+	test("closes the server, then exits 0 when all connections finish", async () => {
+		const closeCallbacks: (() => void)[] = [];
+		let idleSweeps = 0;
+		const server: FakeServer = {
+			close: (callback) => {
+				closeCallbacks.push(callback);
+			},
+			closeIdleConnections: () => {
+				idleSweeps++;
+			},
+		};
+
+		const drainer = createWorkerDrainer({
+			server,
+			exit: (code) => {
+				exits.push(code);
+			},
+			drainTimeoutMs: 5_000,
+			idleSweepIntervalMs: 10,
+			log: () => {},
+		});
+
+		drainer.drain();
+		expect(idleSweeps).toBeGreaterThanOrEqual(1);
+		expect(exits).toHaveLength(0);
+
+		closeCallbacks[0]?.();
+		expect(exits).toEqual([0]);
+	});
+
+	test("exits 0 at the drain timeout even if connections never finish", async () => {
+		const server: FakeServer = {
+			close: () => {},
+		};
+
+		const drainer = createWorkerDrainer({
+			server,
+			exit: (code) => {
+				exits.push(code);
+			},
+			drainTimeoutMs: 30,
+			idleSweepIntervalMs: 10,
+			log: () => {},
+		});
+
+		drainer.drain();
+		expect(exits).toHaveLength(0);
+
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(exits).toEqual([0]);
+	});
+
+	test("drain is idempotent — a second call neither double-closes nor double-exits", async () => {
+		const closeCallbacks: (() => void)[] = [];
+		const server: FakeServer = {
+			close: (callback) => {
+				closeCallbacks.push(callback);
+			},
+		};
+
+		const drainer = createWorkerDrainer({
+			server,
+			exit: (code) => {
+				exits.push(code);
+			},
+			drainTimeoutMs: 5_000,
+			idleSweepIntervalMs: 10,
+			log: () => {},
+		});
+
+		drainer.drain();
+		drainer.drain();
+		closeCallbacks[0]?.();
+
+		expect(closeCallbacks).toHaveLength(1);
+		expect(exits).toEqual([0]);
+	});
+});

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -34,15 +34,21 @@ type CoordinatorHarness = {
 	forked: string[];
 	drained: string[];
 	aborted: string[];
+	killed: string[];
 	respawned: string[];
 };
 
 /** Coordinator with capture-everything callbacks; tests drive the lifecycle
  *  through the handle* methods directly. */
-const createHarness = (): CoordinatorHarness => {
+const createHarness = ({
+	bootTimeoutMs = 5_000,
+}: {
+	bootTimeoutMs?: number;
+} = {}): CoordinatorHarness => {
 	const forked: string[] = [];
 	const drained: string[] = [];
 	const aborted: string[] = [];
+	const killed: string[] = [];
 	const respawned: string[] = [];
 	let nextForkId = 100;
 
@@ -58,13 +64,17 @@ const createHarness = (): CoordinatorHarness => {
 		sendAbort: (workerId) => {
 			aborted.push(workerId);
 		},
+		killWorker: (workerId) => {
+			killed.push(workerId);
+		},
 		respawn: (workerId) => {
 			respawned.push(workerId);
 		},
+		replacementBootTimeoutMs: bootTimeoutMs,
 		log: () => {},
 	});
 
-	return { coordinator, forked, drained, aborted, respawned };
+	return { coordinator, forked, drained, aborted, killed, respawned };
 };
 
 describe("createRecycleCoordinator", () => {
@@ -204,6 +214,61 @@ describe("createRecycleCoordinator", () => {
 		coordinator.handleWorkerExit({ workerId: forked[0] });
 
 		expect(respawned).toEqual([forked[0]]);
+	});
+
+	test("post-drain replacement crash with a queued request keeps the drained exit expected", () => {
+		const { coordinator, forked, drained, respawned } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleRecycleRequest({ workerId: "w2" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toEqual(["w1"]);
+
+		// Replacement dies after listening; w2's queued cycle starts AND the
+		// dead replacement's slot respawns — but w1's exit must stay expected.
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+		expect(respawned).toEqual([forked[0]]);
+		expect(forked).toHaveLength(2);
+
+		expect(coordinator.handleWorkerExit({ workerId: "w1" })).toBe(true);
+		// Accounting: 2 forked + 1 respawned − (w1 out, w2 out after its own
+		// cycle) keeps the fleet at N.
+		coordinator.handleWorkerListening({ workerId: forked[1] });
+		expect(drained).toEqual(["w1", "w2"]);
+	});
+
+	test("a replacement that never listens is killed at the boot deadline and the cycle aborts", async () => {
+		const { coordinator, forked, aborted, killed, respawned } = createHarness({
+			bootTimeoutMs: 25,
+		});
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		await new Promise((resolve) => setTimeout(resolve, 60));
+
+		expect(killed).toEqual([forked[0]]);
+		expect(aborted).toEqual(["w1"]);
+		expect(respawned).toHaveLength(0);
+
+		// The killed replacement's exit needs no further respawn…
+		expect(coordinator.handleWorkerExit({ workerId: forked[0] })).toBe(true);
+		expect(respawned).toHaveLength(0);
+		// …and the worker can request again.
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		expect(forked).toHaveLength(2);
+	});
+
+	test("boot deadline after the old worker crashed refills the slot instead of aborting", async () => {
+		const { coordinator, forked, aborted, killed, respawned } = createHarness({
+			bootTimeoutMs: 25,
+		});
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerExit({ workerId: "w1" });
+		await new Promise((resolve) => setTimeout(resolve, 60));
+
+		expect(killed).toEqual([forked[0]]);
+		expect(respawned).toEqual([forked[0]]);
+		expect(aborted).toHaveLength(0);
 	});
 });
 

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -202,8 +202,12 @@ describe("createWorkerDrainer", () => {
 		});
 
 		drainer.drain();
-		expect(idleSweeps).toBeGreaterThanOrEqual(1);
 		expect(exits).toHaveLength(0);
+
+		// Sweeps start one interval in, never at t=0 (header-retirement beat).
+		expect(idleSweeps).toBe(0);
+		await new Promise((resolve) => setTimeout(resolve, 25));
+		expect(idleSweeps).toBeGreaterThanOrEqual(1);
 
 		closeCallbacks[0]?.();
 		expect(exits).toEqual([0]);
@@ -229,6 +233,29 @@ describe("createWorkerDrainer", () => {
 
 		await new Promise((resolve) => setTimeout(resolve, 60));
 		expect(exits).toEqual([0]);
+	});
+
+	test("onDrainStart fires before the server begins closing", () => {
+		const order: string[] = [];
+		const server: FakeServer = {
+			close: () => {
+				order.push("close");
+			},
+		};
+
+		const drainer = createWorkerDrainer({
+			server,
+			exit: () => {},
+			drainTimeoutMs: 5_000,
+			idleSweepIntervalMs: 10,
+			onDrainStart: () => {
+				order.push("drainStart");
+			},
+			log: () => {},
+		});
+
+		drainer.drain();
+		expect(order).toEqual(["drainStart", "close"]);
 	});
 
 	test("drain is idempotent — a second call neither double-closes nor double-exits", async () => {

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -69,6 +69,7 @@ const createHarness = ({
 		},
 		respawn: (workerId) => {
 			respawned.push(workerId);
+			return `respawn-of-${workerId}`;
 		},
 		replacementBootTimeoutMs: bootTimeoutMs,
 		log: () => {},
@@ -231,9 +232,12 @@ describe("createRecycleCoordinator", () => {
 		expect(forked).toHaveLength(2);
 
 		expect(coordinator.handleWorkerExit({ workerId: "w1" })).toBe(true);
-		// Accounting: 2 forked + 1 respawned − (w1 out, w2 out after its own
-		// cycle) keeps the fleet at N.
+		// Accounting: w2's drain waits for the crash respawn to boot, then the
+		// fleet returns to N (2 forked + 1 respawned − w1 − w2).
 		coordinator.handleWorkerListening({ workerId: forked[1] });
+		coordinator.handleWorkerListening({
+			workerId: `respawn-of-${forked[0]}`,
+		});
 		expect(drained).toEqual(["w1", "w2"]);
 	});
 
@@ -255,6 +259,42 @@ describe("createRecycleCoordinator", () => {
 		// …and the worker can request again.
 		coordinator.handleRecycleRequest({ workerId: "w1" });
 		expect(forked).toHaveLength(2);
+	});
+
+	test("a drain is deferred while a crash respawn is still booting", () => {
+		const { coordinator, forked, drained } = createHarness();
+
+		// Plain crash: its respawn starts booting.
+		coordinator.handleWorkerExit({ workerId: "w-crashed" });
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		// Replacement is up, but draining now would dip below N.
+		expect(drained).toHaveLength(0);
+
+		coordinator.handleWorkerListening({ workerId: "respawn-of-w-crashed" });
+		expect(drained).toEqual(["w1"]);
+	});
+
+	test("queued cycle after a post-drain replacement crash waits for the crash respawn", () => {
+		const { coordinator, forked, drained } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleRecycleRequest({ workerId: "w2" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toEqual(["w1"]);
+
+		// Replacement crashes post-drain: w2's cycle forks, but its drain must
+		// wait until the crash respawn is listening.
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+		expect(forked).toHaveLength(2);
+		coordinator.handleWorkerListening({ workerId: forked[1] });
+		expect(drained).toEqual(["w1"]);
+
+		coordinator.handleWorkerListening({
+			workerId: `respawn-of-${forked[0]}`,
+		});
+		expect(drained).toEqual(["w1", "w2"]);
 	});
 
 	test("boot deadline after the old worker crashed refills the slot instead of aborting", async () => {
@@ -336,6 +376,52 @@ describe("createWorkerDrainer", () => {
 		expect(exits).toHaveLength(0);
 
 		await new Promise((resolve) => setTimeout(resolve, 60));
+		expect(exits).toEqual([0]);
+	});
+
+	test("active requests extend the drain deadline instead of being cut", async () => {
+		let activeCount = 1;
+		const server: FakeServer = { close: () => {} };
+
+		const drainer = createWorkerDrainer({
+			server,
+			exit: (code) => {
+				exits.push(code);
+			},
+			drainTimeoutMs: 20,
+			maxDrainMs: 5_000,
+			idleSweepIntervalMs: 10,
+			getActiveRequestCount: () => activeCount,
+			log: () => {},
+		});
+
+		drainer.drain();
+		await new Promise((resolve) => setTimeout(resolve, 35));
+		// A long-running request held the fork alive past the deadline.
+		expect(exits).toHaveLength(0);
+
+		activeCount = 0;
+		await new Promise((resolve) => setTimeout(resolve, 35));
+		expect(exits).toEqual([0]);
+	});
+
+	test("the hard max-drain bound exits even with requests still active", async () => {
+		const server: FakeServer = { close: () => {} };
+
+		const drainer = createWorkerDrainer({
+			server,
+			exit: (code) => {
+				exits.push(code);
+			},
+			drainTimeoutMs: 20,
+			maxDrainMs: 50,
+			idleSweepIntervalMs: 10,
+			getActiveRequestCount: () => 1,
+			log: () => {},
+		});
+
+		drainer.drain();
+		await new Promise((resolve) => setTimeout(resolve, 110));
 		expect(exits).toEqual([0]);
 	});
 

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -1,9 +1,12 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
 	createRecycleCoordinator,
 	type RecycleCoordinator,
 } from "@/utils/memory/forkRecycling/recycleCoordinator.js";
-import { shouldRequestRecycle } from "@/utils/memory/forkRecycling/recyclePolicy.js";
+import {
+	getForkRecycleConfig,
+	shouldRequestRecycle,
+} from "@/utils/memory/forkRecycling/recyclePolicy.js";
 import { createWorkerDrainer } from "@/utils/memory/forkRecycling/workerDrainer.js";
 
 const MB = 1024 * 1024;
@@ -26,6 +29,64 @@ describe("shouldRequestRecycle", () => {
 
 	test("never recycles a young fork regardless of rss", () => {
 		expect(shouldRequestRecycle({ ...base, ageMs: 5 * 60_000 })).toBe(false);
+	});
+});
+
+describe("getForkRecycleConfig", () => {
+	const ENV_KEYS = [
+		"FORK_RECYCLE_RSS_MB",
+		"FORK_RECYCLE_MIN_AGE_MS",
+		"FORK_RECYCLE_CHECK_INTERVAL_MS",
+		"FORK_RECYCLE_DRAIN_TIMEOUT_MS",
+		"FORK_RECYCLE_DISABLED",
+	] as const;
+	const saved = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		for (const key of ENV_KEYS) {
+			saved.set(key, process.env[key]);
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			const value = saved.get(key);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	test("defaults apply when nothing is set", () => {
+		const config = getForkRecycleConfig();
+		expect(config.enabled).toBe(true);
+		expect(config.rssThresholdBytes).toBe(3072 * MB);
+		expect(config.minAgeMs).toBe(30 * 60_000);
+	});
+
+	test("valid overrides are honored", () => {
+		process.env.FORK_RECYCLE_RSS_MB = "1536";
+		process.env.FORK_RECYCLE_CHECK_INTERVAL_MS = "5000";
+		const config = getForkRecycleConfig();
+		expect(config.rssThresholdBytes).toBe(1536 * MB);
+		expect(config.checkIntervalMs).toBe(5000);
+	});
+
+	test("zero, negative, and garbage values fall back to defaults", () => {
+		process.env.FORK_RECYCLE_CHECK_INTERVAL_MS = "0";
+		process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS = "-5";
+		process.env.FORK_RECYCLE_RSS_MB = "not-a-number";
+		const config = getForkRecycleConfig();
+		expect(config.checkIntervalMs).toBe(30_000);
+		expect(config.drainTimeoutMs).toBe(30_000);
+		expect(config.rssThresholdBytes).toBe(3072 * MB);
+	});
+
+	test("FORK_RECYCLE_DISABLED=true turns recycling off", () => {
+		process.env.FORK_RECYCLE_DISABLED = "true";
+		expect(getForkRecycleConfig().enabled).toBe(false);
+		process.env.FORK_RECYCLE_DISABLED = "false";
+		expect(getForkRecycleConfig().enabled).toBe(true);
 	});
 });
 
@@ -276,6 +337,49 @@ describe("createRecycleCoordinator", () => {
 		expect(drained).toEqual(["w1"]);
 	});
 
+	test("a hung crash respawn is killed at its boot deadline and drains release", async () => {
+		const { coordinator, forked, drained, killed, respawned } = createHarness({
+			bootTimeoutMs: 25,
+		});
+
+		// Plain crash: respawn boots... and hangs (never listens).
+		coordinator.handleWorkerExit({ workerId: "w-crashed" });
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toHaveLength(0);
+
+		// One deadline generation only — the recursion re-arms per respawn.
+		await new Promise((resolve) => setTimeout(resolve, 38));
+
+		// The hung respawn was killed and replaced; second respawn listening
+		// releases the deferred drain.
+		expect(killed).toEqual(["respawn-of-w-crashed"]);
+		expect(respawned).toEqual(["w-crashed", "respawn-of-w-crashed"]);
+		coordinator.handleWorkerListening({
+			workerId: "respawn-of-respawn-of-w-crashed",
+		});
+		expect(drained).toEqual(["w1"]);
+	});
+
+	test("replacement crashing while the drain is deferred aborts without a respawn (capacity intact)", () => {
+		const { coordinator, forked, drained, aborted, respawned } =
+			createHarness();
+
+		coordinator.handleWorkerExit({ workerId: "w-crashed" });
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		// Deferred; now the listening replacement itself dies.
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+
+		// Old worker never got its drain and still serves: no respawn owed
+		// beyond the original crash's, and w1 is re-armed to ask again.
+		expect(respawned).toEqual(["w-crashed"]);
+		expect(aborted).toEqual(["w1"]);
+		expect(drained).toHaveLength(0);
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		expect(forked).toHaveLength(2);
+	});
+
 	test("old worker crashing while its drain is deferred completes the cycle instead of wedging", () => {
 		const { coordinator, forked, drained } = createHarness();
 
@@ -326,7 +430,8 @@ describe("createRecycleCoordinator", () => {
 
 		coordinator.handleRecycleRequest({ workerId: "w1" });
 		coordinator.handleWorkerExit({ workerId: "w1" });
-		await new Promise((resolve) => setTimeout(resolve, 60));
+		// One deadline generation: the refill's own deadline re-arms later.
+		await new Promise((resolve) => setTimeout(resolve, 38));
 
 		expect(killed).toEqual([forked[0]]);
 		expect(respawned).toEqual([forked[0]]);

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -33,17 +33,17 @@ type CoordinatorHarness = {
 	coordinator: RecycleCoordinator;
 	forked: string[];
 	drained: string[];
+	aborted: string[];
 	respawned: string[];
-	listening: Map<string, () => void>;
 };
 
-/** Coordinator with capture-everything callbacks. Replacement forks report
- *  listening only when the test releases them via `listening`. */
+/** Coordinator with capture-everything callbacks; tests drive the lifecycle
+ *  through the handle* methods directly. */
 const createHarness = (): CoordinatorHarness => {
 	const forked: string[] = [];
 	const drained: string[] = [];
+	const aborted: string[] = [];
 	const respawned: string[] = [];
-	const listening = new Map<string, () => void>();
 	let nextForkId = 100;
 
 	const coordinator = createRecycleCoordinator({
@@ -55,13 +55,16 @@ const createHarness = (): CoordinatorHarness => {
 		sendDrain: (workerId) => {
 			drained.push(workerId);
 		},
+		sendAbort: (workerId) => {
+			aborted.push(workerId);
+		},
 		respawn: (workerId) => {
 			respawned.push(workerId);
 		},
 		log: () => {},
 	});
 
-	return { coordinator, forked, drained, respawned, listening };
+	return { coordinator, forked, drained, aborted, respawned };
 };
 
 describe("createRecycleCoordinator", () => {
@@ -139,7 +142,7 @@ describe("createRecycleCoordinator", () => {
 		expect(respawned).toEqual(["w-crashed"]);
 	});
 
-	test("a crash of the worker awaiting drain releases the lock", () => {
+	test("old worker crashing pre-drain is NOT respawned — its replacement adopts the slot", () => {
 		const { coordinator, forked, drained, respawned } = createHarness();
 
 		coordinator.handleRecycleRequest({ workerId: "w1" });
@@ -147,24 +150,60 @@ describe("createRecycleCoordinator", () => {
 		// w1 dies before its replacement reports listening.
 		coordinator.handleWorkerExit({ workerId: "w1" });
 
-		// w1 died on its own, so the standard crash respawn applies…
-		expect(respawned).toEqual(["w1"]);
-		// …and w2's cycle proceeds with a second replacement.
+		// No extra fork: the already-booting replacement is w1's respawn.
+		expect(respawned).toHaveLength(0);
+		expect(forked).toHaveLength(1);
+
+		// Replacement comes up, takes the slot without a drain, then w2's
+		// queued cycle starts.
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toHaveLength(0);
 		expect(forked).toHaveLength(2);
 		coordinator.handleWorkerListening({ workerId: forked[1] });
 		expect(drained).toEqual(["w2"]);
 	});
 
-	test("a crash of a replacement fork before listening aborts the cycle", () => {
-		const { coordinator, forked, drained, respawned } = createHarness();
+	test("replacement dying while booting aborts without a surplus fork and lets the worker re-request", () => {
+		const { coordinator, forked, drained, aborted, respawned } =
+			createHarness();
 
 		coordinator.handleRecycleRequest({ workerId: "w1" });
 		coordinator.handleWorkerExit({ workerId: forked[0] });
 
-		// The dead replacement is respawn-eligible like any crash…
-		expect(respawned).toEqual([forked[0]]);
-		// …and w1 is never drained (it keeps serving).
+		// Old fork still serves: nothing to respawn, worker told to re-arm.
+		expect(respawned).toHaveLength(0);
+		expect(aborted).toEqual(["w1"]);
 		expect(drained).toHaveLength(0);
+
+		// The re-request starts a fresh cycle.
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		expect(forked).toHaveLength(2);
+	});
+
+	test("replacement dying after drain was sent is respawned and the old exit stays expected", () => {
+		const { coordinator, forked, drained, respawned } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toEqual(["w1"]);
+
+		// Replacement crashes while w1 is already draining.
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+		expect(respawned).toEqual([forked[0]]);
+
+		// w1's exit is still a recycle completion, not a crash.
+		expect(coordinator.handleWorkerExit({ workerId: "w1" })).toBe(true);
+	});
+
+	test("adopted replacement dying while booting refills the crashed slot", () => {
+		const { coordinator, forked, respawned } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerExit({ workerId: "w1" });
+		// Both the old worker and its adopted replacement are gone: refill.
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+
+		expect(respawned).toEqual([forked[0]]);
 	});
 });
 

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -276,6 +276,28 @@ describe("createRecycleCoordinator", () => {
 		expect(drained).toEqual(["w1"]);
 	});
 
+	test("old worker crashing while its drain is deferred completes the cycle instead of wedging", () => {
+		const { coordinator, forked, drained } = createHarness();
+
+		// Crash respawn booting defers the upcoming drain.
+		coordinator.handleWorkerExit({ workerId: "w-crashed" });
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleRecycleRequest({ workerId: "w2" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toHaveLength(0);
+
+		// Old worker dies while deferred: cycle must complete, not wait forever.
+		coordinator.handleWorkerExit({ workerId: "w1" });
+		// w2's queued cycle starts…
+		expect(forked).toHaveLength(2);
+
+		// …and when the crash respawn finally listens, no drain goes to the
+		// dead w1 — only w2's normal drain proceeds.
+		coordinator.handleWorkerListening({ workerId: "respawn-of-w-crashed" });
+		coordinator.handleWorkerListening({ workerId: forked[1] });
+		expect(drained).toEqual(["w2"]);
+	});
+
 	test("queued cycle after a post-drain replacement crash waits for the crash respawn", () => {
 		const { coordinator, forked, drained } = createHarness();
 

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -304,11 +304,11 @@ describe("createRecycleCoordinator", () => {
 
 	test("a replacement that never listens is killed at the boot deadline and the cycle aborts", async () => {
 		const { coordinator, forked, aborted, killed, respawned } = createHarness({
-			bootTimeoutMs: 25,
+			bootTimeoutMs: 100,
 		});
 
 		coordinator.handleRecycleRequest({ workerId: "w1" });
-		await new Promise((resolve) => setTimeout(resolve, 60));
+		await new Promise((resolve) => setTimeout(resolve, 150));
 
 		expect(killed).toEqual([forked[0]]);
 		expect(aborted).toEqual(["w1"]);
@@ -339,7 +339,7 @@ describe("createRecycleCoordinator", () => {
 
 	test("a hung crash respawn is killed at its boot deadline and drains release", async () => {
 		const { coordinator, forked, drained, killed, respawned } = createHarness({
-			bootTimeoutMs: 25,
+			bootTimeoutMs: 100,
 		});
 
 		// Plain crash: respawn boots... and hangs (never listens).
@@ -348,8 +348,9 @@ describe("createRecycleCoordinator", () => {
 		coordinator.handleWorkerListening({ workerId: forked[0] });
 		expect(drained).toHaveLength(0);
 
-		// One deadline generation only — the recursion re-arms per respawn.
-		await new Promise((resolve) => setTimeout(resolve, 38));
+		// One deadline generation only (fires at 100ms; the next at 200ms) —
+		// 50ms of margin on both sides against CI timer jitter.
+		await new Promise((resolve) => setTimeout(resolve, 150));
 
 		// The hung respawn was killed and replaced; second respawn listening
 		// releases the deferred drain.
@@ -425,13 +426,13 @@ describe("createRecycleCoordinator", () => {
 
 	test("boot deadline after the old worker crashed refills the slot instead of aborting", async () => {
 		const { coordinator, forked, aborted, killed, respawned } = createHarness({
-			bootTimeoutMs: 25,
+			bootTimeoutMs: 100,
 		});
 
 		coordinator.handleRecycleRequest({ workerId: "w1" });
 		coordinator.handleWorkerExit({ workerId: "w1" });
-		// One deadline generation: the refill's own deadline re-arms later.
-		await new Promise((resolve) => setTimeout(resolve, 38));
+		// One deadline generation (fires at 100ms, refill's at 200ms).
+		await new Promise((resolve) => setTimeout(resolve, 150));
 
 		expect(killed).toEqual([forked[0]]);
 		expect(respawned).toEqual([forked[0]]);

--- a/server/tests/unit/memory/forkRecyclingCluster.test.ts
+++ b/server/tests/unit/memory/forkRecyclingCluster.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import path from "node:path";
+
+const FIXTURE = path.join(import.meta.dir, "fixtures/recycleClusterFixture.ts");
+const PORT = 39000 + Math.floor(Math.random() * 1000);
+
+let fixture: ReturnType<typeof Bun.spawn> | null = null;
+
+afterAll(() => {
+	fixture?.kill();
+});
+
+describe("fork recycling in a real bun cluster", () => {
+	test(
+		"serves every request across repeated recycles and rotates pids",
+		async () => {
+			const stdoutLines: string[] = [];
+			fixture = Bun.spawn({
+				cmd: [process.execPath, FIXTURE],
+				env: {
+					...process.env,
+					FIXTURE_PORT: String(PORT),
+					// Any RSS qualifies; forks recycle as soon as they're old enough.
+					FORK_RECYCLE_RSS_MB: "1",
+					FORK_RECYCLE_MIN_AGE_MS: "500",
+					FORK_RECYCLE_CHECK_INTERVAL_MS: "150",
+					FORK_RECYCLE_DRAIN_TIMEOUT_MS: "5000",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+
+			// stdout is a stream because the spawn above pipes it.
+			const stdout = fixture.stdout as ReadableStream<Uint8Array>;
+			const reader = stdout.getReader();
+			const decoder = new TextDecoder();
+			let buffered = "";
+			const pump = (async () => {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					buffered += decoder.decode(value);
+					const lines = buffered.split("\n");
+					buffered = lines.pop() ?? "";
+					stdoutLines.push(...lines);
+				}
+			})();
+
+			const waitFor = async (predicate: () => boolean, timeoutMs: number) => {
+				const deadline = Date.now() + timeoutMs;
+				while (!predicate()) {
+					if (Date.now() > deadline) return false;
+					await new Promise((resolve) => setTimeout(resolve, 50));
+				}
+				return true;
+			};
+
+			const workerUpCount = () =>
+				stdoutLines.filter((line) => line.startsWith("WORKER_UP")).length;
+
+			expect(await waitFor(() => workerUpCount() >= 2, 15_000)).toBe(true);
+
+			// Drive sequential traffic through several recycle generations.
+			const servedByPid = new Set<string>();
+			let failures = 0;
+			const trafficDeadline = Date.now() + 8_000;
+			while (Date.now() < trafficDeadline) {
+				try {
+					const response = await fetch(`http://127.0.0.1:${PORT}/`);
+					const body = await response.text();
+					if (!response.ok || !body.startsWith("ok:")) {
+						failures++;
+					} else {
+						servedByPid.add(body.slice(3));
+					}
+				} catch {
+					failures++;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 25));
+			}
+
+			expect(failures).toBe(0);
+			// Two boot forks plus at least two recycled replacements served traffic.
+			expect(servedByPid.size).toBeGreaterThanOrEqual(4);
+			// Every exit was a coordinated recycle, never a crash respawn.
+			expect(
+				stdoutLines.filter((line) => line.startsWith("WORKER_DIED")),
+			).toHaveLength(0);
+			expect(
+				stdoutLines.some((line) => line.includes("requesting recycle")),
+			).toBe(true);
+
+			fixture.kill();
+			await pump.catch(() => {});
+		},
+		{ timeout: 40_000 },
+	);
+});

--- a/server/tests/unit/memory/forkRecyclingCluster.test.ts
+++ b/server/tests/unit/memory/forkRecyclingCluster.test.ts
@@ -25,6 +25,7 @@ describe("fork recycling in a real bun cluster", () => {
 					FORK_RECYCLE_MIN_AGE_MS: "500",
 					FORK_RECYCLE_CHECK_INTERVAL_MS: "150",
 					FORK_RECYCLE_DRAIN_TIMEOUT_MS: "5000",
+					FORK_RECYCLE_DISABLED: "false",
 				},
 				stdout: "pipe",
 				stderr: "pipe",
@@ -46,52 +47,54 @@ describe("fork recycling in a real bun cluster", () => {
 				}
 			})();
 
-			const waitFor = async (predicate: () => boolean, timeoutMs: number) => {
-				const deadline = Date.now() + timeoutMs;
-				while (!predicate()) {
-					if (Date.now() > deadline) return false;
-					await new Promise((resolve) => setTimeout(resolve, 50));
-				}
-				return true;
-			};
-
-			const workerUpCount = () =>
-				stdoutLines.filter((line) => line.startsWith("WORKER_UP")).length;
-
-			expect(await waitFor(() => workerUpCount() >= 2, 15_000)).toBe(true);
-
-			// Drive sequential traffic through several recycle generations.
-			const servedByPid = new Set<string>();
-			let failures = 0;
-			const trafficDeadline = Date.now() + 8_000;
-			while (Date.now() < trafficDeadline) {
-				try {
-					const response = await fetch(`http://127.0.0.1:${PORT}/`);
-					const body = await response.text();
-					if (!response.ok || !body.startsWith("ok:")) {
-						failures++;
-					} else {
-						servedByPid.add(body.slice(3));
+			try {
+				const waitFor = async (predicate: () => boolean, timeoutMs: number) => {
+					const deadline = Date.now() + timeoutMs;
+					while (!predicate()) {
+						if (Date.now() > deadline) return false;
+						await new Promise((resolve) => setTimeout(resolve, 50));
 					}
-				} catch {
-					failures++;
+					return true;
+				};
+
+				const workerUpCount = () =>
+					stdoutLines.filter((line) => line.startsWith("WORKER_UP")).length;
+
+				expect(await waitFor(() => workerUpCount() >= 2, 15_000)).toBe(true);
+
+				// Drive sequential traffic through several recycle generations.
+				const servedByPid = new Set<string>();
+				let failures = 0;
+				const trafficDeadline = Date.now() + 8_000;
+				while (Date.now() < trafficDeadline) {
+					try {
+						const response = await fetch(`http://127.0.0.1:${PORT}/`);
+						const body = await response.text();
+						if (!response.ok || !body.startsWith("ok:")) {
+							failures++;
+						} else {
+							servedByPid.add(body.slice(3));
+						}
+					} catch {
+						failures++;
+					}
+					await new Promise((resolve) => setTimeout(resolve, 25));
 				}
-				await new Promise((resolve) => setTimeout(resolve, 25));
+
+				expect(failures).toBe(0);
+				// Two boot forks plus at least two recycled replacements served.
+				expect(servedByPid.size).toBeGreaterThanOrEqual(4);
+				// Every exit was a coordinated recycle, never a crash respawn.
+				expect(
+					stdoutLines.filter((line) => line.startsWith("WORKER_DIED")),
+				).toHaveLength(0);
+				expect(
+					stdoutLines.some((line) => line.includes("requesting recycle")),
+				).toBe(true);
+			} finally {
+				fixture.kill();
+				await pump.catch(() => {});
 			}
-
-			expect(failures).toBe(0);
-			// Two boot forks plus at least two recycled replacements served traffic.
-			expect(servedByPid.size).toBeGreaterThanOrEqual(4);
-			// Every exit was a coordinated recycle, never a crash respawn.
-			expect(
-				stdoutLines.filter((line) => line.startsWith("WORKER_DIED")),
-			).toHaveLength(0);
-			expect(
-				stdoutLines.some((line) => line.includes("requesting recycle")),
-			).toBe(true);
-
-			fixture.kill();
-			await pump.catch(() => {});
 		},
 		{ timeout: 40_000 },
 	);


### PR DESCRIPTION
## Why

Prod server forks grow RSS for their entire life: JSC's allocator retains freed pages and never returns them to the OS. This is a [long-open Bun issue class](https://github.com/oven-sh/bun/issues/27514) with no engine-level knob — `BUN_JSC_forceRAMSize` is behaviorally inert (verified on staging), and `--smol` made prod worse (trialed and reverted today: it contains the JS heap but accelerates native-side retention under prod's allocation diversity, +CPU). Process death is the only complete reclaim, so this applies the same recycle pattern the queue workers have run for months (`MAX_MESSAGES_BEFORE_RECYCLE`) to the HTTP forks, by memory instead of message count — with a drain so no request is ever dropped.

## How

- **Worker side** (`startWorkerForkRecycling`): checks own RSS every 30s (jittered); over 3GB and at least 30min old → asks the primary to recycle it (once).
- **Primary side** (`attachPrimaryForkRecycling`): one recycle in flight at a time. Forks the replacement **first**, waits for its `listening` event, then tells the old fork to drain — task capacity never dips. Expected exits skip the `WORKER DIED` log + crash respawn; crashes behave exactly as before (including a replacement crashing mid-boot, which aborts the cycle and leaves the old fork serving).
- **Drain** (`createWorkerDrainer`): `server.close()` + periodic `closeIdleConnections()` sweeps (idle keep-alive sockets otherwise block close forever) + 30s deadline, exiting through the existing `gracefulShutdown` (OTel/SQS flush, pool close) with a 5s hard backstop.

Plain fork/exit/message IPC only — no reliance on `cluster.disconnect()` semantics.

Tunables (env): `FORK_RECYCLE_RSS_MB` (3072), `FORK_RECYCLE_MIN_AGE_MS` (30min), `FORK_RECYCLE_CHECK_INTERVAL_MS` (30s), `FORK_RECYCLE_DRAIN_TIMEOUT_MS` (30s), `FORK_RECYCLE_DISABLED`.

## Testing

- **Unit** (15): recycle policy, coordinator sequencing (replacement-first, serialization, idempotent requests, crash-during-cycle handling), drainer (close/timeout/idempotence).
- **Real-cluster integration** (spawned Bun `node:cluster` fixture using these exact modules): continuous traffic through repeated recycles — 0 failed requests, ≥4 distinct serving pids, 0 uncoordinated exits.
- **Live drill on the real app** (dw env, `NODE_ENV=production` cluster mode, 20s recycle cadence): **15/15 recycles completed** (request → replacement listening → graceful drain → coordinated exit), **1,893/1,893 requests served, 0 failures, 0 `WORKER DIED`** — at ~30x prod's expected recycle frequency.

At prod's observed growth (~1GB/h/fork under load), expect roughly one recycle per fork every few hours; each logs a `fork_recycle_request` event with rss+age for threshold tuning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recycle HTTP `node:cluster` workers when RSS crosses a threshold, replacing first and draining gracefully to avoid dropped requests. Drains extend for active requests/streams, defer until crash respawns boot, and hung boots are killed on a deadline; shutdown still logs genuine crashes.

- **New Features**
  - Worker checks RSS every ~30s; recycles once over 3GB and 30min.
  - Primary runs one recycle at a time: fork replacement, wait for listening, then drain; drains wait for crash respawns to boot; deferred cycles complete immediately if the old worker crashes; IPC sends are guarded; 120s boot deadlines kill and replace hung replacements and crash respawns; during shutdown only clean/SIGTERM exits are suppressed so real crashes still log.
  - Graceful drain: `server.close()` + `Connection: close`; first idle sweep delayed one interval; deadline extends while active requests or open sockets (streams) remain; 10m hard cap with each arm capped to the remaining budget.
  - Fork-count invariant through crashes: old crash pre-drain → replacement adopts; replacement crash after listen → respawn while old exit stays expected; replacement crash pre-listen → abort and re-arm old (no surplus).

- **Migration**
  - No action needed; enabled by default.
  - Env: `FORK_RECYCLE_RSS_MB` (3072), `FORK_RECYCLE_MIN_AGE_MS` (30m), `FORK_RECYCLE_CHECK_INTERVAL_MS` (30s), `FORK_RECYCLE_DRAIN_TIMEOUT_MS` (30s), `FORK_RECYCLE_DISABLED`; timings clamp to positive values.

<sup>Written for commit 1d18261b46792ddc409e0aa92ffbc58632402344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds memory-based recycling for HTTP cluster workers, replacing each worker before gracefully draining it to reclaim allocator-retained memory without interrupting requests.

- **Improvements:** Workers request recycling after configurable RSS and age thresholds, while the primary serializes replacements and maintains cluster capacity through crashes and hung boots.
- **Improvements:** Draining retires keep-alive connections, waits for active requests and streams, and applies bounded shutdown deadlines.
- **Bug fixes:** Crash accounting now adopts or respawns replacements without creating the surplus workers identified in the previous review.
- **Improvements:** Unit and real-cluster tests cover policy, coordinator sequencing, crash recovery, draining, and repeated recycling under traffic.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/init.ts | Integrates primary and worker recycling with HTTP socket tracking and the existing graceful-shutdown path. |
| server/src/utils/memory/forkRecycling/attachForkRecycling.ts | Connects cluster IPC events to the coordinator and starts threshold checks and draining in workers. |
| server/src/utils/memory/forkRecycling/recycleCoordinator.ts | Serializes recycle cycles and reconciles replacement, crash, timeout, queued-cycle, and expected-exit accounting. |
| server/src/utils/memory/forkRecycling/recyclePolicy.ts | Defines configurable RSS, age, check-interval, and drain-timeout policy with safe defaults. |
| server/src/utils/memory/forkRecycling/workerDrainer.ts | Gracefully closes the HTTP server, sweeps idle connections, extends active drains, and enforces a hard bound. |
| server/tests/unit/memory/forkRecycling.test.ts | Exercises policy, coordinator crash accounting, boot deadlines, queue serialization, and drain behavior. |
| server/tests/unit/memory/forkRecyclingCluster.test.ts | Verifies repeated real-cluster recycling while continuous HTTP traffic remains successful. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Worker over RSS threshold
    participant P as Primary coordinator
    participant R as Replacement worker
    participant C as Clients
    W->>P: Request recycle
    P->>R: Fork replacement
    R-->>P: Listening
    P->>W: Begin graceful drain
    W-->>C: Connection: close
    W->>W: Close idle connections and await active work
    W-->>P: Coordinated exit
    Note over P,R: Replacement retains the worker slot
```
</details>

<sub>Reviews (8): Last reviewed commit: ["fix: keep crash logs visible during shut..."](https://github.com/useautumn/autumn/commit/1d18261b46792ddc409e0aa92ffbc58632402344) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50898736)</sub>

<!-- /greptile_comment -->