### PR TITLE
fix: accept zero allowance on the dashboard reward path

### DIFF
--- a/server/src/internal/rewards/actions/grantRewardEntitlements.ts
+++ b/server/src/internal/rewards/actions/grantRewardEntitlements.ts
@@ -99,9 +99,9 @@ export const grantRewardEntitlements = async ({
 
 		const isBoolean = feature.type === FeatureType.Boolean;
 		const allowance = rewardEnt.allowance;
-		if (!isBoolean && (!allowance || allowance <= 0)) {
+		if (!isBoolean && (allowance == null || allowance < 0)) {
 			throw new RecaseError({
-				message: `Reward entitlement for feature "${feature.id}" must have a positive allowance`,
+				message: `Reward entitlement for feature "${feature.id}" must have a non-negative allowance`,
 				code: ErrCode.InvalidReward,
 				statusCode: 400,
 			});

--- a/server/src/internal/rewards/repos/rewardEntitlementRows.ts
+++ b/server/src/internal/rewards/repos/rewardEntitlementRows.ts
@@ -25,7 +25,7 @@ export const rewardToEntitlementRows = ({
 		const expiry = "expiry" in entitlement ? entitlement.expiry : undefined;
 		// Boolean grants carry no allowance
 		const hasAllowance =
-			entitlement.allowance != null && entitlement.allowance > 0;
+			entitlement.allowance != null && entitlement.allowance >= 0;
 
 		return {
 			id:

--- a/server/src/internal/rewards/rewardUtils.ts
+++ b/server/src/internal/rewards/rewardUtils.ts
@@ -73,9 +73,9 @@ export const constructReward = ({
 			});
 			// Boolean features grant on/off access, so they carry no allowance
 			const isBoolean = feature?.type === FeatureType.Boolean;
-			if (!isBoolean && (!ent.allowance || ent.allowance <= 0)) {
+			if (!isBoolean && (ent.allowance == null || ent.allowance < 0)) {
 				throw new RecaseError({
-					message: "Each entitlement must have a positive allowance",
+					message: "Each entitlement must have a non-negative allowance",
 					code: ErrCode.InvalidReward,
 				});
 			}

--- a/shared/models/rewardModels/rewardModels/rewardAllowanceValidation.test.ts
+++ b/shared/models/rewardModels/rewardModels/rewardAllowanceValidation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { RewardType } from "./rewardEnums.js";
+import { CreateRewardSchema } from "./rewardModels.js";
+
+const base = {
+	name: "Zero Grant",
+	id: "zero-grant",
+	type: RewardType.FeatureGrant,
+	promo_codes: [{ code: "ZERO" }],
+};
+
+const parse = (allowance?: number) =>
+	CreateRewardSchema.safeParse({
+		...base,
+		entitlements: [
+			{
+				internal_feature_id: "if_credits",
+				...(allowance === undefined ? {} : { allowance }),
+			},
+		],
+	}).success;
+
+describe("dashboard reward entitlement allowance", () => {
+	test("accepts zero", () => {
+		expect(parse(0)).toBe(true);
+	});
+
+	test("accepts positive", () => {
+		expect(parse(500)).toBe(true);
+	});
+
+	test("rejects negative", () => {
+		expect(parse(-1)).toBe(false);
+	});
+
+	test("accepts omitted for boolean grants", () => {
+		expect(parse()).toBe(true);
+	});
+});

--- a/shared/models/rewardModels/rewardModels/rewardModels.ts
+++ b/shared/models/rewardModels/rewardModels/rewardModels.ts
@@ -17,7 +17,7 @@ const PromoCodeSchema = z.object({
 const RewardEntitlementSchema = z.object({
 	internal_feature_id: z.string().min(1),
 	// Optional: boolean features grant on/off access with no allowance
-	allowance: z.number().positive().optional(),
+	allowance: z.number().nonnegative().optional(),
 	expiry: EntitlementExpirySchema.optional(),
 });
 


### PR DESCRIPTION
Creating a feature grant with a balance of `0` from the dashboard failed with:

```
[Validation Errors] entitlements.0.allowance: Too small: expected number to be >0
Feature grant rewards require at least one entitlement
```

#2664 and #2667 fixed the frontend, but the dashboard posts to a **different schema** than the public API. There are two:

- `shared/api/rewards/components/apiGrantV0.ts` — public API. `included: z.number().nullable()`, already accepts `0` (covered by `rewardsGrantValidation.test.ts`).
- `shared/models/rewardModels/rewardModels/rewardModels.ts` — dashboard, used by `handleCreateCoupon`. Had `allowance: z.number().positive()`, which rejects `0`.

The second error line was a knock-on: the entitlement failed validation, the array emptied, and the `length > 0` refine fired too.

## Changes

- `rewardModels.ts` — `.positive()` → `.nonnegative()`, matching the public API contract
- `rewardUtils.ts` (`constructReward`) — `!ent.allowance || ent.allowance <= 0` → `ent.allowance == null || ent.allowance < 0`
- `grantRewardEntitlements.ts` — same condition change; error messages updated to say "non-negative"
- `rewardEntitlementRows.ts` — `hasAllowance` `> 0` → `>= 0`. This one mattered: a `0` would otherwise persist as `allowance_type: None, allowance: null`, silently becoming a boolean-style grant instead of a zero-balance one.

Boolean features are unaffected — they're gated on feature type, not on the numeric value.

## Testing

Added `rewardAllowanceValidation.test.ts` covering zero, positive, negative, and omitted allowances against `CreateRewardSchema`.

Verified by parsing payloads through the real schema: zero and positive accepted, negative rejected, omitted accepted. Reverting the schema change reproduces the reported error exactly (`Too small: expected number to be >0` plus the cascading entitlement message), confirming the fix is load-bearing.

`bun ts` clean on `server`. Biome clean on the touched files (the remaining warnings in `rewardUtils.ts` lines 142-319 are pre-existing; the only edit here is line 76).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow zero allowances when creating feature grant rewards from the dashboard. Aligns the dashboard schema with the public API and prevents zero-value grants from being treated as boolean grants.

- **Bug Fixes**
  - Changed dashboard `RewardEntitlementSchema` to `allowance: z.number().nonnegative().optional()` to match the public API.
  - Updated checks in `constructReward` and `grantRewardEntitlements` to allow `0` and reject negatives; error messages now say “non-negative”.
  - Persist zero allowances by treating `>= 0` as having an allowance in `rewardToEntitlementRows`.
  - Added tests covering zero, positive, negative, and omitted allowances for `CreateRewardSchema`.

<sup>Written for commit 4d6b505136e3ac94c9ef066a85de2fada450b402. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes dashboard-created feature grants so a zero allowance is accepted and remains a numeric zero throughout validation, persistence, and granting.

- **Bug fixes, API changes:** Allow dashboard reward schemas and server-side reward validation to accept non-negative allowances.
- **Bug fixes:** Preserve zero as a fixed allowance instead of converting it into a no-allowance grant.
- **Improvements:** Add schema tests covering zero, positive, negative, and omitted allowances.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with zero allowances consistently accepted and preserved through the dashboard reward flow.

The changed validation, persistence, and grant paths consistently distinguish a fixed zero allowance from an omitted Boolean allowance, and no blocking or independently actionable issue remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/actions/grantRewardEntitlements.ts | Permits zero for non-Boolean feature grants while continuing to reject missing and negative allowances. |
| server/src/internal/rewards/repos/rewardEntitlementRows.ts | Persists zero as a fixed allowance rather than collapsing it to a null no-allowance representation. |
| server/src/internal/rewards/rewardUtils.ts | Aligns reward construction validation with the non-negative dashboard contract. |
| shared/models/rewardModels/rewardModels/rewardAllowanceValidation.test.ts | Adds focused schema coverage for zero, positive, negative, and omitted allowance values. |
| shared/models/rewardModels/rewardModels/rewardModels.ts | Changes the dashboard reward entitlement schema from positive-only to non-negative allowances. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Dashboard reward request] --> B[CreateRewardSchema]
  B --> C[Feature-aware reward validation]
  C --> D[Reward entitlement row]
  D --> E[Fixed allowance: 0]
  E --> F[Customer grant balance: 0]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: accept zero allowance on the dashbo..."](https://github.com/useautumn/autumn/commit/4d6b505136e3ac94c9ef066a85de2fada450b402) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51213176)</sub>

<!-- /greptile_comment -->