### PR TITLE
perf: add org-level Tinybird dimension rollup

### DIFF
--- a/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
+++ b/server/src/external/tinybird/pipes/aggregateGroupablePipe.ts
@@ -47,6 +47,7 @@ export const aggregateGroupablePipeParamsSchema = z.object({
 	filter_value_4: z.string().optional(),
 	max_groups: z.number().int().min(1).max(250).optional(),
 	use_daily_rollup: z.enum(["0", "1"]).optional(),
+	use_org_dimension_rollup: z.enum(["0", "1"]).optional(),
 	use_org_property_rollup: z.enum(["0", "1"]).optional(),
 	// "1" forces the ungated events_hourly_mv path when the property key is
 	// absent from events_property_mv (its value-shape gate drops UUID values)

--- a/server/src/internal/analytics/actions/aggregate.ts
+++ b/server/src/internal/analytics/actions/aggregate.ts
@@ -26,6 +26,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { validatePropertyPathForJSON } from "@/internal/analytics/actions/eventValidationUtils.js";
 import { getBillingCycleStartDate } from "../analyticsUtils.js";
 import {
+	shouldUseOrgDimensionRollup,
 	shouldUseOrgPropertyRollup,
 	shouldUsePropertyDailyRollup,
 } from "./dailyRollupRouting.js";
@@ -457,6 +458,12 @@ export const aggregate = async ({
 
 		const filterParams = buildFilterParams({ filter_by: params.filter_by });
 		const customerId = params.aggregateAll ? undefined : params.customer_id;
+		const useOrgDimensionRollup = shouldUseOrgDimensionRollup({
+			groupColumn,
+			hasCustomerId: Boolean(customerId),
+			hasEntityId: Boolean(params.entity_id),
+			hasPropertyFilters: Object.keys(filterParams).length > 0,
+		});
 		const useOrgPropertyRollup = shouldUseOrgPropertyRollup({
 			groupColumn,
 			hasCustomerId: Boolean(customerId),
@@ -490,6 +497,9 @@ export const aggregate = async ({
 			...filterParams,
 			max_groups: params.max_groups,
 			use_daily_rollup: useDailyRollup ? ("1" as const) : undefined,
+			use_org_dimension_rollup: useOrgDimensionRollup
+				? ("1" as const)
+				: undefined,
 			use_org_property_rollup: useOrgPropertyRollup
 				? ("1" as const)
 				: undefined,

--- a/server/src/internal/analytics/actions/dailyRollupRouting.ts
+++ b/server/src/internal/analytics/actions/dailyRollupRouting.ts
@@ -13,6 +13,22 @@ export type CountAndSumSource =
 const DAILY_BIN_SIZES = new Set(["day", "week", "month"]);
 const MILLISECONDS_PER_DAY = 86_400_000;
 
+export const shouldUseOrgDimensionRollup = ({
+	groupColumn,
+	hasCustomerId,
+	hasEntityId,
+	hasPropertyFilters,
+}: {
+	groupColumn: GroupableColumn;
+	hasCustomerId: boolean;
+	hasEntityId: boolean;
+	hasPropertyFilters: boolean;
+}): boolean =>
+	groupColumn !== "property" &&
+	!hasCustomerId &&
+	!hasEntityId &&
+	!hasPropertyFilters;
+
 export const shouldUseOrgPropertyRollup = ({
 	groupColumn,
 	hasCustomerId,

--- a/server/tests/unit/analytics/daily-rollup-routing.test.ts
+++ b/server/tests/unit/analytics/daily-rollup-routing.test.ts
@@ -1,15 +1,42 @@
 /**
- * Contract: eligible UTC property groups use daily states, while exact range edges stay hourly.
- * Reconciliation uses customer-daily states only when no property filter requires raw events.
+ * Contract: org-wide dimensions use their dedicated rollup, eligible UTC property groups use
+ * daily states, and reconciliation keeps exact hourly range edges.
  */
 import { expect, test } from "bun:test";
 import {
 	buildCountAndSumQuery,
 	hasCompleteUtcDay,
 	selectCountAndSumSource,
+	shouldUseOrgDimensionRollup,
 	shouldUseOrgPropertyRollup,
 	shouldUsePropertyDailyRollup,
 } from "@/internal/analytics/actions/dailyRollupRouting.js";
+
+test("org dimension rollup: routes only unfiltered aggregate-all dimensions", () => {
+	const base = {
+		groupColumn: "customer_id" as const,
+		hasCustomerId: false,
+		hasEntityId: false,
+		hasPropertyFilters: false,
+	};
+
+	for (const groupColumn of ["customer_id", "entity_id", "plan_id"] as const) {
+		expect(shouldUseOrgDimensionRollup({ ...base, groupColumn })).toBe(true);
+	}
+
+	expect(
+		shouldUseOrgDimensionRollup({ ...base, groupColumn: "property" }),
+	).toBe(false);
+	expect(shouldUseOrgDimensionRollup({ ...base, hasCustomerId: true })).toBe(
+		false,
+	);
+	expect(shouldUseOrgDimensionRollup({ ...base, hasEntityId: true })).toBe(
+		false,
+	);
+	expect(
+		shouldUseOrgDimensionRollup({ ...base, hasPropertyFilters: true }),
+	).toBe(false);
+});
 
 test("org property rollup: routes only unfiltered aggregate-all property groups", () => {
 	const base = {

--- a/server/tinybird/materializations/events_org_dimension_hourly_mv.datasource
+++ b/server/tinybird/materializations/events_org_dimension_hourly_mv.datasource
@@ -1,0 +1,17 @@
+DESCRIPTION >
+    Org-level hourly states for customer, entity, and plan grouping. Each dimension is stored
+    independently so org-wide queries do not scan irrelevant customer/entity/plan combinations.
+
+SCHEMA >
+    `org_id` String,
+    `env` String,
+    `event_name` String,
+    `dimension` String,
+    `group_value` String,
+    `hour` DateTime,
+    `total_value` AggregateFunction(sum, Float64),
+    `event_count` AggregateFunction(sum, UInt64)
+
+ENGINE AggregatingMergeTree
+ENGINE_PARTITION_KEY toYYYYMM(hour)
+ENGINE_SORTING_KEY org_id, env, dimension, event_name, hour, group_value

--- a/server/tinybird/materializations/events_org_dimension_hourly_mv_pipe.pipe
+++ b/server/tinybird/materializations/events_org_dimension_hourly_mv_pipe.pipe
@@ -1,0 +1,27 @@
+DESCRIPTION >
+    Collapses the customer-leading hourly rollup into independent org-hour dimension states.
+
+NODE materialize
+SQL >
+    SELECT
+        org_id,
+        env,
+        event_name,
+        dimension,
+        multiIf(
+            dimension = 'customer_id',
+            customer_id,
+            dimension = 'entity_id',
+            entity_id,
+            coalesce(internal_product_id, '')
+        ) as group_value,
+        hour,
+        sumState(total_value) as total_value,
+        sumState(event_count) as event_count
+    FROM events_customer_hourly_mv ARRAY
+    JOIN ['customer_id', 'entity_id', 'plan_id'] as dimension
+    WHERE dimension != 'entity_id' OR entity_id != ''
+    GROUP BY org_id, env, event_name, dimension, group_value, hour
+
+TYPE MATERIALIZED
+DATASOURCE events_org_dimension_hourly_mv

--- a/server/tinybird/pipes/aggregate_groupable.pipe
+++ b/server/tinybird/pipes/aggregate_groupable.pipe
@@ -2,6 +2,7 @@ DESCRIPTION >
     Aggregate queries with grouping by a property key, customer_id, or entity_id.
     Routes to the smallest viable MV for the query shape:
       - events_customer_hourly_mv:           customer/entity/plan grouping with no property filters
+      - events_org_dimension_hourly_mv:      org-wide customer/entity/plan grouping
       - events_org_property_hourly_mv:       org-wide unfiltered property grouping
       - events_property_mv:                  unfiltered hourly or non-UTC property grouping
       - events_property_daily_mv:            opted-in UTC property grouping at day-or-coarser bins
@@ -24,10 +25,35 @@ SQL >
        events_hourly_mv path instead of silently returning nothing. #}
     {% set skip_rollup = defined(skip_property_rollup) and String(skip_property_rollup, '0') == '1' %}
     {% set use_property_rollup = (String(group_column, 'property') == 'property') and no_property_filters and not skip_rollup %}
+    {% set read_org_dimension_rollup = use_no_props and defined(use_org_dimension_rollup) and String(use_org_dimension_rollup, '0') == '1' and (not defined(customer_id) or String(customer_id, '') == '') and (not defined(entity_id) or String(entity_id, '') == '') %}
     {% set read_org_property_rollup = use_property_rollup and defined(use_org_property_rollup) and String(use_org_property_rollup, '0') == '1' %}
     {% set use_daily_property_rollup = use_property_rollup and not read_org_property_rollup and defined(use_daily_rollup) and String(use_daily_rollup, '0') == '1' %}
 
-    {% if read_org_property_rollup %}
+    {% if read_org_dimension_rollup %}
+    SELECT
+        {% if String(bin_size, 'day') == 'hour' %}
+        formatDateTime(hour, '%F %T') as period,
+        {% elif String(bin_size, 'day') == 'month' %}
+        formatDateTime(toStartOfMonth(hour, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+        {% elif String(bin_size, 'day') == 'week' %}
+        formatDateTime(toStartOfWeek(hour, 1, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+        {% else %}
+        formatDateTime(toStartOfDay(hour, {{ String(timezone, 'UTC') }}), '%F %T') as period,
+        {% end %}
+        event_name,
+        group_value,
+        sumMerge(total_value) as total_value,
+        sumMerge(event_count) as event_count
+    FROM events_org_dimension_hourly_mv
+    WHERE
+        org_id = {{ String(org_id, '') }}
+        AND env = {{ String(env, 'test') }}
+        AND dimension = {{ String(group_column, 'customer_id') }}
+        AND event_name IN {{ Array(event_names, 'String', default='[]') }}
+        AND hour >= toDateTime({{ String(start_date, '2024-01-01 00:00:00') }})
+        AND hour <= toDateTime({{ String(end_date, '2024-12-31 23:59:59') }})
+    GROUP BY period, event_name, group_value
+    {% elif read_org_property_rollup %}
     SELECT
         {% if String(bin_size, 'day') == 'hour' %}
         formatDateTime(hour, '%F %T') as period,


### PR DESCRIPTION
## What changed

- add an org-level hourly Tinybird materialized view for independent customer, entity, and plan dimensions
- route eligible org-wide, unfiltered grouped analytics queries to the new rollup
- keep scoped queries, property-filtered queries, and property grouping on their existing paths
- add unit coverage for the new routing gate

## Why

Org-wide customer, entity, and plan grouping currently scans the customer-leading hourly rollup, including irrelevant cross-dimensional combinations. Production observations showed representative 30-day queries taking roughly 20-32 seconds and scanning 111-159 million rows.

The new EAV-style rollup stores each supported dimension independently while retaining hourly states for exact timezone-aware bucketing. Read-only sizing checks indicated roughly 82-86% fewer rows for the sampled high-volume organizations.

## Validation

- `bun ts`
- `bun test tests/unit/analytics/daily-rollup-routing.test.ts` (8 passed, 44 assertions)
- focused Biome check
- Tinybird formatting checks for the new datafiles
- `git diff --check`
- read-only production SQL validation and one-hour parity check (0 mismatched groups/values)

## Rollout

No Tinybird deployment or branch was created as part of this PR. The Tinybird materialization should be populated and validated before the server change is deployed; the server only opts into the new path after the new resource is available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an org-level Tinybird dimension rollup and routes eligible org-wide grouped analytics to it to cut scan volume and speed up queries. For 30-day org-wide groupings, this reduces scanned rows by ~82–86% and observed query times from ~20–32s.

- **New Features**
  - Added materialized view `events_org_dimension_hourly_mv` and pipe for independent hourly states of `customer_id`, `entity_id`, and `plan_id`.
  - Introduced routing gate `shouldUseOrgDimensionRollup` and Tinybird param `use_org_dimension_rollup` for unfiltered org-wide grouping.
  - Kept scoped queries, property-filtered queries, and property grouping on existing paths.
  - Updated `aggregate_groupable.pipe` to read `events_org_dimension_hourly_mv` when eligible.
  - Added unit tests for the new routing.

- **Migration**
  - Populate and validate `events_org_dimension_hourly_mv` in Tinybird before deploying server changes.
  - The server routes to the new path only after the materialization exists; no Tinybird deploy or branch was created here.

<sup>Written for commit d05bd26bf40ced0dbeec0b96d4fe20e3d16653fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a smaller Tinybird rollup for faster organization-wide analytics grouped by customer, entity, or plan.

- **Improvements:** Materializes customer, entity, and plan dimensions independently at hourly granularity.
- **Improvements:** Routes eligible organization-wide, unfiltered grouped queries through the new rollup while retaining existing paths for scoped and property-based queries.
- **Improvements:** Adds unit coverage for the routing decision.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge once the acknowledged Tinybird population and deployment ordering is followed.

The new route is narrowly limited to organization-wide, unfiltered customer, entity, and plan grouping, and its aggregation and empty-value behavior match the existing path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/analytics/actions/aggregate.ts | Adds the new routing decision and Tinybird parameter for eligible organization-wide dimension queries. |
| server/src/internal/analytics/actions/dailyRollupRouting.ts | Defines a focused predicate that excludes property grouping, scoped queries, and property-filtered queries. |
| server/tinybird/materializations/events_org_dimension_hourly_mv_pipe.pipe | Builds independent hourly customer, entity, and plan aggregate states from the existing customer-hourly source. |
| server/tinybird/pipes/aggregate_groupable.pipe | Reads the new rollup when explicitly selected and preserves existing query branches otherwise. |
| server/tests/unit/analytics/daily-rollup-routing.test.ts | Covers supported dimensions and each routing exclusion. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q[Grouped analytics query] --> G{Customer, entity, or plan grouping?}
    G -- No --> Existing[Existing property or scoped paths]
    G -- Yes --> S{Organization-wide and unfiltered?}
    S -- No --> Existing
    S -- Yes --> Rollup[Org dimension hourly rollup]
    Rollup --> Bucket[Timezone-aware aggregation]
    Existing --> Bucket
    Bucket --> Result[Grouped analytics response]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["perf: add org-level Tinybird dimension r..."](https://github.com/useautumn/autumn/commit/d05bd26bf40ced0dbeec0b96d4fe20e3d16653fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50934296)</sub>

<!-- /greptile_comment -->