### PR TITLE
chore: name update balance queue explicitly

### DIFF
--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -9,6 +9,7 @@ import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubjec
 import { isAsyncBalanceUpdateEnabled } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import { getUpdateBalanceProducerQueueUrl } from "@/queue/trackAsyncQueueUrls.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
 import { updateExpiresAtV2 } from "./updateExpiresAtV2.js";
 import { updateIncludedGrantV2 } from "./updateIncludedGrantV2.js";
@@ -100,7 +101,7 @@ const queueUpdateBalanceV2 = async ({
 	params: UpdateBalanceParamsV0;
 	targetBalance?: number;
 }) => {
-	const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+	const queueUrl = getUpdateBalanceProducerQueueUrl();
 	if (!queueUrl) {
 		throw new RecaseError({
 			message: ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE,

--- a/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
+++ b/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
@@ -8,7 +8,7 @@ import { getMiscRedis } from "@/external/redis/initRedis.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import { withTimeout } from "@/utils/withTimeout.js";
 import { QUEUE_URL } from "../initSqs.js";
-import { getAsyncTrackWorkerQueueUrls } from "../trackAsyncQueueUrls.js";
+import { getTrackAndUpdateBalanceWorkerQueueUrls } from "../trackAsyncQueueUrls.js";
 import type { BlueGreenProbeResult } from "./blueGreenSchemas.js";
 
 const CHECK_TIMEOUT_MS = 5_000;
@@ -45,7 +45,7 @@ const getConfiguredQueueUrls = () =>
 	[
 		QUEUE_URL,
 		process.env.TRACK_SQS_QUEUE_URL,
-		...getAsyncTrackWorkerQueueUrls(),
+		...getTrackAndUpdateBalanceWorkerQueueUrls(),
 		process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL,
 	].filter((url): url is string => Boolean(url));
 

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -34,7 +34,7 @@ import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
 import { shutdownSqsSendBatchers } from "./queueUtils.js";
-import { getAsyncTrackWorkerQueueUrls } from "./trackAsyncQueueUrls.js";
+import { getTrackAndUpdateBalanceWorkerQueueUrls } from "./trackAsyncQueueUrls.js";
 import {
 	createWorkerActivityTracker,
 	type WorkerActivityTracker,
@@ -657,7 +657,7 @@ export const initWorkers = async ({
 			queueUrl: process.env.TRACK_SQS_QUEUE_URL,
 			defaultEnabled: true,
 		},
-		...getAsyncTrackWorkerQueueUrls().map((queueUrl) => ({
+		...getTrackAndUpdateBalanceWorkerQueueUrls().map((queueUrl) => ({
 			queueId: JOB_QUEUE_IDS.trackAsync,
 			queueUrl,
 			defaultEnabled: true,

--- a/server/src/queue/trackAsyncQueueUrls.ts
+++ b/server/src/queue/trackAsyncQueueUrls.ts
@@ -1,3 +1,10 @@
+const uniqueQueueUrls = (queueUrls: Array<string | undefined>): string[] =>
+	Array.from(
+		new Set(
+			queueUrls.filter((queueUrl): queueUrl is string => Boolean(queueUrl)),
+		),
+	);
+
 export const getAsyncTrackProducerQueueUrl = ({
 	standardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL,
 	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
@@ -12,11 +19,27 @@ export const getAsyncTrackWorkerQueueUrls = ({
 }: {
 	standardQueueUrl?: string;
 	legacyFifoQueueUrl?: string;
+} = {}): string[] => uniqueQueueUrls([standardQueueUrl, legacyFifoQueueUrl]);
+
+export const getUpdateBalanceProducerQueueUrl = ({
+	updateBalanceQueueUrl = process.env.UPDATE_BALANCE_SQS_QUEUE_URL,
+	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+}: {
+	updateBalanceQueueUrl?: string;
+	legacyFifoQueueUrl?: string;
+} = {}): string | undefined => updateBalanceQueueUrl || legacyFifoQueueUrl;
+
+export const getTrackAndUpdateBalanceWorkerQueueUrls = ({
+	standardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL,
+	updateBalanceQueueUrl = process.env.UPDATE_BALANCE_SQS_QUEUE_URL,
+	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+}: {
+	standardQueueUrl?: string;
+	updateBalanceQueueUrl?: string;
+	legacyFifoQueueUrl?: string;
 } = {}): string[] =>
-	Array.from(
-		new Set(
-			[standardQueueUrl, legacyFifoQueueUrl].filter(
-				(queueUrl): queueUrl is string => Boolean(queueUrl),
-			),
-		),
-	);
+	uniqueQueueUrls([
+		standardQueueUrl,
+		updateBalanceQueueUrl,
+		legacyFifoQueueUrl,
+	]);

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -21,6 +21,8 @@ const trackAsyncQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
 const trackAsyncStandardQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev-standard";
+const updateBalanceQueueUrl =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/update-balance-dev.fifo";
 
 const state = {
 	queueCommands: [] as Record<string, unknown>[],
@@ -107,6 +109,8 @@ describe("updateBalanceV2 async routing", () => {
 	const originalQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
 	const originalStandardQueueUrl =
 		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL;
+	const originalUpdateBalanceQueueUrl =
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL;
 
 	beforeEach(() => {
 		state.queueCommands = [];
@@ -117,8 +121,9 @@ describe("updateBalanceV2 async routing", () => {
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
 		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = trackAsyncStandardQueueUrl;
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL = updateBalanceQueueUrl;
 
-		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+		const sqsClient = getSqsClient({ queueUrl: updateBalanceQueueUrl });
 		state.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			state.queueCommands.push(command.input);
@@ -132,7 +137,7 @@ describe("updateBalanceV2 async routing", () => {
 
 	afterEach(() => {
 		if (state.originalSend) {
-			const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+			const sqsClient = getSqsClient({ queueUrl: updateBalanceQueueUrl });
 			sqsClient.send = state.originalSend;
 			state.originalSend = null;
 		}
@@ -141,6 +146,7 @@ describe("updateBalanceV2 async routing", () => {
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalQueueUrl;
 		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = originalStandardQueueUrl;
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL = originalUpdateBalanceQueueUrl;
 	});
 
 	test("enqueues configured async updates without running synchronous mutation helpers", async () => {
@@ -153,21 +159,13 @@ describe("updateBalanceV2 async routing", () => {
 
 		expect(state.queueCommands).toHaveLength(1);
 		expect(state.queueCommands[0]).toMatchObject({
-			QueueUrl: trackAsyncQueueUrl,
-		});
-		// The async-track queue sends through the SQS batcher (SendMessageBatch).
-		const batchEntries = state.queueCommands[0].Entries as Array<
-			Record<string, unknown>
-		>;
-		expect(batchEntries).toHaveLength(1);
-		expect(batchEntries[0]).toMatchObject({
+			QueueUrl: updateBalanceQueueUrl,
 			MessageGroupId: "org_123:sandbox:cus_123:none",
 			MessageDeduplicationId: ctx.id,
 		});
-		const message = JSON.parse(String(batchEntries[0].MessageBody)) as Record<
-			string,
-			unknown
-		>;
+		const message = JSON.parse(
+			String(state.queueCommands[0].MessageBody),
+		) as Record<string, unknown>;
 		expect(message).toMatchObject({
 			name: JobName.UpdateBalance,
 			data: {
@@ -214,6 +212,7 @@ describe("updateBalanceV2 async routing", () => {
 			config: { enabledOrgIds: ["org_123"] },
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL = undefined;
 
 		await expect(
 			updateBalanceV2({

--- a/server/tests/unit/queue/track-async-queue-urls.test.ts
+++ b/server/tests/unit/queue/track-async-queue-urls.test.ts
@@ -1,10 +1,12 @@
 /**
- * TDD contract for migrating async Track from FIFO to Standard SQS.
+ * TDD contract for routing async Track and UpdateBalance jobs.
  *
  * Contract under test:
  *   - Producers prefer TRACK_ASYNC_STANDARD_SQS_QUEUE_URL.
  *   - Producers fall back to TRACK_ASYNC_SQS_QUEUE_URL during rollout.
- *   - Workers consume both configured URLs without duplicate pollers.
+ *   - UpdateBalance prefers its explicit queue URL and falls back to the legacy
+ *     TRACK_ASYNC_SQS_QUEUE_URL.
+ *   - Workers consume all configured URLs without duplicate pollers.
  *   - Standard-queue sends omit FIFO-only message identifiers.
  *
  * Pre-implementation red: the queue URL resolver does not exist and producers
@@ -22,15 +24,20 @@ import { getSqsClient } from "@/queue/initSqs.js";
 import {
 	getAsyncTrackProducerQueueUrl,
 	getAsyncTrackWorkerQueueUrls,
+	getTrackAndUpdateBalanceWorkerQueueUrls,
+	getUpdateBalanceProducerQueueUrl,
 } from "@/queue/trackAsyncQueueUrls.js";
 
 const STANDARD_QUEUE_URL =
 	"https://sqs.us-east-2.amazonaws.com/123456789012/track-async-standard";
 const LEGACY_FIFO_QUEUE_URL =
 	"https://sqs.us-east-2.amazonaws.com/123456789012/track-async.fifo";
+const UPDATE_BALANCE_QUEUE_URL =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/update-balance.fifo";
 
 const originalStandardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL;
 const originalLegacyQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+const originalUpdateBalanceQueueUrl = process.env.UPDATE_BALANCE_SQS_QUEUE_URL;
 
 const restoreEnv = ({ key, value }: { key: string; value?: string }) => {
 	if (value === undefined) delete process.env[key];
@@ -45,6 +52,10 @@ afterEach(() => {
 	restoreEnv({
 		key: "TRACK_ASYNC_SQS_QUEUE_URL",
 		value: originalLegacyQueueUrl,
+	});
+	restoreEnv({
+		key: "UPDATE_BALANCE_SQS_QUEUE_URL",
+		value: originalUpdateBalanceQueueUrl,
 	});
 });
 
@@ -74,6 +85,48 @@ test("falls back to the legacy FIFO and avoids duplicate worker pollers", () => 
 
 	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = "";
 	expect(getAsyncTrackProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
+});
+
+test("routes UpdateBalance through its explicit queue with a legacy fallback", () => {
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = UPDATE_BALANCE_QUEUE_URL;
+	process.env.TRACK_ASYNC_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+
+	expect(getUpdateBalanceProducerQueueUrl()).toBe(UPDATE_BALANCE_QUEUE_URL);
+
+	delete process.env.UPDATE_BALANCE_SQS_QUEUE_URL;
+	expect(getUpdateBalanceProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
+
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = "";
+	expect(getUpdateBalanceProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
+});
+
+test("workers and readiness include each Track and UpdateBalance queue once", () => {
+	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = STANDARD_QUEUE_URL;
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = UPDATE_BALANCE_QUEUE_URL;
+	process.env.TRACK_ASYNC_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+
+	expect(getTrackAndUpdateBalanceWorkerQueueUrls()).toEqual([
+		STANDARD_QUEUE_URL,
+		UPDATE_BALANCE_QUEUE_URL,
+		LEGACY_FIFO_QUEUE_URL,
+	]);
+	for (const queueUrl of [
+		STANDARD_QUEUE_URL,
+		UPDATE_BALANCE_QUEUE_URL,
+		LEGACY_FIFO_QUEUE_URL,
+	]) {
+		expect(
+			getBlueGreenQueueUrls().filter(
+				(configuredQueueUrl) => configuredQueueUrl === queueUrl,
+			),
+		).toHaveLength(1);
+	}
+
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+	expect(getTrackAndUpdateBalanceWorkerQueueUrls()).toEqual([
+		STANDARD_QUEUE_URL,
+		LEGACY_FIFO_QUEUE_URL,
+	]);
 });
 
 test("sends async Track to Standard without FIFO-only identifiers", async () => {


### PR DESCRIPTION
## Summary

- introduce `UPDATE_BALANCE_SQS_QUEUE_URL` for UpdateBalance producers, with a fallback to the existing `TRACK_ASYNC_SQS_QUEUE_URL`
- have workers and blue/green readiness include the Standard Track queue, dedicated UpdateBalance queue, and legacy FIFO queue exactly once
- leave async Track producer routing and Terraform resources unchanged

## Rollout

- this is backward-compatible before the new secret exists because UpdateBalance keeps using the legacy FIFO fallback
- set `UPDATE_BALANCE_SQS_QUEUE_URL` to the current FIFO queue URL in Infisical when ready
- no SQS queue is renamed, replaced, or recreated

## Validation

- `bun test tests/unit/queue/track-async-queue-urls.test.ts tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts` (9 passing)
- `bun ts`
- focused Biome check on the six changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit `UPDATE_BALANCE_SQS_QUEUE_URL` for UpdateBalance jobs with a fallback to `TRACK_ASYNC_SQS_QUEUE_URL`. Workers and blue/green readiness now include the Standard Track queue, the UpdateBalance queue, and the legacy FIFO exactly once.

- **Refactors**
  - Added `getUpdateBalanceProducerQueueUrl` and `getTrackAndUpdateBalanceWorkerQueueUrls` with de-duped URL handling.
  - UpdateBalance V2 producers now use `getUpdateBalanceProducerQueueUrl`.
  - Worker init and blue/green checks now use `getTrackAndUpdateBalanceWorkerQueueUrls`.
  - Async Track producer routing and Terraform resources remain unchanged.

- **Migration**
  - Backward compatible: without `UPDATE_BALANCE_SQS_QUEUE_URL` we fall back to `TRACK_ASYNC_SQS_QUEUE_URL`.
  - Set `UPDATE_BALANCE_SQS_QUEUE_URL` in Infisical to the current FIFO URL when ready; no SQS queues are renamed or recreated.

<sup>Written for commit 68c6b94b0ef5128aa305f7d5927a6dc77a9f0f00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates UpdateBalance producer routing from async Track routing while retaining the legacy FIFO fallback during rollout.
- **[Improvements]** Adds an explicit `UPDATE_BALANCE_SQS_QUEUE_URL` resolver with backward-compatible fallback.
- **[Improvements]** Ensures workers and deployment readiness checks cover the Standard Track, dedicated UpdateBalance, and legacy FIFO queues without duplicate entries among those URLs.
- **[Improvements]** Adds focused tests for dedicated routing, fallback behavior, and queue URL deduplication.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with dedicated UpdateBalance routing, fallback behavior, worker consumption, and readiness coverage aligned.

The new resolver preserves the existing FIFO route until the dedicated queue is configured, and producers, workers, readiness checks, and focused tests consistently include the new route without changing async Track producer selection.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/queue/trackAsyncQueueUrls.ts | Adds dedicated UpdateBalance producer routing and a deduplicated combined worker queue URL list while preserving existing Track producer behavior. |
| server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts | Routes asynchronous UpdateBalance jobs through the new resolver, retaining the legacy FIFO fallback when the dedicated variable is absent. |
| server/src/queue/initWorkers.ts | Extends worker polling to include the configured UpdateBalance queue alongside both Track queues. |
| server/src/queue/blueGreen/blueGreenReadinessChecks.ts | Extends deployment readiness checks to verify all Track and UpdateBalance worker queues. |
| server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts | Verifies dedicated FIFO routing, payload fields, and unavailable-queue behavior for asynchronous balance updates. |
| server/tests/unit/queue/track-async-queue-urls.test.ts | Covers producer precedence, legacy fallback, combined worker queue coverage, and URL deduplication. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UB[UpdateBalance producer] --> R{UPDATE_BALANCE_SQS_QUEUE_URL set?}
  R -->|Yes| D[Dedicated UpdateBalance queue]
  R -->|No| L[Legacy Track FIFO queue]
  AT[Async Track producer] --> S{Standard Track queue set?}
  S -->|Yes| T[Standard Track queue]
  S -->|No| L
  D --> W[Worker polling and processing]
  T --> W
  L --> W
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: name update balance queue explici..."](https://github.com/useautumn/autumn/commit/68c6b94b0ef5128aa305f7d5927a6dc77a9f0f00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51160038)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->