### PR TITLE
Add track WebSocket throughput experiment

### DIFF
--- a/server/experiments/track-throughput/benchmark.ts
+++ b/server/experiments/track-throughput/benchmark.ts
@@ -1,0 +1,213 @@
+export {};
+
+type Result = {
+	transport: "http" | "websocket";
+	concurrency: number;
+	requests: number;
+	errors: number;
+	rps: number;
+	p50Ms: number;
+	p95Ms: number;
+	p99Ms: number;
+};
+
+const httpUrl =
+	process.env.TRACK_HTTP_URL ?? "http://127.0.0.1:8090/v1/balances.track";
+const wsUrl = process.env.TRACK_WS_URL ?? "ws://127.0.0.1:8091";
+const secretKey = process.env.UNIT_TEST_AUTUMN_SECRET_KEY;
+const customerId = process.env.TRACK_BENCH_CUSTOMER_ID;
+const featureId = process.env.TRACK_BENCH_FEATURE_ID ?? "messages";
+const durationMs = Number(process.env.TRACK_BENCH_DURATION_MS ?? 5_000);
+const concurrencies = (process.env.TRACK_BENCH_CONCURRENCIES ?? "1,8,32,128,512")
+	.split(",")
+	.map(Number);
+const transports = (
+	process.env.TRACK_BENCH_TRANSPORTS ?? "http,websocket"
+).split(",");
+
+if (!secretKey || !customerId) {
+	throw new Error(
+		"UNIT_TEST_AUTUMN_SECRET_KEY and TRACK_BENCH_CUSTOMER_ID are required",
+	);
+}
+
+const percentile = (sorted: number[], p: number) =>
+	sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))] ?? 0;
+
+const summarize = ({
+	transport,
+	concurrency,
+	startedAt,
+	latencies,
+	errors,
+}: {
+	transport: Result["transport"];
+	concurrency: number;
+	startedAt: number;
+	latencies: number[];
+	errors: number;
+}): Result => {
+	const elapsedSeconds = (performance.now() - startedAt) / 1_000;
+	latencies.sort((a, b) => a - b);
+	return {
+		transport,
+		concurrency,
+		requests: latencies.length,
+		errors,
+		rps: latencies.length / elapsedSeconds,
+		p50Ms: percentile(latencies, 0.5),
+		p95Ms: percentile(latencies, 0.95),
+		p99Ms: percentile(latencies, 0.99),
+	};
+};
+
+const runHttp = async (concurrency: number): Promise<Result> => {
+	const deadline = performance.now() + durationMs;
+	const latencies: number[] = [];
+	let errors = 0;
+
+	const worker = async () => {
+		while (performance.now() < deadline) {
+			const startedAt = performance.now();
+			try {
+				const response = await fetch(httpUrl, {
+					method: "POST",
+					headers: {
+						authorization: `Bearer ${secretKey}`,
+						"content-type": "application/json",
+						"x-api-version": "2.1",
+					},
+					body: JSON.stringify({
+						customer_id: customerId,
+						feature_id: featureId,
+						value: 1,
+						skip_event: true,
+					}),
+				});
+				const responseBody = await response.json();
+				if (
+					response.status !== 200 ||
+					typeof responseBody.balance?.remaining !== "number"
+				) {
+					throw new Error(
+						`${response.status}: ${JSON.stringify(responseBody).slice(0, 200)}`,
+					);
+				}
+				latencies.push(performance.now() - startedAt);
+			} catch (error) {
+				errors++;
+				if (errors === 1) console.error("first HTTP error", error);
+			}
+		}
+	};
+
+	const startedAt = performance.now();
+	await Promise.all(Array.from({ length: concurrency }, worker));
+	return summarize({
+		transport: "http",
+		concurrency,
+		startedAt,
+		latencies,
+		errors,
+	});
+};
+
+const runWebSocket = async (concurrency: number): Promise<Result> => {
+	const ws = new WebSocket(wsUrl);
+	await new Promise<void>((resolve, reject) => {
+		ws.addEventListener("open", () => resolve(), { once: true });
+		ws.addEventListener("error", () => reject(new Error("WebSocket failed")), {
+			once: true,
+		});
+	});
+
+	const deadline = performance.now() + durationMs;
+	const latencies: number[] = [];
+	const pending = new Map<number, number>();
+	let errors = 0;
+	let nextRequestId = 1;
+	let finished = false;
+
+	const send = () => {
+		if (performance.now() >= deadline) return;
+		const requestId = nextRequestId++;
+		pending.set(requestId, performance.now());
+		ws.send(
+			JSON.stringify([
+				1,
+				requestId,
+				customerId,
+				featureId,
+				1,
+			]),
+		);
+	};
+
+	const completed = new Promise<void>((resolve) => {
+		ws.addEventListener("message", (event) => {
+			const frame = JSON.parse(String(event.data));
+			const requestId = frame[1] as number;
+			const startedAt = pending.get(requestId);
+			pending.delete(requestId);
+
+			if (
+				frame[0] === 2 &&
+				startedAt !== undefined &&
+				typeof frame[2] === "number" &&
+				typeof frame[3] === "number"
+			) {
+				latencies.push(performance.now() - startedAt);
+			} else {
+				errors++;
+				if (errors === 1) console.error("first WebSocket error", frame);
+			}
+
+			if (performance.now() < deadline) {
+				send();
+			} else if (pending.size === 0 && !finished) {
+				finished = true;
+				resolve();
+			}
+		});
+	});
+
+	const startedAt = performance.now();
+	for (let i = 0; i < concurrency; i++) send();
+	await completed;
+	ws.close();
+
+	return summarize({
+		transport: "websocket",
+		concurrency,
+		startedAt,
+		latencies,
+		errors,
+	});
+};
+
+console.log(
+	`duration=${durationMs}ms/arm customer=${customerId} feature=${featureId}`,
+);
+console.log(
+	"transport  conc    requests       rps    p50ms    p95ms    p99ms  errors",
+);
+console.log("-".repeat(78));
+
+const results: Result[] = [];
+for (const concurrency of concurrencies) {
+	for (const run of [
+		...(transports.includes("http") ? [runHttp] : []),
+		...(transports.includes("websocket") ? [runWebSocket] : []),
+	]) {
+		const result = await run(concurrency);
+		results.push(result);
+		console.log(
+			`${result.transport.padEnd(10)} ${String(concurrency).padStart(4)} ` +
+				`${String(result.requests).padStart(11)} ${result.rps.toFixed(0).padStart(9)} ` +
+				`${result.p50Ms.toFixed(2).padStart(8)} ${result.p95Ms.toFixed(2).padStart(8)} ` +
+				`${result.p99Ms.toFixed(2).padStart(8)} ${String(result.errors).padStart(7)}`,
+		);
+	}
+}
+
+console.log(`RESULTS_JSON=${JSON.stringify(results)}`);

--- a/server/experiments/track-throughput/createBenchmarkContext.ts
+++ b/server/experiments/track-throughput/createBenchmarkContext.ts
@@ -1,0 +1,48 @@
+import {
+	ApiVersionClass,
+	AppEnv,
+	AuthType,
+	LATEST_VERSION,
+} from "@autumn/shared";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { generateId } from "@/utils/genUtils.js";
+
+export const createBenchmarkContext = async (): Promise<AutumnContext> => {
+	const orgSlug = process.env.TESTS_ORG;
+	if (!orgSlug) throw new Error("TESTS_ORG is required");
+
+	const { db } = initDrizzle();
+	const org = await OrgService.getBySlug({ db, slug: orgSlug });
+	if (!org) throw new Error(`Organization "${orgSlug}" not found`);
+
+	return {
+		org,
+		env: AppEnv.Sandbox,
+		features: await FeatureService.list({
+			db,
+			orgId: org.id,
+			env: AppEnv.Sandbox,
+		}),
+		db,
+		dbGeneral: db,
+		logger,
+		redisV2: resolveRedisV2(),
+		id: generateId("track_bench"),
+		isPublic: false,
+		authType: AuthType.SecretKey,
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
+		timestamp: Date.now(),
+		scopes: [],
+		skipCache: false,
+		expand: [],
+		extraLogs: {},
+		testOptions: {
+			skipWebhooks: true,
+		},
+	};
+};

--- a/server/experiments/track-throughput/setup.ts
+++ b/server/experiments/track-throughput/setup.ts
@@ -1,0 +1,52 @@
+export {};
+
+if (!process.env.TESTS_ORG || !process.env.UNIT_TEST_AUTUMN_SECRET_KEY) {
+	throw new Error("TESTS_ORG and UNIT_TEST_AUTUMN_SECRET_KEY are required");
+}
+
+process.env.AUTUMN_TEST_BASE_URL ??= "http://127.0.0.1:8090";
+
+const { ApiVersion } = await import("@autumn/shared");
+const { TestFeature } = await import("@tests/setup/v2Features.js");
+const { items } = await import("@tests/utils/fixtures/items.js");
+const { products } = await import("@tests/utils/fixtures/products.js");
+const { AutumnInt } = await import("@/external/autumn/autumnCli.js");
+
+const runId = Date.now();
+const customerId =
+	process.env.TRACK_BENCH_CUSTOMER_ID ?? `track-bench-${runId}`;
+const productGroup = `track-throughput-${runId}`;
+const product = products.base({
+	id: `track-bench-${runId}`,
+	isDefault: true,
+	group: productGroup,
+	items: [
+		items.monthlyMessages({
+			includedUsage: 1_000_000_000_000,
+		}),
+	],
+});
+
+const autumn = new AutumnInt({
+	secretKey: process.env.UNIT_TEST_AUTUMN_SECRET_KEY,
+	baseUrl: `${process.env.AUTUMN_TEST_BASE_URL}/v1`,
+	version: ApiVersion.V1_2,
+});
+await autumn.products.create(product);
+await autumn.customers.create({
+	id: customerId,
+	name: "Track throughput benchmark",
+	email: `${customerId}@example.com`,
+	skipWebhooks: true,
+	internalOptions: {
+		default_group: productGroup,
+	},
+});
+
+console.log(
+	JSON.stringify({
+		customerId,
+		featureId: TestFeature.Messages,
+	}),
+);
+process.exit(0);

--- a/server/experiments/track-throughput/websocketServer.ts
+++ b/server/experiments/track-throughput/websocketServer.ts
@@ -1,0 +1,88 @@
+import { TrackParamsSchema } from "@autumn/shared";
+import { Hono } from "hono";
+import { createBunWebSocket } from "hono/bun";
+import { primeRedisMonitor } from "@/external/redis/availabilityMonitor/redisAvailability.js";
+import { primeRedisV2Monitor } from "@/external/redis/availabilityMonitor/redisV2Availability.js";
+import { getTrackFeatureDeductionsForBody } from "@/internal/balances/track/utils/getFeatureDeductions.js";
+import { runTrackWithRollout } from "@/internal/balances/track/runTrackWithRollout.js";
+import { generateId } from "@/utils/genUtils.js";
+import { createBenchmarkContext } from "./createBenchmarkContext.js";
+
+const TRACK_OPCODE = 1;
+const TRACK_RESULT_OPCODE = 2;
+const ERROR_OPCODE = 3;
+const port = Number(process.env.TRACK_WS_PORT ?? 8091);
+
+await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);
+const baseCtx = await createBenchmarkContext();
+const app = new Hono();
+const { upgradeWebSocket, websocket } = createBunWebSocket();
+
+app.get(
+	"/",
+	upgradeWebSocket(() => ({
+		onMessage(event, ws) {
+			void (async () => {
+				let requestId: number | string = 0;
+				try {
+					const frame = JSON.parse(String(event.data));
+					if (!Array.isArray(frame) || frame[0] !== TRACK_OPCODE) {
+						throw new Error("unsupported opcode");
+					}
+
+					requestId = frame[1];
+					const body = TrackParamsSchema.parse({
+						customer_id: frame[2],
+						feature_id: frame[3],
+						value: frame[4],
+						skip_event: true,
+					});
+					const ctx = {
+						...baseCtx,
+						id: generateId("ws_track"),
+						timestamp: Date.now(),
+						customerId: body.customer_id,
+						entityId: body.entity_id,
+						requestBody: body,
+						extraLogs: {},
+					};
+					const featureDeductions = getTrackFeatureDeductionsForBody({
+						ctx,
+						body,
+					});
+					const response = await runTrackWithRollout({
+						ctx,
+						body,
+						featureDeductions,
+					});
+
+					ws.send(
+						JSON.stringify([
+							TRACK_RESULT_OPCODE,
+							requestId,
+							response.balance?.remaining ?? null,
+							response.balance?.usage ?? null,
+						]),
+					);
+				} catch (error) {
+					ws.send(
+						JSON.stringify([
+							ERROR_OPCODE,
+							requestId,
+							error instanceof Error ? error.message : String(error),
+						]),
+					);
+				}
+			})();
+		},
+	})),
+);
+
+Bun.serve({
+	hostname: "127.0.0.1",
+	port,
+	fetch: app.fetch,
+	websocket,
+});
+
+console.log(`Track WebSocket server listening on ws://127.0.0.1:${port}`);


### PR DESCRIPTION
Adds a reproducible throughput experiment for the hot-cache `balances.track` path and a localhost-only Hono/Bun WebSocket prototype that runs Autumn's production deduction logic directly.

- Encodes tracks as `[1, requestId, customerId, featureId, value]` frames and streams `[2, requestId, remaining, usage]` results, with request IDs allowing out-of-order completion.
- Seeds an isolated trillion-unit balance and compares closed-loop HTTP and WebSocket saturation across configurable concurrency levels.
- Treats queued/fail-open or null-balance responses as benchmark errors so reported throughput only counts live Redis deductions.

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/be103eaf-2e7b-4288-b3c5-0fa95c92024b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open SCO-092" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b35af3bb-4fd0-4e66-b51b-3957d4e8a16c/thread/be103eaf-2e7b-4288-b3c5-0fa95c92024b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-092&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=SCO-092"><img alt="SCO-092" src="https://capy.ai/api/badge/thread.svg?label=SCO-092"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reproducible throughput experiment to compare HTTP `balances.track` with a localhost WebSocket path that runs the production deduction logic. Supports Linear SCO-092 by measuring saturation under configurable concurrency.

- **New Features**
  - Local WebSocket prototype at ws://127.0.0.1:8091 using `hono/bun`; accepts `[1, requestId, customerId, featureId, value]` and returns `[2, requestId, remaining, usage]` (out-of-order supported) while calling `runTrackWithRollout` to mirror production.
  - Benchmark runner for HTTP and WebSocket with RPS and p50/p95/p99; configurable via `TRACK_BENCH_*`, `TRACK_HTTP_URL`, and `TRACK_WS_URL`.
  - `setup.ts` seeds a product with a trillion units and a test customer, outputting `customerId` and `featureId`.
  - Throughput only counts live Redis deductions; queued/fail-open or null-balance responses are treated as errors.

<sup>Written for commit 02d8373905eb18b51b68a196fccd5aabea70b6f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a reproducible HTTP-versus-WebSocket throughput experiment that invokes the production tracking deduction logic against an isolated high-volume balance.
- **Improvements, API changes:** Adds a localhost-only Hono/Bun WebSocket protocol with request IDs for out-of-order tracking responses.
- **Improvements:** Adds benchmark setup and synthetic Autumn-context construction for an isolated sandbox customer.
- **Improvements:** Adds configurable closed-loop HTTP and WebSocket benchmark arms with latency, throughput, and error reporting.
</details>

<h3>Confidence Score: 3/5</h3>

The experiment should not merge until it terminates cleanly when WebSocket replies cannot arrive and excludes Postgres fallback responses from Redis throughput.

The WebSocket benchmark can hang indefinitely for valid environment-driven failure scenarios, and its result protocol counts numeric Postgres fallback responses as successful live Redis deductions.

**Files Needing Attention:** server/experiments/track-throughput/benchmark.ts, server/experiments/track-throughput/websocketServer.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/experiments/track-throughput/benchmark.ts | Adds configurable HTTP/WebSocket saturation loops and metrics, but the WebSocket arm can wait indefinitely when no response can arrive. |
| server/experiments/track-throughput/createBenchmarkContext.ts | Creates an isolated sandbox Autumn context with shared database and Redis resources suitable for concurrent benchmark requests. |
| server/experiments/track-throughput/setup.ts | Seeds a uniquely named customer and product with a trillion-unit message balance for repeatable runs. |
| server/experiments/track-throughput/websocketServer.ts | Adds the localhost WebSocket adapter, but its success frame cannot distinguish Redis deductions from Postgres fallback results. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Setup as Setup Script
  participant API as Autumn HTTP API
  participant Bench as Benchmark
  participant WS as WebSocket Prototype
  participant Track as Production Track Logic
  participant Redis as Redis
  Setup->>API: Create product and benchmark customer
  Bench->>API: HTTP balances.track
  API->>Track: Run deduction
  Track->>Redis: Deduct balance
  API-->>Bench: Balance result
  Bench->>WS: [1, requestId, customerId, featureId, value]
  WS->>Track: runTrackWithRollout
  Track->>Redis: Deduct balance
  WS-->>Bench: [2, requestId, remaining, usage]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/experiments/track-throughput/benchmark.ts:146
**WebSocket completion can hang**

When concurrency is zero or invalid, no frame is sent, so the message handler never resolves `completed`; a mid-run disconnect similarly leaves pending requests without a completion path. The benchmark then waits forever and never prints its results.

### Issue 2
server/experiments/track-throughput/websocketServer.ts:59-66
**Fallback deductions count as Redis**

When Redis deduction falls back to Postgres, this emits the same numeric opcode-2 frame as a Redis success. The benchmark therefore counts Postgres work as successful live Redis throughput, producing misleading results during Redis failures.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: add track websocket throughput exp..."](https://github.com/useautumn/autumn/commit/02d8373905eb18b51b68a196fccd5aabea70b6f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51010980)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->