### PR TITLE
fix(ui): align customer export menu trigger with migrations

### DIFF
--- a/vite/src/views/customers2/components/table/customer-list/CustomerListExportMenu.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListExportMenu.tsx
@@ -17,7 +17,7 @@ export function CustomerListExportMenu() {
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
 					<Button
-						variant="secondary"
+						variant="skeleton"
 						size="icon"
 						type="button"
 						aria-label="More customer actions"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the Customers list export menu trigger to the skeleton button variant to align with the UI migration and match other icon-only actions. This reduces visual weight and keeps the toolbar consistent.

<sup>Written for commit f305ab2ace1c5c21d080622ec90d6bfae4e991c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

