### PR TITLE
perf: in-process L1 for org-with-features + bound the cache write-backs

### DIFF
--- a/server/src/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.ts
+++ b/server/src/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.ts
@@ -1,4 +1,5 @@
 import { AppEnv } from "@autumn/shared";
+import { LRUCache } from "lru-cache";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import {
 	forEachMiscRedisTarget,
@@ -10,6 +11,26 @@ import { runRedisOp, tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 /** Short by design: org config changes are also pushed through clearOrgCache, so
  *  this only has to bound the staleness window for anything that misses that. */
 export const ORG_WITH_FEATURES_CACHE_TTL_SECONDS = 60;
+
+// This TTL is the invalidation window: clearOrgWithFeaturesCache only reaches
+// the calling process's L1, so every other worker serves stale org config until
+// it lapses. Kept well under the 60s Redis TTL for that reason.
+export const ORG_WITH_FEATURES_L1_TTL_MS = 5_000;
+/** An org payload carries every feature, so this is bounded far tighter than the
+ *  secret-key L1 — it holds the handful of orgs a worker process is hot on. */
+export const ORG_WITH_FEATURES_L1_MAX_ENTRIES = 500;
+
+type OrgWithFeaturesL1Entry = { value: unknown };
+
+/** Per-process L1. Each cluster worker gets its own copy — intended. */
+const orgWithFeaturesL1 = new LRUCache<string, OrgWithFeaturesL1Entry>({
+	max: ORG_WITH_FEATURES_L1_MAX_ENTRIES,
+	ttl: ORG_WITH_FEATURES_L1_TTL_MS,
+});
+
+export const _resetOrgWithFeaturesL1ForTesting = () =>
+	orgWithFeaturesL1.clear();
+export const _orgWithFeaturesL1SizeForTesting = () => orgWithFeaturesL1.size;
 
 export const buildOrgWithFeaturesCacheKey = ({
 	orgId,
@@ -31,6 +52,9 @@ export const getCachedOrgWithFeatures = async <T>({
 	const miscRedis = resolveMiscRedis({ requestId });
 	const cacheKey = buildOrgWithFeaturesCacheKey({ orgId, env });
 
+	const local = orgWithFeaturesL1.get(cacheKey);
+	if (local) return local.value as T;
+
 	const cached = await tryRedisOp({
 		operation: () => miscRedis.get(cacheKey),
 		source: "org-features-cache:get",
@@ -40,7 +64,9 @@ export const getCachedOrgWithFeatures = async <T>({
 
 	if (!cached) return null;
 
-	return JSON.parse(cached) as T;
+	const parsed = JSON.parse(cached) as T;
+	orgWithFeaturesL1.set(cacheKey, { value: parsed });
+	return parsed;
 };
 
 export const setCachedOrgWithFeatures = async ({
@@ -59,10 +85,13 @@ export const setCachedOrgWithFeatures = async ({
 	const miscRedis = resolveMiscRedis({ requestId });
 	const cacheKey = buildOrgWithFeaturesCacheKey({ orgId, env });
 
+	orgWithFeaturesL1.set(cacheKey, { value: data });
+
 	await tryRedisOp({
 		operation: () => miscRedis.set(cacheKey, JSON.stringify(data), "EX", ttl),
 		source: "org-features-cache:set",
 		redisInstance: miscRedis,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.orgFeaturesSet,
 	});
 };
 
@@ -80,6 +109,8 @@ export const clearOrgWithFeaturesCache = async ({
 	const cacheKeys = envs.map((targetEnv) =>
 		buildOrgWithFeaturesCacheKey({ orgId, env: targetEnv }),
 	);
+
+	for (const cacheKey of cacheKeys) orgWithFeaturesL1.delete(cacheKey);
 
 	await forEachMiscRedisTarget({
 		// One DEL per key: these keys have no hash tag, so a multi-key DEL is

--- a/server/src/external/redis/actions/secretKeyCache/secretKeyCache.ts
+++ b/server/src/external/redis/actions/secretKeyCache/secretKeyCache.ts
@@ -89,6 +89,7 @@ export const setCachedSecretKeyVerification = async ({
 		operation: () => miscRedis.set(cacheKey, JSON.stringify(data), "EX", ttl),
 		source: "secret-key-cache:set",
 		redisInstance: miscRedis,
+		timeoutMs: REDIS_OP_TIMEOUT_MS.secretKeySet,
 	});
 };
 

--- a/server/src/external/redis/utils/redisOpTimeouts.ts
+++ b/server/src/external/redis/utils/redisOpTimeouts.ts
@@ -2,8 +2,10 @@
  * Opt-in per-operation Redis bounds (positive-limiting): anything absent here
  * keeps the client's `commandTimeout` — 1s on V2, 10s on legacy.
  *
- * Only reads with a working non-Redis path belong here. A timed-out write is
- * ambiguous — `withTimeout` abandons the promise but the command still lands.
+ * Only ops with a working non-Redis path belong here. Reads qualify by default;
+ * a write qualifies only when landing late or not at all is harmless — a TTL'd
+ * read-through cache write costs one extra miss, so `withTimeout` abandoning
+ * the promise is safe. Writes carrying state no other path can rebuild are not.
  * Values are sized above each op's measured production p99.9.
  *
  * A value above the client's `commandTimeout` is inert: ioredis arms that timer
@@ -16,6 +18,10 @@ export const REDIS_OP_TIMEOUT_MS = {
 	secretKeyGet: 200,
 	/** p99.9 208ms — 200 would clip real traffic. */
 	orgFeaturesGet: 300,
+	// The write-back halves. Unbounded they inherit the misc client's 10s prod
+	// `commandTimeout`, and both are awaited inline after the Postgres fallback.
+	secretKeySet: 200,
+	orgFeaturesSet: 300,
 	/** p99.9 297ms on shared V2; this site also serves the dedicated cluster.
 	 *  The only standby-retry caller the wrapper actually bounds, so 500 rather
 	 *  than 400: the reserve has to come out of headroom, not out of the tail. */

--- a/server/tests/unit/redis/orgWithFeaturesL1Cache.test.ts
+++ b/server/tests/unit/redis/orgWithFeaturesL1Cache.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit test for the in-process L1 fronting the Redis org+features cache.
+ * getOrgWithFeaturesCached runs once per queue message, so without an L1 every
+ * message pays a Redis round trip — and during a misc-cache stall, a Postgres
+ * one plus the write-back.
+ *
+ * Contract under test:
+ *   New constants:
+ *     - ORG_WITH_FEATURES_L1_TTL_MS = 5_000
+ *     - ORG_WITH_FEATURES_L1_MAX_ENTRIES = 500
+ *   New behaviors:
+ *     1. L1 miss -> falls through to Redis; a Redis hit populates L1
+ *     2. L1 hit -> value returned, Redis NOT called
+ *     3. setCachedOrgWithFeatures write-through populates L1
+ *     4. clearOrgWithFeaturesCache evicts the calling process's L1 (every env)
+ *     5. A Redis error yields null and never poisons L1
+ *     6. A positive entry stops being served once its TTL elapses
+ *     7. Cache is LRU-bounded at max and never grows past it
+ */
+
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	spyOn,
+	test,
+} from "bun:test";
+import { AppEnv } from "@autumn/shared";
+
+// CI has no misc cache env, and getMiscMainRedis throws without one. These tests
+// only need SET/GET/DEL semantics, so back the client with an in-memory map.
+const realInstances = {
+	...(await import("@/external/redis/miscCache/miscRedisInstances.js")),
+};
+const fakeStore = new Map<string, string>();
+let redisGetCalls: string[] = [];
+/** Set to make the next reads fail — the fake is typed `as never`, so spyOn
+ *  can't stub it. */
+let redisGetError: Error | null = null;
+const fakeMiscRedis = {
+	status: "ready",
+	get: async (key: string) => {
+		redisGetCalls.push(key);
+		if (redisGetError) throw redisGetError;
+		return fakeStore.get(key) ?? null;
+	},
+	set: async (key: string, value: string) => {
+		fakeStore.set(key, String(value));
+		return "OK";
+	},
+	del: async (key: string) => (fakeStore.delete(key) ? 1 : 0),
+} as never;
+
+mock.module("@/external/redis/miscCache/miscRedisInstances.js", () => ({
+	getMiscMainRedis: () => fakeMiscRedis,
+	getMiscBackupRedis: () => null,
+}));
+
+afterAll(() => {
+	mock.module(
+		"@/external/redis/miscCache/miscRedisInstances.js",
+		() => realInstances,
+	);
+});
+
+import {
+	_orgWithFeaturesL1SizeForTesting,
+	_resetOrgWithFeaturesL1ForTesting,
+	buildOrgWithFeaturesCacheKey,
+	clearOrgWithFeaturesCache,
+	getCachedOrgWithFeatures,
+	ORG_WITH_FEATURES_L1_MAX_ENTRIES,
+	ORG_WITH_FEATURES_L1_TTL_MS,
+	setCachedOrgWithFeatures,
+} from "@/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.js";
+
+type CachedOrg = { org: { id: string }; features: unknown[] };
+
+const buildOrgData = (orgId: string): CachedOrg => ({
+	org: { id: orgId },
+	features: [],
+});
+
+/** Unique per test so concurrent runs never share a key. */
+const uniqueOrgId = (label: string) =>
+	`org-l1-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+/**
+ * Runs `fn` with the monotonic clock advanced by `deltaMs`. lru-cache stamps
+ * TTLs with performance.now(), which neither fake timers nor setSystemTime can
+ * move — spying on it is the only way to cross a TTL boundary without a sleep.
+ */
+const withAdvancedClock = async (deltaMs: number, fn: () => Promise<void>) => {
+	// Macrotask yields on both edges: lru-cache caches its clock reading and
+	// clears it via a 1ms setTimeout, so without them the spied clock is either
+	// ignored or leaks a future timestamp into whatever runs next.
+	const yieldMacrotask = () => new Promise((resolve) => setTimeout(resolve, 5));
+	await yieldMacrotask();
+	const realPerfNow = performance.now.bind(performance);
+	const clock = spyOn(performance, "now").mockImplementation(
+		() => realPerfNow() + deltaMs,
+	);
+	try {
+		await fn();
+	} finally {
+		clock.mockRestore();
+		await yieldMacrotask();
+	}
+};
+
+beforeEach(() => {
+	_resetOrgWithFeaturesL1ForTesting();
+	fakeStore.clear();
+	redisGetCalls = [];
+	redisGetError = null;
+});
+
+afterEach(() => {
+	_resetOrgWithFeaturesL1ForTesting();
+});
+
+describe("org-with-features L1 cache", () => {
+	// ── Contracts 1 + 2 ────────────────────────────────────────────────────
+	test("a Redis hit populates L1 so the next get skips Redis entirely", async () => {
+		const orgId = uniqueOrgId("hit");
+		const env = AppEnv.Live;
+
+		await setCachedOrgWithFeatures({ orgId, env, data: buildOrgData(orgId) });
+		_resetOrgWithFeaturesL1ForTesting();
+		redisGetCalls = [];
+
+		const first = await getCachedOrgWithFeatures<CachedOrg>({ orgId, env });
+		expect(first?.org.id).toBe(orgId);
+		expect(redisGetCalls).toHaveLength(1); // contract 1: fell through
+
+		redisGetCalls = [];
+
+		const second = await getCachedOrgWithFeatures<CachedOrg>({ orgId, env });
+		expect(second?.org.id).toBe(orgId);
+		expect(redisGetCalls).toHaveLength(0); // contract 2: served from L1
+	});
+
+	// ── Contract 3 ─────────────────────────────────────────────────────────
+	test("setCachedOrgWithFeatures write-through makes the next get an L1 hit", async () => {
+		const orgId = uniqueOrgId("write-through");
+		const env = AppEnv.Live;
+
+		await setCachedOrgWithFeatures({ orgId, env, data: buildOrgData(orgId) });
+
+		const result = await getCachedOrgWithFeatures<CachedOrg>({ orgId, env });
+
+		expect(result?.org.id).toBe(orgId);
+		expect(redisGetCalls).toHaveLength(0);
+	});
+
+	// ── Contract 4 ─────────────────────────────────────────────────────────
+	test("clearOrgWithFeaturesCache evicts this process's L1 entry for every env", async () => {
+		const orgId = uniqueOrgId("clear");
+
+		for (const env of [AppEnv.Live, AppEnv.Sandbox]) {
+			await setCachedOrgWithFeatures({ orgId, env, data: buildOrgData(orgId) });
+		}
+		expect(_orgWithFeaturesL1SizeForTesting()).toBe(2);
+
+		// Omitted env clears both.
+		await clearOrgWithFeaturesCache({ orgId });
+
+		expect(_orgWithFeaturesL1SizeForTesting()).toBe(0);
+		for (const env of [AppEnv.Live, AppEnv.Sandbox]) {
+			// L1 and Redis are both gone -> the read must go to Redis and miss.
+			expect(await getCachedOrgWithFeatures({ orgId, env })).toBeNull();
+		}
+		expect(redisGetCalls).toHaveLength(2);
+	});
+
+	// ── Contract 5 ─────────────────────────────────────────────────────────
+	test("a Redis error yields null rather than throwing, and never poisons L1", async () => {
+		const orgId = uniqueOrgId("redis-error");
+		redisGetError = new Error("boom");
+
+		const result = await getCachedOrgWithFeatures({ orgId, env: AppEnv.Live });
+
+		expect(result).toBeNull();
+		expect(_orgWithFeaturesL1SizeForTesting()).toBe(0);
+	});
+
+	// ── Contract 6 ─────────────────────────────────────────────────────────
+	test("a positive L1 entry stops being served once its TTL elapses", async () => {
+		const orgId = uniqueOrgId("ttl");
+		const env = AppEnv.Live;
+
+		await setCachedOrgWithFeatures({ orgId, env, data: buildOrgData(orgId) });
+
+		await withAdvancedClock(ORG_WITH_FEATURES_L1_TTL_MS + 400, async () => {
+			redisGetCalls = [];
+
+			const result = await getCachedOrgWithFeatures<CachedOrg>({ orgId, env });
+
+			expect(redisGetCalls).toHaveLength(1); // went back to Redis
+			expect(result?.org.id).toBe(orgId); // Redis still had it (60s TTL)
+		});
+	});
+});
+
+// ── Contract 7 ─────────────────────────────────────────────────────────────
+describe("org-with-features L1 cache: bounded size", () => {
+	test("evicts LRU-style at max and never grows unbounded", async () => {
+		const env = AppEnv.Live;
+		const overfill = ORG_WITH_FEATURES_L1_MAX_ENTRIES + 50;
+
+		for (let i = 0; i < overfill; i++) {
+			await setCachedOrgWithFeatures({
+				orgId: `bounded-${i}`,
+				env,
+				data: buildOrgData(`bounded-${i}`),
+			});
+		}
+
+		expect(_orgWithFeaturesL1SizeForTesting()).toBe(
+			ORG_WITH_FEATURES_L1_MAX_ENTRIES,
+		);
+		redisGetCalls = [];
+
+		// The oldest key was evicted -> must go back to Redis.
+		await getCachedOrgWithFeatures({ orgId: "bounded-0", env });
+		expect(redisGetCalls).toEqual([
+			buildOrgWithFeaturesCacheKey({ orgId: "bounded-0", env }),
+		]);
+
+		redisGetCalls = [];
+
+		// The most recent key survived -> served from L1.
+		await getCachedOrgWithFeatures({ orgId: `bounded-${overfill - 1}`, env });
+		expect(redisGetCalls).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
> **Stacked on #2668** — base is `john/canceled-stripe-sub-no-charge`, so this diff shows only the cache commit. Merge #2668 first, or retarget this to `main` after it lands.

## Problem

`getOrgWithFeaturesCached` runs once per queue message, and `org_with_features` GET is ~89% of misc-cache traffic. Every message pays a Redis round trip — and during a misc-cache stall, a Postgres one plus the write-back on top.

## Changes

**1. Per-process L1 (5s TTL, 500 entries)** in front of the Redis org cache.

```
getCachedOrgWithFeatures
  L1 hit  -> return                      (no Redis)
  L1 miss -> Redis -> populate L1
setCachedOrgWithFeatures  -> write-through to L1
clearOrgWithFeaturesCache -> evict L1 (this process only)
```

The 5s TTL *is* the invalidation window: `clearOrgWithFeaturesCache` only reaches the calling process's L1, so every other worker serves stale org config until it lapses. That's why it's well under the 60s Redis TTL. Entry count is bounded tighter than the secret-key L1 because an org payload carries every feature.

**2. Bound the two cache write-backs** — `secretKeySet: 200ms`, `orgFeaturesSet: 300ms`. Both are awaited inline after the Postgres fallback and otherwise inherit the misc client's 10s prod `commandTimeout`.

This slightly widens the rule in `redisOpTimeouts.ts`, which previously said reads only. The real criterion is whether landing late-or-not-at-all is harmless: a TTL'd read-through cache write costs at most one extra miss, so abandoning the promise is safe. Writes carrying state no other path can rebuild still don't qualify — comment updated to say so.

## Tests

`server/tests/unit/redis/orgWithFeaturesL1Cache.test.ts` — 6 tests, all passing: fall-through populates L1, L1 hit skips Redis, write-through, `clear` evicts every env, a Redis error yields null without poisoning L1, TTL expiry, and LRU bounding at max.

Backed by an in-memory fake (CI has no misc-cache env) with the real module captured and restored in `afterAll`, since `mock.module` leaks across files.

## Reviewer note

`bun test:unit` currently reports **"No unit tests ran — shard collection is broken"** on this repo. I verified this reproduces on a clean tree with none of these changes applied, so it is **pre-existing and unrelated** — but it means the sharded runner is not currently validating anything, and this suite is running blind. The new file passes when invoked directly (`bun test tests/unit/redis/orgWithFeaturesL1Cache.test.ts` → 6 pass). Worth a separate look.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an in-process L1 cache in front of the org-with-features Redis cache to cut round trips per message and improve resilience during misc-cache stalls. Also bound cache write-back timeouts to keep the hot path fast when Redis is slow.

- **Performance**
  - Added per-process L1 (`lru-cache`) with 5s TTL and 500 entries for org-with-features.
  - Get: L1 hit returns; miss goes to Redis and populates L1. Set: write-through to L1.
  - Clear evicts this process’s L1 keys across envs; other workers may serve stale data until 5s TTL lapses (Redis TTL stays 60s).
  - Bounded Redis write-backs: `secretKeySet` 200ms, `orgFeaturesSet` 300ms; safe for TTL’d read-through caches.
  - Added unit tests (6) for L1 hit/miss, write-through, clear, Redis error handling, TTL expiry, and LRU bounds.

<sup>Written for commit 7105f3e44c6dad8a8f7c765369b92c4f6e2c1b4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a short-lived in-process cache ahead of Redis and limits how long two rebuildable cache write-backs can block.

- **[Improvements]** Add a five-second, 500-entry L1 cache for organization and feature data, including write-through and local invalidation.
- **[Improvements]** Bound secret-key and organization-feature Redis write-backs to 200ms and 300ms.
- **[Improvements]** Add focused unit coverage for L1 hits, misses, expiration, invalidation, Redis errors, and capacity limits.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the organization L1 still shares mutable objects between requests.

A request-specific configuration override can modify the same organization object retained in the process-local cache, so a later request on that worker can observe configuration belonging to an earlier request.

**Files Needing Attention:** server/src/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/actions/orgWithFeaturesCache/orgWithFeaturesCache.ts | Adds the bounded five-second L1, Redis-hit population, write-through behavior, local invalidation, and a bounded Redis write-back. |
| server/src/external/redis/actions/secretKeyCache/secretKeyCache.ts | Applies the new 200ms bound to the rebuildable secret-key cache write-back. |
| server/src/external/redis/utils/redisOpTimeouts.ts | Defines the two write-back timeout values and documents when abandoning a cache write is acceptable. |
| server/tests/unit/redis/orgWithFeaturesL1Cache.test.ts | Adds focused tests for the L1 cache lifecycle, fallback behavior, expiration, and entry bound. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant L1 as In-process L1
    participant Redis
    participant Postgres
    Caller->>L1: Get org with features
    alt L1 hit
        L1-->>Caller: Cached object
    else L1 miss
        Caller->>Redis: GET
        alt Redis hit
            Redis-->>L1: Populate for 5 seconds
            L1-->>Caller: Org and features
        else Redis miss or timeout
            Caller->>Postgres: Load org and features
            Postgres-->>L1: Write through
            L1->>Redis: Bounded write-back
            L1-->>Caller: Org and features
        end
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["perf: add an in-process L1 in front of t..."](https://github.com/useautumn/autumn/commit/7105f3e44c6dad8a8f7c765369b92c4f6e2c1b4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51195605)</sub>

<!-- /greptile_comment -->