### PR TITLE
chore(dev): Dragonfly on :6379 for misc cache, quiet pg_pool_stats locally

### DIFF
--- a/docker/dev-services.compose.yml
+++ b/docker/dev-services.compose.yml
@@ -12,12 +12,17 @@ services:
     volumes:
       - autumn-dev-postgres-18:/var/lib/postgresql
 
-  redis-stack:
-    image: redis/redis-stack-server:latest
-    ports:
-      - "6379:6379"
+  # Backs MISC_CACHE_DRAGONFLY_PUBLIC_URL so local dev matches prod's engine
+  # instead of pointing at Redis Cloud.
+  dragonfly-misc:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    network_mode: host
+    command:
+      - --port=6379
+    ulimits:
+      memlock: -1
     volumes:
-      - autumn-dev-redis-stack:/data
+      - autumn-dev-dragonfly-misc:/data
 
   dragonfly:
     image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
@@ -57,5 +62,5 @@ services:
 
 volumes:
   autumn-dev-postgres-18:
-  autumn-dev-redis-stack:
+  autumn-dev-dragonfly-misc:
   autumn-dev-dragonfly:

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -44,6 +44,11 @@ const viteAppEnv = envFile.includes(".env.prod")
 		? "staging"
 		: "dev";
 const useLocalAuthUrls = viteAppEnv === "dev" && !isProductionMode;
+// `bun dev:services up` runs Dragonfly on :6379; use it instead of the shared
+// cloud cache. Worktrees provision their own and set this in their env file.
+const LOCAL_MISC_CACHE_URL = "redis://localhost:6379";
+const useLocalMiscCache =
+	viteAppEnv === "dev" && !isProductionMode && worktreeNum === 1;
 const localUrl = (value: string | undefined, fallback: string) =>
 	value && !value.includes(".useautumn.com") ? value : fallback;
 const slackRedirectFromPublicTunnel = publicTunnelUrl
@@ -316,6 +321,9 @@ async function startDev() {
 						process.env.VITE_FRONTEND_URL,
 						LOCAL_CLIENT_URL,
 					),
+				}),
+				...(useLocalMiscCache && {
+					MISC_CACHE_DRAGONFLY_PUBLIC_URL: LOCAL_MISC_CACHE_URL,
 				}),
 				...(process.env.DB_SCHEMA && { DB_SCHEMA: process.env.DB_SCHEMA }),
 				...(worktreeNum > 1 && {

--- a/scripts/devServices/index.ts
+++ b/scripts/devServices/index.ts
@@ -18,14 +18,14 @@ const ngrokConfigFiles = [
 const localConfig = {
 	postgresPort: 5432,
 	ngrokApiPort: 4040,
-	redisStackPort: 6379,
+	miscCachePort: 6379,
 	dragonflyPort: 6380,
 	dynamoDbPort: 8000,
 	apiServerPort: 8080,
 	mcpServerPort: 3099,
 	databaseUrl: "postgresql://postgres:postgres@localhost:5432/autumn",
 	chatStateDatabaseUrl: "postgresql://postgres:postgres@localhost:5432/chat",
-	cacheUrl: "redis://localhost:6379",
+	miscCacheUrl: "redis://localhost:6379",
 	dragonflyUrl: "redis://localhost:6380",
 	dynamoDbEndpoint: "http://localhost:8000",
 };
@@ -226,9 +226,11 @@ const removeVolumes = ({
 	const volumes = [
 		...(nonPostgres
 			? [
-					"autumn-dev-redis-stack",
+					"autumn-dev-dragonfly-misc",
 					"autumn-dev-dragonfly",
 					"autumn-dev-localstack",
+					// Left behind by the pre-Dragonfly misc cache.
+					"autumn-dev-redis-stack",
 				]
 			: []),
 		...(postgres ? ["autumn-dev-postgres-18", "autumn-dev-postgres"] : []),
@@ -269,11 +271,11 @@ const doctor = async () => {
 				waitForTcp({ port: localConfig.postgresPort, label: "Postgres" }),
 		}),
 		check({
-			label: "Redis Stack :6379",
+			label: "Dragonfly (misc cache) :6379",
 			fn: () =>
 				waitForTcp({
-					port: localConfig.redisStackPort,
-					label: "Redis Stack",
+					port: localConfig.miscCachePort,
+					label: "Dragonfly (misc cache)",
 				}),
 		}),
 		check({
@@ -380,7 +382,10 @@ const up = async ({ ngrokTarget }: { ngrokTarget: "api" | "mcp" }) => {
 
 	await Promise.all([
 		waitForTcp({ port: localConfig.postgresPort, label: "Postgres" }),
-		waitForTcp({ port: localConfig.redisStackPort, label: "Redis Stack" }),
+		waitForTcp({
+			port: localConfig.miscCachePort,
+			label: "Dragonfly (misc cache)",
+		}),
 		waitForTcp({ port: localConfig.dragonflyPort, label: "Dragonfly" }),
 		waitForTcp({ port: localConfig.dynamoDbPort, label: "DynamoDB" }),
 		waitForTcp({ port: localConfig.ngrokApiPort, label: "ngrok" }),
@@ -426,11 +431,11 @@ const help = () => {
 	console.log(`Usage: bun dev:services <command>
 
 Commands:
-  up                         Start local Postgres, Redis Stack, Dragonfly, DynamoDB, and ngrok
+  up                         Start local Postgres, Dragonfly (misc cache + cache v2), DynamoDB, and ngrok
   up --mcp                   Start services with ngrok pointed at localhost:3099
   up:mcp                     Alias for up --mcp
   down                       Stop local services and keep all data
-  down --volumes             Stop services and delete Redis/Dragonfly data
+  down --volumes             Stop services and delete Dragonfly data
   down --postgres            Stop services and delete Postgres data
   doctor                     Check local service readiness
   prune [--postgres]         Delete non-Postgres volumes and prune dangling Docker cache
@@ -440,7 +445,7 @@ Local service values:
   DATABASE_URL=${localConfig.databaseUrl}
   CHAT_STATE_DATABASE_URL=${localConfig.chatStateDatabaseUrl}
   NGROK_URL=<printed by bun dev:services up>
-  MISC_CACHE_DRAGONFLY_PUBLIC_URL=${localConfig.cacheUrl}
+  MISC_CACHE_DRAGONFLY_PUBLIC_URL=${localConfig.miscCacheUrl}
   CACHE_V2_DRAGONFLY_URL=${localConfig.dragonflyUrl}
   DYNAMODB_ENDPOINT=${localConfig.dynamoDbEndpoint}
 `);

--- a/server/src/db/pgPoolMonitor.ts
+++ b/server/src/db/pgPoolMonitor.ts
@@ -216,6 +216,8 @@ const emitSnapshot = (): void => {
 
 export const startPgPoolMonitor = (intervalMs = 30_000): void => {
 	if (snapshotInterval) return;
+	// Pool snapshots are an ops signal; locally they just flood the console.
+	if (process.env.NODE_ENV === "development") return;
 	// Not unref'd: under Bun an unref'd interval was never observed to fire, and
 	// the server keeps the loop alive anyway — stopPgPoolMonitor clears it.
 	snapshotInterval = setInterval(emitSnapshot, intervalMs);


### PR DESCRIPTION
Two unrelated local-dev papercuts, split out of #2652 so that PR stays focused.

## Dragonfly for the misc cache

`dev:services` provisioned **redis-stack** on `:6379` while `MISC_CACHE_DRAGONFLY_PUBLIC_URL` pointed at that port — so local dev ran a different engine than prod.

- `docker/dev-services.compose.yml`: `redis-stack` -> a second Dragonfly (`dragonfly-misc`) on `:6379`, own volume. The existing Dragonfly stays on `:6380` for cache v2.
- `scripts/devServices/index.ts`: `redisStackPort` -> `miscCachePort`, doctor/wait labels and help text updated. `down --volumes` still removes the old `autumn-dev-redis-stack` volume so nobody is left with an orphan.
- `scripts/dev.ts`: `bun dev` sets `MISC_CACHE_DRAGONFLY_PUBLIC_URL=redis://localhost:6379`, gated to non-prod and non-worktree (worktrees provision their own Dragonfly and set this in their env file).

**Behaviour change worth a look:** this overrides the Infisical value, so `bun dev` now expects `bun dev:services up` to have run. Previously it fell back to the shared cloud cache. Happy to make it conditional on `:6379` being reachable if you'd rather keep the fallback.

## Quiet pg_pool_stats in dev

`startPgPoolMonitor` returns early when `NODE_ENV=development` — same guard `memoryMonitor.ts` already uses. It's an ops signal that only floods the local console (both server and workers set this). No timer, no snapshots, no start line. Acquire-timing instrumentation is untouched, so nothing changes in deployed environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch local misc cache to Dragonfly on :6379 to match prod, and disable pg pool snapshot logs in development. `bun dev` now points `MISC_CACHE_DRAGONFLY_PUBLIC_URL` to the local Dragonfly.

- **Refactors**
  - Replace `redis-stack` with `dragonfly-misc` on :6379; keep existing Dragonfly on :6380.
  - `bun dev` sets `MISC_CACHE_DRAGONFLY_PUBLIC_URL=redis://localhost:6379` in dev (non-worktree); doctor/wait/help text updated; old `redis-stack` volume cleaned by `down --volumes`.
  - `startPgPoolMonitor` exits early in development to avoid console noise; production unchanged.

- **Migration**
  - Run `bun dev:services up` before `bun dev` (fallback to shared cloud cache is removed). Worktrees continue using their own env-configured Dragonfly.
  - Optional: run `bun dev:services down --volumes` once to remove the legacy `autumn-dev-redis-stack` volume.

<sup>Written for commit e173ed5304df1c0eed5b0afdc14348ee997dc57d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the primary local misc cache with production by replacing Redis Stack with Dragonfly, points normal local development at it, and suppresses PostgreSQL pool snapshots in development.

- **[Bug fixes]** Replaces the Redis Stack service on port 6379 with a dedicated Dragonfly misc-cache instance and updates local service orchestration.
- **[Improvements]** Makes the primary local development command use the local misc-cache endpoint while preserving worktree-specific configuration.
- **[Improvements]** Suppresses PostgreSQL pool snapshot logs under `NODE_ENV=development`, though this also affects the production-targeting reset-v2 utility.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking observability gap for production reset-v2 runs.

The main deployed server, worker, and cron processes retain pool monitoring, but the reset-v2 utility loses its pool snapshots because it deliberately launches with the environment value covered by the new guard.

**Files Needing Attention:** server/src/db/pgPoolMonitor.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/dev-services.compose.yml | Replaces the port-6379 Redis Stack container and volume with a dedicated host-networked Dragonfly instance. |
| scripts/dev.ts | Overrides the misc-cache URL with localhost:6379 for the primary non-production development workspace. |
| scripts/devServices/index.ts | Renames Redis-specific local-service settings and updates readiness checks, cleanup, and help output for Dragonfly. |
| server/src/db/pgPoolMonitor.ts | Suppresses snapshot startup in development, but also suppresses telemetry for the production-targeting reset-v2 process because it sets NODE_ENV=development. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/db/pgPoolMonitor.ts:220
**Development guard hides production telemetry**

The production-targeting reset-v2 scanner launches its child with `NODE_ENV=development`, so this guard suppresses its `pg_pool_stats` snapshots and removes pool utilization, wait-count, and acquisition-latency visibility during that job.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(dev): run Dragonfly on :6379 for t..."](https://github.com/useautumn/autumn/commit/e173ed5304df1c0eed5b0afdc14348ee997dc57d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50932212)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->