### PR TITLE
fix: don't 400 when a customer product's stripe sub is canceled

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors.ts
@@ -1,8 +1,8 @@
 import {
-    type AttachBillingContext,
-    ErrCode,
-    isCustomerProductPaid,
-    RecaseError,
+	type AttachBillingContext,
+	ErrCode,
+	isCustomerProductPaid,
+	RecaseError,
 } from "@autumn/shared";
 
 export const handleCurrentCustomerProductErrors = ({
@@ -15,6 +15,7 @@ export const handleCurrentCustomerProductErrors = ({
 		attachProduct,
 		stripeSubscription,
 		skipExternalPSPGuard,
+		canceledStripeSubscriptionId,
 	} = billingContext;
 
 	if (currentCustomerProduct?.product.id === attachProduct.id) {
@@ -30,9 +31,11 @@ export const handleCurrentCustomerProductErrors = ({
 	// current products with no Stripe subscription — they opt out via
 	// `skipExternalPSPGuard`. Stripe-origin cus_products with `processor: null`
 	// must still be checked, so this is gated on the explicit flag rather than
-	// on `cusProductToProcessorType`.
+	// on `cusProductToProcessorType`. A subscription that is linked but canceled
+	// is explained linkage, not broken linkage, so it passes too.
 	if (
 		!skipExternalPSPGuard &&
+		!canceledStripeSubscriptionId &&
 		isCustomerProductPaid(currentCustomerProduct) &&
 		!stripeSubscription
 	) {

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -124,6 +124,7 @@ export const setupAttachBillingContext = async ({
 		stripeTaxRate,
 		paymentMethod,
 		testClockFrozenTime,
+		canceledStripeSubscriptionId,
 	} = await setupStripeBillingContext({
 		ctx,
 		fullCustomer,
@@ -280,6 +281,7 @@ export const setupAttachBillingContext = async ({
 
 		currentCustomerProduct,
 		scheduledCustomerProduct,
+		canceledStripeSubscriptionId,
 
 		planTiming,
 		endOfCycleMs,

--- a/server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts
@@ -20,11 +20,15 @@ export const attachParamsToStripeBillingContext = async ({
 	attachParams: AttachParams;
 	fullProduct: FullProduct;
 }): Promise<StripeBillingContextOverride> => {
-	const { stripeSubscription } = await fetchStripeSubscriptionForBilling({
-		ctx,
-		fullCus: attachParams.customer,
-		product: fullProduct,
-	});
+	// canceledStripeSubscriptionId must survive: this override short-circuits
+	// setupStripeBillingContext, so a dropped marker leaves the legacy paths
+	// with no way to tell "no subscription" from "canceled subscription".
+	const { stripeSubscription, canceledStripeSubscriptionId } =
+		await fetchStripeSubscriptionForBilling({
+			ctx,
+			fullCus: attachParams.customer,
+			product: fullProduct,
+		});
 
 	const stripeSubscriptionSchedule =
 		await fetchStripeSubscriptionScheduleForBilling({
@@ -50,6 +54,7 @@ export const attachParamsToStripeBillingContext = async ({
 
 	return {
 		stripeSubscription,
+		canceledStripeSubscriptionId,
 		stripeSubscriptionSchedule,
 		stripeCustomer,
 		stripeDiscounts,

--- a/server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts
@@ -20,7 +20,7 @@ export const attachParamsToStripeBillingContext = async ({
 	attachParams: AttachParams;
 	fullProduct: FullProduct;
 }): Promise<StripeBillingContextOverride> => {
-	const stripeSubscription = await fetchStripeSubscriptionForBilling({
+	const { stripeSubscription } = await fetchStripeSubscriptionForBilling({
 		ctx,
 		fullCus: attachParams.customer,
 		product: fullProduct,

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleCancelEndOfCycleErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleCancelEndOfCycleErrors.ts
@@ -27,7 +27,17 @@ export const handleCancelEndOfCycleErrors = ({
 }) => {
 	if (billingContext.cancelAction !== "cancel_end_of_cycle") return;
 
-	const { customerProduct } = billingContext;
+	const { customerProduct, canceledStripeSubscriptionId } = billingContext;
+
+	// The cycle it would cancel at the end of no longer exists, and Stripe will
+	// never emit another sub.deleted to expire the plan.
+	if (canceledStripeSubscriptionId) {
+		throw new RecaseError({
+			message: `Subscription ${canceledStripeSubscriptionId} is already canceled in Stripe; use cancel: 'cancel_immediately' instead.`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
 
 	if (isCustomerProductFree(customerProduct)) {
 		throw new RecaseError({

--- a/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUncancelErrors.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/errors/handleUncancelErrors.ts
@@ -5,6 +5,7 @@ import { CusProductStatus, RecaseError } from "@autumn/shared";
  * Validates uncancel operation and throws appropriate errors.
  * - Cannot uncancel a scheduled product
  * - Cannot uncancel an expired product
+ * - Cannot uncancel onto a subscription Stripe has already canceled
  * - Uncanceling an already active (non-canceling) product is a no-op (not an error)
  */
 export const handleUncancelErrors = ({
@@ -16,7 +17,7 @@ export const handleUncancelErrors = ({
 		return;
 	}
 
-	const { customerProduct } = billingContext;
+	const { customerProduct, canceledStripeSubscriptionId } = billingContext;
 
 	if (customerProduct.status === CusProductStatus.Scheduled) {
 		throw new RecaseError({
@@ -28,6 +29,15 @@ export const handleUncancelErrors = ({
 	if (customerProduct.status === CusProductStatus.Expired) {
 		throw new RecaseError({
 			message: "Cannot uncancel a subscription that has expired",
+			statusCode: 400,
+		});
+	}
+
+	// There is no subscription left to resume, so the plan would come back
+	// active and permanently unbilled.
+	if (canceledStripeSubscriptionId) {
+		throw new RecaseError({
+			message: `Subscription ${canceledStripeSubscriptionId} is already canceled in Stripe and cannot be uncanceled; attach the plan again to start a new subscription.`,
 			statusCode: 400,
 		});
 	}

--- a/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts
@@ -115,7 +115,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		billingRelatedFields.length === 0 ||
 		isUpdatingFreeCustomerProduct;
 
-	const skipBillingChanges =
+	const skipBillingChangesBase =
 		skipBillingFetching ||
 		params.no_billing_changes === true ||
 		params.processor_subscription_id !== undefined;
@@ -128,6 +128,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		stripeTaxRate,
 		paymentMethod,
 		testClockFrozenTime,
+		canceledStripeSubscriptionId,
 	} = await setupStripeBillingContext({
 		ctx,
 		fullCustomer,
@@ -140,6 +141,11 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		createStripeCustomerIfMissing:
 			!preview && params.no_billing_changes !== true,
 	});
+
+	// Updating a plan whose subscription is already canceled must never fall
+	// through to creating a replacement subscription and charging again.
+	const skipBillingChanges =
+		skipBillingChangesBase || canceledStripeSubscriptionId !== undefined;
 
 	const subscriptionTaxRate = stripeSubscription?.default_tax_rates?.[0];
 	const inheritedTaxRateId =
@@ -255,6 +261,7 @@ export const setupUpdateSubscriptionBillingContext = async ({
 		stripeTaxRate: stripeTaxRate ?? inheritedStripeTaxRate,
 		paymentMethod,
 		taxRateId: inheritedTaxRateId,
+		canceledStripeSubscriptionId,
 
 		currentEpochMs,
 		billingCycleAnchorMs,

--- a/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionForBilling.ts
@@ -12,6 +12,12 @@ import type { StripeSubscriptionWithDiscounts } from "@server/external/stripe/su
 import type { AutumnContext } from "@server/honoUtils/HonoEnv";
 import { isStripeSubscriptionCanceled } from "@/external/stripe/subscriptions/utils/classifyStripeSubscriptionUtils";
 
+export interface StripeSubscriptionForBilling {
+	stripeSubscription?: StripeSubscriptionWithDiscounts;
+	/** Set when the linked subscription exists in Stripe but is already canceled. */
+	canceledStripeSubscriptionId?: string;
+}
+
 /**
  * Fetches a Stripe subscription with expanded discounts for billing operations.
  * Returns the subscription with `discounts.source.coupon.applies_to` expanded.
@@ -30,9 +36,9 @@ export const fetchStripeSubscriptionForBilling = async ({
 	targetCusProductId?: string;
 	newBillingSubscription?: boolean;
 	params?: AttachParamsV1 | MultiAttachParamsV0 | UpdateSubscriptionV1Params;
-}): Promise<StripeSubscriptionWithDiscounts | undefined> => {
+}): Promise<StripeSubscriptionForBilling> => {
 	if (newBillingSubscription) {
-		return undefined;
+		return {};
 	}
 
 	const processorSubscriptionId =
@@ -53,7 +59,7 @@ export const fetchStripeSubscriptionForBilling = async ({
 	const subId =
 		processorSubscriptionId ?? cusProductWithSub?.subscription_ids?.[0];
 
-	if (!subId) return undefined;
+	if (!subId) return {};
 
 	const sub = await stripeCli.subscriptions.retrieve(subId, {
 		expand: ["discounts.source.coupon.applies_to"],
@@ -66,13 +72,6 @@ export const fetchStripeSubscriptionForBilling = async ({
 		});
 	}
 
-	if (isStripeSubscriptionCanceled(sub)) {
-		throw new RecaseError({
-			message: `Subscription ${subId} is canceled`,
-			statusCode: 400,
-		});
-	}
-
 	if (sub.customer !== fullCus.processor.id) {
 		throw new RecaseError({
 			message: `Subscription ${subId} is not for the current customer`,
@@ -80,5 +79,11 @@ export const fetchStripeSubscriptionForBilling = async ({
 		});
 	}
 
-	return sub as StripeSubscriptionWithDiscounts;
+	// A canceled sub carries no live billing state. Report it separately so each
+	// caller decides: abandon it (attach) or block Stripe writes (updateSubscription).
+	if (isStripeSubscriptionCanceled(sub)) {
+		return { canceledStripeSubscriptionId: subId };
+	}
+
+	return { stripeSubscription: sub as StripeSubscriptionWithDiscounts };
 };

--- a/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
@@ -15,7 +15,10 @@ import { stripeSubscriptionToScheduleId } from "@/external/stripe/subscriptions/
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { fetchStripeCustomerForBilling } from "./fetchStripeCustomerForBilling";
 import { fetchStripeDiscountsForBilling } from "./fetchStripeDiscountsForBilling";
-import { fetchStripeSubscriptionForBilling } from "./fetchStripeSubscriptionForBilling";
+import {
+	fetchStripeSubscriptionForBilling,
+	type StripeSubscriptionForBilling,
+} from "./fetchStripeSubscriptionForBilling";
 import { fetchStripeSubscriptionScheduleForBilling } from "./fetchStripeSubscriptionScheduleForBilling";
 import { fetchStripeTaxRateForBilling } from "./fetchStripeTaxRateForBilling";
 
@@ -66,6 +69,7 @@ export const setupStripeBillingContext = async ({
 			stripeTaxRate: undefined,
 			paymentMethod: undefined,
 			testClockFrozenTime: undefined,
+			canceledStripeSubscriptionId: undefined,
 		};
 	}
 
@@ -75,7 +79,7 @@ export const setupStripeBillingContext = async ({
 			paymentMethod,
 			testClockFrozenTime,
 		},
-		stripeSubscription,
+		subscriptionResult,
 		stripeSubscriptionSchedule,
 		stripeDiscounts,
 		stripeTaxRate,
@@ -87,13 +91,13 @@ export const setupStripeBillingContext = async ({
 				createIfMissing: createStripeCustomerIfMissing,
 			});
 		},
-		async stripeSubscription() {
+		async subscriptionResult(): Promise<StripeSubscriptionForBilling> {
 			// If no target customer product, skip subscription/schedule fetching
 			// Skip if product being attached is one off
 			const attachingOneOff = product ? isOneOffProduct({ product }) : false;
 
 			return attachingOneOff || skipSubscriptionFetching
-				? undefined
+				? {}
 				: fetchStripeSubscriptionForBilling({
 						ctx,
 						fullCus: fullCustomer,
@@ -104,7 +108,8 @@ export const setupStripeBillingContext = async ({
 					});
 		},
 		async stripeSubscriptionSchedule() {
-			const localStripeSubscription = await this.$.stripeSubscription;
+			const { stripeSubscription: localStripeSubscription } =
+				await this.$.subscriptionResult;
 
 			return targetCustomerProduct ||
 				notNullish(localStripeSubscription) ||
@@ -122,7 +127,8 @@ export const setupStripeBillingContext = async ({
 		},
 		async stripeDiscounts() {
 			const localStripeCustomer = (await this.$.stripeContext).stripeCus;
-			const localStripeSubscription = await this.$.stripeSubscription;
+			const { stripeSubscription: localStripeSubscription } =
+				await this.$.subscriptionResult;
 
 			return fetchStripeDiscountsForBilling({
 				ctx,
@@ -140,6 +146,9 @@ export const setupStripeBillingContext = async ({
 		},
 	});
 
+	const { stripeSubscription, canceledStripeSubscriptionId } =
+		subscriptionResult;
+
 	const stripeSubscriptionScheduleForContext =
 		stripeSubscription && stripeSubscriptionSchedule
 			? getScheduleSubscriptionId(stripeSubscriptionSchedule) ===
@@ -156,5 +165,6 @@ export const setupStripeBillingContext = async ({
 		stripeTaxRate,
 		paymentMethod,
 		testClockFrozenTime,
+		canceledStripeSubscriptionId,
 	};
 };

--- a/server/src/internal/migrations/v2/stripeCache/createMigrationStripeCache.ts
+++ b/server/src/internal/migrations/v2/stripeCache/createMigrationStripeCache.ts
@@ -110,7 +110,7 @@ export const createMigrationStripeCache = ({
 			ctx,
 			fullCus: fullCustomer,
 			targetCusProductId: customerProduct.id,
-		});
+		}).then(({ stripeSubscription }) => stripeSubscription);
 		subscriptionPromises.set(subscriptionId, promise);
 
 		return promise;

--- a/server/tests/integration/billing/canceled-subscription/canceled-subscription-drift.test.ts
+++ b/server/tests/integration/billing/canceled-subscription/canceled-subscription-drift.test.ts
@@ -1,0 +1,359 @@
+/**
+ * TDD test for: a customer product linked to a Stripe subscription that is
+ * already `canceled` must stop 400-ing every billing call, without ever
+ * turning into a duplicate subscription or a duplicate charge.
+ *
+ * Contract under test:
+ *   New types/fields:
+ *     - BillingContext.canceledStripeSubscriptionId?: string
+ *     - fetchStripeSubscriptionForBilling -> { stripeSubscription, canceledStripeSubscriptionId }
+ *   New behaviors:
+ *     - updateSubscription (feature_quantities) on a canceled sub
+ *         -> 200, no new Stripe sub, no new invoice, subscription_ids preserved,
+ *            Autumn-side quantity still applied
+ *     - updateSubscription cancel_immediately on a canceled sub
+ *         -> 200, product expired, default activated, no new sub, no new invoice
+ *     - updateSubscription cancel_end_of_cycle on a canceled sub
+ *         -> 400 naming the canceled sub and cancel_immediately
+ *     - updateSubscription uncancel on a canceled sub
+ *         -> 400; resuming would leave the plan active and permanently unbilled
+ *     - attach a different plan on a canceled sub
+ *         -> 200, a NEW active Stripe sub, charged full price, no credit from the dead sub
+ *   Side effects:
+ *     - no additional Stripe subscription on the customer for update/cancel paths
+ *     - no additional Autumn invoice row for update/cancel paths
+ *
+ * Pre-impl red: every case fails in `fetchStripeSubscriptionForBilling`, which
+ * throws `Subscription <id> is canceled` (400).
+ * Post-impl green: the fetch reports the canceled id instead of throwing. Each
+ * action then decides what that means — updateSubscription turns it into
+ * skipBillingChanges (which `evaluateStripeBillingPlan` already honours), while
+ * attach abandons the dead sub and buys fresh.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV3,
+	ApiCustomerV5,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	getSubscriptionIdsForProduct,
+	linkCustomerProductToCanceledSubscription,
+	listStripeSubscriptions,
+} from "./utils/canceledSubscriptionUtils";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Behavior 2: update quantity on a canceled sub — no error, no charge, no sub
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub: update feature_quantities succeeds without a new sub or charge")}`, async () => {
+	const customerId = "canceled-sub-update-qty";
+	const billingUnits = 100;
+
+	const prepaidItem = items.prepaidMessages({ billingUnits, price: 10 });
+	const pro = products.pro({ id: "pro", items: [prepaidItem] });
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({
+				productId: pro.id,
+				options: [{ feature_id: TestFeature.Messages, quantity: billingUnits }],
+			}),
+		],
+	});
+
+	const { subscriptionId, stripeCustomerId } =
+		await linkCustomerProductToCanceledSubscription({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+
+	const subscriptionsBefore = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+
+	// ── Contract assertion 1: no longer throws `Subscription <id> is canceled` ──
+	await autumnV2_2.billing.update<UpdateSubscriptionV1ParamsInput>({
+		customer_id: customerId,
+		plan_id: pro.id,
+		feature_quantities: [
+			{ feature_id: TestFeature.Messages, quantity: billingUnits * 2 },
+		],
+	});
+
+	// ── Contract assertion 2: no replacement Stripe subscription ──────────────
+	const subscriptionsAfter = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+	expect(subscriptionsAfter.map((sub) => sub.id).sort()).toEqual(
+		subscriptionsBefore.map((sub) => sub.id).sort(),
+	);
+	expect(
+		subscriptionsAfter.every((sub) => sub.status === "canceled"),
+		"every stripe subscription should still be canceled",
+	).toBe(true);
+
+	// ── Contract assertion 3: no new invoice (attach invoice only) ────────────
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		count: 1,
+	});
+
+	// ── Contract assertion 4: subscription link preserved ─────────────────────
+	expect(
+		await getSubscriptionIdsForProduct({ ctx, customerId, productId: pro.id }),
+	).toEqual([subscriptionId]);
+
+	// ── Contract assertion 5: the Autumn-side update still landed ─────────────
+	await expectBalanceCorrect({
+		customer: await autumnV2_2.customers.get<ApiCustomerV5>(customerId),
+		featureId: TestFeature.Messages,
+		remaining: billingUnits * 2,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Behavior 3: cancel_immediately still works
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub: cancel_immediately expires the plan and activates the default")}`, async () => {
+	const customerId = "canceled-sub-cancel-now";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [free, pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const { stripeCustomerId } = await linkCustomerProductToCanceledSubscription({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	const subscriptionsBefore = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+
+	// ── Contract assertion 1: cancel_immediately does not 400 ─────────────────
+	await autumnV2_2.billing.update<UpdateSubscriptionV1ParamsInput>({
+		customer_id: customerId,
+		plan_id: pro.id,
+		cancel_action: "cancel_immediately",
+	});
+
+	// ── Contract assertion 2: pro gone, default active ────────────────────────
+	await expectCustomerProducts({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		notPresent: [pro.id],
+		active: [free.id],
+	});
+
+	// ── Contract assertion 3: no new sub, no new invoice ──────────────────────
+	const subscriptionsAfter = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+	expect(subscriptionsAfter.length).toBe(subscriptionsBefore.length);
+
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		count: 1,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Behavior 4: cancel_end_of_cycle is blocked
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub: cancel_end_of_cycle is rejected with a remedy")}`, async () => {
+	const customerId = "canceled-sub-cancel-eoc";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [free, pro] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const { subscriptionId } = await linkCustomerProductToCanceledSubscription({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	// ── Contract assertion 1: explicit 400 naming the sub and the remedy ──────
+	await expectAutumnError({
+		errMessage: subscriptionId,
+		func: () =>
+			autumnV2_2.billing.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: pro.id,
+				cancel_action: "cancel_end_of_cycle",
+			}),
+	});
+
+	await expectAutumnError({
+		errMessage: "cancel_immediately",
+		func: () =>
+			autumnV2_2.billing.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: pro.id,
+				cancel_action: "cancel_end_of_cycle",
+			}),
+	});
+
+	// ── Contract assertion 2: state untouched by the rejected call ────────────
+	await expectCustomerProducts({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		active: [pro.id],
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Behavior 4b: uncancel cannot resurrect a plan onto a dead subscription
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub: uncancel is rejected rather than reviving an unbilled plan")}`, async () => {
+	const customerId = "canceled-sub-uncancel";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const free = products.base({
+		id: "free",
+		items: [messagesItem],
+		isDefault: true,
+	});
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [free, pro] }),
+		],
+		// Cancel at end of cycle first: pro is canceling, so uncancel is meaningful.
+		actions: [s.attach({ productId: pro.id }), s.cancel({ productId: pro.id })],
+	});
+
+	const { subscriptionId } = await linkCustomerProductToCanceledSubscription({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	// ── Contract assertion 1: uncancel refuses, naming the dead sub ───────────
+	await expectAutumnError({
+		errMessage: subscriptionId,
+		func: () =>
+			autumnV2_2.billing.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: pro.id,
+				cancel_action: "uncancel",
+			}),
+	});
+
+	// ── Contract assertion 2: the plan is still canceling, not revived ────────
+	await expectCustomerProducts({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		canceling: [pro.id],
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Behavior 5: attach is a fresh purchase, not a resurrection
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub: attaching another plan creates a fresh sub and charges full price")}`, async () => {
+	const customerId = "canceled-sub-attach-fresh";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+	const premium = products.premium({ id: "premium", items: [messagesItem] });
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const { subscriptionId, stripeCustomerId } =
+		await linkCustomerProductToCanceledSubscription({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+
+	// ── Contract assertion 1: attach does not 400 ─────────────────────────────
+	await autumnV2_2.billing.attach({
+		customer_id: customerId,
+		plan_id: premium.id,
+	});
+
+	// ── Contract assertion 2: exactly one NEW, non-canceled subscription ──────
+	const subscriptionsAfter = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+	const liveSubscriptions = subscriptionsAfter.filter(
+		(sub) => sub.status !== "canceled",
+	);
+	expect(liveSubscriptions.length).toBe(1);
+	expect(liveSubscriptions[0].id).not.toBe(subscriptionId);
+
+	// ── Contract assertion 3: full price, no credit from the dead sub ─────────
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		count: 2,
+		latestTotal: 50,
+	});
+
+	// ── Contract assertion 4: premium replaces pro ────────────────────────────
+	await expectCustomerProducts({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		active: [premium.id],
+		notPresent: [pro.id],
+	});
+});

--- a/server/tests/integration/billing/canceled-subscription/canceled-subscription-legacy.test.ts
+++ b/server/tests/integration/billing/canceled-subscription/canceled-subscription-legacy.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The legacy v1 `/attach` entry points build their Stripe context through
+ * `attachParamsToStripeBillingContext`, whose result short-circuits
+ * `setupStripeBillingContext`. If that adapter drops
+ * `canceledStripeSubscriptionId`, every canceled-subscription guard silently
+ * disarms on the v1 paths while still working on v2.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - legacy v1 attach of a different plan on a canceled sub
+ *         -> fresh purchase, same as v2 billing.attach
+ *     - legacy v1 quantity update on a canceled sub
+ *         -> quantity applies, NO charge, no replacement subscription
+ *   Side effects:
+ *     - no additional Autumn invoice row on the quantity path
+ *
+ * Pre-fix red: the adapter kept only `stripeSubscription`. Legacy attach then
+ * rejected the plan as having no linked subscription, and legacy quantity
+ * update — with skipBillingChanges never set — billed a dead subscription
+ * through the manual-invoice path.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, ApiCustomerV5 } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	getSubscriptionIdsForProduct,
+	linkCustomerProductToCanceledSubscription,
+	listStripeSubscriptions,
+} from "./utils/canceledSubscriptionUtils";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Legacy v1 attach — must behave like v2: abandon the dead sub, buy fresh
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub legacy: v1 attach of another plan creates a fresh sub")}`, async () => {
+	const customerId = "canceled-sub-legacy-attach";
+
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({ id: "pro", items: [messagesItem] });
+	const premium = products.premium({ id: "premium", items: [messagesItem] });
+
+	const { autumnV1, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, premium] }),
+		],
+		actions: [s.attach({ productId: pro.id })],
+	});
+
+	const { subscriptionId, stripeCustomerId } =
+		await linkCustomerProductToCanceledSubscription({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+
+	// ── Contract assertion 1: no "paid but no stripe subscription" rejection ──
+	await autumnV1.attach({ customer_id: customerId, product_id: premium.id });
+
+	// ── Contract assertion 2: exactly one NEW, non-canceled subscription ──────
+	const liveSubscriptions = (
+		await listStripeSubscriptions({ ctx, stripeCustomerId })
+	).filter((sub) => sub.status !== "canceled");
+	expect(liveSubscriptions.length).toBe(1);
+	expect(liveSubscriptions[0].id).not.toBe(subscriptionId);
+
+	// ── Contract assertion 3: premium replaces pro and is charged in full ────
+	await expectCustomerProducts({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		active: [premium.id],
+		notPresent: [pro.id],
+	});
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		count: 2,
+		latestTotal: 50,
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Legacy v1 quantity update — the path that actually billed a dead sub
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub legacy: v1 quantity update applies without charging")}`, async () => {
+	const customerId = "canceled-sub-legacy-qty";
+	const billingUnits = 100;
+
+	const prepaidItem = items.prepaidMessages({ billingUnits, price: 10 });
+	const pro = products.pro({ id: "pro", items: [prepaidItem] });
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.attach({
+				productId: pro.id,
+				options: [{ feature_id: TestFeature.Messages, quantity: billingUnits }],
+			}),
+		],
+	});
+
+	const { subscriptionId, stripeCustomerId } =
+		await linkCustomerProductToCanceledSubscription({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+
+	const invoiceCountBefore =
+		(await autumnV1.customers.get<ApiCustomerV3>(customerId)).invoices
+			?.length ?? 0;
+	const subscriptionsBefore = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+
+	// ── Contract assertion 1: the update goes through ─────────────────────────
+	await autumnV1.attach({
+		customer_id: customerId,
+		product_id: pro.id,
+		options: [{ feature_id: TestFeature.Messages, quantity: billingUnits * 2 }],
+	});
+
+	// ── Contract assertion 2: NOT charged for the extra units ────────────────
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		count: invoiceCountBefore,
+	});
+
+	// ── Contract assertion 3: no replacement subscription ────────────────────
+	const subscriptionsAfter = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+	expect(subscriptionsAfter.map((sub) => sub.id).sort()).toEqual(
+		subscriptionsBefore.map((sub) => sub.id).sort(),
+	);
+	expect(
+		subscriptionsAfter.every((sub) => sub.status === "canceled"),
+		"every stripe subscription should still be canceled",
+	).toBe(true);
+
+	// ── Contract assertion 4: Autumn-side quantity applied, link preserved ───
+	await expectBalanceCorrect({
+		customer: await autumnV2_2.customers.get<ApiCustomerV5>(customerId),
+		featureId: TestFeature.Messages,
+		remaining: billingUnits * 2,
+	});
+	expect(
+		await getSubscriptionIdsForProduct({ ctx, customerId, productId: pro.id }),
+	).toEqual([subscriptionId]);
+});

--- a/server/tests/integration/billing/canceled-subscription/canceled-subscription-migration.test.ts
+++ b/server/tests/integration/billing/canceled-subscription/canceled-subscription-migration.test.ts
@@ -1,0 +1,296 @@
+/**
+ * A migration that lands on a customer product whose Stripe subscription is
+ * already `canceled` must apply its Autumn-side changes without billing and
+ * without spawning a replacement subscription.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - update_plan add_items on a canceled sub
+ *         -> items applied, no new Stripe sub, no new invoice, sub link preserved
+ *     - update_plan customize.price with `proration: true` on a canceled sub
+ *         -> price applied, NO charge — while an identical migration on a live
+ *            sub (the control) DOES charge, proving the assertion is not vacuous
+ *   Side effects:
+ *     - no additional Stripe subscription on the drifted customer
+ *     - no additional Autumn invoice row on the drifted customer
+ *
+ * Note on `proration: true`: migrations are charge-free by default, so a bare
+ * "no charge" assertion would pass even with the guard removed. The control
+ * customer is what makes this test meaningful.
+ *
+ * Pre-impl red: both cases fail in `fetchStripeSubscriptionForBilling`, which
+ * throws `Subscription <id> is canceled` (400) before the migration can run.
+ * Post-impl green: the fetch reports the canceled id, so
+ * `setupUpdatePlanProductContext` sets skipBillingChanges (its existing
+ * `stripeSubscription === undefined` rule) and `contextBySubscriptionId` drops
+ * the context before Stripe is ever evaluated.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type ApiCustomerV5,
+	findActiveCustomerProductById,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { CusService } from "@/internal/customers/CusService";
+import { runUpdatePlanMigration } from "../migrations-v2/utils/runUpdatePlanMigration";
+import {
+	getSubscriptionIdsForProduct,
+	linkCustomerProductToCanceledSubscription,
+	listStripeSubscriptions,
+} from "./utils/canceledSubscriptionUtils";
+
+const getInvoiceCount = async ({
+	autumnV1,
+	customerId,
+}: {
+	autumnV1: { customers: { get: <T>(id: string) => Promise<T> } };
+	customerId: string;
+}) =>
+	(await autumnV1.customers.get<ApiCustomerV3>(customerId)).invoices?.length ??
+	0;
+
+/** Fixed-price amounts on the customer's active product, ascending. */
+const getFixedPriceAmounts = async ({
+	ctx,
+	customerId,
+	productId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	productId: string;
+}) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+		skipReset: true,
+	});
+	const customerProduct = findActiveCustomerProductById({
+		fullCus: fullCustomer,
+		productId,
+	});
+
+	return (customerProduct?.customer_prices ?? [])
+		.map(({ price }) =>
+			price.config && "amount" in price.config
+				? price.config.amount
+				: undefined,
+		)
+		.filter((amount): amount is number => typeof amount === "number")
+		.sort((a, b) => a - b);
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Adding items to a plan whose subscription is dead
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub migration: add_items applies without a new sub or charge")}`, async () => {
+	const customerId = "canceled-sub-mig-add-items";
+	const pro = products.pro({ id: "pro", items: [] });
+
+	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.billing.attach({ productId: pro.id })],
+	});
+
+	const { subscriptionId, stripeCustomerId } =
+		await linkCustomerProductToCanceledSubscription({
+			ctx,
+			customerId,
+			productId: pro.id,
+		});
+
+	const invoiceCountBefore = await getInvoiceCount({ autumnV1, customerId });
+	const subscriptionsBefore = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+
+	// ── Contract assertion 1: the migration runs instead of 400-ing ───────────
+	await runUpdatePlanMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: `${customerId}-mig`,
+		customerId,
+		runOnServer: false,
+		filter: { customer: { plan: { plan_id: pro.id } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: pro.id },
+					customize: {
+						add_items: [
+							itemsV2.dashboard(),
+							itemsV2.monthlyMessages({ included: 200 }),
+						],
+					},
+				},
+			],
+		},
+	});
+
+	// ── Contract assertion 2: the Autumn-side change landed ──────────────────
+	const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+	await expectCustomerProducts({ customer, active: [pro.id] });
+	expectFlagCorrect({
+		customer,
+		featureId: TestFeature.Dashboard,
+		planId: pro.id,
+	});
+	expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		remaining: 200,
+		usage: 0,
+		planId: pro.id,
+	});
+
+	// ── Contract assertion 3: no replacement subscription ────────────────────
+	const subscriptionsAfter = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+	expect(subscriptionsAfter.map((sub) => sub.id).sort()).toEqual(
+		subscriptionsBefore.map((sub) => sub.id).sort(),
+	);
+	expect(
+		subscriptionsAfter.every((sub) => sub.status === "canceled"),
+		"every stripe subscription should still be canceled",
+	).toBe(true);
+
+	// ── Contract assertion 4: no new invoice, sub link preserved ─────────────
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		count: invoiceCountBefore,
+	});
+	expect(
+		await getSubscriptionIdsForProduct({ ctx, customerId, productId: pro.id }),
+	).toEqual([subscriptionId]);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Raising the base price with proration ON — control proves it really bills
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(`${chalk.yellowBright("canceled sub migration: prorated base price change bills the live sub but not the canceled one")}`, async () => {
+	const customerId = "canceled-sub-mig-price";
+	const controlKey = "canceled-sub-mig-price-control";
+	const pro = products.pro({ id: "pro", items: [] });
+
+	const { autumnV1, autumnV2_2, ctx, otherCustomers } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.otherCustomers([{ id: controlKey, paymentMethod: "success" }]),
+			s.products({ list: [pro] }),
+		],
+		actions: [
+			s.billing.attach({ productId: pro.id }),
+			s.billing.attach({ productId: pro.id, customerId: controlKey }),
+		],
+	});
+
+	const controlId = otherCustomers.get(controlKey)?.id;
+	if (!controlId) throw new Error("control customer not created");
+
+	const { stripeCustomerId } = await linkCustomerProductToCanceledSubscription({
+		ctx,
+		customerId,
+		productId: pro.id,
+	});
+
+	const priceMigration = {
+		filter: { customer: { plan: { plan_id: pro.id } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan" as const,
+					plan_filter: { plan_id: pro.id },
+					customize: { price: itemsV2.monthlyPrice({ amount: 50 }) },
+					// Migrations are charge-free unless proration is explicitly enabled.
+					proration: true,
+				},
+			],
+		},
+	};
+
+	// ── Control: identical migration on a LIVE sub must actually bill ────────
+	const controlInvoicesBefore = await getInvoiceCount({
+		autumnV1,
+		customerId: controlId,
+	});
+
+	await runUpdatePlanMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: `${controlKey}-mig`,
+		customerId: controlId,
+		runOnServer: false,
+		...priceMigration,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(controlId),
+		count: controlInvoicesBefore + 1,
+	});
+	expect(
+		await getFixedPriceAmounts({
+			ctx,
+			customerId: controlId,
+			productId: pro.id,
+		}),
+	).toEqual([50]);
+
+	// ── Subject: same migration on the canceled sub must NOT bill ────────────
+	const invoiceCountBefore = await getInvoiceCount({ autumnV1, customerId });
+	const subscriptionsBefore = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+
+	await runUpdatePlanMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: `${customerId}-mig`,
+		customerId,
+		runOnServer: false,
+		...priceMigration,
+	});
+
+	await expectCustomerInvoiceCorrect({
+		customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+		count: invoiceCountBefore,
+	});
+
+	const subscriptionsAfter = await listStripeSubscriptions({
+		ctx,
+		stripeCustomerId,
+	});
+	expect(subscriptionsAfter.map((sub) => sub.id).sort()).toEqual(
+		subscriptionsBefore.map((sub) => sub.id).sort(),
+	);
+	expect(
+		subscriptionsAfter.every((sub) => sub.status === "canceled"),
+		"every stripe subscription should still be canceled",
+	).toBe(true);
+
+	// The Autumn-side price change still applied — only the money was dropped.
+	expect(
+		await getFixedPriceAmounts({ ctx, customerId, productId: pro.id }),
+	).toEqual([50]);
+});

--- a/server/tests/integration/billing/canceled-subscription/utils/canceledSubscriptionUtils.ts
+++ b/server/tests/integration/billing/canceled-subscription/utils/canceledSubscriptionUtils.ts
@@ -1,0 +1,90 @@
+import { findActiveCustomerProductById } from "@autumn/shared";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import type Stripe from "stripe";
+import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { timeout } from "@/utils/genUtils";
+
+const WEBHOOK_SETTLE_MS = 12_000;
+
+/**
+ * Produces the drifted state these suites are about: an ACTIVE Autumn customer
+ * product whose `subscription_ids` point at a canceled Stripe subscription.
+ * Unlinking before the cancel makes `sub.deleted` a no-op — the same shape
+ * production lands in when Autumn's own post-cancel bookkeeping never runs.
+ */
+export const linkCustomerProductToCanceledSubscription = async ({
+	ctx,
+	customerId,
+	productId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	productId: string;
+}) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+
+	const customerProduct = findActiveCustomerProductById({
+		fullCus: fullCustomer,
+		productId,
+	});
+
+	const subscriptionIds = customerProduct?.subscription_ids ?? [];
+	if (!customerProduct || subscriptionIds.length === 0) {
+		throw new Error(`No active subscribed customer product for ${productId}`);
+	}
+
+	const stripeCustomerId = fullCustomer.processor?.id;
+	if (!stripeCustomerId) throw new Error("Missing stripe customer id");
+
+	await CusProductService.update({
+		ctx,
+		cusProductId: customerProduct.id,
+		updates: { subscription_ids: [] },
+	});
+
+	await ctx.stripeCli.subscriptions.cancel(subscriptionIds[0]);
+	await timeout(WEBHOOK_SETTLE_MS);
+
+	await CusProductService.update({
+		ctx,
+		cusProductId: customerProduct.id,
+		updates: { subscription_ids: subscriptionIds },
+	});
+
+	return { subscriptionId: subscriptionIds[0], stripeCustomerId };
+};
+
+export const listStripeSubscriptions = async ({
+	ctx,
+	stripeCustomerId,
+}: {
+	ctx: TestContext;
+	stripeCustomerId: string;
+}): Promise<Stripe.Subscription[]> => {
+	const { data } = await ctx.stripeCli.subscriptions.list({
+		customer: stripeCustomerId,
+		status: "all",
+	});
+	return data;
+};
+
+export const getSubscriptionIdsForProduct = async ({
+	ctx,
+	customerId,
+	productId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	productId: string;
+}) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	return findActiveCustomerProductById({ fullCus: fullCustomer, productId })
+		?.subscription_ids;
+};

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -76,6 +76,10 @@ export interface BillingContext {
 	// Stripe context
 	stripeCustomer?: Stripe.Customer;
 	stripeSubscription?: Stripe.Subscription;
+	/** The subscription linked to the target customer product exists but is
+	 * canceled, so `stripeSubscription` is absent. Each action decides what that
+	 * means: updateSubscription blocks billing changes, attach buys fresh. */
+	canceledStripeSubscriptionId?: string;
 	stripeSubscriptionSchedule?: Stripe.SubscriptionSchedule;
 	stripeDiscounts?: StripeDiscountWithCoupon[];
 	stripeTaxRate?: Stripe.TaxRate;

--- a/shared/models/billingModels/context/billingContextOverride.ts
+++ b/shared/models/billingModels/context/billingContextOverride.ts
@@ -22,6 +22,8 @@ export interface StripeBillingContextOverride {
 	testClockFrozenTime?: number;
 	stripeDiscounts: StripeDiscountWithCoupon[];
 	stripeTaxRate?: Stripe.TaxRate;
+	/** See `BillingContext.canceledStripeSubscriptionId`. */
+	canceledStripeSubscriptionId?: string;
 }
 
 export interface BillingContextOverride {


### PR DESCRIPTION
## Problem

`fetchStripeSubscriptionForBilling` threw a 400 whenever a customer product's `subscription_ids` pointed at a Stripe subscription with `status: "canceled"`:

```ts
if (isStripeSubscriptionCanceled(sub)) {
  throw new RecaseError({ message: `Subscription ${subId} is canceled`, statusCode: 400 });
}
```

That state is drift — the sub died in Stripe but Autumn's bookkeeping never caught up — and once a customer is in it, *every* billing call fails: update, cancel, attach, and any migration that selects them.

## Approach

Report the canceled id instead of throwing, and let each action decide what it means. The fetch now returns `{ stripeSubscription, canceledStripeSubscriptionId }`.

```
fetchStripeSubscriptionForBilling
  sub.status === "canceled"  ->  { canceledStripeSubscriptionId }
      |
      +-- updateSubscription -> skipBillingChanges = true
      +-- attach             -> abandon the dead sub, buy fresh
```

| Flow | Before | After |
|---|---|---|
| `updateSubscription` | 400 | applies Autumn-side, **zero Stripe writes** |
| `cancel_immediately` | 400 | works — plan expires, default activates |
| `cancel_end_of_cycle` | 400 (unclear) | 400 naming the sub + `cancel_immediately` |
| `uncancel` | 400 | 400 — would revive an unbilled plan |
| `attach` / `multiAttach` | 400 | fresh purchase: new sub, charged |
| migrations | 400 | run, charge-free |
| `allocatedInvoice` | 400 | existing `if (!stripeSubscription) return null` |
| `batchTransition` / `attachLicense` | 400 | anchor fallback, never wrote Stripe anyway |

### On not charging twice

`skipBillingChanges` is the existing `no_billing_changes` mechanism: the plan is computed in full, then only the money is stripped — at `finalizeLineItems` (line items dropped) and `evaluateStripeBillingPlan` (no subscription/invoice action). Both are load-bearing; each blocks a different route to a charge.

Migrations were already safe via three independent layers, including `contextBySubscriptionId` dropping any context with no `stripeSubscription.id` before Stripe is evaluated. This PR doesn't make them safe — it makes them *reachable*.

`evaluateStripeBillingPlan` is deliberately **unchanged**. An earlier draft added a `canceledStripeSubscriptionId` clause there; it was unreachable (updateSubscription already sets `skipBillingChanges` from the same condition) and was an active hazard — setting that field on an attach-like context would have silently stopped attach from charging. Removing it also collapsed a two-field workaround back to one field.

### Uncancel

Not in the original scope, but the same family: `uncancel` on a *canceling* plan whose sub had died passed every guard, flipped the plan back to active, and — because of the `skipBillingChanges` added here — never touched Stripe. An active paid plan, silently unbilled. Blocked with the same remedy (re-attach, which now works).

## Tests

`server/tests/integration/billing/canceled-subscription/` — 7 cases, all green.

The drifted state is built through the real production mechanism (unlink → cancel in Stripe → `sub.deleted` no-ops → relink), not a synthetic DB poke.

The migration price test uses a **control customer on a live subscription running the identical migration**. Migrations are charge-free unless `proration: true`, so without the control both migration assertions would pass even with the guard removed.

- typecheck clean, biome clean on touched files
- unit suite 2533 passed / 0 failed
- 7/7 integration cases in the new suite

## Reviewer notes

Two things worth a look:

1. **No broader integration regression pass** was run. Riskiest file is `handleCurrentCustomerProductErrors.ts` — attach's "paid but no stripe sub" guard gains an escape hatch.
2. **`cancel_immediately` issues no Stripe refund** on a drifted plan, since `skipBillingChanges` suppresses line items. Correct when Stripe already settled the cancellation; wrong if a sub was killed without proration. Worth checking real data before this ships.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops 400s when a customer product links to a canceled Stripe subscription and prevents duplicate charges. We detect the canceled sub and let each action decide, across v2 and legacy v1 paths.

- **Bug Fixes**
  - `fetchStripeSubscriptionForBilling` no longer throws on canceled subs; returns `{ stripeSubscription?, canceledStripeSubscriptionId? }`.
  - `BillingContext` gains `canceledStripeSubscriptionId`; propagated through setup helpers.
  - `updateSubscription`: skips Stripe writes when the linked sub is canceled; Autumn-side changes apply. `cancel_end_of_cycle` and `uncancel` now 400 with clear guidance; `cancel_immediately` works.
  - `attach`: treats linked-but-canceled as explained linkage; creates a new subscription and charges as expected.
  - Legacy v1: `attachParamsToStripeBillingContext` now threads `canceledStripeSubscriptionId`; v1 attach buys fresh and v1 quantity updates apply without charging.
  - Migrations on canceled subs now run and apply without billing or creating a new subscription.
  - Added integration tests for drifted flows, legacy v1 attach/quantity, and migrations.

<sup>Written for commit 73757d464b0c63bd845d9e2e81ce993eb77a5fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up completes the canceled Stripe-subscription recovery flow, including the previously missing legacy adapter propagation.
- **[Bug fixes]** Reports canceled Stripe subscription IDs separately so billing actions can recover instead of failing every request.
- **[Bug fixes]** Prevents updates from writing to Stripe when the linked subscription is already canceled, while allowing immediate cancellation and fresh attachment.
- **[Bug fixes]** Preserves the canceled-subscription marker through legacy attach, renewal, and quantity-update adapters.
- **[API changes]** Extends billing context and override models with `canceledStripeSubscriptionId`.
- **[Improvements]** Adds integration coverage for drifted subscriptions, legacy billing paths, and migrations.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/setup/fetchStripeSubscriptionForBilling.ts | Returns canceled subscription linkage as explicit context instead of throwing a blanket client error. |
| server/src/internal/billing/v2/actions/updateSubscription/setup/setupUpdateSubscriptionBillingContext.ts | Suppresses Stripe writes when an update targets an already-canceled subscription. |
| server/src/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors.ts | Allows fresh attachment when the missing live subscription is explained by a canceled linked subscription. |
| server/src/internal/billing/v2/actions/legacy/utils/attachParamsToStripeBillingContext.ts | Correctly preserves the canceled-subscription marker through the legacy billing-context override, resolving the previous finding. |
| shared/models/billingModels/context/billingContextOverride.ts | Adds the optional cancellation marker to the typed Stripe billing-context override. |
| server/src/internal/migrations/v2/stripeCache/createMigrationStripeCache.ts | Adapts migration subscription caching to the fetch helper's new result shape. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Fetch linked Stripe subscription] --> B{Subscription canceled?}
  B -- No --> C[Use live Stripe subscription]
  B -- Yes --> D[Return canceled subscription ID]
  D --> E{Billing action}
  E -- Update or migration --> F[Apply Autumn changes without Stripe writes]
  E -- Immediate cancellation --> G[Expire Autumn plan]
  E -- Attach --> H[Create and charge a fresh subscription]
  E -- End-of-cycle or uncancel --> I[Reject with recovery guidance]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: keep the canceled-sub marker throug..."](https://github.com/useautumn/autumn/commit/73757d464b0c63bd845d9e2e81ce993eb77a5fcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51186956)</sub>

<!-- /greptile_comment -->