### PR TITLE
Release 07/08/2026

### DIFF
--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -9,6 +9,7 @@ import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubjec
 import { isAsyncBalanceUpdateEnabled } from "@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
+import { getUpdateBalanceProducerQueueUrl } from "@/queue/trackAsyncQueueUrls.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
 import { updateExpiresAtV2 } from "./updateExpiresAtV2.js";
 import { updateIncludedGrantV2 } from "./updateIncludedGrantV2.js";
@@ -100,7 +101,7 @@ const queueUpdateBalanceV2 = async ({
 	params: UpdateBalanceParamsV0;
 	targetBalance?: number;
 }) => {
-	const queueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+	const queueUrl = getUpdateBalanceProducerQueueUrl();
 	if (!queueUrl) {
 		throw new RecaseError({
 			message: ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE,

--- a/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
+++ b/server/src/queue/blueGreen/blueGreenReadinessChecks.ts
@@ -8,7 +8,7 @@ import { getMiscRedis } from "@/external/redis/initRedis.js";
 import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
 import { withTimeout } from "@/utils/withTimeout.js";
 import { QUEUE_URL } from "../initSqs.js";
-import { getAsyncTrackWorkerQueueUrls } from "../trackAsyncQueueUrls.js";
+import { getTrackAndUpdateBalanceWorkerQueueUrls } from "../trackAsyncQueueUrls.js";
 import type { BlueGreenProbeResult } from "./blueGreenSchemas.js";
 
 const CHECK_TIMEOUT_MS = 5_000;
@@ -45,7 +45,7 @@ const getConfiguredQueueUrls = () =>
 	[
 		QUEUE_URL,
 		process.env.TRACK_SQS_QUEUE_URL,
-		...getAsyncTrackWorkerQueueUrls(),
+		...getTrackAndUpdateBalanceWorkerQueueUrls(),
 		process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL,
 	].filter((url): url is string => Boolean(url));
 

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -34,7 +34,7 @@ import { getSqsClient, QUEUE_URL, recreateSqsClient } from "./initSqs.js";
 import { JobName } from "./JobName.js";
 import { processMessage, type SqsJob } from "./processMessage.js";
 import { shutdownSqsSendBatchers } from "./queueUtils.js";
-import { getAsyncTrackWorkerQueueUrls } from "./trackAsyncQueueUrls.js";
+import { getTrackAndUpdateBalanceWorkerQueueUrls } from "./trackAsyncQueueUrls.js";
 import {
 	createWorkerActivityTracker,
 	type WorkerActivityTracker,
@@ -657,7 +657,7 @@ export const initWorkers = async ({
 			queueUrl: process.env.TRACK_SQS_QUEUE_URL,
 			defaultEnabled: true,
 		},
-		...getAsyncTrackWorkerQueueUrls().map((queueUrl) => ({
+		...getTrackAndUpdateBalanceWorkerQueueUrls().map((queueUrl) => ({
 			queueId: JOB_QUEUE_IDS.trackAsync,
 			queueUrl,
 			defaultEnabled: true,

--- a/server/src/queue/trackAsyncQueueUrls.ts
+++ b/server/src/queue/trackAsyncQueueUrls.ts
@@ -1,3 +1,10 @@
+const uniqueQueueUrls = (queueUrls: Array<string | undefined>): string[] =>
+	Array.from(
+		new Set(
+			queueUrls.filter((queueUrl): queueUrl is string => Boolean(queueUrl)),
+		),
+	);
+
 export const getAsyncTrackProducerQueueUrl = ({
 	standardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL,
 	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
@@ -12,11 +19,27 @@ export const getAsyncTrackWorkerQueueUrls = ({
 }: {
 	standardQueueUrl?: string;
 	legacyFifoQueueUrl?: string;
+} = {}): string[] => uniqueQueueUrls([standardQueueUrl, legacyFifoQueueUrl]);
+
+export const getUpdateBalanceProducerQueueUrl = ({
+	updateBalanceQueueUrl = process.env.UPDATE_BALANCE_SQS_QUEUE_URL,
+	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+}: {
+	updateBalanceQueueUrl?: string;
+	legacyFifoQueueUrl?: string;
+} = {}): string | undefined => updateBalanceQueueUrl || legacyFifoQueueUrl;
+
+export const getTrackAndUpdateBalanceWorkerQueueUrls = ({
+	standardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL,
+	updateBalanceQueueUrl = process.env.UPDATE_BALANCE_SQS_QUEUE_URL,
+	legacyFifoQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL,
+}: {
+	standardQueueUrl?: string;
+	updateBalanceQueueUrl?: string;
+	legacyFifoQueueUrl?: string;
 } = {}): string[] =>
-	Array.from(
-		new Set(
-			[standardQueueUrl, legacyFifoQueueUrl].filter(
-				(queueUrl): queueUrl is string => Boolean(queueUrl),
-			),
-		),
-	);
+	uniqueQueueUrls([
+		standardQueueUrl,
+		updateBalanceQueueUrl,
+		legacyFifoQueueUrl,
+	]);

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -21,6 +21,8 @@ const trackAsyncQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev.fifo";
 const trackAsyncStandardQueueUrl =
 	"https://sqs.eu-west-1.amazonaws.com/123456789012/track-async-dev-standard";
+const updateBalanceQueueUrl =
+	"https://sqs.eu-west-1.amazonaws.com/123456789012/update-balance-dev.fifo";
 
 const state = {
 	queueCommands: [] as Record<string, unknown>[],
@@ -107,6 +109,8 @@ describe("updateBalanceV2 async routing", () => {
 	const originalQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
 	const originalStandardQueueUrl =
 		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL;
+	const originalUpdateBalanceQueueUrl =
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL;
 
 	beforeEach(() => {
 		state.queueCommands = [];
@@ -117,8 +121,9 @@ describe("updateBalanceV2 async routing", () => {
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = trackAsyncQueueUrl;
 		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = trackAsyncStandardQueueUrl;
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL = updateBalanceQueueUrl;
 
-		const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+		const sqsClient = getSqsClient({ queueUrl: updateBalanceQueueUrl });
 		state.originalSend = sqsClient.send.bind(sqsClient);
 		sqsClient.send = (async (command: { input: Record<string, unknown> }) => {
 			state.queueCommands.push(command.input);
@@ -132,7 +137,7 @@ describe("updateBalanceV2 async routing", () => {
 
 	afterEach(() => {
 		if (state.originalSend) {
-			const sqsClient = getSqsClient({ queueUrl: trackAsyncQueueUrl });
+			const sqsClient = getSqsClient({ queueUrl: updateBalanceQueueUrl });
 			sqsClient.send = state.originalSend;
 			state.originalSend = null;
 		}
@@ -141,6 +146,7 @@ describe("updateBalanceV2 async routing", () => {
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = originalQueueUrl;
 		process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = originalStandardQueueUrl;
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL = originalUpdateBalanceQueueUrl;
 	});
 
 	test("enqueues configured async updates without running synchronous mutation helpers", async () => {
@@ -153,21 +159,13 @@ describe("updateBalanceV2 async routing", () => {
 
 		expect(state.queueCommands).toHaveLength(1);
 		expect(state.queueCommands[0]).toMatchObject({
-			QueueUrl: trackAsyncQueueUrl,
-		});
-		// The async-track queue sends through the SQS batcher (SendMessageBatch).
-		const batchEntries = state.queueCommands[0].Entries as Array<
-			Record<string, unknown>
-		>;
-		expect(batchEntries).toHaveLength(1);
-		expect(batchEntries[0]).toMatchObject({
+			QueueUrl: updateBalanceQueueUrl,
 			MessageGroupId: "org_123:sandbox:cus_123:none",
 			MessageDeduplicationId: ctx.id,
 		});
-		const message = JSON.parse(String(batchEntries[0].MessageBody)) as Record<
-			string,
-			unknown
-		>;
+		const message = JSON.parse(
+			String(state.queueCommands[0].MessageBody),
+		) as Record<string, unknown>;
 		expect(message).toMatchObject({
 			name: JobName.UpdateBalance,
 			data: {
@@ -214,6 +212,7 @@ describe("updateBalanceV2 async routing", () => {
 			config: { enabledOrgIds: ["org_123"] },
 		});
 		process.env.TRACK_ASYNC_SQS_QUEUE_URL = undefined;
+		process.env.UPDATE_BALANCE_SQS_QUEUE_URL = undefined;
 
 		await expect(
 			updateBalanceV2({

--- a/server/tests/unit/queue/track-async-queue-urls.test.ts
+++ b/server/tests/unit/queue/track-async-queue-urls.test.ts
@@ -1,10 +1,12 @@
 /**
- * TDD contract for migrating async Track from FIFO to Standard SQS.
+ * TDD contract for routing async Track and UpdateBalance jobs.
  *
  * Contract under test:
  *   - Producers prefer TRACK_ASYNC_STANDARD_SQS_QUEUE_URL.
  *   - Producers fall back to TRACK_ASYNC_SQS_QUEUE_URL during rollout.
- *   - Workers consume both configured URLs without duplicate pollers.
+ *   - UpdateBalance prefers its explicit queue URL and falls back to the legacy
+ *     TRACK_ASYNC_SQS_QUEUE_URL.
+ *   - Workers consume all configured URLs without duplicate pollers.
  *   - Standard-queue sends omit FIFO-only message identifiers.
  *
  * Pre-implementation red: the queue URL resolver does not exist and producers
@@ -22,15 +24,20 @@ import { getSqsClient } from "@/queue/initSqs.js";
 import {
 	getAsyncTrackProducerQueueUrl,
 	getAsyncTrackWorkerQueueUrls,
+	getTrackAndUpdateBalanceWorkerQueueUrls,
+	getUpdateBalanceProducerQueueUrl,
 } from "@/queue/trackAsyncQueueUrls.js";
 
 const STANDARD_QUEUE_URL =
 	"https://sqs.us-east-2.amazonaws.com/123456789012/track-async-standard";
 const LEGACY_FIFO_QUEUE_URL =
 	"https://sqs.us-east-2.amazonaws.com/123456789012/track-async.fifo";
+const UPDATE_BALANCE_QUEUE_URL =
+	"https://sqs.us-east-2.amazonaws.com/123456789012/update-balance.fifo";
 
 const originalStandardQueueUrl = process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL;
 const originalLegacyQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
+const originalUpdateBalanceQueueUrl = process.env.UPDATE_BALANCE_SQS_QUEUE_URL;
 
 const restoreEnv = ({ key, value }: { key: string; value?: string }) => {
 	if (value === undefined) delete process.env[key];
@@ -45,6 +52,10 @@ afterEach(() => {
 	restoreEnv({
 		key: "TRACK_ASYNC_SQS_QUEUE_URL",
 		value: originalLegacyQueueUrl,
+	});
+	restoreEnv({
+		key: "UPDATE_BALANCE_SQS_QUEUE_URL",
+		value: originalUpdateBalanceQueueUrl,
 	});
 });
 
@@ -74,6 +85,48 @@ test("falls back to the legacy FIFO and avoids duplicate worker pollers", () => 
 
 	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = "";
 	expect(getAsyncTrackProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
+});
+
+test("routes UpdateBalance through its explicit queue with a legacy fallback", () => {
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = UPDATE_BALANCE_QUEUE_URL;
+	process.env.TRACK_ASYNC_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+
+	expect(getUpdateBalanceProducerQueueUrl()).toBe(UPDATE_BALANCE_QUEUE_URL);
+
+	delete process.env.UPDATE_BALANCE_SQS_QUEUE_URL;
+	expect(getUpdateBalanceProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
+
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = "";
+	expect(getUpdateBalanceProducerQueueUrl()).toBe(LEGACY_FIFO_QUEUE_URL);
+});
+
+test("workers and readiness include each Track and UpdateBalance queue once", () => {
+	process.env.TRACK_ASYNC_STANDARD_SQS_QUEUE_URL = STANDARD_QUEUE_URL;
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = UPDATE_BALANCE_QUEUE_URL;
+	process.env.TRACK_ASYNC_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+
+	expect(getTrackAndUpdateBalanceWorkerQueueUrls()).toEqual([
+		STANDARD_QUEUE_URL,
+		UPDATE_BALANCE_QUEUE_URL,
+		LEGACY_FIFO_QUEUE_URL,
+	]);
+	for (const queueUrl of [
+		STANDARD_QUEUE_URL,
+		UPDATE_BALANCE_QUEUE_URL,
+		LEGACY_FIFO_QUEUE_URL,
+	]) {
+		expect(
+			getBlueGreenQueueUrls().filter(
+				(configuredQueueUrl) => configuredQueueUrl === queueUrl,
+			),
+		).toHaveLength(1);
+	}
+
+	process.env.UPDATE_BALANCE_SQS_QUEUE_URL = LEGACY_FIFO_QUEUE_URL;
+	expect(getTrackAndUpdateBalanceWorkerQueueUrls()).toEqual([
+		STANDARD_QUEUE_URL,
+		LEGACY_FIFO_QUEUE_URL,
+	]);
 });
 
 test("sends async Track to Standard without FIFO-only identifiers", async () => {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route UpdateBalance async jobs to a dedicated SQS queue with a safe fallback, and unify worker/readiness queue resolution to avoid duplicate pollers.

- **Refactors**
  - Added `UPDATE_BALANCE_SQS_QUEUE_URL` and `getUpdateBalanceProducerQueueUrl()` with fallback to `TRACK_ASYNC_SQS_QUEUE_URL`.
  - Introduced `getTrackAndUpdateBalanceWorkerQueueUrls()` to include Track Standard, UpdateBalance, and legacy FIFO once each.
  - Updated workers and blue/green readiness to use the unified resolver; deduplicates queue URLs.
  - `updateBalanceV2` now uses the new resolver; tests updated for routing and message shape.

- **Migration**
  - Optionally set `UPDATE_BALANCE_SQS_QUEUE_URL` to the dedicated UpdateBalance queue; otherwise the legacy `TRACK_ASYNC_SQS_QUEUE_URL` is used.

<sup>Written for commit 4f8b7d5cef4cbe8cb3d5e0bab327c891de726b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release separates asynchronous balance updates onto a dedicated SQS queue while retaining the legacy queue fallback.
- **[Improvements]** Adds dedicated producer routing and deduplicated worker/readiness queue enumeration.
- **[Bug fixes]** Updates workers and blue-green readiness checks to include the new balance-update queue.
- **[Improvements]** Adds unit coverage for dedicated routing, legacy fallback, FIFO message fields, and duplicate queue URLs.
</details>

<h3>Confidence Score: 4/5</h3>

The queue-routing change should be fixed before merging because independently deployed API instances can send balance updates to a queue that the active worker version does not consume.

The producer adopts the dedicated queue immediately, but consumer support only becomes effective after the separate worker service cuts over, leaving a realistic deployment window where customer balance updates remain queued.

**Files Needing Attention:** server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts, server/src/queue/initWorkers.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts | Routes balance updates to the dedicated queue, but can activate before a compatible worker during an independent deployment. |
| server/src/queue/trackAsyncQueueUrls.ts | Adds dedicated producer resolution and deduplicated combined worker queue enumeration with a legacy fallback. |
| server/src/queue/initWorkers.ts | Adds polling for the dedicated balance-update queue under the existing asynchronous queue controls. |
| server/src/queue/blueGreen/blueGreenReadinessChecks.ts | Extends readiness probing to cover every configured Track and UpdateBalance queue. |
| server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts | Verifies dedicated FIFO routing and the unavailable-queue response, but does not cover mixed producer/worker deployment versions. |
| server/tests/unit/queue/track-async-queue-urls.test.ts | Covers queue preference, fallback, deduplication, worker enumeration, and FIFO versus standard message fields. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as New API
  participant Queue as UpdateBalance Queue
  participant OldWorker as Active Old Worker
  participant NewWorker as New Worker Slot
  API->>Queue: Enqueue balance update
  Note over OldWorker: Does not poll dedicated queue
  Queue--xOldWorker: Message remains queued
  NewWorker->>Queue: Begin polling after cutover
  Queue-->>NewWorker: Deliver delayed update
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts:104
**Queue activates before its consumer**

If the new API version receives traffic while the previous worker version remains active, this selects the dedicated UpdateBalance queue even though that worker does not poll it, causing customer balance updates to remain unprocessed until the new worker cuts over—or indefinitely if its rollout fails.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #2665 from useautumn/..."](https://github.com/useautumn/autumn/commit/4f8b7d5cef4cbe8cb3d5e0bab327c891de726b3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51162256)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->