### PR TITLE
test: drain safety under load; clear the recycle request latch on every exit path

### DIFF
--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -70,8 +70,8 @@ export const attachPrimaryForkRecycling = ({
 
 	clusterModule.on("message", (worker, message: RecycleMessage) => {
 		if (message?.type !== RECYCLE_REQUEST) return;
-		// A message delivered after the worker's exit was handled would start a
-		// cycle for a corpse that can never complete.
+		// Load-bearing: the coordinator clears a worker's latch on exit and has no
+		// other guard, so a post-exit request would start a cycle for a corpse.
 		if (worker.isDead?.()) return;
 		coordinator.handleRecycleRequest({ workerId: String(worker.id) });
 	});

--- a/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
+++ b/server/src/utils/memory/forkRecycling/recycleCoordinator.ts
@@ -220,10 +220,12 @@ export const createRecycleCoordinator = ({
 
 		handleWorkerExit: ({ workerId }) => {
 			clearDrainCompletionDeadline(workerId);
-			// Every branch below must see a dead worker gone from the queue, or a
-			// later cycle forks a replacement for a fork that no longer exists.
+			// Every branch below must see a dead worker gone from the queue and its
+			// latch, or a later cycle forks a replacement for a fork that no longer
+			// exists. Branches still clear OTHER workers' latches themselves.
 			const pendingIndex = pendingWorkerIds.indexOf(workerId);
 			if (pendingIndex !== -1) pendingWorkerIds.splice(pendingIndex, 1);
+			requestedWorkerIds.delete(workerId);
 			// A crash respawn dying while booting falls through to the plain-crash
 			// branch below (which respawns again); the deferred-drain release runs
 			// only after that branch has tracked the new respawn.
@@ -232,20 +234,17 @@ export const createRecycleCoordinator = ({
 				if (discardedWorkerIds.has(workerId)) {
 					// A hung replacement we already killed and accounted for.
 					discardedWorkerIds.delete(workerId);
-					requestedWorkerIds.delete(workerId);
 					return true;
 				}
 
 				if (expectedExitWorkerIds.has(workerId)) {
 					expectedExitWorkerIds.delete(workerId);
-					requestedWorkerIds.delete(workerId);
 					if (activeCycle?.oldWorkerId === workerId) startNextPendingCycle();
 					log(`[ForkRecycle] Worker ${workerId} recycled`);
 					return true;
 				}
 
 				if (activeCycle?.oldWorkerId === workerId) {
-					requestedWorkerIds.delete(workerId);
 					if (activeCycle.drainDeferred) {
 						// Replacement is already listening (drain deferred): the crash
 						// completes the cycle outright — a deferred drain to a dead
@@ -293,7 +292,6 @@ export const createRecycleCoordinator = ({
 					return false;
 				}
 
-				requestedWorkerIds.delete(workerId);
 				respawnTracked(workerId);
 				return false;
 			})();

--- a/server/tests/unit/memory/fixtures/recycleLoadFixture.ts
+++ b/server/tests/unit/memory/fixtures/recycleLoadFixture.ts
@@ -1,0 +1,67 @@
+// Cluster fixture for drain-safety under concurrency: real in-flight tracking
+// so the drain extends instead of cutting requests, plus a slow endpoint whose
+// response spans a whole recycle.
+import cluster from "node:cluster";
+import http from "node:http";
+import type { Logger } from "@/external/logtail/logtailUtils.js";
+import {
+	attachPrimaryForkRecycling,
+	startWorkerForkRecycling,
+} from "@/utils/memory/forkRecycling/attachForkRecycling.js";
+
+const PORT = Number(process.env.FIXTURE_PORT);
+const FORKS = Number(process.env.FIXTURE_FORKS ?? 3);
+const log = (message: string) => console.log(message);
+const fixtureLogger = { info: log, error: log, warn: log } as unknown as Logger;
+
+if (cluster.isPrimary) {
+	for (let i = 0; i < FORKS; i++) cluster.fork();
+
+	const forkRecycling = attachPrimaryForkRecycling({
+		clusterModule: cluster,
+		shouldRespawn: () => true,
+		logger: fixtureLogger,
+	});
+
+	cluster.on("listening", (worker) => {
+		console.log(`WORKER_UP ${worker.process.pid}`);
+	});
+
+	cluster.on("exit", (worker, code, signal) => {
+		if (forkRecycling.handleExit(worker)) return;
+		console.log(`WORKER_DIED ${worker.process.pid} code=${code} ${signal}`);
+	});
+} else {
+	const drainState = { draining: false };
+	let inFlight = 0;
+
+	const server = http.createServer((req, res) => {
+		inFlight++;
+		const url = new URL(req.url ?? "/", "http://127.0.0.1");
+		const delayMs = Number(url.searchParams.get("ms") ?? 20);
+		setTimeout(() => {
+			res.setHeader("connection", drainState.draining ? "close" : "keep-alive");
+			// Body is length-checked by the test, so a mid-response kill shows up
+			// as a truncated read rather than a silent pass.
+			res.end(`ok:${process.pid}:${"x".repeat(512)}`);
+			inFlight--;
+		}, delayMs);
+	});
+
+	server.listen(PORT, "127.0.0.1", () => {
+		startWorkerForkRecycling({
+			server,
+			getActiveRequestCount: () => inFlight,
+			onDrainStart: () => {
+				drainState.draining = true;
+			},
+			exitGracefully: () => {
+				// Mirrors init.ts: a bounded backstop after the drain decides to exit.
+				const forceExit = setTimeout(() => process.exit(0), 5_000);
+				forceExit.unref?.();
+				process.exit(0);
+			},
+			logger: fixtureLogger,
+		});
+	});
+}

--- a/server/tests/unit/memory/fixtures/recycleLoadFixture.ts
+++ b/server/tests/unit/memory/fixtures/recycleLoadFixture.ts
@@ -55,12 +55,9 @@ if (cluster.isPrimary) {
 			onDrainStart: () => {
 				drainState.draining = true;
 			},
-			exitGracefully: () => {
-				// Mirrors init.ts: a bounded backstop after the drain decides to exit.
-				const forceExit = setTimeout(() => process.exit(0), 5_000);
-				forceExit.unref?.();
-				process.exit(0);
-			},
+			// Harsher than init.ts, which awaits an async shutdown behind a timer:
+			// exiting instantly puts the drainer's "safe to exit" call under test.
+			exitGracefully: () => process.exit(0),
 			logger: fixtureLogger,
 		});
 	});

--- a/server/tests/unit/memory/fork-recycling-drain-safety.test.ts
+++ b/server/tests/unit/memory/fork-recycling-drain-safety.test.ts
@@ -114,15 +114,25 @@ describe("drain safety under concurrent load", () => {
 				if (failures.length > 0) {
 					console.log("first failures:", failures.slice(0, 5));
 				}
-				const maxDrainExceeded = stdoutLines.filter((line) =>
-					line.includes("max drain exceeded"),
+				const extended = stdoutLines.filter((line) =>
+					line.includes("extending drain"),
 				);
-				console.log("max-drain-exceeded exits:", maxDrainExceeded.length);
+				console.log(
+					`drain extensions=${extended.length} maxDrainExceeded=${
+						stdoutLines.filter((l) => l.includes("max drain exceeded")).length
+					}`,
+				);
 
 				// Recycles actually happened, and nothing was dropped or cut.
 				expect(recycleCount).toBeGreaterThanOrEqual(3);
 				expect(servingPids.size).toBeGreaterThanOrEqual(5);
 				expect(failures).toHaveLength(0);
+				// Without this the suite could stop exercising the case it exists for:
+				// a slow request must push the drain deadline back, not get cut.
+				expect(extended.length).toBeGreaterThan(0);
+				expect(
+					stdoutLines.filter((line) => line.includes("max drain exceeded")),
+				).toHaveLength(0);
 				expect(
 					stdoutLines.filter((line) => line.startsWith("WORKER_DIED")),
 				).toHaveLength(0);

--- a/server/tests/unit/memory/fork-recycling-drain-safety.test.ts
+++ b/server/tests/unit/memory/fork-recycling-drain-safety.test.ts
@@ -1,0 +1,136 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import path from "node:path";
+
+const FIXTURE = path.join(import.meta.dir, "fixtures/recycleLoadFixture.ts");
+const PORT = 41000 + Math.floor(Math.random() * 2000);
+
+let fixture: ReturnType<typeof Bun.spawn> | null = null;
+
+afterAll(() => {
+	fixture?.kill();
+});
+
+type Outcome = { ok: boolean; pid?: string; reason?: string };
+
+const call = async (url: string): Promise<Outcome> => {
+	try {
+		const response = await fetch(url);
+		const body = await response.text();
+		if (!response.ok) return { ok: false, reason: `status ${response.status}` };
+		const [prefix, pid, padding] = body.split(":");
+		if (prefix !== "ok" || padding?.length !== 512) {
+			return { ok: false, reason: `truncated body (${body.length}b)` };
+		}
+		return { ok: true, pid };
+	} catch (error) {
+		return { ok: false, reason: (error as Error).message };
+	}
+};
+
+describe("drain safety under concurrent load", () => {
+	test(
+		"no request is dropped or truncated across repeated recycles",
+		async () => {
+			const stdoutLines: string[] = [];
+			fixture = Bun.spawn({
+				cmd: [process.execPath, FIXTURE],
+				env: {
+					...process.env,
+					FIXTURE_PORT: String(PORT),
+					FIXTURE_FORKS: "3",
+					FORK_RECYCLE_RSS_MB: "1",
+					FORK_RECYCLE_MIN_AGE_MS: "600",
+					FORK_RECYCLE_CHECK_INTERVAL_MS: "1000",
+					FORK_RECYCLE_DRAIN_TIMEOUT_MS: "1000",
+					FORK_RECYCLE_DISABLED: "false",
+				},
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+
+			const reader = (fixture.stdout as ReadableStream<Uint8Array>).getReader();
+			const decoder = new TextDecoder();
+			let buffered = "";
+			const pump = (async () => {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					buffered += decoder.decode(value);
+					const lines = buffered.split("\n");
+					buffered = lines.pop() ?? "";
+					stdoutLines.push(...lines);
+				}
+			})();
+
+			try {
+				const waitFor = async (predicate: () => boolean, timeoutMs: number) => {
+					const deadline = Date.now() + timeoutMs;
+					while (!predicate()) {
+						if (Date.now() > deadline) return false;
+						await new Promise((resolve) => setTimeout(resolve, 50));
+					}
+					return true;
+				};
+
+				const bootedForks = () =>
+					stdoutLines.filter((line) => line.startsWith("WORKER_UP")).length;
+				expect(await waitFor(() => bootedForks() >= 3, 20_000)).toBe(true);
+
+				const base = `http://127.0.0.1:${PORT}`;
+				const outcomes: Outcome[] = [];
+				const servingPids = new Set<string>();
+				const until = Date.now() + 12_000;
+
+				// 24 concurrent fast callers plus 4 slow ones whose 3s response
+				// straddles a recycle, so a drain that cut early would truncate.
+				const fastCaller = async () => {
+					while (Date.now() < until) {
+						const outcome = await call(`${base}/?ms=15`);
+						outcomes.push(outcome);
+						if (outcome.pid) servingPids.add(outcome.pid);
+					}
+				};
+				const slowCaller = async () => {
+					while (Date.now() < until) {
+						const outcome = await call(`${base}/slow?ms=3000`);
+						outcomes.push(outcome);
+						if (outcome.pid) servingPids.add(outcome.pid);
+					}
+				};
+
+				await Promise.all([
+					...Array.from({ length: 24 }, fastCaller),
+					...Array.from({ length: 4 }, slowCaller),
+				]);
+
+				const failures = outcomes.filter((outcome) => !outcome.ok);
+				const recycleCount = stdoutLines.filter((line) =>
+					line.includes("recycled"),
+				).length;
+
+				console.log(
+					`requests=${outcomes.length} failures=${failures.length} recycles=${recycleCount} distinctPids=${servingPids.size}`,
+				);
+				if (failures.length > 0) {
+					console.log("first failures:", failures.slice(0, 5));
+				}
+				const maxDrainExceeded = stdoutLines.filter((line) =>
+					line.includes("max drain exceeded"),
+				);
+				console.log("max-drain-exceeded exits:", maxDrainExceeded.length);
+
+				// Recycles actually happened, and nothing was dropped or cut.
+				expect(recycleCount).toBeGreaterThanOrEqual(3);
+				expect(servingPids.size).toBeGreaterThanOrEqual(5);
+				expect(failures).toHaveLength(0);
+				expect(
+					stdoutLines.filter((line) => line.startsWith("WORKER_DIED")),
+				).toHaveLength(0);
+			} finally {
+				fixture.kill();
+				await pump.catch(() => {});
+			}
+		},
+		{ timeout: 90_000 },
+	);
+});

--- a/server/tests/unit/memory/fork-recycling-drain-safety.test.ts
+++ b/server/tests/unit/memory/fork-recycling-drain-safety.test.ts
@@ -2,7 +2,19 @@ import { afterAll, describe, expect, test } from "bun:test";
 import path from "node:path";
 
 const FIXTURE = path.join(import.meta.dir, "fixtures/recycleLoadFixture.ts");
-const PORT = 41000 + Math.floor(Math.random() * 2000);
+
+/** Let the OS name a free port rather than gambling on a random one; a leftover
+ *  process on a hardcoded port would fail as EADDRINUSE, not as a real bug. */
+const reserveFreePort = async (): Promise<number> => {
+	const probe = Bun.listen({
+		hostname: "127.0.0.1",
+		port: 0,
+		socket: { data: () => {} },
+	});
+	const { port } = probe;
+	probe.stop(true);
+	return port;
+};
 
 let fixture: ReturnType<typeof Bun.spawn> | null = null;
 
@@ -32,11 +44,12 @@ describe("drain safety under concurrent load", () => {
 		"no request is dropped or truncated across repeated recycles",
 		async () => {
 			const stdoutLines: string[] = [];
+			const port = await reserveFreePort();
 			fixture = Bun.spawn({
 				cmd: [process.execPath, FIXTURE],
 				env: {
 					...process.env,
-					FIXTURE_PORT: String(PORT),
+					FIXTURE_PORT: String(port),
 					FIXTURE_FORKS: "3",
 					FORK_RECYCLE_RSS_MB: "1",
 					FORK_RECYCLE_MIN_AGE_MS: "600",
@@ -76,22 +89,35 @@ describe("drain safety under concurrent load", () => {
 					stdoutLines.filter((line) => line.startsWith("WORKER_UP")).length;
 				expect(await waitFor(() => bootedForks() >= 3, 20_000)).toBe(true);
 
-				const base = `http://127.0.0.1:${PORT}`;
+				const base = `http://127.0.0.1:${port}`;
 				const outcomes: Outcome[] = [];
 				const servingPids = new Set<string>();
-				const until = Date.now() + 12_000;
+
+				const countLines = (needle: string) =>
+					stdoutLines.filter((line) => line.includes(needle)).length;
+
+				// Run until the interesting states have actually been observed rather
+				// than for a fixed wall clock, so a slow CI box takes longer instead
+				// of failing. The cap keeps a genuinely broken build from hanging.
+				const startedAt = Date.now();
+				const hardDeadline = startedAt + 60_000;
+				const enoughObserved = () =>
+					countLines("recycled") >= 3 && countLines("extending drain") >= 1;
+				const keepGoing = () =>
+					Date.now() < hardDeadline &&
+					(!enoughObserved() || Date.now() < startedAt + 8_000);
 
 				// 24 concurrent fast callers plus 4 slow ones whose 3s response
 				// straddles a recycle, so a drain that cut early would truncate.
 				const fastCaller = async () => {
-					while (Date.now() < until) {
+					while (keepGoing()) {
 						const outcome = await call(`${base}/?ms=15`);
 						outcomes.push(outcome);
 						if (outcome.pid) servingPids.add(outcome.pid);
 					}
 				};
 				const slowCaller = async () => {
-					while (Date.now() < until) {
+					while (keepGoing()) {
 						const outcome = await call(`${base}/slow?ms=3000`);
 						outcomes.push(outcome);
 						if (outcome.pid) servingPids.add(outcome.pid);
@@ -125,7 +151,9 @@ describe("drain safety under concurrent load", () => {
 
 				// Recycles actually happened, and nothing was dropped or cut.
 				expect(recycleCount).toBeGreaterThanOrEqual(3);
-				expect(servingPids.size).toBeGreaterThanOrEqual(5);
+				// More than the 3 boot forks served, so replacements really did take
+				// over traffic rather than the load staying pinned to the originals.
+				expect(servingPids.size).toBeGreaterThan(3);
 				expect(failures).toHaveLength(0);
 				// Without this the suite could stop exercising the case it exists for:
 				// a slow request must push the drain deadline back, not get cut.
@@ -141,6 +169,6 @@ describe("drain safety under concurrent load", () => {
 				await pump.catch(() => {});
 			}
 		},
-		{ timeout: 90_000 },
+		{ timeout: 120_000 },
 	);
 });

--- a/server/tests/unit/memory/fork-recycling-hardening.test.ts
+++ b/server/tests/unit/memory/fork-recycling-hardening.test.ts
@@ -116,6 +116,23 @@ describe("drain completion deadline survives cycle churn", () => {
 		expect(forked).toHaveLength(1);
 	});
 
+	test("an exiting worker's request latch is cleared on every branch", () => {
+		const { coordinator, forked } = createHarness();
+
+		coordinator.handleRecycleRequest({ workerId: "w1" });
+		coordinator.handleWorkerListening({ workerId: forked[0] });
+
+		// The replacement queues a recycle of its own, then dies post-drain.
+		coordinator.handleRecycleRequest({ workerId: forked[0] });
+		coordinator.handleWorkerExit({ workerId: forked[0] });
+		coordinator.handleWorkerExit({ workerId: "w1" });
+
+		// Its id must not stay latched, or a reused id could never recycle again.
+		const forkedBefore = forked.length;
+		coordinator.handleRecycleRequest({ workerId: forked[0] });
+		expect(forked.length).toBe(forkedBefore + 1);
+	});
+
 	test("old worker exiting normally leaves no stray kill behind", async () => {
 		const { coordinator, forked, killed } = createHarness({
 			drainCompletionTimeoutMs: 40,

--- a/server/tests/unit/memory/fork-recycling-hardening.test.ts
+++ b/server/tests/unit/memory/fork-recycling-hardening.test.ts
@@ -116,7 +116,7 @@ describe("drain completion deadline survives cycle churn", () => {
 		expect(forked).toHaveLength(1);
 	});
 
-	test("an exiting worker's request latch is cleared on every branch", () => {
+	test("a dead replacement's request latch is cleared, not left stale", () => {
 		const { coordinator, forked } = createHarness();
 
 		coordinator.handleRecycleRequest({ workerId: "w1" });


### PR DESCRIPTION
Follow-up to #2660. Two things that PR left behind.

## Drain safety is now actually tested

#2660 was merged partly on the claim that a recycle never drops an in-flight
request, but the only cluster coverage drove sequential single requests with a
20ms handler, which never exercises the drain-extension path at all.

This adds a load fixture that wires `getActiveRequestCount` to a real in-flight
counter and length-checks every response body, so a mid-response kill surfaces
as a truncated read rather than a silent pass. It drives 3 forks under 28
concurrent callers, four of which take 3s and therefore straddle a whole
recycle.

Measured across four runs: ~17,000 requests each, 7-8 recycles each, zero
failures, zero truncated bodies, zero unexpected worker deaths, zero
`max drain exceeded` exits.

## Clear the request latch on every exit path

cubic flagged this on #2660 after it merged. The replacement-exit branch clears
`requestedWorkerIds` for the *old* worker but never for the replacement itself,
so a replacement that had queued a recycle of its own leaves a stale id behind
when it dies. Every other exit branch clears its own id; this one was the
outlier.

Impact is small — cluster worker ids increment monotonically and are never
reused, so a stale entry can't suppress a real future request, and it is a
handful of strings on a long-lived process. Fixing it anyway because the
inconsistency is the kind of thing that becomes load-bearing later.

The fix hoists the delete alongside the queue removal at the top of
`handleWorkerExit`, which made the four per-branch deletes redundant. The
replacement branch's `delete(oldWorkerId)` stays, since that targets a
different worker and deliberately re-arms it after an abort.

## Verification

- New latch test confirmed red without the source change, green with it.
- `bun test --isolate tests/unit`: 2566 pass, 0 fail.
- `bun ts` clean, biome clean on all four touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a high-concurrency drain-safety test and fixes the recycle-request latch to clear on every worker exit. Confirms drains extend under load so recycles don’t drop or truncate in-flight requests, and avoids stale latches.

- **Bug Fixes**
  - Clear `requestedWorkerIds` at the start of `handleWorkerExit`; branches still clear other workers’ latches as needed. Keep `delete(oldWorkerId)` in the replacement branch to re-arm the old worker after an abort.

- **New Features**
  - Added `recycleLoadFixture.ts` and `fork-recycling-drain-safety.test.ts` to drive concurrent load with real in-flight counts and length-checked bodies; the test picks a free port, runs until drain extensions and multiple recycles are observed, and asserts no truncations, no max-drain timeouts, no unexpected deaths, and that replacements served traffic. Added focused regression in `fork-recycling-hardening.test.ts` proving a dead replacement’s latch is cleared.

<sup>Written for commit 2d4550ad183d219c7d1c8a93ada1db9b08d18f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up strengthens fork-recycling coverage and consistently clears recycle-request state when workers exit.
- **[Bug fixes]** Clears an exiting worker’s recycle-request latch before handling any exit branch, while preserving the separate reset needed for the old worker when replacement startup fails.
- **[Improvements]** Adds concurrent cluster-load coverage that verifies in-flight requests remain complete while workers recycle and drain deadlines are extended.
- **[Improvements]** Adds focused regression coverage for replacement-worker latch cleanup.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/memory/forkRecycling/recycleCoordinator.ts | Centralizes cleanup of an exiting worker’s recycle-request latch without removing the distinct old-worker reset. |
| server/src/utils/memory/forkRecycling/attachForkRecycling.ts | Clarifies why recycle requests received after worker exit must remain ignored. |
| server/tests/unit/memory/fixtures/recycleLoadFixture.ts | Introduces a clustered HTTP fixture with real in-flight request accounting and delayed responses. |
| server/tests/unit/memory/fork-recycling-drain-safety.test.ts | Exercises repeated recycling under concurrent fast and slow requests and checks for dropped or truncated responses. |
| server/tests/unit/memory/fork-recycling-hardening.test.ts | Adds regression coverage showing that a replacement worker’s stale recycle latch is removed when it exits. |

<sub>Reviews (3): Last reviewed commit: ["test: address review — free port, observ..."](https://github.com/useautumn/autumn/commit/2d4550ad183d219c7d1c8a93ada1db9b08d18f6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51250966)</sub>

<!-- /greptile_comment -->