### PR TITLE
fix: emit fork-recycle events via console so FireLens delivers them

### DIFF
--- a/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
+++ b/server/src/utils/memory/forkRecycling/attachForkRecycling.ts
@@ -32,10 +32,10 @@ export const attachPrimaryForkRecycling = ({
 	const sendSafely = (workerId: string, type: string) => {
 		try {
 			workerIds.get(workerId)?.send({ type }, (error) => {
-				if (error) logger.warn(`[ForkRecycle] ${type} -> ${workerId} failed`);
+				if (error) console.warn(`[ForkRecycle] ${type} -> ${workerId} failed`);
 			});
 		} catch {
-			logger.warn(`[ForkRecycle] ${type} -> ${workerId} failed`);
+			console.warn(`[ForkRecycle] ${type} -> ${workerId} failed`);
 		}
 	};
 
@@ -51,7 +51,7 @@ export const attachPrimaryForkRecycling = ({
 			try {
 				workerIds.get(workerId)?.kill();
 			} catch {
-				logger.warn(`[ForkRecycle] kill -> ${workerId} failed`);
+				console.warn(`[ForkRecycle] kill -> ${workerId} failed`);
 			}
 		},
 		respawn: () => {
@@ -60,7 +60,9 @@ export const attachPrimaryForkRecycling = ({
 			workerIds.set(String(worker.id), worker);
 			return String(worker.id);
 		},
-		log: (message) => logger.info(message),
+		// FireLens delivers console output reliably; the logger transport
+		// drops most lines, which hid the first prod recycle wave entirely.
+		log: (message) => console.log(message),
 	});
 
 	clusterModule.on("listening", (worker) => {
@@ -112,7 +114,7 @@ export const startWorkerForkRecycling = ({
 		drainTimeoutMs: config.drainTimeoutMs,
 		getActiveRequestCount,
 		onDrainStart,
-		log: (message) => logger.info(message),
+		log: (message) => console.log(message),
 	});
 
 	process.on("message", (message: RecycleMessage) => {
@@ -123,7 +125,7 @@ export const startWorkerForkRecycling = ({
 		if (message?.type === RECYCLE_ABORT) {
 			// Replacement failed to boot; re-arm so a later check can ask again.
 			requested = false;
-			logger.info(
+			console.log(
 				`[ForkRecycle] Worker ${process.pid} recycle aborted; will re-request if still over threshold`,
 			);
 		}
@@ -144,6 +146,10 @@ export const startWorkerForkRecycling = ({
 		}
 
 		requested = true;
+		console.log(
+			`[ForkRecycle] Worker ${process.pid} requesting recycle at rss=${Math.round(rssBytes / 1024 / 1024)}MB after ${Math.round((Date.now() - startedAt) / 60_000)}min`,
+		);
+		// Keep the structured event for the fraction the logger pipeline delivers.
 		logger.info(
 			`[ForkRecycle] Worker ${process.pid} requesting recycle at rss=${Math.round(rssBytes / 1024 / 1024)}MB after ${Math.round((Date.now() - startedAt) / 60_000)}min`,
 			{


### PR DESCRIPTION
Tonight's first prod recycle wave (~20 tasks) ran completely invisibly: all `[ForkRecycle]` lines go through the structured logger transport, which FireLens drops at memory_log rates (0/100+ lines delivered), while console output ships reliably (183/183 warmup lines today).

One-file change: recycle event lines move to `console.log`/`console.warn`; the structured `fork_recycle_request` logger event is kept alongside for the fraction that survives the pipeline.

Off main so it can deploy without waiting for the next dev train — observability for a mechanism that's now live and cycling in prod.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move fork recycle logs to console to restore visibility in prod. FireLens ships console output reliably; structured logs were being dropped.

- **Bug Fixes**
  - Switch `[ForkRecycle]` messages to `console.log`/`console.warn` in primary and worker paths.
  - Keep structured `fork_recycle_request` via `logger.info` as a secondary signal.
  - Add explicit console logs on recycle request and abort.

<sup>Written for commit a5cd790d6ed5027117767fef6075594a0d5808c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes fork-recycling lifecycle and failure messages through console output so FireLens can deliver them reliably, while preserving the structured recycle-request event as a secondary signal.
- **[Bug fixes]** Sends primary-process recycle events and IPC/kill failures through `console.log` or `console.warn`.
- **[Bug fixes]** Sends worker drain, abort, and recycle-request events through console output.
- **[Improvements]** Retains the structured `fork_recycle_request` event alongside the reliable console message.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional or security issues identified.

The change only redirects existing fork-recycling diagnostics to the output path FireLens reliably delivers and intentionally retains the structured request event as a fallback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/memory/forkRecycling/attachForkRecycling.ts | Redirects fork-recycling operational messages to console output for reliable FireLens delivery without changing recycling behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix: emit fork-recycle events via consol..."](https://github.com/useautumn/autumn/commit/a5cd790d6ed5027117767fef6075594a0d5808c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51288761)</sub>

<!-- /greptile_comment -->