### PR TITLE
fix: harden fork recycling against stale requests, lost drains, and closed channels

### DIFF
--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -70,6 +70,9 @@ export const attachPrimaryForkRecycling = ({
 
 	clusterModule.on("message", (worker, message: RecycleMessage) => {
 		if (message?.type !== RECYCLE_REQUEST) return;
+		// A message delivered after the worker's exit was handled would start a
+		// cycle for a corpse that can never complete.
+		if (worker.isDead?.()) return;
 		coordinator.handleRecycleRequest({ workerId: String(worker.id) });
 	});
 
@@ -155,7 +158,11 @@ export const startWorkerForkRecycling = ({
 				},
 			},
 		);
-		process.send?.({ type: RECYCLE_REQUEST });
+		try {
+			process.send?.({ type: RECYCLE_REQUEST }, undefined, undefined, () => {});
+		} catch {
+			// Channel already closed (primary going away); the process is exiting.
+		}
 	};
 
 	// Jitter so same-boot forks never check in sync.

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -87,11 +87,17 @@ export const createRecycleCoordinator = ({
 		respawnBootDeadlines.set(newWorkerId, deadline);
 	};
 
-	let drainCompletionDeadline: ReturnType<typeof setTimeout> | null = null;
+	// Keyed by drained worker, not by cycle: a cycle can be replaced while its
+	// old fork is still draining, and that fork still needs its deadline.
+	const drainCompletionDeadlines = new Map<
+		string,
+		ReturnType<typeof setTimeout>
+	>();
 
-	const clearDrainCompletionDeadline = () => {
-		if (drainCompletionDeadline) clearTimeout(drainCompletionDeadline);
-		drainCompletionDeadline = null;
+	const clearDrainCompletionDeadline = (workerId: string) => {
+		const deadline = drainCompletionDeadlines.get(workerId);
+		if (deadline) clearTimeout(deadline);
+		drainCompletionDeadlines.delete(workerId);
 	};
 
 	const sendDrainNow = (cycle: RecycleCycle) => {
@@ -105,14 +111,15 @@ export const createRecycleCoordinator = ({
 		// A lost drain message (or wedged drainer) must not hold the queue
 		// forever. The replacement is already serving, so past the worker's own
 		// drain bounds the old fork is killed and its exit completes the cycle.
-		drainCompletionDeadline = setTimeout(() => {
-			if (activeCycle?.oldWorkerId !== cycle.oldWorkerId) return;
+		const deadline = setTimeout(() => {
+			drainCompletionDeadlines.delete(cycle.oldWorkerId);
 			log(
 				`[ForkRecycle] Worker ${cycle.oldWorkerId} did not exit within ${drainCompletionTimeoutMs}ms of its drain; killing it (replacement already serving)`,
 			);
 			killWorker(cycle.oldWorkerId);
 		}, drainCompletionTimeoutMs);
-		drainCompletionDeadline.unref?.();
+		deadline.unref?.();
+		drainCompletionDeadlines.set(cycle.oldWorkerId, deadline);
 	};
 
 	const releaseDeferredDrainIfClear = () => {
@@ -163,7 +170,6 @@ export const createRecycleCoordinator = ({
 
 	const startNextPendingCycle = () => {
 		clearBootDeadline();
-		clearDrainCompletionDeadline();
 		activeCycle = null;
 		const next = pendingWorkerIds.shift();
 		if (next !== undefined) startCycle(next);
@@ -213,6 +219,11 @@ export const createRecycleCoordinator = ({
 		},
 
 		handleWorkerExit: ({ workerId }) => {
+			clearDrainCompletionDeadline(workerId);
+			// Every branch below must see a dead worker gone from the queue, or a
+			// later cycle forks a replacement for a fork that no longer exists.
+			const pendingIndex = pendingWorkerIds.indexOf(workerId);
+			if (pendingIndex !== -1) pendingWorkerIds.splice(pendingIndex, 1);
 			// A crash respawn dying while booting falls through to the plain-crash
 			// branch below (which respawns again); the deferred-drain release runs
 			// only after that branch has tracked the new respawn.
@@ -283,8 +294,6 @@ export const createRecycleCoordinator = ({
 				}
 
 				requestedWorkerIds.delete(workerId);
-				const pendingIndex = pendingWorkerIds.indexOf(workerId);
-				if (pendingIndex !== -1) pendingWorkerIds.splice(pendingIndex, 1);
 				respawnTracked(workerId);
 				return false;
 			})();

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -19,6 +19,8 @@ export type RecycleCoordinator = {
 };
 
 export const DEFAULT_REPLACEMENT_BOOT_TIMEOUT_MS = 120_000;
+// Above the drainer's own max-drain (10min) + graceful-shutdown backstop.
+export const DEFAULT_DRAIN_COMPLETION_TIMEOUT_MS = 12 * 60_000;
 
 /** One recycle in flight at a time, and an invariant every path must hold:
  *  the serving fork count returns to N — no surplus, no deficit. */
@@ -29,6 +31,7 @@ export const createRecycleCoordinator = ({
 	killWorker,
 	respawn,
 	replacementBootTimeoutMs = DEFAULT_REPLACEMENT_BOOT_TIMEOUT_MS,
+	drainCompletionTimeoutMs = DEFAULT_DRAIN_COMPLETION_TIMEOUT_MS,
 	log,
 }: {
 	forkReplacement: () => string;
@@ -42,6 +45,7 @@ export const createRecycleCoordinator = ({
 	 *  caller is shutting down and skipped the fork). */
 	respawn: (workerId: string) => string | undefined;
 	replacementBootTimeoutMs?: number;
+	drainCompletionTimeoutMs?: number;
 	log: (message: string) => void;
 }): RecycleCoordinator => {
 	let activeCycle: RecycleCycle | null = null;
@@ -83,6 +87,13 @@ export const createRecycleCoordinator = ({
 		respawnBootDeadlines.set(newWorkerId, deadline);
 	};
 
+	let drainCompletionDeadline: ReturnType<typeof setTimeout> | null = null;
+
+	const clearDrainCompletionDeadline = () => {
+		if (drainCompletionDeadline) clearTimeout(drainCompletionDeadline);
+		drainCompletionDeadline = null;
+	};
+
 	const sendDrainNow = (cycle: RecycleCycle) => {
 		cycle.drainSent = true;
 		cycle.drainDeferred = false;
@@ -91,6 +102,17 @@ export const createRecycleCoordinator = ({
 			`[ForkRecycle] Replacement ${cycle.replacementId} listening; draining ${cycle.oldWorkerId}`,
 		);
 		sendDrain(cycle.oldWorkerId);
+		// A lost drain message (or wedged drainer) must not hold the queue
+		// forever. The replacement is already serving, so past the worker's own
+		// drain bounds the old fork is killed and its exit completes the cycle.
+		drainCompletionDeadline = setTimeout(() => {
+			if (activeCycle?.oldWorkerId !== cycle.oldWorkerId) return;
+			log(
+				`[ForkRecycle] Worker ${cycle.oldWorkerId} did not exit within ${drainCompletionTimeoutMs}ms of its drain; killing it (replacement already serving)`,
+			);
+			killWorker(cycle.oldWorkerId);
+		}, drainCompletionTimeoutMs);
+		drainCompletionDeadline.unref?.();
 	};
 
 	const releaseDeferredDrainIfClear = () => {
@@ -141,6 +163,7 @@ export const createRecycleCoordinator = ({
 
 	const startNextPendingCycle = () => {
 		clearBootDeadline();
+		clearDrainCompletionDeadline();
 		activeCycle = null;
 		const next = pendingWorkerIds.shift();
 		if (next !== undefined) startCycle(next);

--- a/server/src/utils/memory/forkRecycling/recyclePolicy.ts
+++ b/server/src/utils/memory/forkRecycling/recyclePolicy.ts
@@ -21,11 +21,15 @@ export const shouldRequestRecycle = ({
 	minAgeMs: number;
 }): boolean => rssBytes >= thresholdBytes && ageMs >= minAgeMs;
 
-// Zero/negative timings would hot-loop checks or defeat the drain bounds.
+// Sub-second timings would hot-loop checks or defeat the drain bounds, so
+// intervals floor at 1s (thresholds/ages just need to be positive).
 const positiveOr = (raw: string | undefined, fallback: number): number => {
 	const value = Number(raw);
 	return Number.isFinite(value) && value > 0 ? value : fallback;
 };
+
+const intervalOr = (raw: string | undefined, fallback: number): number =>
+	Math.max(1_000, positiveOr(raw, fallback));
 
 export const getForkRecycleConfig = () => {
 	return {
@@ -39,11 +43,11 @@ export const getForkRecycleConfig = () => {
 			process.env.FORK_RECYCLE_MIN_AGE_MS,
 			FORK_RECYCLE_DEFAULTS.minAgeMs,
 		),
-		checkIntervalMs: positiveOr(
+		checkIntervalMs: intervalOr(
 			process.env.FORK_RECYCLE_CHECK_INTERVAL_MS,
 			FORK_RECYCLE_DEFAULTS.checkIntervalMs,
 		),
-		drainTimeoutMs: positiveOr(
+		drainTimeoutMs: intervalOr(
 			process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS,
 			FORK_RECYCLE_DEFAULTS.drainTimeoutMs,
 		),

--- a/server/tests/unit/memory/fork-recycling-hardening.test.ts
+++ b/server/tests/unit/memory/fork-recycling-hardening.test.ts
@@ -295,11 +295,13 @@ const runTrial = ({
 	steps,
 	forkCount,
 	ageGateSteps = 6,
+	allowCrashes = true,
 }: {
 	seed: number;
 	steps: number;
 	forkCount: number;
 	ageGateSteps?: number;
+	allowCrashes?: boolean;
 }): TrialResult => {
 	const rand = mulberry32(seed);
 	const history: string[] = [];
@@ -406,7 +408,7 @@ const runTrial = ({
 				history.push(`request ${id}`);
 				coordinator.handleRecycleRequest({ workerId: id });
 			}
-		} else {
+		} else if (allowCrashes) {
 			// Crash: any live process can die at any time.
 			const id = pick(serving) ?? pick(booting);
 			if (id) exit(id);
@@ -473,10 +475,19 @@ describe("coordinator fork-count invariant under random event streams", () => {
 		expect(offenders).toHaveLength(0);
 	});
 
-	test("a recycle never runs more than one surplus fork", () => {
+	// With crashes in the mix the coordinator can transiently overshoot further:
+	// a replacement dying post-drain forks both a respawn and the next cycle's
+	// replacement while the old fork is still draining. It always converges back
+	// to N, so only the crash-free ceiling is a fixed guarantee.
+	test("a crash-free recycle runs exactly one surplus fork", () => {
 		const forkCount = 3;
 		for (let seed = 1; seed <= 200; seed++) {
-			const { peakAlive } = runTrial({ seed, steps: 40, forkCount });
+			const { peakAlive } = runTrial({
+				seed,
+				steps: 40,
+				forkCount,
+				allowCrashes: false,
+			});
 			expect(peakAlive).toBeLessThanOrEqual(forkCount + 1);
 		}
 	});

--- a/server/tests/unit/memory/fork-recycling-hardening.test.ts
+++ b/server/tests/unit/memory/fork-recycling-hardening.test.ts
@@ -1,0 +1,483 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { attachPrimaryForkRecycling } from "@/utils/memory/forkRecycling/attachForkRecycling.js";
+import {
+	createRecycleCoordinator,
+	type RecycleCoordinator,
+} from "@/utils/memory/forkRecycling/recycleCoordinator.js";
+import { getForkRecycleConfig } from "@/utils/memory/forkRecycling/recyclePolicy.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type Harness = {
+	coordinator: RecycleCoordinator;
+	forked: string[];
+	drained: string[];
+	aborted: string[];
+	killed: string[];
+	respawned: string[];
+};
+
+const createHarness = ({
+	bootTimeoutMs = 5_000,
+	drainCompletionTimeoutMs = 5_000,
+}: {
+	bootTimeoutMs?: number;
+	drainCompletionTimeoutMs?: number;
+} = {}): Harness => {
+	const forked: string[] = [];
+	const drained: string[] = [];
+	const aborted: string[] = [];
+	const killed: string[] = [];
+	const respawned: string[] = [];
+	let nextForkId = 100;
+
+	const coordinator = createRecycleCoordinator({
+		forkReplacement: () => {
+			const id = `fork-${nextForkId++}`;
+			forked.push(id);
+			return id;
+		},
+		sendDrain: (workerId) => drained.push(workerId),
+		sendAbort: (workerId) => aborted.push(workerId),
+		killWorker: (workerId) => killed.push(workerId),
+		respawn: (workerId) => {
+			respawned.push(workerId);
+			return `respawn-of-${workerId}`;
+		},
+		replacementBootTimeoutMs: bootTimeoutMs,
+		drainCompletionTimeoutMs,
+		log: () => {},
+	});
+
+	return { coordinator, forked, drained, aborted, killed, respawned };
+};
+
+describe("drain completion deadline survives cycle churn", () => {
+	test("control: a drained worker that never exits is killed", async () => {
+		const { coordinator, forked, killed } = createHarness({
+			drainCompletionTimeoutMs: 40,
+		});
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		await sleep(120);
+
+		expect(killed).toContain("w1");
+	});
+
+	test("replacement dying after listening must not disarm the old worker's deadline", async () => {
+		const { coordinator, forked, drained, killed } = createHarness({
+			drainCompletionTimeoutMs: 40,
+		});
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toEqual(["w1"]);
+
+		// Replacement crashes after it was already serving. w1 is still draining.
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+		await sleep(120);
+
+		expect(killed).toContain("w1");
+	});
+
+	test("a queued cycle must not disarm the previous drain's deadline", async () => {
+		const { coordinator, forked, killed } = createHarness({
+			drainCompletionTimeoutMs: 40,
+		});
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		coordinator.handleRecycleRequest({ workerId: "w2" });
+
+		// Replacement crash pops w2's cycle while w1 is still draining.
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+		await sleep(120);
+
+		expect(killed).toContain("w1");
+	});
+
+	test("a dead worker left in the pending queue gets no replacement forked", () => {
+		const { coordinator, forked } = createHarness();
+
+		// A boot fork crashes, so a respawn is booting and drains defer behind it.
+		coordinator.handleWorkerExit({ workerId: "b0" });
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+
+		// The replacement is serving but its drain of w1 is still deferred, and it
+		// queues a recycle of its own. Then it crashes.
+		coordinator.handleRecycleRequest({ workerId: forked[0] });
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+
+		// Nothing should be forked to replace a worker that is already dead.
+		expect(forked).toHaveLength(1);
+	});
+
+	test("old worker exiting normally leaves no stray kill behind", async () => {
+		const { coordinator, forked, killed } = createHarness({
+			drainCompletionTimeoutMs: 40,
+		});
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		coordinator.handleWorkerExit({ workerId: "w1" });
+		await sleep(120);
+
+		expect(killed).toHaveLength(0);
+	});
+});
+
+describe("interval flooring", () => {
+	const ENV_KEYS = [
+		"FORK_RECYCLE_CHECK_INTERVAL_MS",
+		"FORK_RECYCLE_DRAIN_TIMEOUT_MS",
+	] as const;
+	const saved = new Map<string, string | undefined>();
+
+	beforeEach(() => {
+		for (const key of ENV_KEYS) {
+			saved.set(key, process.env[key]);
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			const value = saved.get(key);
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	test("sub-second intervals floor at 1s instead of hot-looping", () => {
+		process.env.FORK_RECYCLE_CHECK_INTERVAL_MS = "1";
+		process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS = "500";
+		const config = getForkRecycleConfig();
+		expect(config.checkIntervalMs).toBe(1_000);
+		expect(config.drainTimeoutMs).toBe(1_000);
+	});
+
+	test("fractional and exponent-notation values still floor", () => {
+		process.env.FORK_RECYCLE_CHECK_INTERVAL_MS = "0.5";
+		process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS = "1e-3";
+		const config = getForkRecycleConfig();
+		expect(config.checkIntervalMs).toBe(1_000);
+		expect(config.drainTimeoutMs).toBe(1_000);
+	});
+
+	test("values at or above the floor are untouched", () => {
+		process.env.FORK_RECYCLE_CHECK_INTERVAL_MS = "1000";
+		process.env.FORK_RECYCLE_DRAIN_TIMEOUT_MS = "45000";
+		const config = getForkRecycleConfig();
+		expect(config.checkIntervalMs).toBe(1_000);
+		expect(config.drainTimeoutMs).toBe(45_000);
+	});
+});
+
+class FakeWorker extends EventEmitter {
+	dead = false;
+	sent: unknown[] = [];
+	killedTimes = 0;
+	constructor(public id: number) {
+		super();
+	}
+	isDead() {
+		return this.dead;
+	}
+	send(message: unknown, callback?: (error: Error | null) => void) {
+		if (this.dead) {
+			const error = new Error("channel closed");
+			if (callback) {
+				callback(error);
+				return false;
+			}
+			throw error;
+		}
+		this.sent.push(message);
+		callback?.(null);
+		return true;
+	}
+	kill() {
+		this.killedTimes++;
+	}
+}
+
+const createFakeCluster = () => {
+	const emitter = new EventEmitter();
+	const workers: FakeWorker[] = [];
+	let nextId = 1;
+	const clusterModule = Object.assign(emitter, {
+		fork: () => {
+			const worker = new FakeWorker(nextId++);
+			workers.push(worker);
+			return worker;
+		},
+	});
+	return { clusterModule, workers, emitter };
+};
+
+describe("primary-side message guards", () => {
+	const logger = {
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+		debug: () => {},
+	};
+
+	test("a recycle request from a dead worker starts no cycle", () => {
+		const { clusterModule, workers, emitter } = createFakeCluster();
+		// biome-ignore lint/suspicious/noExplicitAny: minimal cluster stand-in
+		attachPrimaryForkRecycling({
+			clusterModule: clusterModule as any,
+			shouldRespawn: () => true,
+			logger: logger as any,
+		});
+
+		const alive = new FakeWorker(50);
+		const dead = new FakeWorker(51);
+		dead.dead = true;
+
+		emitter.emit("message", dead, { type: "fork-recycle:request" });
+		expect(workers).toHaveLength(0);
+
+		emitter.emit("message", alive, { type: "fork-recycle:request" });
+		expect(workers).toHaveLength(1);
+	});
+
+	test("a failed drain send does not throw out of the coordinator", () => {
+		const { clusterModule, workers, emitter } = createFakeCluster();
+		// biome-ignore lint/suspicious/noExplicitAny: minimal cluster stand-in
+		attachPrimaryForkRecycling({
+			clusterModule: clusterModule as any,
+			shouldRespawn: () => true,
+			logger: logger as any,
+		});
+
+		const worker = new FakeWorker(60);
+		emitter.emit("message", worker, { type: "fork-recycle:request" });
+		const replacement = workers[0];
+
+		// Old worker's channel dies before the drain is sent.
+		worker.dead = true;
+		expect(() => emitter.emit("listening", replacement)).not.toThrow();
+	});
+});
+
+/** Deterministic PRNG so a failing trial is reproducible from its seed. */
+const mulberry32 = (seed: number) => {
+	let state = seed;
+	return () => {
+		state += 0x6d2b79f5;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+};
+
+type TrialResult = {
+	seed: number;
+	aliveAtEnd: number;
+	peakAlive: number;
+	converged: boolean;
+	/** Drains or kills aimed at a worker that had already exited. */
+	corpseMessages: string[];
+	history: string[];
+};
+
+/** Drives the coordinator through a random but legal event stream, then
+ *  quiesces and checks the file's stated invariant: alive forks return to N. */
+const runTrial = ({
+	seed,
+	steps,
+	forkCount,
+	ageGateSteps = 6,
+}: {
+	seed: number;
+	steps: number;
+	forkCount: number;
+	ageGateSteps?: number;
+}): TrialResult => {
+	const rand = mulberry32(seed);
+	const history: string[] = [];
+	let nextId = 0;
+
+	const booting = new Set<string>();
+	const serving = new Set<string>();
+	const draining = new Set<string>();
+	// Mirrors the worker-side `requested` latch: a fork asks once, and only an
+	// abort re-arms it.
+	const requested = new Set<string>();
+	const listenedAt = new Map<string, number>();
+	const dead = new Set<string>();
+	const corpseMessages: string[] = [];
+	let peakAlive = 0;
+
+	const spawn = (tag: string) => {
+		const id = `${tag}-${nextId++}`;
+		booting.add(id);
+		return id;
+	};
+
+	const coordinator = createRecycleCoordinator({
+		forkReplacement: () => spawn("repl"),
+		respawn: () => spawn("resp"),
+		sendDrain: (workerId) => {
+			if (dead.has(workerId)) {
+				corpseMessages.push(`drain -> dead ${workerId}`);
+				return;
+			}
+			draining.add(workerId);
+		},
+		sendAbort: (workerId) => {
+			requested.delete(workerId);
+		},
+		killWorker: (workerId) => {
+			if (dead.has(workerId)) {
+				corpseMessages.push(`kill -> dead ${workerId}`);
+				return;
+			}
+			// A kill lands as an exit; the model delivers it on the next exit pick.
+			draining.add(workerId);
+		},
+		// Deadlines are driven explicitly by this model, never by wall clock.
+		replacementBootTimeoutMs: 1_000_000,
+		drainCompletionTimeoutMs: 1_000_000,
+		log: () => {},
+	});
+
+	for (let i = 0; i < forkCount; i++) {
+		const id = `boot-${nextId++}`;
+		booting.add(id);
+	}
+
+	const pick = <T>(items: Set<T>): T | undefined => {
+		if (items.size === 0) return undefined;
+		const list = [...items];
+		return list[Math.floor(rand() * list.length)];
+	};
+
+	let stepIndex = 0;
+	const listen = (id: string) => {
+		booting.delete(id);
+		serving.add(id);
+		listenedAt.set(id, stepIndex);
+		history.push(`listen ${id}`);
+		coordinator.handleWorkerListening({ workerId: id });
+	};
+
+	const exit = (id: string) => {
+		booting.delete(id);
+		serving.delete(id);
+		draining.delete(id);
+		requested.delete(id);
+		dead.add(id);
+		history.push(`exit ${id}`);
+		coordinator.handleWorkerExit({ workerId: id });
+	};
+
+	for (let step = 0; step < steps; step++) {
+		stepIndex = step;
+		const roll = rand();
+		if (roll < 0.35) {
+			const id = pick(booting);
+			if (id) listen(id);
+		} else if (roll < 0.6) {
+			const id = pick(draining);
+			if (id) exit(id);
+		} else if (roll < 0.8) {
+			// Only a serving fork that has not asked and has outlived the age gate
+			// can ask — minAgeMs (30min) far exceeds a cycle's ~12min worst case,
+			// so a fresh replacement never requests inside its own cycle.
+			const candidates = new Set(
+				[...serving].filter(
+					(id) =>
+						!requested.has(id) &&
+						!draining.has(id) &&
+						step - (listenedAt.get(id) ?? 0) >= ageGateSteps,
+				),
+			);
+			const id = pick(candidates);
+			if (id) {
+				requested.add(id);
+				history.push(`request ${id}`);
+				coordinator.handleRecycleRequest({ workerId: id });
+			}
+		} else {
+			// Crash: any live process can die at any time.
+			const id = pick(serving) ?? pick(booting);
+			if (id) exit(id);
+		}
+		peakAlive = Math.max(peakAlive, booting.size + serving.size);
+	}
+
+	// Quiesce: everything that can still make progress does.
+	let converged = false;
+	for (let round = 0; round < 500; round++) {
+		if (booting.size === 0 && draining.size === 0) {
+			converged = true;
+			break;
+		}
+		for (const id of [...booting]) listen(id);
+		for (const id of [...draining]) exit(id);
+	}
+
+	return {
+		seed,
+		aliveAtEnd: booting.size + serving.size,
+		peakAlive,
+		converged,
+		corpseMessages,
+		history,
+	};
+};
+
+describe("coordinator fork-count invariant under random event streams", () => {
+	test("alive forks always return to N after quiescing", () => {
+		const forkCount = 3;
+		const failures: TrialResult[] = [];
+
+		for (let seed = 1; seed <= 400; seed++) {
+			const result = runTrial({ seed, steps: 60, forkCount });
+			if (!result.converged || result.aliveAtEnd !== forkCount) {
+				failures.push(result);
+			}
+		}
+
+		if (failures.length > 0) {
+			const worst = failures[0];
+			throw new Error(
+				`${failures.length}/400 trials broke the invariant. seed=${worst.seed} alive=${worst.aliveAtEnd} converged=${worst.converged}\n${worst.history.slice(-25).join("\n")}`,
+			);
+		}
+		expect(failures).toHaveLength(0);
+	});
+
+	test("no drain or kill is ever aimed at a worker that already exited", () => {
+		const offenders: TrialResult[] = [];
+
+		for (let seed = 1; seed <= 400; seed++) {
+			const result = runTrial({ seed, steps: 60, forkCount: 3 });
+			if (result.corpseMessages.length > 0) offenders.push(result);
+		}
+
+		if (offenders.length > 0) {
+			const worst = offenders[0];
+			throw new Error(
+				`${offenders.length}/400 trials messaged a dead worker. seed=${worst.seed}\n${worst.corpseMessages.join("\n")}\n--- tail ---\n${worst.history.slice(-15).join("\n")}`,
+			);
+		}
+		expect(offenders).toHaveLength(0);
+	});
+
+	test("a recycle never runs more than one surplus fork", () => {
+		const forkCount = 3;
+		for (let seed = 1; seed <= 200; seed++) {
+			const { peakAlive } = runTrial({ seed, steps: 40, forkCount });
+			expect(peakAlive).toBeLessThanOrEqual(forkCount + 1);
+		}
+	});
+});

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -103,8 +103,10 @@ type CoordinatorHarness = {
  *  through the handle* methods directly. */
 const createHarness = ({
 	bootTimeoutMs = 5_000,
+	drainCompletionTimeoutMs = 5_000,
 }: {
 	bootTimeoutMs?: number;
+	drainCompletionTimeoutMs?: number;
 } = {}): CoordinatorHarness => {
 	const forked: string[] = [];
 	const drained: string[] = [];
@@ -133,6 +135,7 @@ const createHarness = ({
 			return `respawn-of-${workerId}`;
 		},
 		replacementBootTimeoutMs: bootTimeoutMs,
+		drainCompletionTimeoutMs,
 		log: () => {},
 	});
 
@@ -335,6 +338,27 @@ describe("createRecycleCoordinator", () => {
 
 		coordinator.handleWorkerListening({ workerId: "respawn-of-w-crashed" });
 		expect(drained).toEqual(["w1"]);
+	});
+
+	test("a drained worker that never exits is killed at the completion deadline", async () => {
+		const { coordinator, forked, drained, killed, respawned } = createHarness({
+			drainCompletionTimeoutMs: 100,
+		});
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleRecycleRequest({ workerId: "w2" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+		expect(drained).toEqual(["w1"]);
+
+		// Drain message lost / drainer wedged: no exit arrives.
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		expect(killed).toEqual(["w1"]);
+
+		// The kill's exit completes the cycle through the expected path —
+		// no respawn (replacement already serves) and w2's cycle starts.
+		expect(coordinator.handleWorkerExit({ workerId: "w1" })).toBe(true);
+		expect(respawned).toHaveLength(0);
+		expect(forked).toHaveLength(2);
 	});
 
 	test("a hung crash respawn is killed at its boot deadline and drains release", async () => {


### PR DESCRIPTION
Addresses the four valid cubic findings on the recycling code from the release PR (#2658) review:

- **Stale recycle request from a dead worker** could start a phantom cycle that never completes — requests from dead workers are now ignored at the primary.
- **Worker-side `process.send` was unguarded** — a closed IPC channel (primary going away) crashed the worker; now wrapped like the primary's sends.
- **Interval env values floor at 1s** — a 1ms `FORK_RECYCLE_CHECK_INTERVAL_MS` could hot-loop the RSS check.
- **Drain-completion deadline** — a lost drain message or wedged drainer left the cycle waiting forever at N+1 serving forks; the old worker is now killed 12 minutes after its drain was sent (its replacement is already serving) and its exit completes the cycle.

Not addressed (test-ergonomics nits, tracked for the hardening follow-up): random-port retry in the cluster test, fake-clock injection for deadline tests.

42/42 tests, typecheck + lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens fork recycling to prevent stuck N+1 states and worker crashes. Adds a per‑worker drain deadline that survives cycle churn, ignores stale requests from dead workers, and floors sub‑second intervals.

- **Bug Fixes**
  - Ignore recycle requests from dead workers to avoid phantom cycles.
  - Guard worker `process.send` to avoid crashes on closed IPC.
  - Add a 12‑min per‑worker drain‑completion deadline that persists across replacement exits and queued cycles.
  - Clear the deadline on worker exit and drop dead workers from the pending queue to prevent forking for corpses.
  - Floor `FORK_RECYCLE_CHECK_INTERVAL_MS` and `FORK_RECYCLE_DRAIN_TIMEOUT_MS` to 1s min to prevent hot loops and respect drain bounds.

<sup>Written for commit 56a28a9a6f423f16ccef398f92a717aeb6cd8489. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens fork recycling so worker failures and delayed shutdowns do not leave the server with extra workers or stalled recycle cycles.

- **Bug fixes:** Keeps each draining worker’s shutdown deadline active even when its replacement exits or another recycle cycle starts.
- **Bug fixes:** Removes dead workers from the pending recycle queue and ignores recycle requests received from workers already known to be dead.
- **Bug fixes:** Safely handles recycle requests sent after the worker IPC channel closes.
- **Improvements:** Floors recycle-check and drain intervals at one second and adds lifecycle-focused tests for worker-count convergence.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/memory/forkRecycling/recycleCoordinator.ts | Associates drain deadlines with individual workers, preserves them across cycle transitions, and removes exited workers from the pending queue. |
| server/src/utils/memory/forkRecycling/attachForkRecycling.ts | Ignores stale requests from dead workers and guards worker-side IPC sends against closed channels. |
| server/src/utils/memory/forkRecycling/recyclePolicy.ts | Floors recycle-check and drain interval configuration values at one second. |
| server/tests/unit/memory/fork-recycling-hardening.test.ts | Adds focused and randomized coverage for deadline survival, stale requests, closed channels, interval flooring, and worker-count convergence. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Worker requests recycle] --> B[Primary forks replacement]
  B --> C{Replacement listening?}
  C -- No --> D[Boot deadline kills replacement and aborts cycle]
  C -- Yes --> E[Send drain to old worker]
  E --> F[Start worker-specific drain deadline]
  F --> G{Old worker exits?}
  G -- Yes --> H[Clear its deadline and complete cycle]
  G -- No --> I[Deadline force-kills old worker]
  I --> H
  H --> J[Start next pending cycle]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: key the drain deadline to the worke..."](https://github.com/useautumn/autumn/commit/56a28a9a6f423f16ccef398f92a717aeb6cd8489) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51130610)</sub>

<!-- /greptile_comment -->