### PR TITLE
fix: exclude drained standalone balances from customers.list

### DIFF
--- a/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.ts
@@ -6,6 +6,7 @@ import {
 import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { filterDrainedLooseEntitlements } from "../filterDrainedLooseEntitlements.js";
 import { isReplicaSourced } from "../subjectProvenance.js";
 import { getCachedFullSubject } from "./getCachedFullSubject.js";
 import { rehydrateWithLiveBalances } from "./rehydrateWithLiveBalances.js";
@@ -52,7 +53,7 @@ export const getOrSetCachedFullSubject = async ({
 				`[getOrSetCachedFullSubject] Subject hit for ${customerId}${entityId ? `:${entityId}` : ""}, source: ${source}`,
 			);
 			if (ctx.subjectReadTrace) ctx.subjectReadTrace.source = "cache";
-			return cached;
+			return filterDrainedLooseEntitlements({ fullSubject: cached });
 		}
 	}
 
@@ -100,8 +101,10 @@ export const getOrSetCachedFullSubject = async ({
 			ctx,
 			normalized,
 		});
-		if (withLiveBalances) return withLiveBalances;
+		// Live balance patches can drain a grant that was still live at query time.
+		if (withLiveBalances)
+			return filterDrainedLooseEntitlements({ fullSubject: withLiveBalances });
 	}
 
-	return fullSubject;
+	return filterDrainedLooseEntitlements({ fullSubject });
 };

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getOrSetCachedPartialFullSubject.ts
@@ -6,6 +6,7 @@ import {
 import type { SubjectReadFrom } from "@/db/resolveSubjectReadDb.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getFullSubjectNormalized } from "@/internal/customers/repos/getFullSubject/index.js";
+import { filterDrainedLooseEntitlements } from "../../filterDrainedLooseEntitlements.js";
 import { filterFullSubjectByFeatureIds } from "../../filterFullSubjectByFeatureIds.js";
 import { isReplicaSourced } from "../../subjectProvenance.js";
 import { rehydrateWithLiveBalances } from "../rehydrateWithLiveBalances.js";
@@ -50,7 +51,7 @@ export const getOrSetCachedPartialFullSubject = async ({
 				`[getOrSetCachedPartialFullSubject] Subject hit for ${customerId}${entityId ? `:${entityId}` : ""}, source: ${source}`,
 			);
 			if (ctx.subjectReadTrace) ctx.subjectReadTrace.source = "cache";
-			return cached;
+			return filterDrainedLooseEntitlements({ fullSubject: cached });
 		}
 	}
 
@@ -88,16 +89,21 @@ export const getOrSetCachedPartialFullSubject = async ({
 			ctx,
 			normalized,
 		});
+		// Live balance patches can drain a grant that was still live at query time.
 		if (withLiveBalances) {
-			return filterFullSubjectByFeatureIds({
-				fullSubject: withLiveBalances,
-				featureIds,
+			return filterDrainedLooseEntitlements({
+				fullSubject: filterFullSubjectByFeatureIds({
+					fullSubject: withLiveBalances,
+					featureIds,
+				}),
 			});
 		}
 	}
 
-	return filterFullSubjectByFeatureIds({
-		fullSubject,
-		featureIds,
+	return filterDrainedLooseEntitlements({
+		fullSubject: filterFullSubjectByFeatureIds({
+			fullSubject,
+			featureIds,
+		}),
 	});
 };

--- a/server/src/internal/customers/cache/fullSubject/filterDrainedLooseEntitlements.ts
+++ b/server/src/internal/customers/cache/fullSubject/filterDrainedLooseEntitlements.ts
@@ -1,0 +1,34 @@
+import {
+	type FullCustomerEntitlement,
+	type FullSubject,
+	isBooleanCusEnt,
+	isUnlimitedCusEnt,
+	notNullish,
+} from "@autumn/shared";
+
+/**
+ * Mirrors the `looseEntitlementIsLiveSql` predicate the hydration queries apply.
+ * A cached subject can still hold a loose grant that a deduction has since
+ * patched to zero, so the same rule has to run on the way out of the cache —
+ * otherwise customers.get reports a drained grant that customers.list filtered.
+ */
+const isLiveLooseEntitlement = (cusEnt: FullCustomerEntitlement): boolean =>
+	(notNullish(cusEnt.balance) && cusEnt.balance !== 0) ||
+	cusEnt.unlimited === true ||
+	isUnlimitedCusEnt(cusEnt) ||
+	isBooleanCusEnt({ cusEnt });
+
+export const filterDrainedLooseEntitlements = ({
+	fullSubject,
+}: {
+	fullSubject: FullSubject;
+}): FullSubject => {
+	const live = fullSubject.extra_customer_entitlements.filter(
+		isLiveLooseEntitlement,
+	);
+	if (live.length === fullSubject.extra_customer_entitlements.length) {
+		return fullSubject;
+	}
+
+	return { ...fullSubject, extra_customer_entitlements: live };
+};

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -22,6 +22,7 @@ import {
 	getCustomerListFilterSql,
 	POOLED_CUSTOMER_ENTITLEMENT_LIMIT,
 } from "./getFullCusQuery.js";
+import { looseEntitlementIsLiveSql } from "./looseEntitlementSql.js";
 
 export type CursorPaginatedFullCusQueryArgs = {
 	orgId: string;
@@ -250,6 +251,7 @@ export const getCursorPaginatedFullCusQuery = ({
 					AND ce.pooled_balance_id IS NULL
 					AND ce.pooled_contribution_id IS NULL
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+					AND ${looseEntitlementIsLiveSql()}
 				ORDER BY ce.id DESC
 				LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
 			) ce ON true

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -7,6 +7,7 @@ import {
 } from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
+import { looseEntitlementIsLiveSql } from "./looseEntitlementSql.js";
 
 const RECURRING_BILLING_INTERVALS = [
 	BillingInterval.Week,
@@ -406,6 +407,7 @@ const buildExtraEntitlementsCTE = () => {
 		  AND ce.pooled_balance_id IS NULL
 		  AND ce.pooled_contribution_id IS NULL
           AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+          AND ${looseEntitlementIsLiveSql()}
         ORDER BY ce.id DESC
 		LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
       ) ce
@@ -764,6 +766,7 @@ export const getPaginatedFullCusQuery = ({
 		AND ce.pooled_balance_id IS NULL
 		AND ce.pooled_contribution_id IS NULL
         AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
+        AND ${looseEntitlementIsLiveSql()}
       ORDER BY ce.id DESC
 	  LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}
     ) ce ON true

--- a/server/src/internal/customers/looseEntitlementSql.ts
+++ b/server/src/internal/customers/looseEntitlementSql.ts
@@ -1,0 +1,28 @@
+import { sql } from "drizzle-orm";
+
+/**
+ * Keeps loose (plan-less) customer entitlements that still mean something:
+ * a spendable balance, unlimited, or a boolean flag. Drained one-off grants
+ * are dropped so they stop inflating reported granted/usage.
+ *
+ * Every query that hydrates loose entitlements must apply this — customers.get
+ * and customers.list disagreed for exactly as long as one of them didn't.
+ */
+export const looseEntitlementIsLiveSql = ({
+	alias = "ce",
+}: {
+	alias?: string;
+} = {}) => {
+	const ce = sql.raw(alias);
+	return sql`(
+		${ce}.balance != 0
+		OR ${ce}.unlimited IS TRUE
+		OR EXISTS (
+			SELECT 1
+			FROM entitlements e
+			JOIN features f ON f.internal_id = e.internal_feature_id
+			WHERE e.id = ${ce}.entitlement_id
+				AND f.type = 'boolean'
+		)
+	)`;
+};

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -6,6 +6,7 @@ import {
 import { type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import { notLicenseAssignmentSql } from "@/internal/licenses/repos/licenseAssignmentRepo.js";
+import { looseEntitlementIsLiveSql } from "../../looseEntitlementSql.js";
 import { composeCustomerLicensesCtes } from "./composeCustomerLicensesCtes.js";
 import { getEntityAggregateFragments } from "./getEntityAggregateFragments.js";
 
@@ -70,9 +71,7 @@ const subjectAggregateJoins = sql.join(
 
 const catalogKeyValues = sql.join(
 	CATALOG_AGGREGATES.map(({ cte, column }) =>
-		sql.raw(
-			`'${column}', COALESCE((SELECT items FROM ${cte}), '[]'::json)`,
-		),
+		sql.raw(`'${column}', COALESCE((SELECT items FROM ${cte}), '[]'::json)`),
 	),
 	sql`,
 			`,
@@ -300,17 +299,7 @@ export const getFullSubjectRowsQuery = ({
 					AND ce.pooled_balance_id IS NULL
 					AND ce.pooled_contribution_id IS NULL
 					AND (ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
-					AND (
-						ce.balance != 0
-						OR ce.unlimited IS TRUE
-						OR EXISTS (
-							SELECT 1
-							FROM entitlements e
-							JOIN features f ON f.internal_id = e.internal_feature_id
-							WHERE e.id = ce.entitlement_id
-								AND f.type = 'boolean'
-						)
-					)
+					AND ${looseEntitlementIsLiveSql()}
 					${customerEntitlementSubjectPredicate}
 				ORDER BY subject_entity_priority ASC, ce.id DESC
 				LIMIT ${EXTRA_CUSTOMER_ENTITLEMENT_LIMIT}

--- a/server/tests/integration/crud/customers/list-customers-standalone-balances.test.ts
+++ b/server/tests/integration/crud/customers/list-customers-standalone-balances.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression test for drained standalone balances leaking into customers.list.
+ *
+ * A standalone balance is a customer_entitlement with customer_product_id = NULL
+ * (created by balances.create, or minted as a carry-over on plan transitions).
+ * It surfaces in the API as a breakdown item with plan_id: null.
+ *
+ * Once such a grant is fully consumed it is dead weight: it can't be spent, but
+ * it still adds its grant to `granted` and its consumption to `usage`.
+ * getFullSubject (customers.get) already filtered those rows out; the two
+ * customers.list queries did not.
+ *
+ * Red-failure mode (reported):
+ *  - customers.list reports granted 20,000 / usage 186,446
+ *  - customers.get  reports granted 10,000 / usage 176,446
+ *  Both deltas are exactly the drained standalone grant.
+ *
+ * Green-success criteria:
+ *  - A standalone grant with balance remaining shows up on every read path.
+ *  - A fully drained one shows up on none of them.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const PLAN_GRANT = 10_000;
+const STANDALONE_GRANT = 10_000;
+
+/**
+ * Asserts customers.get and both customers.list paginations report the same
+ * balance. `standaloneGrant: null` means the plan_id: null breakdown item must
+ * be absent from every read path.
+ */
+const expectBalanceParityAcrossReadPaths = async ({
+	autumnV2_2,
+	autumnV2_3,
+	customerId,
+	featureId,
+	granted,
+	usage,
+	standaloneGrant,
+}: {
+	autumnV2_2: AutumnInt;
+	autumnV2_3: AutumnInt;
+	customerId: string;
+	featureId: string;
+	granted: number;
+	usage: number;
+	standaloneGrant: number | null;
+}) => {
+	const fetched = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+	// Forces a FullSubject rebuild from Postgres rather than a cache read — a
+	// warm subject keeps rows the rebuild query would filter out.
+	const rebuilt = await autumnV2_2.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	const offsetPage = (await autumnV2_2.customers.listV2({
+		search: customerId,
+	})) as { list: ApiCustomerV5[] };
+	const cursorPage = (await autumnV2_3.customers.listV2({
+		search: customerId,
+		limit: 10,
+	})) as { list: ApiCustomerV5[] };
+
+	const sources = [
+		["customers.get", fetched],
+		["customers.get (skip_cache)", rebuilt],
+		[
+			"customers.list offset (v2.2)",
+			offsetPage.list.find((c) => c.id === customerId),
+		],
+		[
+			"customers.list cursor (v2.3)",
+			cursorPage.list.find((c) => c.id === customerId),
+		],
+	] as const;
+
+	for (const [label, customer] of sources) {
+		expect(customer, `${label}: customer missing`).toBeDefined();
+
+		const balance = customer?.balances[featureId];
+		expect(balance?.granted, `${label}: granted`).toBe(granted);
+		expect(balance?.usage, `${label}: usage`).toBe(usage);
+		expect(balance?.remaining, `${label}: remaining`).toBe(granted - usage);
+
+		const standaloneItem = balance?.breakdown?.find(
+			(item) => item.plan_id === null,
+		);
+
+		if (standaloneGrant === null) {
+			expect(
+				standaloneItem,
+				`${label}: drained standalone should be excluded`,
+			).toBeUndefined();
+			continue;
+		}
+
+		expect(
+			standaloneItem,
+			`${label}: standalone breakdown item missing`,
+		).toBeDefined();
+		expect(standaloneItem?.included_grant, `${label}: standalone grant`).toBe(
+			standaloneGrant,
+		);
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("list-customers standalone balances: partially used standalone grant is reported on every read path")}`,
+	async () => {
+		const customerId = "list-cus-standalone-partial";
+		const usage = 500;
+
+		const pro = products.pro({
+			id: "pro-standalone-partial",
+			items: [items.monthlyMessages({ includedUsage: PLAN_GRANT })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		await autumnV2_2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: STANDALONE_GRANT,
+		});
+
+		await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: usage,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 3000));
+
+		await expectBalanceParityAcrossReadPaths({
+			autumnV2_2,
+			autumnV2_3,
+			customerId,
+			featureId: TestFeature.Messages,
+			granted: PLAN_GRANT + STANDALONE_GRANT,
+			usage,
+			standaloneGrant: STANDALONE_GRANT,
+		});
+	},
+);
+
+// Mirrors the reported prod shape. Pre-fix, customers.list kept the drained
+// grant and reported granted/usage 10,000 higher than customers.get.
+test.concurrent(
+	`${chalk.yellowBright("list-customers standalone balances: fully drained standalone grant is excluded from every read path")}`,
+	async () => {
+		const customerId = "list-cus-standalone-drained";
+
+		const pro = products.pro({
+			id: "pro-standalone-drained",
+			items: [items.monthlyMessages({ includedUsage: PLAN_GRANT })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.attach({ productId: pro.id })],
+		});
+
+		await autumnV2_2.balances.create({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			included_grant: STANDALONE_GRANT,
+		});
+
+		// Drains the plan grant and then the standalone grant to zero.
+		await autumnV2_2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: PLAN_GRANT + STANDALONE_GRANT,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 3000));
+
+		// Only the plan cusEnt survives: it is drained too, but it is not loose.
+		await expectBalanceParityAcrossReadPaths({
+			autumnV2_2,
+			autumnV2_3,
+			customerId,
+			featureId: TestFeature.Messages,
+			granted: PLAN_GRANT,
+			usage: PLAN_GRANT,
+			standaloneGrant: null,
+		});
+	},
+);

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -1,11 +1,14 @@
-import type { BasePriceParams } from "@api/products/components/basePrice/basePrice.js";
+// Deep imports, not the "@autumn/shared" barrel: the barrel re-exports
+// updatePlanParamsV1, which reaches back here via variants/updateVariantParams,
+// and the resulting cycle throws a TDZ ReferenceError depending on load order.
 import {
-	type ApiPlanV1,
-	type CreatePlanItemParamsV1,
 	CustomizePlanV1BaseSchema,
-	type PlanItemFilter,
 	refineCustomizePlanV1Schema,
-} from "@autumn/shared";
+} from "@api/billing/common/customizePlan/customizePlanV1.js";
+import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
+import type { BasePriceParams } from "@api/products/components/basePrice/basePrice.js";
+import type { CreatePlanItemParamsV1 } from "@api/products/items/crud/createPlanItemParamsV1.js";
+import type { PlanItemFilter } from "@api/products/items/filter/planItemFilter.js";
 import { FreeTrialDuration } from "@models/productModels/freeTrialModels/freeTrialEnums.js";
 import { TierBehavior } from "@models/productModels/priceModels/priceConfig/usagePriceConfig.js";
 import type { z } from "zod/v4";


### PR DESCRIPTION
## Problem

A **standalone balance** is a `customer_entitlement` with `customer_product_id = NULL` — created by `balances.create`, or minted as a carry-over on a plan transition. It surfaces in the API as a breakdown item with `plan_id: null`.

Once such a grant is fully consumed it's dead weight: it can't be spent, but it still adds its grant to `granted` and its consumption to `usage`.

`getFullSubjectRowsQuery` has filtered those rows out since #  "fix: optimized queries / dedupe". Neither `customers.list` query ever got the same predicate, so the endpoints disagreed by exactly the drained grant — on **both** `granted` and `usage`:

```
                          granted    usage
customers.list             20,000    186,446
customers.get              10,000    176,446
```

## Fix

**1. One predicate, applied everywhere.** Extracted to `looseEntitlementSql.ts` and used by all four hydration queries — single-customer, list offset (v2.2), list cursor (v2.3), and full subject. The drift between those copies *was* the bug, so they now share one definition.

**2. Cache-side filter.** SQL alone isn't enough — it only bites on rebuild:

```
track drains grant 10,000 -> 0
   Postgres row: balance 0   -> filtered
   Redis blob:   patched in place, row still present
```

`filterDrainedLooseEntitlements` applies the same rule on every return path out of `getOrSetCachedFullSubject` and `getOrSetCachedPartialFullSubject`, including after `rehydrateWithLiveBalances`, where a concurrent deduction can drain a row that was still live at query time. It's built on the shared classifiers (`isBooleanCusEnt`, `isUnlimitedCusEnt`, `notNullish`).

Retained: non-zero balances **including negative** (overage rows survive), unlimited, and boolean flags.

## Tests

`list-customers-standalone-balances.test.ts` — 2 cases x 4 read paths (`get`, `get` with `skip_cache`, list offset, list cursor):

- partially-used standalone grant -> present on every path
- fully drained -> absent on every path

44 assertions, green. The `skip_cache` path forces the cold rebuild that originally exposed the split.

Also ran clean: `tests/balances/track/loose/`, `tests/integration/billing/attach/one-off-prepaid-preserve/` (23 tests, 11 files).

## Note for reviewers

**`usage` will drop for affected customers** — 186,446 -> 176,446 in the case above. That's the intended consequence of dropping drained grants, but it is a visible customer-facing number moving.

Unrelated pre-existing failure, verified identical on a clean tree: `full-subject-ordering.test.ts` expects 50 `customer_products`, gets 59.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect granted/usage totals in `customers.list` by excluding drained standalone balances and filtering cached subjects to match `customers.get`. Also breaks a barrel import cycle in plan diff code to stop module init (TDZ) errors.

- **Bug Fixes**
  - Apply one shared predicate across hydration queries (single-customer, list v2.2 offset, list v2.3 cursor, full subject) to drop drained standalone grants.
  - Filter cached subjects with `filterDrainedLooseEntitlements` on full and partial paths, including after `rehydrateWithLiveBalances`.
  - Keep non-zero (including negative), unlimited, and boolean entitlements; granted/usage drop when a standalone grant was fully consumed.
  - Break `@autumn/shared` barrel import cycle in `diffPlanV1` by switching to deep imports to avoid TDZ ReferenceErrors.

- **Refactors**
  - Extract `looseEntitlementIsLiveSql` for reuse across queries.
  - Add integration tests covering partial vs. drained standalone grants across `get`, `skip_cache`, list v2.2, and list v2.3.

<sup>Written for commit 851d301c9f587a4892e4f95dcf23b82e9a57840c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns customer read paths by excluding fully consumed standalone balances from both database and cached results, while preserving meaningful balance types.
- **[Bug fixes, API changes]** Applies one shared SQL predicate to offset-list, cursor-list, single-customer, and full-subject hydration queries.
- **[Bug fixes, API changes]** Filters drained standalone entitlements from cached full and partial subjects, including after live-balance rehydration.
- **[Improvements]** Adds integration coverage for partially consumed and fully drained standalone grants across cached, rebuilt, offset-list, and cursor-list reads.
- **[Improvements]** Replaces a shared-package barrel import with targeted imports to avoid a load-order cycle.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/looseEntitlementSql.ts | Defines the shared SQL predicate that retains non-zero, unlimited, and boolean standalone entitlements. |
| server/src/internal/customers/cache/fullSubject/filterDrainedLooseEntitlements.ts | Mirrors the database rule for cached subjects so fully consumed standalone balances are removed from warm reads. |
| server/src/internal/customers/getFullCusQuery.ts | Applies the shared predicate to single-customer and offset-paginated hydration. |
| server/src/internal/customers/cursorPaginatedFullCusQuery.ts | Applies the shared predicate to cursor-paginated customer listing. |
| server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts | Replaces the previous inline predicate with the shared equivalent. |
| server/tests/integration/crud/customers/list-customers-standalone-balances.test.ts | Verifies partial and drained standalone balances across four customer read paths. |
| shared/utils/planV1Utils/diff/diffPlanV1.ts | Uses targeted imports to break a shared barrel-import initialization cycle. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[Customer read request] --> Path{Read path}
  Path -->|customers.get| Subject[Full-subject query]
  Path -->|list offset| Offset[Offset query]
  Path -->|list cursor| Cursor[Cursor query]
  Path -->|warm cache| Cache[Cached subject]
  Subject --> SQL[Shared live-entitlement SQL predicate]
  Offset --> SQL
  Cursor --> SQL
  Cache --> Filter[Cache-side drained-entitlement filter]
  SQL --> Result[Consistent customer balances]
  Filter --> Result
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: break the shared barrel import cycl..."](https://github.com/useautumn/autumn/commit/851d301c9f587a4892e4f95dcf23b82e9a57840c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50931112)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->