### PR TITLE
fix: keep boolean feature grants allowance-free when zero is supplied

### DIFF
--- a/server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts
+++ b/server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts
@@ -137,6 +137,7 @@ export const handleUpdateCoupon = createRoute({
 			env,
 			orgId: org.id,
 			update: rewardBody,
+			features: ctx.features,
 		});
 
 		return c.json(updatedCoupon);

--- a/server/src/internal/rewards/actions/createReward.ts
+++ b/server/src/internal/rewards/actions/createReward.ts
@@ -83,5 +83,5 @@ export const createReward = async ({
 		}
 	}
 
-	return rewardRepo.insert({ db, data: reward });
+	return rewardRepo.insert({ db, data: reward, features: ctx.features });
 };

--- a/server/src/internal/rewards/actions/rewardCrud/updateApiReward.ts
+++ b/server/src/internal/rewards/actions/rewardCrud/updateApiReward.ts
@@ -276,6 +276,7 @@ export const updateApiReward = async ({
 			Object.keys(rewardColumns).length > 0
 				? update
 				: { ...update, name: reward.name },
+		features,
 	});
 
 	// Re-read: the update only returns joined entitlements when it rewrote them

--- a/server/src/internal/rewards/repos/insertReward.ts
+++ b/server/src/internal/rewards/repos/insertReward.ts
@@ -1,4 +1,9 @@
-import { entitlements, type Reward, rewards } from "@autumn/shared";
+import {
+	entitlements,
+	type Feature,
+	type Reward,
+	rewards,
+} from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import {
 	type RewardWithEntitlementInputs,
@@ -9,9 +14,11 @@ import {
 export const insertReward = async ({
 	db,
 	data,
+	features,
 }: {
 	db: DrizzleCli;
 	data: RewardWithEntitlementInputs | RewardWithEntitlementInputs[];
+	features?: Feature[];
 }) => {
 	const rewardsToInsert = Array.isArray(data) ? data : [data];
 	const rewardData = rewardsToInsert.map((reward) => {
@@ -19,7 +26,7 @@ export const insertReward = async ({
 		return rewardRow;
 	});
 	const entitlementRows = rewardsToInsert.flatMap((reward) =>
-		rewardToEntitlementRows({ reward }),
+		rewardToEntitlementRows({ reward, features }),
 	);
 
 	const insertedRewards = await db

--- a/server/src/internal/rewards/repos/rewardEntitlementRows.ts
+++ b/server/src/internal/rewards/repos/rewardEntitlementRows.ts
@@ -1,6 +1,9 @@
 import {
 	AllowanceType,
 	type Entitlement,
+	type Feature,
+	FeatureType,
+	findFeatureByInternalId,
 	type Reward,
 	type RewardEntitlement,
 } from "@autumn/shared";
@@ -16,16 +19,24 @@ export type RewardWithEntitlementInputs = Partial<
 
 export const rewardToEntitlementRows = ({
 	reward,
+	features,
 }: {
 	reward: RewardWithEntitlementInputs;
+	features?: Feature[];
 }): Entitlement[] => {
 	const entitlements = reward.entitlements ?? [];
 
 	return entitlements.map((entitlement) => {
 		const expiry = "expiry" in entitlement ? entitlement.expiry : undefined;
-		// Boolean grants carry no allowance
+		// Boolean grants carry no allowance, whatever the payload says
+		const isBoolean =
+			features != null &&
+			findFeatureByInternalId({
+				features,
+				internalId: entitlement.internal_feature_id,
+			})?.type === FeatureType.Boolean;
 		const hasAllowance =
-			entitlement.allowance != null && entitlement.allowance >= 0;
+			!isBoolean && entitlement.allowance != null && entitlement.allowance >= 0;
 
 		return {
 			id:

--- a/server/src/internal/rewards/repos/updateReward.ts
+++ b/server/src/internal/rewards/repos/updateReward.ts
@@ -2,6 +2,7 @@ import {
 	type AppEnv,
 	ErrCode,
 	entitlements,
+	type Feature,
 	RecaseError,
 	type Reward,
 	rewards,
@@ -20,12 +21,14 @@ export const updateReward = async ({
 	env,
 	orgId,
 	update,
+	features,
 }: {
 	db: DrizzleCli;
 	internalId: string;
 	env: AppEnv;
 	orgId: string;
 	update: Partial<RewardWithEntitlementInputs>;
+	features?: Feature[];
 }) => {
 	const { entitlements: entitlementInputs, ...rewardUpdate } = update;
 
@@ -59,6 +62,7 @@ export const updateReward = async ({
 				entitlements: entitlementInputs,
 				org_id: orgId,
 			},
+			features,
 		});
 
 		if (entitlementRows.length > 0) {

--- a/server/tests/unit/rewards/rewardEntitlementRows.test.ts
+++ b/server/tests/unit/rewards/rewardEntitlementRows.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { AllowanceType, type Feature, FeatureType } from "@autumn/shared";
+import { rewardToEntitlementRows } from "@/internal/rewards/repos/rewardEntitlementRows.js";
+
+const metered = {
+	internal_id: "fe_metered",
+	id: "credits",
+	type: FeatureType.Metered,
+} as unknown as Feature;
+
+const boolean = {
+	internal_id: "fe_bool",
+	id: "dashboard",
+	type: FeatureType.Boolean,
+} as unknown as Feature;
+
+const features = [metered, boolean];
+
+const rowsFor = ({
+	internalFeatureId,
+	allowance,
+}: {
+	internalFeatureId: string;
+	allowance?: number;
+}) =>
+	rewardToEntitlementRows({
+		reward: {
+			internal_id: "rew_1",
+			org_id: "org_1",
+			entitlements: [
+				{
+					internal_feature_id: internalFeatureId,
+					...(allowance === undefined ? {} : { allowance }),
+				},
+			],
+		},
+		features,
+	})[0];
+
+describe("rewardToEntitlementRows allowance mapping", () => {
+	test("zero allowance persists as fixed, not none", () => {
+		const row = rowsFor({ internalFeatureId: "fe_metered", allowance: 0 });
+		expect(row.allowance_type).toBe(AllowanceType.Fixed);
+		expect(row.allowance).toBe(0);
+	});
+
+	test("positive allowance persists as fixed", () => {
+		const row = rowsFor({ internalFeatureId: "fe_metered", allowance: 500 });
+		expect(row.allowance_type).toBe(AllowanceType.Fixed);
+		expect(row.allowance).toBe(500);
+	});
+
+	test("omitted allowance persists as none", () => {
+		const row = rowsFor({ internalFeatureId: "fe_metered" });
+		expect(row.allowance_type).toBe(AllowanceType.None);
+		expect(row.allowance).toBeNull();
+	});
+
+	test("boolean feature stays none even when zero is supplied", () => {
+		const row = rowsFor({ internalFeatureId: "fe_bool", allowance: 0 });
+		expect(row.allowance_type).toBe(AllowanceType.None);
+		expect(row.allowance).toBeNull();
+	});
+
+	test("boolean feature stays none even when a positive amount is supplied", () => {
+		const row = rowsFor({ internalFeatureId: "fe_bool", allowance: 100 });
+		expect(row.allowance_type).toBe(AllowanceType.None);
+		expect(row.allowance).toBeNull();
+	});
+});


### PR DESCRIPTION
Follow-up to #2673, which merged with an unaddressed P2 review comment. That comment was correct.

## The bug

`#2673` widened `hasAllowance` to `>= 0` so zero-amount grants persist as `fixed/0`. But that mapper has no feature-type context, so a **boolean** feature sent with `allowance: 0` also persisted as `allowance_type: fixed, allowance: 0` instead of `none/null`.

The PR description for #2673 claimed boolean features were gated on feature type. That was only half true: `constructReward` gates the *validation* (skipping the non-negative check for booleans), but nothing gated the *persistence*. And `constructReward` is only on the create path — `rewardCrud` update bypasses it entirely.

Reproduced against a running server before fixing:

```
POST /v1/rewards  boolean feature, allowance: 0
-> "allowance_type":"fixed","allowance":0     # wrong
```

## Fix

`rewardToEntitlementRows` is the single choke point both insert and update share, so the gate belongs there:

- `rewardEntitlementRows.ts` — takes an optional `features` array and resolves the feature type; boolean features get `none/null` regardless of the payload value
- `insertReward.ts` / `updateReward.ts` — accept and forward `features`
- `createReward.ts`, `updateApiReward.ts`, `handleUpdateCoupon.ts` — pass `ctx.features`

`features` is optional so the migration-task call site keeps its current behaviour rather than silently changing under a code path this PR doesn't cover.

## Testing

Added `server/tests/unit/rewards/rewardEntitlementRows.test.ts` — 5 cases covering zero/positive/omitted on a metered feature and zero/positive on a boolean. Verified the two boolean cases fail without the gate and pass with it, so the coverage is real rather than tautological.

End-to-end against a local server on a seeded DB, create path:

| case | result |
|---|---|
| boolean + `allowance: 0` | `none/null` |
| metered + `allowance: 0` | `fixed/0` |
| metered + `allowance: 250` | `fixed/250` |
| boolean, omitted | `none/null` |
| metered + `allowance: -5` | rejected |

Update path (the one #2673 never exercised):

| case | result |
|---|---|
| metered `250 -> 0` | `fixed/0` |
| boolean + `allowance: 0` | `none/null` |

`bun ts` clean on `server`. Biome clean on the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes allowance mapping so boolean feature grants never store an allowance, even when `allowance: 0` is sent. Metered features still persist `fixed/0`. Applies to both create and update paths.

- **Bug Fixes**
  - Gate allowance mapping by feature type in `rewardToEntitlementRows`; booleans always map to `AllowanceType.None`/`null`.
  - Thread `features` through `createReward`, `insertReward`, `updateApiReward`, `updateReward`, and `handleUpdateCoupon` to provide feature context.
  - Add unit tests covering metered (zero/positive/omitted) and boolean (zero/positive) cases.

<sup>Written for commit 8d6b4828c0a5b395771fbd4b0f6d82ba0448922e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes reward persistence so boolean feature grants remain allowance-free while metered grants retain an explicitly supplied zero allowance.

- **Bug fixes:** Resolve each reward entitlement’s feature type at the shared insert/update mapping boundary and persist boolean grants as `none/null`.
- **Improvements:** Forward feature metadata through reward creation, API updates, and coupon updates while preserving existing migration behavior.
- **Improvements:** Add focused unit coverage for omitted, zero, and positive allowances on metered and boolean features.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intended boolean and metered allowance behavior consistently applied across current production create and update paths.

The shared persistence mapper now uses feature type to remove allowances from boolean grants, all production entitlement-writing callers provide the required feature metadata, and the remaining caller without metadata does not rewrite entitlements.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/rewards/repos/rewardEntitlementRows.ts | Adds feature-type-aware allowance mapping at the shared entitlement persistence boundary without changing metered zero-allowance behavior. |
| server/src/internal/rewards/repos/insertReward.ts | Accepts optional feature metadata and forwards it when converting inserted rewards into entitlement rows. |
| server/src/internal/rewards/repos/updateReward.ts | Forwards feature metadata when entitlement rows are rewritten during reward updates. |
| server/src/internal/rewards/actions/createReward.ts | Supplies request-context features to reward insertion on the create path. |
| server/src/internal/rewards/actions/rewardCrud/updateApiReward.ts | Supplies the validated environment feature list to persistence on API reward updates. |
| server/src/internal/api/rewards/handlers/rewards/handleUpdateCoupon.ts | Supplies request-context features to the coupon update repository call. |
| server/tests/unit/rewards/rewardEntitlementRows.test.ts | Covers metered and boolean allowance mapping for zero, positive, and omitted values. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Create or update reward] --> B[Forward environment features]
    B --> C[Map reward entitlements]
    C --> D{Feature type is boolean?}
    D -->|Yes| E[Persist none / null]
    D -->|No, allowance supplied| F[Persist fixed / amount]
    D -->|No allowance| E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: keep boolean feature grants allowan..."](https://github.com/useautumn/autumn/commit/8d6b4828c0a5b395771fbd4b0f6d82ba0448922e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51237162)</sub>

<!-- /greptile_comment -->