### PR TITLE
fix: leave balance grant empty so the zero placeholder shows

### DIFF
--- a/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx
@@ -72,7 +72,6 @@ export function FeatureGrantRewardConfig({
 				...entitlements,
 				{
 					feature_id: "",
-					allowance: 0,
 					expiry: existingExpiry ? { ...existingExpiry } : undefined,
 				},
 			],

--- a/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
+++ b/vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx
@@ -112,7 +112,7 @@ export function SelectRewardType({
 								discount_config: null,
 								free_product_id: null,
 								free_product_config: null,
-								featureGrantEntitlements: [{ feature_id: "", allowance: 0 }],
+								featureGrantEntitlements: [{ feature_id: "" }],
 							})
 						}
 						icon={<LightningIcon size={16} color="currentColor" />}


### PR DESCRIPTION
Follow-up to #2664. That PR made `0` a valid balance grant, but the field still prefilled a literal `0` rather than showing an empty input with the `0` placeholder — so the default read as an intentional zero-amount grant instead of an unfilled field.

## Changes

Both sites that seed a new grant dropped `allowance: 0`:

- `SelectRewardType.tsx` — seeds the first grant when Feature Grant is selected
- `FeatureGrantRewardConfig.tsx` — seeds each subsequent "Add Grant"

A new grant now starts with `allowance` unset, so `value={ent.allowance ?? ""}` renders empty and `placeholder="0"` shows through.

## Behaviour

- New grant renders as an empty field with a `0` placeholder
- Typing `0` is accepted and saved — `Math.max(0, 0)` → `0`, which passes the `allowance == null || allowance < 0` check and serializes via the mapper's `>= 0`
- An untouched grant stays `undefined` and fails validation, which is correct for a required field
- Boolean features are unaffected — the allowance input is not rendered for them

## Testing

- `tsc --noEmit` clean on `vite`
- Biome clean on both touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the grant allowance input so new Feature Grant entitlements start empty and show the "0" placeholder instead of a prefilled 0. This prevents users from thinking a zero-amount grant was set by default.

- **Bug Fixes**
  - Removed `allowance: 0` when seeding new grants in `SelectRewardType.tsx` and `FeatureGrantRewardConfig.tsx`.
  - New grants render an empty input with a "0" placeholder; entering 0 is accepted and saved; untouched fields remain undefined and fail required validation as expected.

<sup>Written for commit a389befdcd67b9dd5b7a121d97ef43f4bb97ba8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR leaves the allowance unset when creating a feature grant so the field displays its `0` placeholder rather than looking intentionally filled.

- **Bug fixes:** Removes the seeded zero allowance from the first feature grant created when selecting the reward type.
- **Bug fixes:** Removes the seeded zero allowance from subsequent grants added in the reward configuration.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both initialization paths now consistently leave the required allowance field empty.

The changed state shape is supported by the optional frontend field, renders correctly as an empty input, and remains blocked by validation until the user supplies an allowance.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/products/rewards/reward-config/components/FeatureGrantRewardConfig.tsx | Newly added grants now leave allowance unset, allowing the existing empty-value rendering and required-field validation to work as intended. |
| vite/src/views/products/rewards/reward-config/components/SelectRewardType.tsx | The initial feature grant now starts without an allowance so the placeholder remains visible. |

<sub>Reviews (1): Last reviewed commit: ["fix: leave balance grant empty so the ze..."](https://github.com/useautumn/autumn/commit/a389befdcd67b9dd5b7a121d97ef43f4bb97ba8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51173214)</sub>

<!-- /greptile_comment -->