### PR TITLE
fix: allow zero feature grant amounts, block only negatives

### DIFF
--- a/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx
@@ -91,7 +91,7 @@ export function CreateRewardSheet({
 					const isBoolean =
 						features.find((f) => f.id === e.feature_id)?.type ===
 						FeatureType.Boolean;
-					return !isBoolean && (!e.allowance || e.allowance <= 0);
+					return !isBoolean && (e.allowance == null || e.allowance < 0);
 				})
 			)
 				return false;

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -306,7 +306,7 @@ export function FeatureGrantRewardConfig({
 															allowance:
 																e.target.value === ""
 																	? undefined
-																	: Number(e.target.value),
+																	: Math.max(0, Number(e.target.value)),
 														},
 													})
 												}

--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -297,11 +297,17 @@ export function FeatureGrantRewardConfig({
 											<FormLabel>Balance Grant</FormLabel>
 											<Input
 												type="number"
-												value={ent.allowance || ""}
+												min={0}
+												value={ent.allowance ?? ""}
 												onChange={(e) =>
 													updateEntitlement({
 														index,
-														updates: { allowance: Number(e.target.value) },
+														updates: {
+															allowance:
+																e.target.value === ""
+																	? undefined
+																	: Number(e.target.value),
+														},
 													})
 												}
 												placeholder="0"

--- a/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx
@@ -102,7 +102,7 @@ export function UpdateRewardSheet({
 					const isBoolean =
 						features.find((f) => f.id === e.feature_id)?.type ===
 						FeatureType.Boolean;
-					return !isBoolean && (!e.allowance || e.allowance <= 0);
+					return !isBoolean && (e.allowance == null || e.allowance < 0);
 				})
 			)
 				return false;

--- a/vite/src/views/products/rewards/utils/rewardMappers.ts
+++ b/vite/src/views/products/rewards/utils/rewardMappers.ts
@@ -100,7 +100,7 @@ export function mapFrontendToApiReward({
 			const feature = features
 				? findFeatureById({ features, featureId: e.feature_id })
 				: undefined;
-			const hasAllowance = e.allowance != null && e.allowance > 0;
+			const hasAllowance = e.allowance != null && e.allowance >= 0;
 			return {
 				internal_feature_id: feature?.internal_id ?? e.feature_id,
 				allowance: hasAllowance ? e.allowance : undefined,

--- a/vite/src/views/products/rewards/utils/rewardMappers.ts
+++ b/vite/src/views/products/rewards/utils/rewardMappers.ts
@@ -1,6 +1,7 @@
 import {
 	type CreateReward,
 	type Feature,
+	FeatureType,
 	findFeatureById,
 	findFeatureByInternalId,
 	getGlobalMaxRedemption,
@@ -100,7 +101,9 @@ export function mapFrontendToApiReward({
 			const feature = features
 				? findFeatureById({ features, featureId: e.feature_id })
 				: undefined;
-			const hasAllowance = e.allowance != null && e.allowance >= 0;
+			const isBoolean = feature?.type === FeatureType.Boolean;
+			const hasAllowance =
+				!isBoolean && e.allowance != null && e.allowance >= 0;
 			return {
 				internal_feature_id: feature?.internal_id ?? e.feature_id,
 				allowance: hasAllowance ? e.allowance : undefined,
@@ -152,7 +155,7 @@ export function mapApiToFrontendReward({
 			: undefined;
 		return {
 			feature_id: feature?.id ?? e.internal_feature_id,
-			allowance: e.allowance ?? 0,
+			allowance: e.allowance ?? undefined,
 			expiry: getFrontendExpiry(e),
 		};
 	});


### PR DESCRIPTION
The reward feature-grant UI blocked an allowance of `0`, but the backend explicitly supports it — `shared/api/rewards/rewardsGrantValidation.test.ts` asserts `included: 0` parses on both create and update, and rejects `-1`. This aligns the dashboard with that contract: zero is valid, negatives are not.

## Changes

- `CreateRewardSheet.tsx` / `UpdateRewardSheet.tsx` — validity check goes from `!e.allowance || e.allowance <= 0` to `e.allowance == null || e.allowance < 0`. Zero passes; unset and negative still fail.
- `rewardMappers.ts` — `hasAllowance` now uses `>= 0` instead of `> 0`. Previously a `0` was coerced to `undefined` and dropped from the payload, so it could never reach the API even if the form allowed it.
- `FeatureGrantRewardConfig.tsx` — input uses `?? ""` instead of `|| ""` so a stored `0` renders as `0` rather than an empty box, adds `min={0}`, and maps an empty input back to `undefined` instead of `Number("")` → `0`.

Boolean features are unaffected — they still grant on/off access with no allowance.

## Why this mattered

A reward created through the API with `included: 0` would load into the update sheet, fail validation, and block saving until the amount was changed.

## Testing

- `tsc --noEmit` clean on `vite`
- Biome clean on all four touched files (the one remaining `noUnusedVariables` warning in `rewardMappers.ts:143` is pre-existing on `main` and untouched here)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow zero feature grant allowances in the dashboard and only block negatives, while keeping boolean grants allowance-free to match the API.

- **Bug Fixes**
  - Validation: Treat `undefined` as invalid and negatives as invalid; `0` is valid in create/update sheets.
  - Mapping: For non-boolean features, preserve `0` (send to API); for boolean features, omit `allowance`. Do not coerce missing allowances to `0` when loading.
  - UI: Show `0` instead of empty, add `min={0}`, clamp negative input to `0`, and map empty input to `undefined`.

<sup>Written for commit 9d5045a133007b345afaaf9570129e3f129869ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The follow-up changes complete the zero-allowance fix while preventing boolean grants from receiving numeric allowances.

- **Bug fixes:** Numeric feature grants now accept, display, and preserve an explicit allowance of `0`.
- **Bug fixes:** Empty numeric inputs remain unset, while negative values are blocked.
- **Bug fixes:** Boolean feature grants omit allowances when mapped to API payloads.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/rewards/reward-config/components/CreateRewardSheet.tsx | Create validation now accepts zero for numeric grants while continuing to reject missing and negative allowances. |
| vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx | The allowance input preserves zero, clears to undefined, and constrains entered values to nonnegative numbers. |
| vite/src/views/products/rewards/reward-config/components/UpdateRewardSheet.tsx | Update validation now permits existing numeric grants with a zero allowance. |
| vite/src/views/products/rewards/utils/rewardMappers.ts | Reward mapping preserves numeric zero allowances and explicitly strips allowances from boolean grants, resolving the previous review finding. |

<sub>Reviews (2): Last reviewed commit: ["fix: keep boolean grants allowance-free ..."](https://github.com/useautumn/autumn/commit/9d5045a133007b345afaaf9570129e3f129869ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51149506)</sub>

<!-- /greptile_comment -->