### PR TITLE
feat(website): add RB2B visitor tracking to site head

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Reb2b from "@/components/reb2b";
 import type { LayoutProps } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import "./globals.css";
@@ -95,7 +96,12 @@ export default function RootLayout({ children }: LayoutProps) {
 				"h-full max-w-full overflow-x-clip overscroll-x-none bg-black antialiased",
 			)}
 		>
-			<body className="min-h-full max-w-full overflow-x-clip overscroll-x-none flex flex-col">{children}</body>
+			<head>
+				<Reb2b />
+			</head>
+			<body className="min-h-full max-w-full overflow-x-clip overscroll-x-none flex flex-col">
+				{children}
+			</body>
 		</html>
 	);
 }

--- a/apps/website/components/reb2b.tsx
+++ b/apps/website/components/reb2b.tsx
@@ -1,0 +1,12 @@
+const REB2B_KEY = "4N210HX5V56Z";
+
+const REB2B_SNIPPET = `!function(key) {if (window.reb2b) return;window.reb2b = {loaded: true};var s = document.createElement("script");s.async = true;s.src = "https://ddwl4m2hdecbv.cloudfront.net/b/" + key + "/" + key + ".js.gz";document.getElementsByTagName("script")[0].parentNode.insertBefore(s, document.getElementsByTagName("script")[0]);}("${REB2B_KEY}");`;
+
+export default function Reb2b() {
+	return (
+		<script
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: vendor loader snippet, no user input
+			dangerouslySetInnerHTML={{ __html: REB2B_SNIPPET }}
+		/>
+	);
+}

--- a/apps/website/content/blog/component-fail.mdx
+++ b/apps/website/content/blog/component-fail.mdx
@@ -12,7 +12,7 @@ You know those moments where you have an idea so brilliant you feel like Steve J
 
 Unfortunately, it didn't. We ended up with a weird mess and had to spend the last week rewriting everything.
 
-_For context: we're building Autumn, pricing and billing software. Part of our offering is frontend components for things like a pricing table, paywalls etc. You can read more about them_ [_here_](https://docs.useautumn.com/quickstart/shadcn)_._
+_For context: we're building [Autumn](https://docs.useautumn.com/welcome), pricing and billing software. Part of our offering is frontend components for things like a pricing table, paywalls etc. We wrote about_ [_why we went with shadcn_](/blog/shadcn) _for this._
 
 ### **V1 as a React library**
 
@@ -149,3 +149,5 @@ Maybe we're still trying too hard to be clever but here's the cool part: instead
 ![](https://framerusercontent.com/images/RsmW3zsJedW8xAhbTJljALEvylI.png)
 
 To be honest we have no idea how that script works but it does. Thanks Claude Code!
+
+**Update:** we've since stepped back from maintaining shadcn components and React hooks entirely. Read why in [Saying goodbye to our React hooks and old positioning](/blog/saying-goodbye-to-react-hooks).

--- a/apps/website/content/blog/saying-goodbye-to-react-hooks.mdx
+++ b/apps/website/content/blog/saying-goodbye-to-react-hooks.mdx
@@ -32,7 +32,7 @@ const { allowed } = await check({ featureId: "messages" });
 await attach({ productId: "pro" });
 ```
 
-Alongside them we shipped a set of shadcn/ui components (pricing tables, paywalls, upgrade and downgrade flows) that you installed straight into your codebase and owned as your own files, which was its [own mess](/blog/component-fail).
+Alongside them we shipped a set of [shadcn/ui components](/blog/shadcn) (pricing tables, paywalls, upgrade and downgrade flows) that you installed straight into your codebase and owned as your own files, which was its [own mess](/blog/component-fail).
 
 But our early users liked them! At the time, Cursor tab and short-running agents were the state of the art. The React library was genuinely helpful in integrating faster and cutting "glue code".
 

--- a/apps/website/content/blog/shadcn.mdx
+++ b/apps/website/content/blog/shadcn.mdx
@@ -8,7 +8,9 @@ image: "/images/blog/shadcn.png"
 featured: true
 ---
 
-We're building Autumn, which is a billing platform that helps devs integrate [stripe](/blog/what-if-stripe-builds-this) and manage their pricing model. One feature of this is a UI library to drop-in things like a pricing table, upgrade/downgrade flows, paywalls--similar to Clerk with auth.
+[Read the updated version of this article](/blog/saying-goodbye-to-react-hooks)
+
+We're building [Autumn](https://docs.useautumn.com/welcome), which is a billing platform that helps devs integrate [stripe](/blog/what-if-stripe-builds-this) and manage their pricing model. One feature of this is a UI library to drop-in things like a pricing table, upgrade/downgrade flows, paywalls--similar to Clerk with auth.
 
 We are heavy users of shadcn/ui and love having full design customisability. When Supabase launched it’s UI library through shadcn, we wanted to do the same.
 

--- a/apps/website/content/blog/thanks-hn.mdx
+++ b/apps/website/content/blog/thanks-hn.mdx
@@ -62,3 +62,5 @@ Over the last few days we rewrote the whole library. Instead of reinventing the 
 We're happier with this for now, although set up is slightly longer and possibly less "magical". It's a lot clearer what happens on the client, what happens on the server, and where to use each package.
 
 Thanks HN for the tough love.
+
+**Update:** we later built a full React hooks library on top of this backend-safe approach, and have since scaled that back too. Here's [why we said goodbye to it](/blog/saying-goodbye-to-react-hooks).

--- a/apps/website/content/blog/what-if-stripe-builds-this.mdx
+++ b/apps/website/content/blog/what-if-stripe-builds-this.mdx
@@ -10,7 +10,7 @@ featured: true
 
 The "what if `${incumbent}` builds this" question is usually asked as a meme. Really the only time it comes up is when founders make fun of crappy VCs. For some reason though, we hear this a lot. I think it's because:
 
-1.  People don't quite understand what we do. Which is fair enough. It's quite new and we're still not great at explaining it.
+1.  People don't quite understand [what we do](https://docs.useautumn.com/welcome). Which is fair enough. It's quite new and we're still not great at explaining it.
     
 2.  Stripe is still totally revered in the Startup ecosystem.
     
@@ -42,6 +42,8 @@ From a high level it seems like we're a couple features on top of Stripe, and I 
 Creating a platform that is simple to start with, but is flexible enough to run any pricing model is an infinite matrix of logic, scenarios, payment states, edge cases etc. This only gets harder and harder as we move upmarket.
 
 Technically speaking it's a totally different challenge too: at scale we look more like a database (eg Supabase/Convex), or feature flagging system like LaunchDarkly. This is pretty far away from what Stripe is good at.
+
+A year on, we wrote a longer breakdown of exactly [where our layer ends and Stripe's begins](/blog/we-built-a-billing-company-but-didnt-replace-stripe-billing).
 
 That's not to say that the best product always wins. But in devtools it certainly matters more than in other product categories.
 


### PR DESCRIPTION
Installs the RB2B visitor-identification snippet on the marketing site.

## What

- New `apps/website/components/reb2b.tsx` renders the loader as an inline `<script>`.
- Root layout mounts it inside a `<head>` block, so it applies to every page including `/blog`.

## Why an inline `<script>` and not `next/script`

`next/script` cannot put a tag in the head in App Router. Measured against the SSR HTML:

| Approach | Lands in | Executes |
|---|---|---|
| `strategy="afterInteractive"` | body | after hydration |
| `strategy="beforeInteractive"` | body, byte 5997 | `__next_s` queue replay, pre-hydration |
| inline `<script>` in `<head>` | head, byte 5822 | raw snippet, during HTML parse |

`beforeInteractive` emits `(self.__next_s=self.__next_s||[]).push(...)` just after `<body>` opens rather than the snippet itself. React 19 does not hoist inline scripts either, so an explicit `<head>` element is the only way to get parse-time execution.

Caveat: a `<head>` element in the App Router root layout is not the documented path, though it merges with the Metadata API output correctly here. Worth knowing as a possible Next-upgrade regression point.

## Verification

- Snippet confirmed inside `<head>` on `/` and `/blog` in the SSR HTML.
- Next's own metadata (favicon, apple-touch-icon links) still renders in the same head.
- Vendor URL returns 200 / 9979 bytes, so the key is live.
- Biome and `tsc --noEmit` clean; no dev-server errors.

## Note on scope

Also carries blog cross-linking edits to five posts, which were part of the same local `site change` commit.

## Follow-up worth considering

RB2B de-anonymizes visitors to named people and companies, which puts it in scope for GDPR/CCPA disclosure. It currently fires unconditionally, as the site has no consent gate to hook into. May want a privacy-policy line or a consent gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RB2B visitor identification site-wide by injecting an inline script in the root layout `<head>`. Runs during HTML parse for earlier execution on all pages, including `/blog`.

- **New Features**
  - Added `Reb2b` component that renders the vendor loader as an inline `<script>`.
  - Mounted in `<head>` of the App Router root layout to execute at parse time (avoids `next/script` head-placement limits).
  - Updated internal blog links across five posts.

- **Migration**
  - No action required. The snippet fires on all pages.
  - If needed for GDPR/CCPA, consider adding a consent gate before loading.

<sup>Written for commit 2df03cb44bfec6769e8657711a7ecd5bd676a5a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR installs RB2B visitor identification across the marketing site and adds cross-links between related blog posts. The production Content Security Policy currently prevents the RB2B vendor script from loading.

- **Improvements:** Adds a global inline RB2B loader to the root website layout.
- **Improvements:** Adds updated context and navigation links across five blog posts.
</details>

<h3>Confidence Score: 4/5</h3>

The RB2B integration needs its vendor host added to the production script policy before merging, otherwise the advertised tracking will not run.

The inline bootstrap code executes, but the production Content Security Policy blocks the external CloudFront script it injects, leaving RB2B uninitialized on every production page.

**Files Needing Attention:** apps/website/components/reb2b.tsx and apps/website/next.config.mjs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/app/layout.tsx | Mounts the RB2B loader in the root head so it executes across every website route. |
| apps/website/components/reb2b.tsx | Adds the inline vendor loader, but its external CloudFront source is blocked by the production Content Security Policy. |
| apps/website/content/blog/component-fail.mdx | Adds valid links to current documentation and related blog posts. |
| apps/website/content/blog/saying-goodbye-to-react-hooks.mdx | Adds a valid cross-link to the shadcn article. |
| apps/website/content/blog/shadcn.mdx | Adds an update link and a current documentation link. |
| apps/website/content/blog/thanks-hn.mdx | Adds a valid update link to the React hooks retrospective. |
| apps/website/content/blog/what-if-stripe-builds-this.mdx | Adds valid links to the product documentation and a related billing article. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant V as Visitor browser
    participant W as Autumn website
    participant C as Production CSP
    participant R as RB2B CloudFront
    V->>W: Request any page
    W-->>V: HTML with inline RB2B loader and CSP
    V->>C: Evaluate inline loader
    C-->>V: Allow inline execution
    V->>R: Request RB2B script
    C-->>V: Block disallowed script host
    Note over V,R: Visitor tracking never initializes
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/website/components/reb2b.tsx:3
**Production CSP blocks RB2B**

When any page loads in production, this loader requests executable code from `ddwl4m2hdecbv.cloudfront.net`, but the production `script-src` policy does not allow that host, causing the browser to block RB2B tracking.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(website): add RB2B visitor tracking..."](https://github.com/useautumn/autumn/commit/2df03cb44bfec6769e8657711a7ecd5bd676a5a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51349347)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)

<!-- /greptile_comment -->