### PR TITLE
Show source branch in shipped summaries

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Post summary to shipped
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           SLACK_SHIPPED_WEBHOOK_URL: ${{ secrets.SLACK_SHIPPED_WEBHOOK_URL }}
@@ -34,6 +35,16 @@ jobs:
           if [ -z "$SLACK_SHIPPED_WEBHOOK_URL" ]; then
             echo "::error::SLACK_SHIPPED_WEBHOOK_URL is not configured"
             exit 1
+          fi
+
+          if [ "$PR_HEAD_REF" = "dev" ]; then
+            route_label="dev2main"
+          else
+            slack_head_ref=$(printf '%s' "$PR_HEAD_REF" | sed \
+              -e 's/&/\&amp;/g' \
+              -e 's/</\&lt;/g' \
+              -e 's/>/\&gt;/g')
+            route_label="$slack_head_ref → main"
           fi
 
           start_marker="## Summary by cubic"
@@ -52,8 +63,8 @@ jobs:
             -e 's/&/\&amp;/g' \
             -e 's/</\&lt;/g' \
             -e 's/>/\&gt;/g')
-          printf -v SLACK_MESSAGE '*→ main* :rocket:\n<%s|PR #%s>\n\n%s' \
-            "$PR_URL" "$PR_NUMBER" "$slack_summary"
+          printf -v SLACK_MESSAGE '*%s* :rocket:\n<%s|PR #%s>\n\n%s' \
+            "$route_label" "$PR_URL" "$PR_NUMBER" "$slack_summary"
           export SLACK_MESSAGE
 
           node -e 'process.stdout.write(JSON.stringify({ text: process.env.SLACK_MESSAGE }))' \


### PR DESCRIPTION
Keeps the dev2main label for dev releases and shows <source branch> → main for other PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the source branch in Shipped Slack summaries to make release routes clear. Dev PRs keep the `dev2main` label; all others show "<branch> → main".

- **New Features**
  - Build a `route_label` from `PR_HEAD_REF`: `dev2main` for `dev`, otherwise "<branch> → main" with `&`, `<`, `>` escaped.
  - Replace the hardcoded "*→ main*" with `*{route_label}*` in the Slack message.

<sup>Written for commit a91d1ce9e51f4c44377642aa448cdb9d3b9b1ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the source branch to shipped Slack summaries while preserving the existing `dev2main` label for releases from `dev`.

- **Improvements:** Displays `<source branch> → main` for shipped pull requests from branches other than `dev`.
- **Improvements:** Keeps the familiar `dev2main` label for pull requests from `dev`.
- **Improvements:** Escapes Slack entity-sensitive characters in the displayed branch name.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The workflow reads the source branch from the configured pull request event, preserves the special `dev2main` route, escapes Slack entity-sensitive characters, and safely serializes the resulting message as JSON.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/post-cubic-summary.yml | Adds a safely interpolated source-branch route label to shipped Slack notifications without changing workflow triggering behavior. |

<sub>Reviews (1): Last reviewed commit: ["show source branch in shipped summaries"](https://github.com/useautumn/autumn/commit/a91d1ce9e51f4c44377642aa448cdb9d3b9b1ee9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51123169)</sub>

<!-- /greptile_comment -->