### PR TITLE
feat(customers): sort_order on customers.list + dashboard created-at sorting

### DIFF
--- a/packages/ui/src/components/table/table-body-virtualized.tsx
+++ b/packages/ui/src/components/table/table-body-virtualized.tsx
@@ -96,7 +96,6 @@ const VirtualRow = memo(VirtualRowInner, (prevProps, nextProps) => {
 export function TableBodyVirtualized() {
 	const {
 		table,
-		numberOfColumns,
 		enableSelection,
 		isLoading,
 		isTransitioning,
@@ -178,6 +177,10 @@ export function TableBodyVirtualized() {
 		skeleton: col.columnDef.meta?.skeleton,
 	}));
 
+	// Spanning more columns than are rendered makes the browser invent extra ones,
+	// which steal width from the real columns and break header alignment.
+	const spannedColumnCount = columns.length + (enableSelection ? 1 : 0);
+
 	const configuredSkeletonRows = virtualization?.skeletonRowCount;
 	const containerPx = scrollContainer?.clientHeight ?? 0;
 
@@ -218,7 +221,7 @@ export function TableBodyVirtualized() {
 				<TableRow className="hover:bg-transparent dark:hover:bg-transparent">
 					<TableCell
 						className="h-10 text-center py-0"
-						colSpan={numberOfColumns}
+						colSpan={spannedColumnCount}
 					>
 						<div className="text-subtle text-xs text-center w-full h-full items-center justify-center flex">
 							{emptyStateChildren || emptyStateText}
@@ -272,7 +275,7 @@ export function TableBodyVirtualized() {
 			{paddingTop > 0 && (
 				<tr style={{ height: paddingTop }}>
 					<td
-						colSpan={numberOfColumns}
+						colSpan={spannedColumnCount}
 						style={{ padding: 0, border: "none" }}
 					/>
 				</tr>
@@ -304,7 +307,7 @@ export function TableBodyVirtualized() {
 			{paddingBottom > 0 && (
 				<tr style={{ height: paddingBottom }}>
 					<td
-						colSpan={numberOfColumns}
+						colSpan={spannedColumnCount}
 						style={{ padding: 0, border: "none" }}
 					/>
 				</tr>

--- a/packages/ui/src/components/table/table-content-virtualized.tsx
+++ b/packages/ui/src/components/table/table-content-virtualized.tsx
@@ -19,7 +19,6 @@ export function TableContentVirtualized({
 }) {
 	const context = useTableContext();
 	const {
-		flexibleTableColumns,
 		enableColumnVisibility,
 		columnVisibilityInToolbar,
 		columnVisibilityClassName,
@@ -128,10 +127,9 @@ export function TableContentVirtualized({
 								<TableColumnVisibility />
 							</div>
 						)}
-						<Table
-							className="p-0 w-full rounded-t-lg"
-							flexibleTableColumns={flexibleTableColumns}
-						>
+						{/* Header and body are separate tables: they only stay column-aligned
+						    under fixed layout, so flexibleTableColumns is deliberately not forwarded. */}
+						<Table className="p-0 w-full rounded-t-lg">
 							<TableHeader hideBorder />
 						</Table>
 					</div>
@@ -152,11 +150,7 @@ export function TableContentVirtualized({
 						scrollbarGutter,
 					}}
 				>
-					<Table
-						className="p-0 w-full"
-						flexibleTableColumns={flexibleTableColumns}
-						style={{ minWidth: `${totalWidth}px` }}
-					>
+					<Table className="p-0 w-full" style={{ minWidth: `${totalWidth}px` }}>
 						{React.Children.map(children, (child) =>
 							React.isValidElement(child)
 								? React.cloneElement(child, { key: visibleColumnKey })

--- a/packages/ui/src/components/table/table-content-virtualized.tsx
+++ b/packages/ui/src/components/table/table-content-virtualized.tsx
@@ -19,6 +19,7 @@ export function TableContentVirtualized({
 }) {
 	const context = useTableContext();
 	const {
+		flexibleTableColumns,
 		enableColumnVisibility,
 		columnVisibilityInToolbar,
 		columnVisibilityClassName,
@@ -127,9 +128,10 @@ export function TableContentVirtualized({
 								<TableColumnVisibility />
 							</div>
 						)}
-						{/* Header and body are separate tables: they only stay column-aligned
-						    under fixed layout, so flexibleTableColumns is deliberately not forwarded. */}
-						<Table className="p-0 w-full rounded-t-lg">
+						<Table
+							className="p-0 w-full rounded-t-lg"
+							flexibleTableColumns={flexibleTableColumns}
+						>
 							<TableHeader hideBorder />
 						</Table>
 					</div>
@@ -150,7 +152,11 @@ export function TableContentVirtualized({
 						scrollbarGutter,
 					}}
 				>
-					<Table className="p-0 w-full" style={{ minWidth: `${totalWidth}px` }}>
+					<Table
+						className="p-0 w-full"
+						flexibleTableColumns={flexibleTableColumns}
+						style={{ minWidth: `${totalWidth}px` }}
+					>
 						{React.Children.map(children, (child) =>
 							React.isValidElement(child)
 								? React.cloneElement(child, { key: visibleColumnKey })

--- a/packages/ui/src/components/table/table-content-virtualized.tsx
+++ b/packages/ui/src/components/table/table-content-virtualized.tsx
@@ -8,7 +8,7 @@ import { TableHeader } from "@autumn/ui/components/table/table-header";
 import { TableMobileCards } from "@autumn/ui/components/table/table-mobile-cards";
 import { Table } from "@autumn/ui/components/ui/table";
 import { cn } from "@autumn/ui/lib/utils";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useMemo, useState } from "react";
 
 export function TableContentVirtualized({
 	children,
@@ -19,7 +19,6 @@ export function TableContentVirtualized({
 }) {
 	const context = useTableContext();
 	const {
-		flexibleTableColumns,
 		enableColumnVisibility,
 		columnVisibilityInToolbar,
 		columnVisibilityClassName,
@@ -30,31 +29,15 @@ export function TableContentVirtualized({
 	const rows = table.getRowModel().rows;
 	const showMobileCards = useShowMobileCards();
 
-	// Use state instead of ref so changes trigger re-renders for virtualizer
+	// State, not a ref, so the virtualizer re-renders once the container mounts.
 	const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
 		null,
 	);
 
-	// Ref for header container to sync horizontal scroll
-	const headerRef = useRef<HTMLDivElement>(null);
-
-	// Sync header horizontal scroll with body scroll
-	const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
-		if (headerRef.current) {
-			headerRef.current.scrollLeft = e.currentTarget.scrollLeft;
-		}
-	}, []);
-
-	// Calculate header height for scroll container offset
-	const headerHeight = 28; // h-7 = 1.75rem = 28px
 	const rowHeight = virtualization?.rowHeight ?? 40;
-
-	// Calculate actual content height based on row count
 	const contentHeight = rows.length * rowHeight;
 
-	// minHeight ensures usability on small screens, but only when content would exceed it
-	// This allows small tables to be exactly as tall as their content
-	// Skip minHeight if containerHeight is explicitly set to a small value
+	// Small tables stay as short as their content; taller ones get a usable floor.
 	const MIN_TABLE_HEIGHT = 400;
 	const containerHeightPx = virtualization?.containerHeight
 		? Number.parseInt(virtualization.containerHeight, 10)
@@ -66,23 +49,15 @@ export function TableContentVirtualized({
 				? MIN_TABLE_HEIGHT
 				: undefined;
 
-	const viewportHeight = containerHeightPx
-		? containerHeightPx - headerHeight
-		: (minHeight ?? Number.POSITIVE_INFINITY);
-	const hasVerticalScroll = contentHeight > viewportHeight;
-	const scrollbarGutter = hasVerticalScroll ? "stable" : undefined;
-
-	// Calculate total width from visible columns to sync header and body tables
+	// Declared column widths are the floor before horizontal scrolling kicks in.
 	const visibleColumns = table.getVisibleLeafColumns();
 	const totalWidth = useMemo(() => {
 		return visibleColumns.reduce((sum, col) => sum + col.getSize(), 0);
 	}, [visibleColumns]);
 
-	// Create a key that changes when visible columns change to force body remount
-	// Using full column IDs ensures any visibility change is detected
+	// Remounts the body whenever the visible column set changes.
 	const visibleColumnKey = visibleColumns.map((col) => col.id).join(",");
 
-	// Provide updated context with scroll container to children
 	const contextWithRef = {
 		...context,
 		scrollContainer,
@@ -109,54 +84,31 @@ export function TableContentVirtualized({
 					<div className="bg-white/40 dark:bg-black/40 absolute pointer-events-none rounded-lg -inset-[1px] z-70" />
 				)}
 
-				<div
-					ref={headerRef}
-					className="overflow-x-auto overflow-y-hidden scrollbar-none shrink-0"
-					style={{ scrollbarWidth: "none", scrollbarGutter }}
-				>
+				{enableColumnVisibility && !columnVisibilityInToolbar && (
 					<div
-						className="relative bg-card border-b"
-						style={{ minWidth: `${totalWidth}px` }}
-					>
-						{enableColumnVisibility && !columnVisibilityInToolbar && (
-							<div
-								className={cn(
-									"absolute right-7 top-1 z-45",
-									columnVisibilityClassName,
-								)}
-							>
-								<TableColumnVisibility />
-							</div>
+						className={cn(
+							"absolute right-7 top-1 z-45",
+							columnVisibilityClassName,
 						)}
-						<Table
-							className="p-0 w-full rounded-t-lg"
-							flexibleTableColumns={flexibleTableColumns}
-						>
-							<TableHeader hideBorder />
-						</Table>
+					>
+						<TableColumnVisibility />
 					</div>
-				</div>
+				)}
 
 				<div
 					key={visibleColumnKey}
 					ref={setScrollContainer}
-					onScroll={handleScroll}
 					className={cn("w-full overflow-auto", isFlexFill && "flex-1 min-h-0")}
 					style={{
 						minHeight: isFlexFill ? undefined : minHeight,
-						maxHeight:
-							!isFlexFill && virtualization?.containerHeight
-								? `calc(${virtualization.containerHeight} - ${headerHeight}px)`
-								: undefined,
+						maxHeight: isFlexFill ? undefined : virtualization?.containerHeight,
 						willChange: "scroll-position",
-						scrollbarGutter,
 					}}
 				>
-					<Table
-						className="p-0 w-full"
-						flexibleTableColumns={flexibleTableColumns}
-						style={{ minWidth: `${totalWidth}px` }}
-					>
+					{/* One table with a sticky thead: separate header/body tables size their
+					    columns independently. Fixed layout pins them to the header row. */}
+					<Table className="p-0 w-full" style={{ minWidth: `${totalWidth}px` }}>
+						<TableHeader />
 						{React.Children.map(children, (child) =>
 							React.isValidElement(child)
 								? React.cloneElement(child, { key: visibleColumnKey })

--- a/packages/ui/src/components/table/table-content-virtualized.tsx
+++ b/packages/ui/src/components/table/table-content-virtualized.tsx
@@ -19,10 +19,10 @@ export function TableContentVirtualized({
 }) {
 	const context = useTableContext();
 	const {
-		flexibleTableColumns,
 		enableColumnVisibility,
 		columnVisibilityInToolbar,
 		columnVisibilityClassName,
+		enableSelection,
 		table,
 		virtualization,
 	} = context;
@@ -82,6 +82,17 @@ export function TableContentVirtualized({
 	// Using full column IDs ensures any visibility change is detected
 	const visibleColumnKey = visibleColumns.map((col) => col.id).join(",");
 
+	// Header and body are separate fixed-layout tables; a shared colgroup pins
+	// identical column widths in both, immune to colSpan spacer rows.
+	const columnWidths = (
+		<colgroup>
+			{enableSelection && <col style={{ width: "50px" }} />}
+			{visibleColumns.map((column) => (
+				<col key={column.id} style={{ width: `${column.getSize()}px` }} />
+			))}
+		</colgroup>
+	);
+
 	// Provide updated context with scroll container to children
 	const contextWithRef = {
 		...context,
@@ -128,10 +139,8 @@ export function TableContentVirtualized({
 								<TableColumnVisibility />
 							</div>
 						)}
-						<Table
-							className="p-0 w-full rounded-t-lg"
-							flexibleTableColumns={flexibleTableColumns}
-						>
+						<Table className="p-0 w-full rounded-t-lg">
+							{columnWidths}
 							<TableHeader hideBorder />
 						</Table>
 					</div>
@@ -152,11 +161,8 @@ export function TableContentVirtualized({
 						scrollbarGutter,
 					}}
 				>
-					<Table
-						className="p-0 w-full"
-						flexibleTableColumns={flexibleTableColumns}
-						style={{ minWidth: `${totalWidth}px` }}
-					>
+					<Table className="p-0 w-full" style={{ minWidth: `${totalWidth}px` }}>
+						{columnWidths}
 						{React.Children.map(children, (child) =>
 							React.isValidElement(child)
 								? React.cloneElement(child, { key: visibleColumnKey })

--- a/packages/ui/src/components/table/table-content-virtualized.tsx
+++ b/packages/ui/src/components/table/table-content-virtualized.tsx
@@ -19,10 +19,10 @@ export function TableContentVirtualized({
 }) {
 	const context = useTableContext();
 	const {
+		flexibleTableColumns,
 		enableColumnVisibility,
 		columnVisibilityInToolbar,
 		columnVisibilityClassName,
-		enableSelection,
 		table,
 		virtualization,
 	} = context;
@@ -82,17 +82,6 @@ export function TableContentVirtualized({
 	// Using full column IDs ensures any visibility change is detected
 	const visibleColumnKey = visibleColumns.map((col) => col.id).join(",");
 
-	// Header and body are separate fixed-layout tables; a shared colgroup pins
-	// identical column widths in both, immune to colSpan spacer rows.
-	const columnWidths = (
-		<colgroup>
-			{enableSelection && <col style={{ width: "50px" }} />}
-			{visibleColumns.map((column) => (
-				<col key={column.id} style={{ width: `${column.getSize()}px` }} />
-			))}
-		</colgroup>
-	);
-
 	// Provide updated context with scroll container to children
 	const contextWithRef = {
 		...context,
@@ -139,8 +128,10 @@ export function TableContentVirtualized({
 								<TableColumnVisibility />
 							</div>
 						)}
-						<Table className="p-0 w-full rounded-t-lg">
-							{columnWidths}
+						<Table
+							className="p-0 w-full rounded-t-lg"
+							flexibleTableColumns={flexibleTableColumns}
+						>
 							<TableHeader hideBorder />
 						</Table>
 					</div>
@@ -161,8 +152,11 @@ export function TableContentVirtualized({
 						scrollbarGutter,
 					}}
 				>
-					<Table className="p-0 w-full" style={{ minWidth: `${totalWidth}px` }}>
-						{columnWidths}
+					<Table
+						className="p-0 w-full"
+						flexibleTableColumns={flexibleTableColumns}
+						style={{ minWidth: `${totalWidth}px` }}
+					>
 						{React.Children.map(children, (child) =>
 							React.isValidElement(child)
 								? React.cloneElement(child, { key: visibleColumnKey })

--- a/packages/ui/src/components/table/table-header.tsx
+++ b/packages/ui/src/components/table/table-header.tsx
@@ -59,12 +59,6 @@ function HeaderContent<T>({
 			onClick={
 				enableSorting ? header.column.getToggleSortingHandler() : undefined
 			}
-			onKeyDown={(e) => {
-				if (e.key === "Enter" || e.key === " ") {
-					e.preventDefault();
-					header.column.getToggleSortingHandler()?.(e);
-				}
-			}}
 			type="button"
 		>
 			<span className="truncate">
@@ -77,13 +71,7 @@ function HeaderContent<T>({
 	);
 }
 
-export function TableHeader({
-	className,
-	hideBorder,
-}: {
-	className?: string;
-	hideBorder?: boolean;
-}) {
+export function TableHeader({ className }: { className?: string }) {
 	const {
 		table,
 		enableSelection,
@@ -98,8 +86,7 @@ export function TableHeader({
 			{headerGroups.map((headerGroup) => (
 				<TableRow
 					className={cn(
-						"bg-card text-subtle",
-						!hideBorder && "border-b",
+						"bg-card text-subtle border-b",
 						!rows.length && "border-dashed",
 					)}
 					key={headerGroup.id}

--- a/packages/ui/src/components/table/table-header.tsx
+++ b/packages/ui/src/components/table/table-header.tsx
@@ -15,7 +15,7 @@ function SortIcon({ sortDirection }: { sortDirection: string | false }) {
 			<ChevronUpIcon
 				aria-hidden="true"
 				className="shrink-0 text-foreground"
-				size={16}
+				size={12}
 			/>
 		);
 	}
@@ -27,7 +27,7 @@ function SortIcon({ sortDirection }: { sortDirection: string | false }) {
 				"shrink-0",
 				sortDirection ? "text-foreground" : "opacity-30",
 			)}
-			size={16}
+			size={12}
 		/>
 	);
 }
@@ -53,7 +53,7 @@ function HeaderContent<T>({
 	return (
 		<button
 			className={cn(
-				"flex h-full select-none items-center gap-1",
+				"flex min-w-0 select-none items-center gap-1",
 				enableSorting && "cursor-pointer",
 			)}
 			onClick={
@@ -67,7 +67,9 @@ function HeaderContent<T>({
 			}}
 			type="button"
 		>
-			{flexRender(header.column.columnDef.header, header.getContext())}
+			<span className="truncate">
+				{flexRender(header.column.columnDef.header, header.getContext())}
+			</span>
 			{enableSorting && (
 				<SortIcon sortDirection={header.column.getIsSorted()} />
 			)}

--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -459,6 +459,7 @@ export class AutumnInt {
 			plans?: Array<{ id: string; versions?: number[] }>;
 			subscription_status?: string[];
 			processors?: Array<"stripe" | "revenuecat" | "vercel">;
+			sort_order?: "asc" | "desc";
 			keepInternalFields?: boolean;
 		}) => {
 			const { keepInternalFields, ...listParams } = params || {};

--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -25,6 +25,7 @@ import {
 	type CreateBalanceParamsV0,
 	type CreateCustomerInternalOptions,
 	type CreateCustomerParamsV0Input,
+	type CreatedAtRange,
 	type CreateEntityParams,
 	type CreateRewardProgram,
 	type CreateScheduleParamsV0Input,
@@ -460,7 +461,7 @@ export class AutumnInt {
 			subscription_status?: string[];
 			processors?: Array<"stripe" | "revenuecat" | "vercel">;
 			sort_order?: "asc" | "desc";
-			created_at_range?: { start?: number; end?: number };
+			created_at_range?: CreatedAtRange;
 			keepInternalFields?: boolean;
 		}) => {
 			const { keepInternalFields, ...listParams } = params || {};

--- a/server/src/external/autumn/autumnCli.ts
+++ b/server/src/external/autumn/autumnCli.ts
@@ -460,6 +460,7 @@ export class AutumnInt {
 			subscription_status?: string[];
 			processors?: Array<"stripe" | "revenuecat" | "vercel">;
 			sort_order?: "asc" | "desc";
+			created_at_range?: { start?: number; end?: number };
 			keepInternalFields?: boolean;
 		}) => {
 			const { keepInternalFields, ...listParams } = params || {};

--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -196,7 +196,14 @@ export class CusBatchService {
 		ctx: RequestContext;
 		query: ListCustomersV2_3Params;
 	}): Promise<{ list: ApiCustomerV5[]; next_cursor: string | null }> {
-		const { limit, plans, subscription_status, search, processors } = query;
+		const {
+			limit,
+			plans,
+			subscription_status,
+			search,
+			processors,
+			created_at_range,
+		} = query;
 
 		const cursor: StandardCursorFields | null = StandardCursor.decode(
 			query.start_cursor,
@@ -219,6 +226,7 @@ export class CusBatchService {
 			search,
 			plans,
 			processors,
+			createdAtRange: created_at_range,
 			cusProductLimit,
 			sortOrder: query.sort_order,
 		});
@@ -391,6 +399,9 @@ export class CusBatchService {
 			processors: requiresResolveStep
 				? undefined
 				: parseDashboardProcessorFilter(filters?.processor),
+			createdAtRange: requiresResolveStep
+				? undefined
+				: filters?.created_at_range,
 			cusProductLimit,
 			sortOrder,
 		});

--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -10,6 +10,7 @@ import {
 	type ListCustomersV2_3Params,
 	type ListCustomersV2Params,
 	RELEVANT_STATUSES,
+	type SortOrder,
 	StandardCursor,
 	type StandardCursorFields,
 } from "@autumn/shared";
@@ -219,6 +220,7 @@ export class CusBatchService {
 			plans,
 			processors,
 			cusProductLimit,
+			sortOrder: query.sort_order,
 		});
 
 		const tSqlStart = performance.now();
@@ -311,12 +313,14 @@ export class CusBatchService {
 		filters,
 		cursor,
 		limit,
+		sortOrder,
 	}: {
 		ctx: RequestContext;
 		search: string;
 		filters?: CustomerListFilters;
 		cursor: { t: number; id: string } | null;
 		limit: number;
+		sortOrder?: SortOrder;
 	}): Promise<{
 		fullCustomers: FullCustomer[];
 		next_cursor: string | null;
@@ -354,6 +358,7 @@ export class CusBatchService {
 				filters,
 				cursor,
 				limit,
+				sortOrder,
 			});
 			internalIds = resolved.internalIds;
 			resolvedPeek = resolved.peek;
@@ -387,6 +392,7 @@ export class CusBatchService {
 				? undefined
 				: parseDashboardProcessorFilter(filters?.processor),
 			cusProductLimit,
+			sortOrder,
 		});
 
 		const tSqlStart = performance.now();

--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -226,7 +226,7 @@ export class CusBatchService {
 			search,
 			plans,
 			processors,
-			createdAtRange: created_at_range,
+			createdAtRangeFilter: created_at_range,
 			cusProductLimit,
 			sortOrder: query.sort_order,
 		});
@@ -399,7 +399,7 @@ export class CusBatchService {
 			processors: requiresResolveStep
 				? undefined
 				: parseDashboardProcessorFilter(filters?.processor),
-			createdAtRange: requiresResolveStep
+			createdAtRangeFilter: requiresResolveStep
 				? undefined
 				: filters?.created_at_range,
 			cusProductLimit,

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -191,6 +191,12 @@ export const buildSearchPredicates = ({
 						sql` OR `,
 					)})`
 				: null,
+			filters?.created_at_range?.start !== undefined
+				? sql`${customers.created_at} >= ${filters.created_at_range.start}`
+				: null,
+			filters?.created_at_range?.end !== undefined
+				? sql`${customers.created_at} <= ${filters.created_at_range.end}`
+				: null,
 		].filter((c): c is NonNullable<typeof c> => c !== null),
 		sql` AND `,
 	);

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -106,7 +106,6 @@ export class CusSearchService {
 	}> {
 		const predicates = buildSearchPredicates({ orgId, env, search, filters });
 		const fetchLimit = limit + 1;
-		const cursorOp = sortOrder === "asc" ? sql.raw(">") : sql.raw("<");
 		const orderColumn = sortOrder === "asc" ? asc : desc;
 
 		const matched = db
@@ -119,9 +118,12 @@ export class CusSearchService {
 			.where(
 				and(
 					predicates.whereRaw,
-					// Drizzle has no native row-tuple comparison for keyset pagination.
+					// Expanded instead of a row-tuple compare: asc sorts NULL ids after
+					// the cursor, where a tuple compare is UNKNOWN and drops them.
 					cursor
-						? sql`(${customers.created_at}, ${customers.id}) ${cursorOp} (${cursor.t}, ${cursor.id})`
+						? sortOrder === "asc"
+							? sql`(${customers.created_at} >= ${cursor.t} AND (${customers.created_at} > ${cursor.t} OR ${customers.id} > ${cursor.id} OR ${customers.id} IS NULL))`
+							: sql`(${customers.created_at} <= ${cursor.t} AND (${customers.created_at} < ${cursor.t} OR ${customers.id} < ${cursor.id}))`
 						: undefined,
 				),
 			)

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -4,9 +4,10 @@ import {
 	type CustomerListFilters,
 	customerProducts,
 	customers,
+	type SortOrder,
 } from "@autumn/shared";
 
-import { and, desc, type SQL, sql } from "drizzle-orm";
+import { and, asc, desc, type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import {
@@ -89,6 +90,7 @@ export class CusSearchService {
 		filters,
 		cursor,
 		limit,
+		sortOrder = "desc",
 	}: {
 		db: DrizzleCli;
 		orgId: string;
@@ -97,12 +99,15 @@ export class CusSearchService {
 		filters?: SearchFilters;
 		cursor?: { t: number; id: string } | null;
 		limit: number;
+		sortOrder?: SortOrder;
 	}): Promise<{
 		internalIds: string[];
 		peek: { t: number; id: string } | null;
 	}> {
 		const predicates = buildSearchPredicates({ orgId, env, search, filters });
 		const fetchLimit = limit + 1;
+		const cursorOp = sortOrder === "asc" ? sql.raw(">") : sql.raw("<");
+		const orderColumn = sortOrder === "asc" ? asc : desc;
 
 		const matched = db
 			.select({
@@ -116,11 +121,11 @@ export class CusSearchService {
 					predicates.whereRaw,
 					// Drizzle has no native row-tuple comparison for keyset pagination.
 					cursor
-						? sql`(${customers.created_at}, ${customers.id}) < (${cursor.t}, ${cursor.id})`
+						? sql`(${customers.created_at}, ${customers.id}) ${cursorOp} (${cursor.t}, ${cursor.id})`
 						: undefined,
 				),
 			)
-			.orderBy(desc(customers.created_at), desc(customers.id))
+			.orderBy(orderColumn(customers.created_at), orderColumn(customers.id))
 			.limit(fetchLimit);
 
 		const rows = await db.execute<{

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -10,6 +10,7 @@ import {
 import { and, asc, desc, type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { getCursorPredicateSql } from "./cursorPaginatedFullCusQuery.js";
 import {
 	type DashboardIntervalFilter,
 	type DashboardProductVersionFilter,
@@ -118,12 +119,13 @@ export class CusSearchService {
 			.where(
 				and(
 					predicates.whereRaw,
-					// Expanded instead of a row-tuple compare: asc sorts NULL ids after
-					// the cursor, where a tuple compare is UNKNOWN and drops them.
 					cursor
-						? sortOrder === "asc"
-							? sql`(${customers.created_at} >= ${cursor.t} AND (${customers.created_at} > ${cursor.t} OR ${customers.id} > ${cursor.id} OR ${customers.id} IS NULL))`
-							: sql`(${customers.created_at} <= ${cursor.t} AND (${customers.created_at} < ${cursor.t} OR ${customers.id} < ${cursor.id}))`
+						? getCursorPredicateSql({
+								createdAtColumn: customers.created_at,
+								idColumn: customers.id,
+								cursor,
+								sortOrder,
+							})
 						: undefined,
 				),
 			)

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -5,6 +5,7 @@ import {
 	type CusProductStatus,
 	type ListCustomersV2Params,
 	RELEVANT_STATUSES,
+	type SortOrder,
 	type StandardCursorFields,
 } from "@autumn/shared";
 import { sql } from "drizzle-orm";
@@ -46,6 +47,7 @@ export type CursorPaginatedFullCusQueryArgs = {
 	customerId?: string;
 	/** Emit products_page / products_total_count. Dashboard only. */
 	withProductsPage?: boolean;
+	sortOrder?: SortOrder;
 };
 
 /**
@@ -75,6 +77,7 @@ export const getCursorPaginatedFullCusQuery = ({
 	cusProductLimit,
 	customerId,
 	withProductsPage = false,
+	sortOrder = "desc",
 }: CursorPaginatedFullCusQueryArgs) => {
 	const cpStatusFilter = cpStatusInClause(inStatuses);
 
@@ -106,8 +109,13 @@ export const getCursorPaginatedFullCusQuery = ({
 		intervalFilters,
 	});
 
+	// The cursor comparison operator must match the ORDER BY direction, or
+	// pagination walks the wrong way and repeats/skips rows.
+	const cursorOp = sortOrder === "asc" ? sql.raw(">") : sql.raw("<");
+	const orderDirection = sql.raw(sortOrder === "asc" ? "ASC" : "DESC");
+
 	const cursorPredicate = cursor
-		? sql`AND (c.created_at, c.id) < (${cursor.t}, ${cursor.id})`
+		? sql`AND (c.created_at, c.id) ${cursorOp} (${cursor.t}, ${cursor.id})`
 		: sql``;
 
 	const fetchLimit = limit + 1;
@@ -172,7 +180,7 @@ export const getCursorPaginatedFullCusQuery = ({
 		WHERE c.org_id = ${orgId}
 			AND c.env = ${env}
 			${customerId ? sql`AND (c.id = ${customerId} OR c.internal_id = ${customerId})` : sql`${customerListFilterSql}${cursorPredicate}`}
-		ORDER BY c.created_at DESC, c.id DESC
+		ORDER BY c.created_at ${orderDirection}, c.id ${orderDirection}
 		LIMIT ${fetchLimit}
 		),
 		cp_ranked_raw AS MATERIALIZED (

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -109,13 +109,14 @@ export const getCursorPaginatedFullCusQuery = ({
 		intervalFilters,
 	});
 
-	// The cursor comparison operator must match the ORDER BY direction, or
-	// pagination walks the wrong way and repeats/skips rows.
-	const cursorOp = sortOrder === "asc" ? sql.raw(">") : sql.raw("<");
 	const orderDirection = sql.raw(sortOrder === "asc" ? "ASC" : "DESC");
 
+	// Expanded instead of a row-tuple compare: asc sorts NULL ids after the
+	// cursor, where a tuple compare evaluates UNKNOWN and silently drops them.
 	const cursorPredicate = cursor
-		? sql`AND (c.created_at, c.id) ${cursorOp} (${cursor.t}, ${cursor.id})`
+		? sortOrder === "asc"
+			? sql`AND c.created_at >= ${cursor.t} AND (c.created_at > ${cursor.t} OR c.id > ${cursor.id} OR c.id IS NULL)`
+			: sql`AND c.created_at <= ${cursor.t} AND (c.created_at < ${cursor.t} OR c.id < ${cursor.id})`
 		: sql``;
 
 	const fetchLimit = limit + 1;

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -44,7 +44,7 @@ export type CursorPaginatedFullCusQueryArgs = {
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
 	intervalFilters?: DashboardIntervalFilter[];
-	createdAtRange?: CreatedAtRange;
+	createdAtRangeFilter?: CreatedAtRange;
 	cusProductLimit: number;
 	customerId?: string;
 	/** Emit products_page / products_total_count. Dashboard only. */
@@ -95,7 +95,7 @@ export const getCursorPaginatedFullCusQuery = ({
 	noneFilter,
 	productVersionFilters,
 	intervalFilters,
-	createdAtRange,
+	createdAtRangeFilter,
 	cusProductLimit,
 	customerId,
 	withProductsPage = false,
@@ -129,7 +129,7 @@ export const getCursorPaginatedFullCusQuery = ({
 		noneFilter,
 		productVersionFilters,
 		intervalFilters,
-		createdAtRange,
+		createdAtRangeFilter,
 	});
 
 	const orderDirection = sql.raw(sortOrder === "asc" ? "ASC" : "DESC");

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -8,7 +8,7 @@ import {
 	type SortOrder,
 	type StandardCursorFields,
 } from "@autumn/shared";
-import { sql } from "drizzle-orm";
+import { type Column, type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import {
 	cpStatusInClause,
@@ -49,6 +49,25 @@ export type CursorPaginatedFullCusQueryArgs = {
 	withProductsPage?: boolean;
 	sortOrder?: SortOrder;
 };
+
+/**
+ * NULL-id-safe keyset predicate: a row-tuple compare is UNKNOWN for NULL ids,
+ * which asc sorts after the cursor — they'd be silently dropped.
+ */
+export const getCursorPredicateSql = ({
+	createdAtColumn,
+	idColumn,
+	cursor,
+	sortOrder,
+}: {
+	createdAtColumn: SQL | Column;
+	idColumn: SQL | Column;
+	cursor: { t: number; id: string };
+	sortOrder: SortOrder;
+}): SQL =>
+	sortOrder === "asc"
+		? sql`(${createdAtColumn} >= ${cursor.t} AND (${createdAtColumn} > ${cursor.t} OR ${idColumn} > ${cursor.id} OR ${idColumn} IS NULL))`
+		: sql`(${createdAtColumn} <= ${cursor.t} AND (${createdAtColumn} < ${cursor.t} OR ${idColumn} < ${cursor.id}))`;
 
 /**
  * Set-based variant: customer_products/entitlements/prices fetched via single
@@ -111,12 +130,13 @@ export const getCursorPaginatedFullCusQuery = ({
 
 	const orderDirection = sql.raw(sortOrder === "asc" ? "ASC" : "DESC");
 
-	// Expanded instead of a row-tuple compare: asc sorts NULL ids after the
-	// cursor, where a tuple compare evaluates UNKNOWN and silently drops them.
 	const cursorPredicate = cursor
-		? sortOrder === "asc"
-			? sql`AND c.created_at >= ${cursor.t} AND (c.created_at > ${cursor.t} OR c.id > ${cursor.id} OR c.id IS NULL)`
-			: sql`AND c.created_at <= ${cursor.t} AND (c.created_at < ${cursor.t} OR c.id < ${cursor.id})`
+		? sql`AND ${getCursorPredicateSql({
+				createdAtColumn: sql.raw("c.created_at"),
+				idColumn: sql.raw("c.id"),
+				cursor,
+				sortOrder,
+			})}`
 		: sql``;
 
 	const fetchLimit = limit + 1;

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -1,6 +1,7 @@
 import {
 	ACTIVE_STATUSES,
 	type AppEnv,
+	type CreatedAtRange,
 	CUSTOMER_PRODUCTS_DEFAULT_LIMIT,
 	type CusProductStatus,
 	type ListCustomersV2Params,
@@ -43,6 +44,7 @@ export type CursorPaginatedFullCusQueryArgs = {
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
 	intervalFilters?: DashboardIntervalFilter[];
+	createdAtRange?: CreatedAtRange;
 	cusProductLimit: number;
 	customerId?: string;
 	/** Emit products_page / products_total_count. Dashboard only. */
@@ -93,6 +95,7 @@ export const getCursorPaginatedFullCusQuery = ({
 	noneFilter,
 	productVersionFilters,
 	intervalFilters,
+	createdAtRange,
 	cusProductLimit,
 	customerId,
 	withProductsPage = false,
@@ -126,6 +129,7 @@ export const getCursorPaginatedFullCusQuery = ({
 		noneFilter,
 		productVersionFilters,
 		intervalFilters,
+		createdAtRange,
 	});
 
 	const orderDirection = sql.raw(sortOrder === "asc" ? "ASC" : "DESC");

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -1,6 +1,7 @@
 import {
 	type AppEnv,
 	BillingInterval,
+	type CreatedAtRange,
 	CusProductStatus,
 	type ListCustomersV2Params,
 	RELEVANT_STATUSES,
@@ -1039,6 +1040,7 @@ export const getCustomerListFilterSql = ({
 	noneFilter,
 	productVersionFilters,
 	intervalFilters,
+	createdAtRange,
 }: {
 	internalCustomerIds?: string[];
 	orgId?: string;
@@ -1051,8 +1053,17 @@ export const getCustomerListFilterSql = ({
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
 	intervalFilters?: DashboardIntervalFilter[];
+	createdAtRange?: CreatedAtRange;
 }) => {
 	const filters = [];
+
+	if (createdAtRange?.start !== undefined) {
+		filters.push(sql`AND c.created_at >= ${createdAtRange.start}`);
+	}
+
+	if (createdAtRange?.end !== undefined) {
+		filters.push(sql`AND c.created_at <= ${createdAtRange.end}`);
+	}
 
 	if (internalCustomerIds && internalCustomerIds.length > 0) {
 		filters.push(

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -1040,7 +1040,7 @@ export const getCustomerListFilterSql = ({
 	noneFilter,
 	productVersionFilters,
 	intervalFilters,
-	createdAtRange,
+	createdAtRangeFilter,
 }: {
 	internalCustomerIds?: string[];
 	orgId?: string;
@@ -1053,16 +1053,16 @@ export const getCustomerListFilterSql = ({
 	noneFilter?: boolean;
 	productVersionFilters?: DashboardProductVersionFilter[];
 	intervalFilters?: DashboardIntervalFilter[];
-	createdAtRange?: CreatedAtRange;
+	createdAtRangeFilter?: CreatedAtRange;
 }) => {
 	const filters = [];
 
-	if (createdAtRange?.start !== undefined) {
-		filters.push(sql`AND c.created_at >= ${createdAtRange.start}`);
+	if (createdAtRangeFilter?.start !== undefined) {
+		filters.push(sql`AND c.created_at >= ${createdAtRangeFilter.start}`);
 	}
 
-	if (createdAtRange?.end !== undefined) {
-		filters.push(sql`AND c.created_at <= ${createdAtRange.end}`);
+	if (createdAtRangeFilter?.end !== undefined) {
+		filters.push(sql`AND c.created_at <= ${createdAtRangeFilter.end}`);
 	}
 
 	if (internalCustomerIds && internalCustomerIds.length > 0) {

--- a/server/src/internal/customers/internalHandlers/handleGetFullCustomers.ts
+++ b/server/src/internal/customers/internalHandlers/handleGetFullCustomers.ts
@@ -1,6 +1,7 @@
 import {
 	CustomerListFiltersSchema,
 	Scopes,
+	SortOrderSchema,
 	StandardCursor,
 } from "@autumn/shared";
 import { z } from "zod/v4";
@@ -14,10 +15,11 @@ export const handleGetFullCustomers = createRoute({
 		limit: z.number().int().min(1).max(1000).optional().default(50),
 		cursor: z.string().optional().default(""),
 		filters: CustomerListFiltersSchema.optional(),
+		sort_order: SortOrderSchema.optional(),
 	}),
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { search, limit, cursor, filters } = c.req.valid("json");
+		const { search, limit, cursor, filters, sort_order } = c.req.valid("json");
 
 		const decoded = StandardCursor.decode(cursor);
 
@@ -28,6 +30,7 @@ export const handleGetFullCustomers = createRoute({
 				filters,
 				cursor: decoded ? { t: decoded.t, id: decoded.id } : null,
 				limit,
+				sortOrder: sort_order,
 			});
 
 		return c.json({ fullCustomers, next_cursor });

--- a/server/src/internal/customers/internalHandlers/handleSearchCustomers.ts
+++ b/server/src/internal/customers/internalHandlers/handleSearchCustomers.ts
@@ -2,6 +2,7 @@ import {
 	CustomerListFiltersSchema,
 	type FullCusProduct,
 	Scopes,
+	SortOrderSchema,
 	StandardCursor,
 } from "@autumn/shared";
 import { z } from "zod/v4";
@@ -15,10 +16,11 @@ export const handleSearchCustomers = createRoute({
 		limit: z.number().int().min(1).max(1000).optional().default(50),
 		cursor: z.string().optional().default(""),
 		filters: CustomerListFiltersSchema.optional(),
+		sort_order: SortOrderSchema.optional(),
 	}),
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { search, limit, cursor, filters } = c.req.valid("json");
+		const { search, limit, cursor, filters, sort_order } = c.req.valid("json");
 
 		const decoded = StandardCursor.decode(cursor);
 
@@ -29,6 +31,7 @@ export const handleSearchCustomers = createRoute({
 				filters,
 				cursor: decoded ? { t: decoded.t, id: decoded.id } : null,
 				limit,
+				sortOrder: sort_order,
 			});
 
 		const customers = fullCustomers.map((c) => ({

--- a/server/tests/integration/crud/customers/list-customers-created-at-range.test.ts
+++ b/server/tests/integration/crud/customers/list-customers-created-at-range.test.ts
@@ -1,8 +1,6 @@
 /**
- * customers.list created_at_range (V2.3 cursor path):
- * - both bounds inclusive, each independently optional
- * - start > end is rejected as invalid input
- * - composes with sort_order and cursor pagination
+ * customers.list created_at_range (V2.3 cursor path): inclusive optional bounds,
+ * start > end rejected, composes with sort_order and cursor pagination.
  */
 
 import { beforeAll, describe, expect, test } from "bun:test";

--- a/server/tests/integration/crud/customers/list-customers-created-at-range.test.ts
+++ b/server/tests/integration/crud/customers/list-customers-created-at-range.test.ts
@@ -1,0 +1,282 @@
+/**
+ * customers.list created_at_range (V2.3 cursor path):
+ * - both bounds inclusive, each independently optional
+ * - start > end is rejected as invalid input
+ * - composes with sort_order and cursor pagination
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	ApiVersion,
+	type CreatedAtRange,
+	ErrCode,
+} from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const SEARCH = "created-at-range-lc";
+const PRIMARY_CUSTOMER_ID = `${SEARCH}-a`;
+const OTHER_CUSTOMER_IDS = [`${SEARCH}-b`, `${SEARCH}-c`, `${SEARCH}-d`];
+const EXPECTED_CUSTOMER_COUNT = OTHER_CUSTOMER_IDS.length + 1;
+
+type ListPage = { list: ApiCustomerV5[]; next_cursor: string | null };
+type ObservedCustomer = { id: string; created_at: number };
+
+const listPage = async ({
+	autumn,
+	params,
+}: {
+	autumn: AutumnInt;
+	params: Record<string, unknown>;
+}): Promise<ListPage> =>
+	(await autumn.customers.listV2({
+		start_cursor: "",
+		limit: 50,
+		search: SEARCH,
+		keepInternalFields: true,
+		...params,
+	})) as ListPage;
+
+const walkPages = async ({
+	autumn,
+	createdAtRange,
+	sortOrder,
+}: {
+	autumn: AutumnInt;
+	createdAtRange: CreatedAtRange;
+	sortOrder?: "asc" | "desc";
+}): Promise<string[]> => {
+	const ids: string[] = [];
+	let cursor = "";
+	for (let page = 0; page < 10; page++) {
+		const res = (await autumn.customers.listV2({
+			start_cursor: cursor,
+			limit: 1,
+			search: SEARCH,
+			created_at_range: createdAtRange,
+			sort_order: sortOrder,
+			keepInternalFields: true,
+		})) as ListPage;
+		ids.push(...res.list.map((customer) => customer.id ?? ""));
+		if (!res.next_cursor) break;
+		cursor = res.next_cursor;
+	}
+	return ids;
+};
+
+const sorted = (ids: string[]): string[] => [...ids].sort();
+
+describe("list-customers-created-at-range", () => {
+	const autumn = new AutumnInt({ version: ApiVersion.V2_3 });
+	// created_at is server-assigned, so every bound below is derived from what the
+	// unfiltered ascending page actually reported.
+	let observed: ObservedCustomer[] = [];
+
+	const idsInRange = ({ start, end }: CreatedAtRange): string[] =>
+		observed
+			.filter(
+				(customer) =>
+					(start === undefined || customer.created_at >= start) &&
+					(end === undefined || customer.created_at <= end),
+			)
+			.map((customer) => customer.id);
+
+	const listRange = async (createdAtRange: CreatedAtRange): Promise<ListPage> =>
+		listPage({ autumn, params: { created_at_range: createdAtRange } });
+
+	beforeAll(async () => {
+		await initScenario({
+			customerId: PRIMARY_CUSTOMER_ID,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers(OTHER_CUSTOMER_IDS.map((id) => ({ id }))),
+			],
+			actions: [],
+		});
+
+		const ascendingPage = await listPage({
+			autumn,
+			params: { sort_order: "asc" },
+		});
+
+		observed = ascendingPage.list.map((customer) => ({
+			id: customer.id ?? "",
+			created_at: customer.created_at,
+		}));
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: range between observed timestamps returns exactly that subset")}`, async () => {
+		expect(observed.length).toBe(EXPECTED_CUSTOMER_COUNT);
+
+		const start = observed[1]?.created_at ?? 0;
+		const end = observed[2]?.created_at ?? 0;
+		const expectedIds = idsInRange({ start, end });
+
+		const page = await listRange({ start, end });
+
+		expect(sorted(page.list.map((customer) => customer.id ?? ""))).toEqual(
+			sorted(expectedIds),
+		);
+		for (const customer of page.list) {
+			expect(customer.created_at).toBeGreaterThanOrEqual(start);
+			expect(customer.created_at).toBeLessThanOrEqual(end);
+		}
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: bounds are inclusive on both ends")}`, async () => {
+		const boundary = observed[0]?.created_at ?? 0;
+		const expectedIds = idsInRange({ start: boundary, end: boundary });
+
+		const [startBound, endBound, exactBound] = await Promise.all([
+			listRange({ start: boundary }),
+			listRange({ end: boundary }),
+			listRange({ start: boundary, end: boundary }),
+		]);
+
+		const boundaryId = observed[0]?.id ?? "";
+		expect(startBound.list.map((customer) => customer.id)).toContain(
+			boundaryId,
+		);
+		expect(endBound.list.map((customer) => customer.id)).toContain(boundaryId);
+		expect(
+			sorted(exactBound.list.map((customer) => customer.id ?? "")),
+		).toEqual(sorted(expectedIds));
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: end only returns customers created at or before end")}`, async () => {
+		const end = observed[1]?.created_at ?? 0;
+		const expectedIds = idsInRange({ end });
+
+		const page = await listRange({ end });
+
+		expect(sorted(page.list.map((customer) => customer.id ?? ""))).toEqual(
+			sorted(expectedIds),
+		);
+		for (const customer of page.list) {
+			expect(customer.created_at).toBeLessThanOrEqual(end);
+		}
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: start only returns customers created at or after start")}`, async () => {
+		const start = observed[2]?.created_at ?? 0;
+		const expectedIds = idsInRange({ start });
+
+		const page = await listRange({ start });
+
+		expect(sorted(page.list.map((customer) => customer.id ?? ""))).toEqual(
+			sorted(expectedIds),
+		);
+		for (const customer of page.list) {
+			expect(customer.created_at).toBeGreaterThanOrEqual(start);
+		}
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: a range excluding every match returns an empty page with a null cursor")}`, async () => {
+		const earliest = observed[0]?.created_at ?? 0;
+		const latest = observed[observed.length - 1]?.created_at ?? 0;
+
+		const [beforeAllMatches, afterAllMatches] = await Promise.all([
+			listRange({ end: earliest - 1 }),
+			listRange({ start: latest + 1 }),
+		]);
+
+		expect(beforeAllMatches.list).toEqual([]);
+		expect(beforeAllMatches.next_cursor).toBeNull();
+		expect(afterAllMatches.list).toEqual([]);
+		expect(afterAllMatches.next_cursor).toBeNull();
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: start after end is rejected as invalid input")}`, async () => {
+		const start = observed[1]?.created_at ?? 1;
+		const end = start - 1;
+
+		// AutumnInt drops the HTTP status, and InvalidInputs is only produced by
+		// the 400 request-validation path.
+		const error = await listRange({ start, end }).then(
+			() => null,
+			(caught) => caught as { code?: string },
+		);
+
+		expect(error).not.toBeNull();
+		expect(error?.code).toBe(ErrCode.InvalidInputs);
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: asc and desc over the same range return the same set")}`, async () => {
+		const start = observed[0]?.created_at ?? 0;
+		const end = observed[observed.length - 1]?.created_at ?? 0;
+		const expectedIds = idsInRange({ start, end });
+
+		const [ascending, descending] = await Promise.all([
+			listPage({
+				autumn,
+				params: {
+					created_at_range: { start, end },
+					sort_order: "asc",
+				},
+			}),
+			listPage({
+				autumn,
+				params: {
+					created_at_range: { start, end },
+					sort_order: "desc",
+				},
+			}),
+		]);
+
+		const ascendingIds = ascending.list.map((customer) => customer.id ?? "");
+		const descendingIds = descending.list.map((customer) => customer.id ?? "");
+
+		expect(sorted(ascendingIds)).toEqual(sorted(expectedIds));
+		expect(sorted(descendingIds)).toEqual(sorted(expectedIds));
+
+		const ascendingTimes = ascending.list.map(
+			(customer) => customer.created_at,
+		);
+		for (let i = 1; i < ascendingTimes.length; i++) {
+			expect(ascendingTimes[i]).toBeGreaterThanOrEqual(
+				ascendingTimes[i - 1] ?? 0,
+			);
+		}
+		const descendingTimes = descending.list.map(
+			(customer) => customer.created_at,
+		);
+		for (let i = 1; i < descendingTimes.length; i++) {
+			expect(descendingTimes[i]).toBeLessThanOrEqual(
+				descendingTimes[i - 1] ?? 0,
+			);
+		}
+
+		// Exact reversal only holds when no two customers share a millisecond.
+		const timestampsAreDistinct =
+			new Set(ascendingTimes).size === ascendingTimes.length;
+		if (timestampsAreDistinct) {
+			expect(ascendingIds).toEqual([...descendingIds].reverse());
+		}
+	});
+
+	test(`${chalk.yellowBright("list-customers-created-at-range: cursor pagination inside a range yields each match once")}`, async () => {
+		const start = observed[1]?.created_at ?? 0;
+		const end = observed[observed.length - 1]?.created_at ?? 0;
+		const expectedIds = idsInRange({ start, end });
+
+		const [ascendingWalk, descendingWalk] = await Promise.all([
+			walkPages({
+				autumn,
+				createdAtRange: { start, end },
+				sortOrder: "asc",
+			}),
+			walkPages({
+				autumn,
+				createdAtRange: { start, end },
+				sortOrder: "desc",
+			}),
+		]);
+
+		expect(new Set(ascendingWalk).size).toBe(ascendingWalk.length);
+		expect(new Set(descendingWalk).size).toBe(descendingWalk.length);
+		expect(sorted(ascendingWalk)).toEqual(sorted(expectedIds));
+		expect(sorted(descendingWalk)).toEqual(sorted(expectedIds));
+	});
+});

--- a/server/tests/integration/crud/customers/list-customers-sort-order.test.ts
+++ b/server/tests/integration/crud/customers/list-customers-sort-order.test.ts
@@ -1,8 +1,6 @@
 /**
- * customers.list sort_order (V2.3 cursor path):
- * - omitted / "desc" → newest first (existing behavior)
- * - "asc" → oldest first, exact reverse of desc
- * - cursor pagination walks forward correctly in both directions
+ * customers.list sort_order (V2.3 cursor path): "asc" is the exact reverse of
+ * the default "desc"; cursor pagination walks correctly in both directions.
  */
 
 import { expect, test } from "bun:test";

--- a/server/tests/integration/crud/customers/list-customers-sort-order.test.ts
+++ b/server/tests/integration/crud/customers/list-customers-sort-order.test.ts
@@ -1,0 +1,113 @@
+/**
+ * customers.list sort_order (V2.3 cursor path):
+ * - omitted / "desc" → newest first (existing behavior)
+ * - "asc" → oldest first, exact reverse of desc
+ * - cursor pagination walks forward correctly in both directions
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiCustomerV5, ApiVersion } from "@autumn/shared";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+
+const SEARCH = "sort-order-lc";
+
+type ListPage = { list: ApiCustomerV5[]; next_cursor: string | null };
+
+const listPage = async (
+	autumn: AutumnInt,
+	params: Record<string, unknown>,
+): Promise<ListPage> =>
+	(await autumn.customers.listV2({
+		start_cursor: "",
+		limit: 50,
+		search: SEARCH,
+		keepInternalFields: true,
+		...params,
+	})) as ListPage;
+
+const walkPages = async (
+	autumn: AutumnInt,
+	sortOrder: "asc" | "desc",
+): Promise<string[]> => {
+	const ids: string[] = [];
+	let cursor = "";
+	for (let page = 0; page < 10; page++) {
+		const res = (await autumn.customers.listV2({
+			start_cursor: cursor,
+			limit: 1,
+			search: SEARCH,
+			sort_order: sortOrder,
+			keepInternalFields: true,
+		})) as ListPage;
+		ids.push(...res.list.map((customer) => customer.id ?? ""));
+		if (!res.next_cursor) break;
+		cursor = res.next_cursor;
+	}
+	return ids;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("list-customers-sort-order: asc reverses desc and cursor walks match")}`,
+	async () => {
+		await initScenario({
+			customerId: `${SEARCH}-a`,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: `${SEARCH}-b` }, { id: `${SEARCH}-c` }]),
+			],
+			actions: [],
+		});
+
+		const autumn = new AutumnInt({ version: ApiVersion.V2_3 });
+
+		const [defaultPage, descPage, ascPage] = await Promise.all([
+			listPage(autumn, {}),
+			listPage(autumn, { sort_order: "desc" }),
+			listPage(autumn, { sort_order: "asc" }),
+		]);
+
+		expect(defaultPage.list.length).toBe(3);
+		expect(descPage.list.length).toBe(3);
+		expect(ascPage.list.length).toBe(3);
+
+		const defaultIds = defaultPage.list.map((customer) => customer.id ?? "");
+		const descIds = descPage.list.map((customer) => customer.id ?? "");
+		const ascIds = ascPage.list.map((customer) => customer.id ?? "");
+
+		expect(defaultIds).toEqual(descIds);
+		expect(ascIds).toEqual([...descIds].reverse());
+
+		const ascTimes = ascPage.list.map((customer) => customer.created_at);
+		for (let i = 1; i < ascTimes.length; i++) {
+			expect(ascTimes[i]!).toBeGreaterThanOrEqual(ascTimes[i - 1]!);
+		}
+		const descTimes = descPage.list.map((customer) => customer.created_at);
+		for (let i = 1; i < descTimes.length; i++) {
+			expect(descTimes[i]!).toBeLessThanOrEqual(descTimes[i - 1]!);
+		}
+
+		const [ascWalk, descWalk] = await Promise.all([
+			walkPages(autumn, "asc"),
+			walkPages(autumn, "desc"),
+		]);
+		expect(ascWalk).toEqual(ascIds);
+		expect(descWalk).toEqual(descIds);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("list-customers-sort-order: invalid sort_order rejected")}`,
+	async () => {
+		const autumn = new AutumnInt({ version: ApiVersion.V2_3 });
+
+		await expect(
+			autumn.customers.listV2({
+				start_cursor: "",
+				limit: 1,
+				sort_order: "newest" as unknown as "asc",
+			}),
+		).rejects.toThrow();
+	},
+);

--- a/shared/api/common/cursorPaginationSchemas.ts
+++ b/shared/api/common/cursorPaginationSchemas.ts
@@ -1,7 +1,7 @@
-import { sql, type Column, type SQL } from "drizzle-orm";
+import { type Column, type SQL, sql } from "drizzle-orm";
 import { z } from "zod/v4";
-import { RecaseError } from "../errors/base/RecaseError.js";
 import { ErrCode } from "../../enums/ErrCode.js";
+import { RecaseError } from "../errors/base/RecaseError.js";
 
 const CURRENT_CURSOR_VERSION = 0 as const;
 
@@ -22,7 +22,9 @@ export function defineCursor<TFields extends { v: number }>({
 }: {
 	fieldsSchema: z.ZodType<TFields>;
 }): CursorCodec<TFields> {
-	const encode = (fields: Omit<TFields, "v"> & { v?: TFields["v"] }): string => {
+	const encode = (
+		fields: Omit<TFields, "v"> & { v?: TFields["v"] },
+	): string => {
 		const full = { v: CURRENT_CURSOR_VERSION, ...fields } as TFields;
 		const json = JSON.stringify(full);
 		return Buffer.from(json, "utf8").toString("base64url");
@@ -123,6 +125,10 @@ export type StandardCursorFields = z.infer<typeof StandardCursorFieldsSchema>;
 export const StandardCursor = defineCursor({
 	fieldsSchema: StandardCursorFieldsSchema,
 });
+
+export const SortOrderSchema = z.enum(["asc", "desc"]);
+
+export type SortOrder = z.infer<typeof SortOrderSchema>;
 
 export const PaginationDefaults = {
 	DefaultLimit: 50,

--- a/shared/api/customers/crud/listCustomersParamsV2_3.ts
+++ b/shared/api/customers/crud/listCustomersParamsV2_3.ts
@@ -1,8 +1,9 @@
 import { z } from "zod/v4";
 import {
-	createCursorLimitSchema,
 	CursorRequestFieldSchema,
+	createCursorLimitSchema,
 	PaginationDefaults,
+	SortOrderSchema,
 } from "../../common/cursorPaginationSchemas.js";
 
 export const ListCustomersV2_3ParamsSchema = z.object({
@@ -40,6 +41,11 @@ export const ListCustomersV2_3ParamsSchema = z.object({
 			description:
 				"Filter by customer processor type (stripe, revenuecat, vercel).",
 		}),
+
+	sort_order: SortOrderSchema.optional().meta({
+		description:
+			"Sort by customer creation time. Defaults to desc (newest first).",
+	}),
 });
 
 export type ListCustomersV2_3Params = z.infer<

--- a/shared/api/customers/crud/listCustomersParamsV2_3.ts
+++ b/shared/api/customers/crud/listCustomersParamsV2_3.ts
@@ -5,6 +5,7 @@ import {
 	PaginationDefaults,
 	SortOrderSchema,
 } from "../../common/cursorPaginationSchemas.js";
+import { CreatedAtRangeSchema } from "../customerListFilters.js";
 
 export const ListCustomersV2_3ParamsSchema = z.object({
 	start_cursor: CursorRequestFieldSchema,
@@ -45,6 +46,11 @@ export const ListCustomersV2_3ParamsSchema = z.object({
 	sort_order: SortOrderSchema.optional().meta({
 		description:
 			"Sort by customer creation time. Defaults to desc (newest first).",
+	}),
+
+	created_at_range: CreatedAtRangeSchema.optional().meta({
+		description:
+			"Filter by customer creation time (epoch milliseconds, inclusive bounds).",
 	}),
 });
 

--- a/shared/api/customers/customerListFilters.ts
+++ b/shared/api/customers/customerListFilters.ts
@@ -8,12 +8,36 @@ const FilterValuesSchema = z
 	.array(z.string().max(MAX_FILTER_VALUE_LENGTH))
 	.max(MAX_FILTER_VALUES);
 
+export const CreatedAtRangeSchema = z
+	.object({
+		start: z.coerce
+			.number()
+			.optional()
+			.describe(
+				"Include customers created at or after this timestamp (epoch milliseconds, inclusive)",
+			),
+		end: z.coerce
+			.number()
+			.optional()
+			.describe(
+				"Include customers created at or before this timestamp (epoch milliseconds, inclusive)",
+			),
+	})
+	.refine(
+		({ start, end }) =>
+			start === undefined || end === undefined || start <= end,
+		{ message: "created_at_range.start must be <= created_at_range.end" },
+	);
+
+export type CreatedAtRange = z.infer<typeof CreatedAtRangeSchema>;
+
 export const CustomerListFiltersSchema = z.object({
 	status: FilterValuesSchema.optional(),
 	version: FilterValuesSchema.optional(),
 	none: z.boolean().optional(),
 	processor: FilterValuesSchema.optional(),
 	interval: FilterValuesSchema.optional(),
+	created_at_range: CreatedAtRangeSchema.optional(),
 });
 
 export type CustomerListFilters = z.infer<typeof CustomerListFiltersSchema>;

--- a/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
@@ -85,7 +85,7 @@ export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 			}}
 		>
 			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
-				Joined
+				Created At
 				{label && (
 					<span className="truncate text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
 						{label}

--- a/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
@@ -1,0 +1,135 @@
+import {
+	Calendar,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from "@autumn/ui";
+import { endOfDay, format, isSameDay, startOfDay, subMonths } from "date-fns";
+import { useState } from "react";
+import type { DateRange } from "react-day-picker";
+import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+
+type JoinedBounds = { from: number | null; to: number | null };
+
+const ACTION_BUTTON_CLASS =
+	"flex-1 rounded-md px-2 py-1 text-xs text-tertiary-foreground hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40";
+
+const toDateRange = ({ from, to }: JoinedBounds): DateRange | undefined => {
+	if (from === null && to === null) return undefined;
+	return {
+		from: from === null ? undefined : new Date(from),
+		to: to === null ? undefined : new Date(to),
+	};
+};
+
+const getJoinedLabel = ({ from, to }: JoinedBounds): string | null => {
+	if (from !== null && to !== null) {
+		return isSameDay(from, to)
+			? format(from, "MMM d, yyyy")
+			: `${format(from, "MMM d")} – ${format(to, "MMM d, yyyy")}`;
+	}
+	if (to !== null) return `Before ${format(to, "MMM d, yyyy")}`;
+	if (from !== null) return `After ${format(from, "MMM d, yyyy")}`;
+	return null;
+};
+
+export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
+	const { queryStates, setFilters } = useCustomerFilters();
+	const [draftRange, setDraftRange] = useState<DateRange | undefined>(
+		undefined,
+	);
+
+	const bounds: JoinedBounds = {
+		from: queryStates.joinedFrom,
+		to: queryStates.joinedTo,
+	};
+	const selectedRange = toDateRange(bounds);
+	const label = getJoinedLabel(bounds);
+
+	const applyBounds = ({ from, to }: JoinedBounds) => {
+		setFilters({ joinedFrom: from, joinedTo: to });
+		onChange?.();
+	};
+
+	const handleSelect = (range: DateRange | undefined) => {
+		setDraftRange(range);
+		if (!range?.from) {
+			applyBounds({ from: null, to: null });
+			return;
+		}
+		applyBounds({
+			from: startOfDay(range.from).getTime(),
+			to: endOfDay(range.to ?? range.from).getTime(),
+		});
+	};
+
+	const keepEndBoundOnly = () => {
+		setDraftRange({ from: undefined, to: draftRange?.to });
+		applyBounds({ from: null, to: bounds.to });
+	};
+
+	const keepStartBoundOnly = () => {
+		setDraftRange({ from: draftRange?.from, to: undefined });
+		applyBounds({ from: bounds.from, to: null });
+	};
+
+	const clearJoinedRange = () => {
+		setDraftRange(undefined);
+		applyBounds({ from: null, to: null });
+	};
+
+	return (
+		<DropdownMenuSub
+			onOpenChange={(open) => {
+				if (open) setDraftRange(selectedRange);
+			}}
+		>
+			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
+				Joined
+				{label && (
+					<span className="truncate text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
+						{label}
+					</span>
+				)}
+			</DropdownMenuSubTrigger>
+			<DropdownMenuSubContent className="p-0">
+				<Calendar
+					mode="range"
+					numberOfMonths={2}
+					selected={draftRange ?? selectedRange}
+					onSelect={handleSelect}
+					defaultMonth={
+						draftRange?.from ?? draftRange?.to ?? subMonths(new Date(), 1)
+					}
+					disabled={{ after: new Date() }}
+				/>
+				<div className="flex items-center gap-1 border-t border-border p-1">
+					<button
+						type="button"
+						className={ACTION_BUTTON_CLASS}
+						disabled={bounds.to === null}
+						onClick={keepEndBoundOnly}
+					>
+						Before
+					</button>
+					<button
+						type="button"
+						className={ACTION_BUTTON_CLASS}
+						disabled={bounds.from === null}
+						onClick={keepStartBoundOnly}
+					>
+						After
+					</button>
+					<button
+						type="button"
+						className={ACTION_BUTTON_CLASS}
+						disabled={label === null}
+						onClick={clearJoinedRange}
+					>
+						Clear
+					</button>
+				</div>
+			</DropdownMenuSubContent>
+		</DropdownMenuSub>
+	);
+};

--- a/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
@@ -119,6 +119,9 @@ export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 		commitSelection({ mode: "range", anchor: null });
 
 	const hasAnchor = anchor !== null;
+	// Before/After are single-date modes; a multi-day range has no unambiguous boundary.
+	const hasSingleDayAnchor =
+		anchor !== null && isSameDay(anchor.from, anchor.to);
 
 	return (
 		<DropdownMenuSub
@@ -151,7 +154,7 @@ export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 							mode === "before" && ACTION_BUTTON_ACTIVE_CLASS,
 						)}
 						aria-pressed={mode === "before"}
-						disabled={!hasAnchor}
+						disabled={!hasSingleDayAnchor}
 						onClick={() => toggleMode("before")}
 					>
 						Before
@@ -163,7 +166,7 @@ export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 							mode === "after" && ACTION_BUTTON_ACTIVE_CLASS,
 						)}
 						aria-pressed={mode === "after"}
-						disabled={!hasAnchor}
+						disabled={!hasSingleDayAnchor}
 						onClick={() => toggleMode("after")}
 					>
 						After

--- a/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
@@ -7,19 +7,59 @@ import {
 import { endOfDay, format, isSameDay, startOfDay, subMonths } from "date-fns";
 import { useState } from "react";
 import type { DateRange } from "react-day-picker";
+import { cn } from "@/lib/utils";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
 
 type JoinedBounds = { from: number | null; to: number | null };
+type JoinedMode = "range" | "before" | "after";
+type JoinedAnchor = { from: Date; to: Date };
+type JoinedSelection = { mode: JoinedMode; anchor: JoinedAnchor | null };
 
 const ACTION_BUTTON_CLASS =
 	"flex-1 rounded-md px-2 py-1 text-xs text-tertiary-foreground hover:bg-accent hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-40";
+const ACTION_BUTTON_ACTIVE_CLASS = "bg-accent text-foreground";
 
-const toDateRange = ({ from, to }: JoinedBounds): DateRange | undefined => {
-	if (from === null && to === null) return undefined;
+const toJoinedBounds = ({ mode, anchor }: JoinedSelection): JoinedBounds => {
+	if (anchor === null) return { from: null, to: null };
+	if (mode === "before")
+		return { from: null, to: endOfDay(anchor.to).getTime() };
+	if (mode === "after")
+		return { from: startOfDay(anchor.from).getTime(), to: null };
 	return {
-		from: from === null ? undefined : new Date(from),
-		to: to === null ? undefined : new Date(to),
+		from: startOfDay(anchor.from).getTime(),
+		to: endOfDay(anchor.to).getTime(),
 	};
+};
+
+const toJoinedSelection = ({ from, to }: JoinedBounds): JoinedSelection => {
+	if (from !== null && to !== null)
+		return {
+			mode: "range",
+			anchor: { from: new Date(from), to: new Date(to) },
+		};
+	if (to !== null) {
+		const boundary = new Date(to);
+		return { mode: "before", anchor: { from: boundary, to: boundary } };
+	}
+	if (from !== null) {
+		const boundary = new Date(from);
+		return { mode: "after", anchor: { from: boundary, to: boundary } };
+	}
+	return { mode: "range", anchor: null };
+};
+
+/** react-day-picker reports the resulting range, not the day, so infer it from whichever endpoint moved. */
+const getClickedDay = ({
+	from,
+	to,
+	anchor,
+}: {
+	from: Date;
+	to: Date | undefined;
+	anchor: JoinedAnchor | null;
+}): Date => {
+	if (anchor === null || to === undefined) return from;
+	return isSameDay(from, anchor.from) ? to : from;
 };
 
 const getJoinedLabel = ({ from, to }: JoinedBounds): string | null => {
@@ -35,53 +75,55 @@ const getJoinedLabel = ({ from, to }: JoinedBounds): string | null => {
 
 export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 	const { queryStates, setFilters } = useCustomerFilters();
-	const [draftRange, setDraftRange] = useState<DateRange | undefined>(
-		undefined,
-	);
 
 	const bounds: JoinedBounds = {
 		from: queryStates.joinedFrom,
 		to: queryStates.joinedTo,
 	};
-	const selectedRange = toDateRange(bounds);
+
+	const [selection, setSelection] = useState<JoinedSelection>(() =>
+		toJoinedSelection(bounds),
+	);
+	const { mode, anchor } = selection;
 	const label = getJoinedLabel(bounds);
 
-	const applyBounds = ({ from, to }: JoinedBounds) => {
-		setFilters({ joinedFrom: from, joinedTo: to });
+	const commitSelection = (next: JoinedSelection) => {
+		const nextBounds = toJoinedBounds(next);
+		setSelection(next);
+		setFilters({ joinedFrom: nextBounds.from, joinedTo: nextBounds.to });
 		onChange?.();
 	};
 
 	const handleSelect = (range: DateRange | undefined) => {
-		setDraftRange(range);
 		if (!range?.from) {
-			applyBounds({ from: null, to: null });
+			commitSelection({ mode: "range", anchor: null });
 			return;
 		}
-		applyBounds({
-			from: startOfDay(range.from).getTime(),
-			to: endOfDay(range.to ?? range.from).getTime(),
-		});
+		if (mode === "range") {
+			commitSelection({
+				mode,
+				anchor: { from: range.from, to: range.to ?? range.from },
+			});
+			return;
+		}
+		const boundary = getClickedDay({ from: range.from, to: range.to, anchor });
+		commitSelection({ mode, anchor: { from: boundary, to: boundary } });
 	};
 
-	const keepEndBoundOnly = () => {
-		setDraftRange({ from: undefined, to: draftRange?.to });
-		applyBounds({ from: null, to: bounds.to });
+	const toggleMode = (nextMode: JoinedMode) => {
+		if (anchor === null) return;
+		commitSelection({ mode: mode === nextMode ? "range" : nextMode, anchor });
 	};
 
-	const keepStartBoundOnly = () => {
-		setDraftRange({ from: draftRange?.from, to: undefined });
-		applyBounds({ from: bounds.from, to: null });
-	};
+	const clearJoinedRange = () =>
+		commitSelection({ mode: "range", anchor: null });
 
-	const clearJoinedRange = () => {
-		setDraftRange(undefined);
-		applyBounds({ from: null, to: null });
-	};
+	const hasAnchor = anchor !== null;
 
 	return (
 		<DropdownMenuSub
 			onOpenChange={(open) => {
-				if (open) setDraftRange(selectedRange);
+				if (open) setSelection(toJoinedSelection(bounds));
 			}}
 		>
 			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
@@ -96,34 +138,40 @@ export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 				<Calendar
 					mode="range"
 					numberOfMonths={2}
-					selected={draftRange ?? selectedRange}
+					selected={anchor ?? undefined}
 					onSelect={handleSelect}
-					defaultMonth={
-						draftRange?.from ?? draftRange?.to ?? subMonths(new Date(), 1)
-					}
+					defaultMonth={anchor?.from ?? subMonths(new Date(), 1)}
 					disabled={{ after: new Date() }}
 				/>
 				<div className="flex items-center gap-1 border-t border-border p-1">
 					<button
 						type="button"
-						className={ACTION_BUTTON_CLASS}
-						disabled={bounds.to === null}
-						onClick={keepEndBoundOnly}
+						className={cn(
+							ACTION_BUTTON_CLASS,
+							mode === "before" && ACTION_BUTTON_ACTIVE_CLASS,
+						)}
+						aria-pressed={mode === "before"}
+						disabled={!hasAnchor}
+						onClick={() => toggleMode("before")}
 					>
 						Before
 					</button>
 					<button
 						type="button"
-						className={ACTION_BUTTON_CLASS}
-						disabled={bounds.from === null}
-						onClick={keepStartBoundOnly}
+						className={cn(
+							ACTION_BUTTON_CLASS,
+							mode === "after" && ACTION_BUTTON_ACTIVE_CLASS,
+						)}
+						aria-pressed={mode === "after"}
+						disabled={!hasAnchor}
+						onClick={() => toggleMode("after")}
 					>
 						After
 					</button>
 					<button
 						type="button"
 						className={ACTION_BUTTON_CLASS}
-						disabled={label === null}
+						disabled={!hasAnchor}
 						onClick={clearJoinedRange}
 					>
 						Clear

--- a/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
@@ -9,16 +9,12 @@ import {
 	PopoverTrigger,
 } from "@autumn/ui";
 import { TrashIcon } from "@phosphor-icons/react";
+import { parseAsInteger } from "nuqs";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
-
-const parseTimestampParam = (value: string | null) => {
-	const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
-	return Number.isNaN(parsed) ? null : parsed;
-};
 
 interface SavedView {
 	id: string;
@@ -62,8 +58,12 @@ export const SavedViews = ({
 					? processorParam.split(",").filter(Boolean)
 					: [],
 				interval: intervalParam ? intervalParam.split(",").filter(Boolean) : [],
-				joinedFrom: parseTimestampParam(params.get("joinedFrom")),
-				joinedTo: parseTimestampParam(params.get("joinedTo")),
+				joinedFrom: parseAsInteger.parseServerSide(
+					params.get("joinedFrom") ?? undefined,
+				),
+				joinedTo: parseAsInteger.parseServerSide(
+					params.get("joinedTo") ?? undefined,
+				),
 			});
 
 			toast.success(`Applied filters from ${view.name} view`);

--- a/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/SavedViews.tsx
@@ -1,16 +1,24 @@
-import { Button, Popover, PopoverContent, PopoverTrigger } from "@autumn/ui";
-import { TrashIcon } from "@phosphor-icons/react";
-import { useState } from "react";
-import { toast } from "sonner";
 import {
+	Button,
 	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
 } from "@autumn/ui";
+import { TrashIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { toast } from "sonner";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCustomerFilters } from "../../hooks/useCustomerFilters";
+
+const parseTimestampParam = (value: string | null) => {
+	const parsed = value ? Number.parseInt(value, 10) : Number.NaN;
+	return Number.isNaN(parsed) ? null : parsed;
+};
 
 interface SavedView {
 	id: string;
@@ -53,9 +61,9 @@ export const SavedViews = ({
 				processor: processorParam
 					? processorParam.split(",").filter(Boolean)
 					: [],
-				interval: intervalParam
-					? intervalParam.split(",").filter(Boolean)
-					: [],
+				interval: intervalParam ? intervalParam.split(",").filter(Boolean) : [],
+				joinedFrom: parseTimestampParam(params.get("joinedFrom")),
+				joinedTo: parseTimestampParam(params.get("joinedTo")),
 			});
 
 			toast.success(`Applied filters from ${view.name} view`);

--- a/vite/src/views/customers/hooks/useCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useCusSearchQuery.tsx
@@ -22,6 +22,7 @@ export const useCusSearchQuery = () => {
 			cursor: currentCursor,
 			limit: queryStates.pageSize,
 			filters: buildCustomerFilterPayload(queryStates),
+			sort_order: queryStates.sort,
 		});
 		return {
 			customers: data.customers as CustomerWithProducts[],
@@ -48,6 +49,7 @@ export const useCusSearchQuery = () => {
 			queryStates.none,
 			queryStates.processor,
 			queryStates.interval,
+			queryStates.sort,
 			trimmedSearch,
 		]),
 		queryFn: fetcher,

--- a/vite/src/views/customers/hooks/useCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useCusSearchQuery.tsx
@@ -49,6 +49,8 @@ export const useCusSearchQuery = () => {
 			queryStates.none,
 			queryStates.processor,
 			queryStates.interval,
+			queryStates.joinedFrom,
+			queryStates.joinedTo,
 			queryStates.sort,
 			trimmedSearch,
 		]),

--- a/vite/src/views/customers/hooks/useCustomerCountQuery.tsx
+++ b/vite/src/views/customers/hooks/useCustomerCountQuery.tsx
@@ -24,6 +24,8 @@ export const useCustomerCountQuery = ({
 			filters.none,
 			filters.processor,
 			filters.interval,
+			filters.created_at_range?.start,
+			filters.created_at_range?.end,
 			search,
 		]),
 		enabled,

--- a/vite/src/views/customers/hooks/useCustomerFilters.tsx
+++ b/vite/src/views/customers/hooks/useCustomerFilters.tsx
@@ -31,6 +31,8 @@ const FILTER_PARAM_KEYS = [
 	"interval",
 	"pageSize",
 	"sort",
+	"joinedFrom",
+	"joinedTo",
 ] as const;
 
 type PersistedCustomerFilters = {
@@ -41,6 +43,8 @@ type PersistedCustomerFilters = {
 	interval: string[];
 	pageSize: number;
 	sort?: SortOrder;
+	joinedFrom?: number | null;
+	joinedTo?: number | null;
 };
 
 function getStorageKey({ orgId, env }: { orgId: string; env: string }) {
@@ -79,6 +83,8 @@ function buildRestoredState({
 				? filters.pageSize
 				: null,
 		sort: filters?.sort === "asc" ? filters.sort : null,
+		joinedFrom: filters?.joinedFrom ?? null,
+		joinedTo: filters?.joinedTo ?? null,
 	};
 }
 
@@ -91,6 +97,8 @@ const queryStatesConfig = {
 	interval: parseAsArrayOf(parseAsString).withDefault([]),
 	pageSize: parseAsInteger.withDefault(DEFAULT_CUSTOMER_LIST_PAGE_SIZE),
 	sort: parseAsStringLiteral(SortOrderSchema.options).withDefault("desc"),
+	joinedFrom: parseAsInteger,
+	joinedTo: parseAsInteger,
 };
 
 type QueryStates = ReturnType<typeof useQueryStates<typeof queryStatesConfig>>;
@@ -101,17 +109,28 @@ export function hasActiveCustomerFilters(queryStates: QueryStates[0]) {
 		queryStates.version.length > 0 ||
 		queryStates.none ||
 		queryStates.processor.length > 0 ||
-		queryStates.interval.length > 0
+		queryStates.interval.length > 0 ||
+		queryStates.joinedFrom !== null ||
+		queryStates.joinedTo !== null
 	);
 }
 
 export function buildCustomerFilterPayload(queryStates: QueryStates[0]) {
+	const { joinedFrom, joinedTo } = queryStates;
+	const hasJoinedRange = joinedFrom !== null || joinedTo !== null;
+
 	return {
 		status: queryStates.status,
 		version: queryStates.version,
 		none: queryStates.none,
 		processor: queryStates.processor,
 		interval: queryStates.interval,
+		...(hasJoinedRange && {
+			created_at_range: {
+				start: joinedFrom ?? undefined,
+				end: joinedTo ?? undefined,
+			},
+		}),
 	};
 }
 
@@ -210,6 +229,8 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 					interval: queryStates.interval,
 					pageSize: queryStates.pageSize,
 					sort: queryStates.sort,
+					joinedFrom: queryStates.joinedFrom,
+					joinedTo: queryStates.joinedTo,
 				}),
 			);
 		} catch {}
@@ -224,6 +245,8 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 		queryStates.interval,
 		queryStates.pageSize,
 		queryStates.sort,
+		queryStates.joinedFrom,
+		queryStates.joinedTo,
 	]);
 
 	return (

--- a/vite/src/views/customers/hooks/useCustomerFilters.tsx
+++ b/vite/src/views/customers/hooks/useCustomerFilters.tsx
@@ -1,3 +1,4 @@
+import { type SortOrder, SortOrderSchema } from "@autumn/shared";
 import {
 	parseAsArrayOf,
 	parseAsBoolean,
@@ -32,9 +33,6 @@ const FILTER_PARAM_KEYS = [
 	"sort",
 ] as const;
 
-const SORT_ORDERS = ["asc", "desc"] as const;
-export type CustomerSortOrder = (typeof SORT_ORDERS)[number];
-
 type PersistedCustomerFilters = {
 	status: string[];
 	version: string[];
@@ -42,7 +40,7 @@ type PersistedCustomerFilters = {
 	processor: string[];
 	interval: string[];
 	pageSize: number;
-	sort?: CustomerSortOrder;
+	sort?: SortOrder;
 };
 
 function getStorageKey({ orgId, env }: { orgId: string; env: string }) {
@@ -92,7 +90,7 @@ const queryStatesConfig = {
 	processor: parseAsArrayOf(parseAsString).withDefault([]),
 	interval: parseAsArrayOf(parseAsString).withDefault([]),
 	pageSize: parseAsInteger.withDefault(DEFAULT_CUSTOMER_LIST_PAGE_SIZE),
-	sort: parseAsStringLiteral(SORT_ORDERS).withDefault("desc"),
+	sort: parseAsStringLiteral(SortOrderSchema.options).withDefault("desc"),
 };
 
 type QueryStates = ReturnType<typeof useQueryStates<typeof queryStatesConfig>>;

--- a/vite/src/views/customers/hooks/useCustomerFilters.tsx
+++ b/vite/src/views/customers/hooks/useCustomerFilters.tsx
@@ -3,6 +3,7 @@ import {
 	parseAsBoolean,
 	parseAsInteger,
 	parseAsString,
+	parseAsStringLiteral,
 	useQueryStates,
 } from "nuqs";
 import {
@@ -28,7 +29,11 @@ const FILTER_PARAM_KEYS = [
 	"processor",
 	"interval",
 	"pageSize",
+	"sort",
 ] as const;
+
+const SORT_ORDERS = ["asc", "desc"] as const;
+export type CustomerSortOrder = (typeof SORT_ORDERS)[number];
 
 type PersistedCustomerFilters = {
 	status: string[];
@@ -37,6 +42,7 @@ type PersistedCustomerFilters = {
 	processor: string[];
 	interval: string[];
 	pageSize: number;
+	sort?: CustomerSortOrder;
 };
 
 function getStorageKey({ orgId, env }: { orgId: string; env: string }) {
@@ -74,6 +80,7 @@ function buildRestoredState({
 			filters?.pageSize && filters.pageSize !== DEFAULT_CUSTOMER_LIST_PAGE_SIZE
 				? filters.pageSize
 				: null,
+		sort: filters?.sort === "asc" ? filters.sort : null,
 	};
 }
 
@@ -85,6 +92,7 @@ const queryStatesConfig = {
 	processor: parseAsArrayOf(parseAsString).withDefault([]),
 	interval: parseAsArrayOf(parseAsString).withDefault([]),
 	pageSize: parseAsInteger.withDefault(DEFAULT_CUSTOMER_LIST_PAGE_SIZE),
+	sort: parseAsStringLiteral(SORT_ORDERS).withDefault("desc"),
 };
 
 type QueryStates = ReturnType<typeof useQueryStates<typeof queryStatesConfig>>;
@@ -203,6 +211,7 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 					processor: queryStates.processor,
 					interval: queryStates.interval,
 					pageSize: queryStates.pageSize,
+					sort: queryStates.sort,
 				}),
 			);
 		} catch {}
@@ -216,6 +225,7 @@ export function CustomerFiltersProvider({ children }: { children: ReactNode }) {
 		queryStates.processor,
 		queryStates.interval,
 		queryStates.pageSize,
+		queryStates.sort,
 	]);
 
 	return (

--- a/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
@@ -27,6 +27,7 @@ export const useFullCusSearchQuery = () => {
 			queryStates.none,
 			queryStates.processor,
 			queryStates.interval,
+			queryStates.sort,
 			queryStates.q,
 		]),
 		queryFn: async ({ signal }) => {
@@ -37,6 +38,7 @@ export const useFullCusSearchQuery = () => {
 					cursor: currentCursor,
 					limit: queryStates.pageSize,
 					filters: buildCustomerFilterPayload(queryStates),
+					sort_order: queryStates.sort,
 				},
 				{ signal },
 			);

--- a/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
+++ b/vite/src/views/customers/hooks/useFullCusSearchQuery.tsx
@@ -27,6 +27,8 @@ export const useFullCusSearchQuery = () => {
 			queryStates.none,
 			queryStates.processor,
 			queryStates.interval,
+			queryStates.joinedFrom,
+			queryStates.joinedTo,
 			queryStates.sort,
 			queryStates.q,
 		]),

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
@@ -210,6 +210,7 @@ export const createCustomerListColumns = (): ColumnDef<
 		header: "Created At",
 		accessorKey: "created_at",
 		size: 90,
+		enableSorting: true,
 		meta: { skeleton: dateSkeleton },
 		cell: ({ row }: { row: Row<CustomerWithProducts> }) => {
 			const { date, time } = formatUnixToDateTime(row.original.created_at);

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListColumns.tsx
@@ -209,7 +209,7 @@ export const createCustomerListColumns = (): ColumnDef<
 		id: "created_at",
 		header: "Created At",
 		accessorKey: "created_at",
-		size: 90,
+		size: 100,
 		enableSorting: true,
 		meta: { skeleton: dateSkeleton },
 		cell: ({ row }: { row: Row<CustomerWithProducts> }) => {

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { FilterStatusSubMenu } from "@/views/customers/components/filter-dropdown/FilterStatusSubMenu";
 import { IntervalSubMenu } from "@/views/customers/components/filter-dropdown/IntervalSubMenu";
+import { JoinedDateSubMenu } from "@/views/customers/components/filter-dropdown/JoinedDateSubMenu";
 import { ProcessorSubMenu } from "@/views/customers/components/filter-dropdown/ProcessorSubMenu";
 import { ProductsSubMenu } from "@/views/customers/components/filter-dropdown/ProductsSubMenu";
 import { SaveViewPopover } from "@/views/customers/components/filter-dropdown/SavedViewPopover";
@@ -54,6 +55,8 @@ export function CustomerListFilterButton({
 			none: false,
 			processor: [],
 			interval: [],
+			joinedFrom: null,
+			joinedTo: null,
 		});
 		onFilterChange?.();
 		onClearExtra?.();
@@ -92,6 +95,7 @@ export function CustomerListFilterButton({
 					<ProductsSubMenu onChange={onFilterChange} />
 					<IntervalSubMenu onChange={onFilterChange} />
 					<ProcessorSubMenu onChange={onFilterChange} />
+					<JoinedDateSubMenu onChange={onFilterChange} />
 				</DropdownMenuGroup>
 				<DropdownMenuSeparator className="m-0" />
 				{!hideSavedViews && views.length > 0 && (

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
@@ -29,6 +29,8 @@ interface CustomerListFilterButtonProps {
 	onClearExtra?: () => void;
 	onFilterChange?: () => void;
 	hideSavedViews?: boolean;
+	hideInterval?: boolean;
+	hideCreatedAt?: boolean;
 }
 
 export function CustomerListFilterButton({
@@ -37,6 +39,8 @@ export function CustomerListFilterButton({
 	onClearExtra,
 	onFilterChange,
 	hideSavedViews,
+	hideInterval,
+	hideCreatedAt,
 }: CustomerListFilterButtonProps = {}) {
 	const { queryStates, setFilters } = useCustomerFilters();
 	const [open, setOpen] = useState(false);
@@ -93,9 +97,9 @@ export function CustomerListFilterButton({
 					{extraMenuItems}
 					<FilterStatusSubMenu onChange={onFilterChange} />
 					<ProductsSubMenu onChange={onFilterChange} />
-					<IntervalSubMenu onChange={onFilterChange} />
+					{!hideInterval && <IntervalSubMenu onChange={onFilterChange} />}
 					<ProcessorSubMenu onChange={onFilterChange} />
-					<JoinedDateSubMenu onChange={onFilterChange} />
+					{!hideCreatedAt && <JoinedDateSubMenu onChange={onFilterChange} />}
 				</DropdownMenuGroup>
 				<DropdownMenuSeparator className="m-0" />
 				{!hideSavedViews && views.length > 0 && (

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -59,6 +59,8 @@ export function CustomerListTable({
 			queryStates.none,
 			queryStates.processor,
 			queryStates.interval,
+			queryStates.joinedFrom,
+			queryStates.joinedTo,
 			queryStates.sort,
 			queryStates.q,
 		]),

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -122,8 +122,7 @@ export function CustomerListTable({
 		columnGroups,
 	});
 
-	// Sorting is server-side: header clicks update the sort URL param (resetting
-	// the cursor stack), and the backend re-queries in the new direction.
+	// setFilters resets the cursor stack, so a sort toggle lands back on page 1.
 	const sorting = useMemo<SortingState>(
 		() => [{ id: "created_at", desc: queryStates.sort !== "asc" }],
 		[queryStates.sort],

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -124,12 +124,12 @@ export function CustomerListTable({
 		columnGroups,
 	});
 
-	// setFilters resets the cursor stack, so a sort toggle lands back on page 1.
 	const sorting = useMemo<SortingState>(
 		() => [{ id: "created_at", desc: queryStates.sort !== "asc" }],
 		[queryStates.sort],
 	);
 
+	// setFilters resets the cursor stack, so a sort toggle lands back on page 1.
 	const onSortingChange = useCallback<OnChangeFn<SortingState>>(
 		(updater) => {
 			const next = typeof updater === "function" ? updater(sorting) : updater;

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -2,7 +2,8 @@ import { AppEnv, type FullCustomer } from "@autumn/shared";
 import { IconButton, useColumnVisibility } from "@autumn/ui";
 import { ArrowSquareOutIcon, UsersIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import type { OnChangeFn, SortingState } from "@tanstack/react-table";
+import { useCallback, useMemo } from "react";
 import { Table } from "@/components/general/table";
 import { EmptyState } from "@/components/v2/empty-states/EmptyState";
 import { getLastSwitchedOrgId, useOrg } from "@/hooks/common/useOrg";
@@ -41,7 +42,7 @@ export function CustomerListTable({
 		env === AppEnv.Sandbox ? "calc(100vh - 230px)" : "calc(100vh - 190px)";
 
 	const { features } = useFeaturesQuery();
-	const { queryStates, currentCursor } = useCustomerFilters();
+	const { queryStates, setFilters, currentCursor } = useCustomerFilters();
 	const buildKey = useQueryKeyFactory();
 
 	const {
@@ -58,6 +59,7 @@ export function CustomerListTable({
 			queryStates.none,
 			queryStates.processor,
 			queryStates.interval,
+			queryStates.sort,
 			queryStates.q,
 		]),
 		queryFn: () => Promise.resolve({ fullCustomers: [], next_cursor: null }),
@@ -120,14 +122,37 @@ export function CustomerListTable({
 		columnGroups,
 	});
 
+	// Sorting is server-side: header clicks update the sort URL param (resetting
+	// the cursor stack), and the backend re-queries in the new direction.
+	const sorting = useMemo<SortingState>(
+		() => [{ id: "created_at", desc: queryStates.sort !== "asc" }],
+		[queryStates.sort],
+	);
+
+	const onSortingChange = useCallback<OnChangeFn<SortingState>>(
+		(updater) => {
+			const next = typeof updater === "function" ? updater(sorting) : updater;
+			const createdAtSort = next.find((sort) => sort.id === "created_at");
+			setFilters({
+				sort: createdAtSort && !createdAtSort.desc ? "asc" : "desc",
+			});
+		},
+		[sorting, setFilters],
+	);
+
 	const table = useCustomerTable({
 		data: mergedCustomers,
 		columns,
 		options: {
 			globalFilterFn: "includesString",
 			enableGlobalFilter: true,
-			state: { columnVisibility },
+			enableSorting: true,
+			enableSortingRemoval: false,
+			manualSorting: true,
+			defaultColumn: { enableSorting: false },
+			state: { columnVisibility, sorting },
 			onColumnVisibilityChange: setColumnVisibility,
+			onSortingChange,
 		},
 	});
 
@@ -173,7 +198,7 @@ export function CustomerListTable({
 			config={{
 				table,
 				numberOfColumns: columns.length,
-				enableSorting: false,
+				enableSorting: true,
 				isLoading: isFetchingUncached && customers.length === 0,
 				isTransitioning: isFetchingUncached && customers.length > 0,
 				getRowHref,

--- a/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
+++ b/vite/src/views/migrations/migration/live/MigrationLiveView.tsx
@@ -768,6 +768,8 @@ export function MigrationLiveView({
 						hasActiveExtraFilters={hasActiveExecutionFilters(executionStatuses)}
 						onClearExtra={() => handleExecutionStatusesChange([])}
 						hideSavedViews
+						hideInterval
+						hideCreatedAt
 					/>
 				}
 				trailing={


### PR DESCRIPTION
## What

Adds a `sort_order` param (`"asc" | "desc"`, defaults to `"desc"`) to customer listing, sorted by creation time. First step toward date jump/range filtering on the customers list.

**Backend (`4d383afe5`):**
- New optional `sort_order` on `ListCustomersV2_3ParamsSchema` (additive on v2.3, no version bump; v2.2 offset + legacy GET paths left frozen). The OpenAPI contract and MCP `listCustomers` tool pick it up from the schema. `.optional()` rather than `.default()` so the MCP tool schema doesn't advertise it as required; the `desc` default is applied server-side.
- Shared `SortOrderSchema` / `SortOrder` in `cursorPaginationSchemas.ts`.
- The ORDER BY and cursor tuple comparison flip together in both DESC sites: the raw SQL in `cursorPaginatedFullCusQuery` and the Drizzle pre-resolve query in `CusSearchService.resolveInternalIdsByCursor`, threaded through `CusBatchService.getCursorPage` (public API) and `getDashboardCursorPage` (dashboard).
- Internal dashboard endpoints (`/customers/all/search`, `/all/full_customers`) accept `sort_order` in the body.
- No DB changes: ascending is a backward scan of the existing `idx_customers_cursor (org_id, env, created_at DESC, id DESC)`.

**Dashboard (`90a739a22`):**
- "Created At" column header is clickable, toggling desc ↔ asc (server-side via `sort_order`, TanStack `manualSorting`; only that column is sortable).
- Sort lives in the `sort` URL param (nuqs) and localStorage alongside the other filters; changing it resets the cursor stack.

## Tests

`server/tests/integration/crud/customers/list-customers-sort-order.test.ts`: default equals explicit desc, asc is the exact reverse, `created_at` monotonicity both directions, limit-1 cursor walks match the single-page order in both directions, invalid `sort_order` rejected.

## Notes

- Keeping `sort_order` and any filters identical across a pagination walk is the caller's responsibility (same as existing filters).
- Speakeasy SDK + docs regen to follow once this settles.
- Next step (separate PR): `created_at_range: { start?, end? }` for jump-to-date / before / after / range, same shape as `custom_range` on `events.list`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Created At sorting and date-range filtering to `customers.list` (v2.3) and the dashboard. Also fixes header/body misalignment in virtualized tables by rendering one sticky-header table.

- **New Features**
  - API: `sort_order` ("asc" | "desc", default "desc") and `created_at_range` ({ start?, end? } ms, inclusive) added to `customers.list` (v2.3); internal dashboard endpoints accept both; `autumn` CLI supports both; shared `CreatedAtRange` and `SortOrder` types reused across surfaces.
  - Pagination: ORDER BY and cursor predicates flip with sort; ASC uses a NULL‑safe cursor compare so rows with NULL `id` aren’t dropped.
  - Dashboard: “Created At” is sortable (server‑side via `manualSorting`); sort persists in `nuqs` URL/localStorage and resets the cursor stack when changed.
  - Filtering: `created_at_range` enforced in raw SQL and `drizzle-orm`; validation ensures start <= end. Dashboard adds a “Created At” picker (before/after/range) that composes with sorting, pagination, `nuqs`, and saved views. Internal code uses `createdAtRangeFilter` naming for consistency.

- **Bug Fixes**
  - Date picker: can toggle between “Before” and “After”; these modes are only enabled for single‑day selections to avoid ambiguous ranges.
  - UI: render one sticky‑header table and fix spacer colSpans to keep header/body columns aligned; drop unused header prop; truncate header text; use a smaller sort icon.
  - Migrations execution view: hide interval and “Created At” filters.

<sup>Written for commit c24af9b538d0647981ea05d583b7aae94012b4a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

