### PR TITLE
feat: migrate async Track to Standard SQS

### DIFF
--- a/server/src/internal/balances/track/utils/queueTrack.ts
+++ b/server/src/internal/balances/track/utils/queueTrack.ts
@@ -2,6 +2,7 @@ import type { TrackParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import { getAsyncTrackProducerQueueUrl } from "@/queue/trackAsyncQueueUrls.js";
 import { addToExtraLogs } from "@/utils/logging/addToExtraLogs.js";
 import { getQueuedTrackResponse } from "./getQueuedTrackResponse.js";
 
@@ -39,16 +40,15 @@ export const queueTrack = async ({
 	} = options;
 
 	try {
-		// Sync fallbacks and async tracks share ONE queue. TRACK_SQS_QUEUE_URL
-		// is deprecated — read only as a fallback for envs that haven't set the
-		// async URL yet (its poller stays alive to drain in-flight messages).
+		// Prefer the Standard async queue while keeping the legacy FIFO as a
+		// rollout fallback. TRACK_SQS_QUEUE_URL is the final deprecated fallback.
 		const resolvedQueueUrl =
 			queueUrl ??
-			process.env.TRACK_ASYNC_SQS_QUEUE_URL ??
+			getAsyncTrackProducerQueueUrl() ??
 			process.env.TRACK_SQS_QUEUE_URL;
 		if (!resolvedQueueUrl) {
 			ctx.logger.warn(
-				"[track] TRACK_ASYNC_SQS_QUEUE_URL is unset; falling back to synchronous track",
+				"[track] async Track queue URLs are unset; falling back to synchronous track",
 			);
 			return null;
 		}

--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -9,7 +9,6 @@ import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubjec
 import { isAsyncBalanceUpdateEnabled } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
-import { getAsyncTrackProducerQueueUrl } from "@/queue/trackAsyncQueueUrls.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
 import { updateExpiresAtV2 } from "./updateExpiresAtV2.js";
 import { updateIncludedGrantV2 } from "./updateIncludedGrantV2.js";
@@ -101,7 +100,7 @@ const queueUpdateBalanceV2 = async ({
 	params: UpdateBalanceParamsV0;
 	targetBalance?: number;
 }) => {
-	const queueUrl = getAsyncTrackProducerQueueUrl();
+	const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
 	if (!queueUrl) {
 		throw new RecaseError({
 			message: ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE,

--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -9,6 +9,7 @@ import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubjec
 import { isAsyncBalanceUpdateEnabled } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import { getAsyncTrackProducerQueueUrl } from "@/queue/trackAsyncQueueUrls.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
 import { updateExpiresAtV2 } from "./updateExpiresAtV2.js";
 import { updateIncludedGrantV2 } from "./updateIncludedGrantV2.js";
@@ -100,7 +101,7 @@ const queueUpdateBalanceV2 = async ({
 	params: UpdateBalanceParamsV0;
 	targetBalance?: number;
 }) => {
-	const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+	const queueUrl = getAsyncTrackProducerQueueUrl();
 	if (!queueUrl) {
 		throw new RecaseError({
 			message: ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE,

--- a/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
+++ b/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
@@ -8,6 +8,7 @@ import { getMiscRedis } from "@/external/redis/initRedis.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import { withTimeout } from "@/utils/withTimeout.js";
 import { QUEUE_URL } from "../initSqs.js";
+import { getAsyncTrackWorkerQueueUrls } from "../trackAsyncQueueUrls.js";
 import type { BlueGreenProbeResult } from "./blueGreenSchemas.js";
 
 const CHECK_TIMEOUT_MS = 5_000;
@@ -44,7 +45,7 @@ const getConfiguredQueueUrls = () =>
 	[
 		QUEUE_URL,
 		process.env.TRACK_SQS_QUEUE_URL,
-		process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+		...getAsyncTrackWorkerQueueUrls(),
 		process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL,
 	].filter((url): url is string => Boolean(url));
 

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -34,6 +34,7 @@ import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
 import { shutdownSqsSendBatchers } from "./queueUtils.js";
+import { getAsyncTrackWorkerQueueUrls } from "./trackAsyncQueueUrls.js";
 import {
 	createWorkerActivityTracker,
 	type WorkerActivityTracker,
@@ -640,12 +641,12 @@ export const initWorkers = async ({
 		idleAfterMs: IDLE_SELF_KILL_MS,
 	});
 
-	for (const {
-		queueId,
-		queueUrl,
-		defaultEnabled,
-		visibilityTimeoutSeconds,
-	} of [
+	const queueConfigs: Array<{
+		queueId: string;
+		queueUrl?: string;
+		defaultEnabled: boolean;
+		visibilityTimeoutSeconds?: number;
+	}> = [
 		{
 			queueId: JOB_QUEUE_IDS.primary,
 			queueUrl: QUEUE_URL,
@@ -656,11 +657,11 @@ export const initWorkers = async ({
 			queueUrl: process.env.TRACK_SQS_QUEUE_URL,
 			defaultEnabled: true,
 		},
-		{
+		...getAsyncTrackWorkerQueueUrls().map((queueUrl) => ({
 			queueId: JOB_QUEUE_IDS.trackAsync,
-			queueUrl: process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+			queueUrl,
 			defaultEnabled: true,
-		},
+		})),
 		{
 			queueId: JOB_QUEUE_IDS.customerCreationRecovery,
 			queueUrl: process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL,
@@ -681,7 +682,14 @@ export const initWorkers = async ({
 			// depth, so a long window stalls the whole sweep.
 			visibilityTimeoutSeconds: 900,
 		},
-	]) {
+	];
+
+	for (const {
+		queueId,
+		queueUrl,
+		defaultEnabled,
+		visibilityTimeoutSeconds,
+	} of queueConfigs) {
 		if (!queueUrl) continue;
 
 		pollingLoops.push(

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -17,6 +17,7 @@ import type { GenerateFeatureDisplayPayload } from "@/internal/features/workflow
 import { getSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { SqsBatchAccumulator } from "./SqsBatchAccumulator.js";
+import { getAsyncTrackProducerQueueUrl } from "./trackAsyncQueueUrls.js";
 import {
 	type SqsBatchMessage,
 	type SqsSendResult,
@@ -136,7 +137,7 @@ const resolveSqsSendBatcher = (queueUrl: string) => {
 	if (queueUrl === process.env.SQS_QUEUE_URL_V2) {
 		return globalPrimarySqsSendBatcher;
 	}
-	if (queueUrl === process.env.TRACK_ASYNC_SQS_QUEUE_URL) {
+	if (queueUrl === getAsyncTrackProducerQueueUrl()) {
 		return globalAsyncTrackSqsSendBatcher;
 	}
 	return null;

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -17,7 +17,7 @@ import type { GenerateFeatureDisplayPayload } from "@/internal/features/workflow
 import { getSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { SqsBatchAccumulator } from "./SqsBatchAccumulator.js";
-import { getAsyncTrackProducerQueueUrl } from "./trackAsyncQueueUrls.js";
+import { getAsyncTrackWorkerQueueUrls } from "./trackAsyncQueueUrls.js";
 import {
 	type SqsBatchMessage,
 	type SqsSendResult,
@@ -137,7 +137,7 @@ const resolveSqsSendBatcher = (queueUrl: string) => {
 	if (queueUrl === process.env.SQS_QUEUE_URL_V2) {
 		return globalPrimarySqsSendBatcher;
 	}
-	if (queueUrl === getAsyncTrackProducerQueueUrl()) {
+	if (getAsyncTrackWorkerQueueUrls().includes(queueUrl)) {
 		return globalAsyncTrackSqsSendBatcher;
 	}
 	return null;

--- a/server/src/queue/trackAsyncQueueUrls.ts
+++ b/server/src/queue/trackAsyncQueueUrls.ts
@@ -1,0 +1,22 @@
+export const getAsyncTrackProducerQueueUrl = ({
+	standardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL,
+	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+}: {
+	standardQueueUrl?: string;
+	legacyFifoQueueUrl?: string;
+} = {}): string | undefined => standardQueueUrl ?? legacyFifoQueueUrl;
+
+export const getAsyncTrackWorkerQueueUrls = ({
+	standardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL,
+	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+}: {
+	standardQueueUrl?: string;
+	legacyFifoQueueUrl?: string;
+} = {}): string[] =>
+	Array.from(
+		new Set(
+			[standardQueueUrl, legacyFifoQueueUrl].filter(
+				(queueUrl): queueUrl is string => Boolean(queueUrl),
+			),
+		),
+	);

--- a/server/src/queue/trackAsyncQueueUrls.ts
+++ b/server/src/queue/trackAsyncQueueUrls.ts
@@ -4,7 +4,7 @@ export const getAsyncTrackProducerQueueUrl = ({
 }: {
 	standardQueueUrl?: string;
 	legacyFifoQueueUrl?: string;
-} = {}): string | undefined => standardQueueUrl ?? legacyFifoQueueUrl;
+} = {}): string | undefined => standardQueueUrl || legacyFifoQueueUrl;
 
 export const getAsyncTrackWorkerQueueUrls = ({
 	standardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL,

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -118,7 +118,7 @@ describe("updateBalanceV2 async routing", () => {
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
 		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = trackAsyncStandardQueueUrl;
 
-		const sqsClient = getSqsClient({ queueUrl: trackAsyncStandardQueueUrl });
+		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
 		state.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			state.queueCommands.push(command.input);
@@ -132,7 +132,7 @@ describe("updateBalanceV2 async routing", () => {
 
 	afterEach(() => {
 		if (state.originalSend) {
-			const sqsClient = getSqsClient({ queueUrl: trackAsyncStandardQueueUrl });
+			const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
 			sqsClient.send = state.originalSend;
 			state.originalSend = null;
 		}
@@ -153,15 +153,17 @@ describe("updateBalanceV2 async routing", () => {
 
 		expect(state.queueCommands).toHaveLength(1);
 		expect(state.queueCommands[0]).toMatchObject({
-			QueueUrl: trackAsyncStandardQueueUrl,
+			QueueUrl: trackAsyncQueueUrl,
 		});
 		// The async-track queue sends through the SQS batcher (SendMessageBatch).
 		const batchEntries = state.queueCommands[0].Entries as Array<
 			Record<string, unknown>
 		>;
 		expect(batchEntries).toHaveLength(1);
-		expect(batchEntries[0]).not.toHaveProperty("MessageGroupId");
-		expect(batchEntries[0]).not.toHaveProperty("MessageDeduplicationId");
+		expect(batchEntries[0]).toMatchObject({
+			MessageGroupId: "org_123:sandbox:cus_123:none",
+			MessageDeduplicationId: ctx.id,
+		});
 		const message = JSON.parse(String(batchEntries[0].MessageBody)) as Record<
 			string,
 			unknown
@@ -212,7 +214,6 @@ describe("updateBalanceV2 async routing", () => {
 			config: { enabledOrgIds: ["org_123"] },
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
-		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = undefined;
 
 		await expect(
 			updateBalanceV2({

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -19,6 +19,8 @@ import { mockModuleWithRestore } from "../../utils/mockModuleWithRestore.js";
 
 const trackAsyncQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
+const trackAsyncStandardQueueUrl =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev-standard";
 
 const state = {
 	queueCommands: [] as Record<string, unknown>[],
@@ -103,6 +105,8 @@ const params = {
 
 describe("updateBalanceV2 async routing", () => {
 	const originalQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+	const originalStandardQueueUrl =
+		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL;
 
 	beforeEach(() => {
 		state.queueCommands = [];
@@ -112,8 +116,9 @@ describe("updateBalanceV2 async routing", () => {
 			config: AsyncBalanceUpdateConfigSchema.parse({}),
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
+		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = trackAsyncStandardQueueUrl;
 
-		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+		const sqsClient = getSqsClient({ queueUrl: trackAsyncStandardQueueUrl });
 		state.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			state.queueCommands.push(command.input);
@@ -127,7 +132,7 @@ describe("updateBalanceV2 async routing", () => {
 
 	afterEach(() => {
 		if (state.originalSend) {
-			const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+			const sqsClient = getSqsClient({ queueUrl: trackAsyncStandardQueueUrl });
 			sqsClient.send = state.originalSend;
 			state.originalSend = null;
 		}
@@ -135,6 +140,7 @@ describe("updateBalanceV2 async routing", () => {
 			config: AsyncBalanceUpdateConfigSchema.parse({}),
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalQueueUrl;
+		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = originalStandardQueueUrl;
 	});
 
 	test("enqueues configured async updates without running synchronous mutation helpers", async () => {
@@ -147,17 +153,15 @@ describe("updateBalanceV2 async routing", () => {
 
 		expect(state.queueCommands).toHaveLength(1);
 		expect(state.queueCommands[0]).toMatchObject({
-			QueueUrl: trackAsyncQueueUrl,
+			QueueUrl: trackAsyncStandardQueueUrl,
 		});
 		// The async-track queue sends through the SQS batcher (SendMessageBatch).
 		const batchEntries = state.queueCommands[0].Entries as Array<
 			Record<string, unknown>
 		>;
 		expect(batchEntries).toHaveLength(1);
-		expect(batchEntries[0]).toMatchObject({
-			MessageGroupId: "org_123:sandbox:cus_123:none",
-			MessageDeduplicationId: ctx.id,
-		});
+		expect(batchEntries[0]).not.toHaveProperty("MessageGroupId");
+		expect(batchEntries[0]).not.toHaveProperty("MessageDeduplicationId");
 		const message = JSON.parse(String(batchEntries[0].MessageBody)) as Record<
 			string,
 			unknown
@@ -208,6 +212,7 @@ describe("updateBalanceV2 async routing", () => {
 			config: { enabledOrgIds: ["org_123"] },
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
+		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = undefined;
 
 		await expect(
 			updateBalanceV2({

--- a/server/tests/unit/queue/track-async-queue-urls.test.ts
+++ b/server/tests/unit/queue/track-async-queue-urls.test.ts
@@ -1,0 +1,125 @@
+/**
+ * TDD contract for migrating async Track from FIFO to Standard SQS.
+ *
+ * Contract under test:
+ *   - Producers prefer TRACK_ASYNC_STANDARD_SQS_QUEUE_URL.
+ *   - Producers fall back to TRACK_ASYNC_SQS_QUEUE_URL during rollout.
+ *   - Workers consume both configured URLs without duplicate pollers.
+ *   - Standard-queue sends omit FIFO-only message identifiers.
+ *
+ * Pre-implementation red: the queue URL resolver does not exist and producers
+ * ignore TRACK_ASYNC_STANDARD_SQS_QUEUE_URL.
+ * Post-implementation green: producer and worker routing support the migration.
+ */
+
+import { afterEach, expect, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { runAsyncTrack } from "@/internal/balances/track/runAsyncTrack.js";
+import { getBlueGreenQueueUrls } from "@/queue/blueGreen/blueGreenReadinessChecks.js";
+import { getSqsClient } from "@/queue/initSqs.js";
+import {
+	getAsyncTrackProducerQueueUrl,
+	getAsyncTrackWorkerQueueUrls,
+} from "@/queue/trackAsyncQueueUrls.js";
+
+const STANDARD_QUEUE_URL =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/track-async-standard";
+const LEGACY_FIFO_QUEUE_URL =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/track-async.fifo";
+
+const originalStandardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL;
+const originalLegacyQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+
+const restoreEnv = ({ key, value }: { key: string; value?: string }) => {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+};
+
+afterEach(() => {
+	restoreEnv({
+		key: "TRACK_ASYNC_STANDARD_SQS_QUEUE_URL",
+		value: originalStandardQueueUrl,
+	});
+	restoreEnv({
+		key: "TRACK_ASYNC_SQS_QUEUE_URL",
+		value: originalLegacyQueueUrl,
+	});
+});
+
+test("prefers Standard for producers while workers consume Standard and FIFO", () => {
+	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = STANDARD_QUEUE_URL;
+	process.env.TRACK_ASYNC_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+
+	expect(getAsyncTrackProducerQueueUrl()).toBe(STANDARD_QUEUE_URL);
+	expect(getAsyncTrackWorkerQueueUrls()).toEqual([
+		STANDARD_QUEUE_URL,
+		LEGACY_FIFO_QUEUE_URL,
+	]);
+	expect(getBlueGreenQueueUrls()).toEqual(
+		expect.arrayContaining([STANDARD_QUEUE_URL, LEGACY_FIFO_QUEUE_URL]),
+	);
+});
+
+test("falls back to the legacy FIFO and avoids duplicate worker pollers", () => {
+	delete process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL;
+	process.env.TRACK_ASYNC_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+
+	expect(getAsyncTrackProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
+	expect(getAsyncTrackWorkerQueueUrls()).toEqual([LEGACY_FIFO_QUEUE_URL]);
+
+	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+	expect(getAsyncTrackWorkerQueueUrls()).toEqual([LEGACY_FIFO_QUEUE_URL]);
+});
+
+test("sends async Track to Standard without FIFO-only identifiers", async () => {
+	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = STANDARD_QUEUE_URL;
+	process.env.TRACK_ASYNC_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+
+	const sqsClient = getSqsClient({ queueUrl: STANDARD_QUEUE_URL });
+	const originalSend = sqsClient.send.bind(sqsClient);
+	const commands: Array<{ input: Record<string, unknown> }> = [];
+	sqsClient.send = (async (command: {
+		input: { Entries?: Array<{ Id: string }> };
+	}) => {
+		commands.push(command);
+		return {
+			Successful: command.input.Entries?.map(({ Id }) => ({ Id })) ?? [],
+		};
+	}) as typeof sqsClient.send;
+
+	const ctx = {
+		id: "req_standard_1",
+		org: { id: "org_123" },
+		env: AppEnv.Live,
+		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		extraLogs: {},
+		logger: { warn: () => undefined, error: () => undefined },
+	} as unknown as AutumnContext;
+
+	try {
+		await runAsyncTrack({
+			ctx,
+			body: {
+				customer_id: "cus_123",
+				feature_id: "messages",
+				value: 1,
+				async: true,
+			},
+		});
+
+		expect(commands).toHaveLength(1);
+		expect(commands[0].input.QueueUrl).toBe(STANDARD_QUEUE_URL);
+		const entries = commands[0].input.Entries as Array<Record<string, unknown>>;
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).not.toHaveProperty("MessageGroupId");
+		expect(entries[0]).not.toHaveProperty("MessageDeduplicationId");
+		expect(JSON.parse(entries[0].MessageBody as string)).toMatchObject({
+			name: "track",
+			data: { requestId: "req_standard_1" },
+		});
+	} finally {
+		sqsClient.send = originalSend as SQSClient["send"];
+	}
+});

--- a/server/tests/unit/queue/track-async-queue-urls.test.ts
+++ b/server/tests/unit/queue/track-async-queue-urls.test.ts
@@ -71,6 +71,9 @@ test("falls back to the legacy FIFO and avoids duplicate worker pollers", () => 
 
 	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
 	expect(getAsyncTrackWorkerQueueUrls()).toEqual([LEGACY_FIFO_QUEUE_URL]);
+
+	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = "";
+	expect(getAsyncTrackProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
 });
 
 test("sends async Track to Standard without FIFO-only identifiers", async () => {


### PR DESCRIPTION
## Summary

- prefer `TRACK_ASYNC_STANDARD_SQS_QUEUE_URL` for async Track and async balance-update producers
- consume both the Standard queue and legacy FIFO during the migration
- include both queues in blue/green readiness checks and avoid duplicate pollers
- rely on the existing queue-type detection to omit FIFO-only fields on Standard sends

## Rollout

Requires useautumn/terraform#80 to be applied first.

1. Configure `TRACK_ASYNC_STANDARD_SQS_QUEUE_URL` with the new Standard queue URL.
2. Keep `TRACK_ASYNC_SQS_QUEUE_URL` configured with the legacy FIFO URL.
3. Deploy this PR; new producers switch to Standard and workers drain both queues.
4. Remove the legacy FIFO in a later change after visible and in-flight messages remain at zero for several visibility windows.

If the new env is absent, producers continue using the legacy FIFO, so the application change is backward compatible with the current infrastructure.

## Validation

- 34 focused queue and async Track/update-balance tests pass
- `bun ts` passes in `server`
- focused Biome check passes with two pre-existing unused-import warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate async Track to a Standard SQS queue while workers consume both the new Standard queue and the legacy FIFO; keep async balance-update producers on FIFO to preserve ordering. Readiness checks and worker init dedupe URLs to avoid duplicate pollers.

- **New Features**
  - Track producers prefer `TRACK_ASYNC_STANDARD_SQS_QUEUE_URL`, fall back to `TRACK_ASYNC_SQS_QUEUE_URL`; balance updates remain on `TRACK_ASYNC_SQS_QUEUE_URL` (FIFO).
  - Workers poll both Track queues; blue/green readiness includes both with URL deduping.
  - Standard sends omit FIFO-only fields via existing detection.
  - Shared helpers for Track: `getAsyncTrackProducerQueueUrl`, `getAsyncTrackWorkerQueueUrls`.

- **Migration**
  - Create the Standard SQS queue and set `TRACK_ASYNC_STANDARD_SQS_QUEUE_URL`.
  - Keep `TRACK_ASYNC_SQS_QUEUE_URL` for the legacy FIFO during rollout.
  - Deploy; Track producers switch to Standard, workers drain both; balance updates stay on FIFO.
  - Remove the FIFO after visible/in-flight messages are zero for several visibility windows.

<sup>Written for commit c8377da89a60da22aeb625eefcb0f0d2a3c288bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates async Track producers to a Standard SQS queue while workers temporarily drain both the new and legacy queues.
- **[Improvements]** Prefer the new Standard queue for async Track while retaining the legacy FIFO fallback.
- **[Improvements]** Poll both configured queues and include both in blue/green readiness checks without creating duplicate pollers.
- **[Improvements]** Omit FIFO-only message fields when sending to the Standard queue.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the previously reported loss of ordering for related async Track balance changes remains at the current head.

Async Track producers still prefer Standard SQS, whose messages can be delivered and processed concurrently without the per-group ordering previously supplied by FIFO; distinct balance-changing requests therefore can leave an incorrect final balance.

**Files Needing Attention:** server/src/queue/trackAsyncQueueUrls.ts, server/src/queue/queueUtils.ts, server/src/queue/initWorkers.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/trackAsyncQueueUrls.ts | Adds producer and worker queue resolution, but preferring Standard SQS removes the ordering guarantee required by related balance updates. |
| server/src/queue/initWorkers.ts | Starts pollers for both migration queues and deduplicates identical URLs; concurrent Standard-queue processing leaves the previously reported ordering issue outstanding. |
| server/src/queue/queueUtils.ts | Routes both async Track queue URLs through the shared batcher and correctly omits FIFO-only fields for Standard sends. |
| server/src/internal/balances/track/utils/queueTrack.ts | Switches async Track producers to the shared resolver, making the Standard queue the preferred destination. |
| server/src/queue/blueGreen/blueGreenReadinessChecks.ts | Adds both migration queues to readiness checks. |
| server/tests/unit/queue/track-async-queue-urls.test.ts | Covers queue preference, fallback, poller URL deduplication, readiness, and omission of FIFO-only send fields. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  P[Async Track producer] --> R{Standard URL configured?}
  R -->|Yes| S[Standard SQS]
  R -->|No| F[Legacy FIFO SQS]
  S --> W[Worker pollers]
  F --> W
  W --> H[Track balance handler]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into og/async-track-..."](https://github.com/useautumn/autumn/commit/e35566706ecff34117a4b124b1bf4622f1a76d99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51133704)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->