### PR TITLE
fix(website): allow RB2B and Framer hosts through CSP

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -9,6 +9,20 @@ const isProd = process.env.NODE_ENV === "production";
 // which holds the hoisted node_modules the app symlinks into.
 const monorepoRoot = join(import.meta.dirname, "..", "..");
 
+// RB2B's loader fans out to several identity/data providers (and LiveIntent
+// loads a second script of its own), so every host is allowed on each
+// directive the chain touches rather than mapped one-by-one.
+const RB2B_HOSTS = [
+  "https://ddwl4m2hdecbv.cloudfront.net",
+  "https://app.rb2b.com",
+  "https://b2bjsstore.s3.us-west-2.amazonaws.com",
+  "https://s3-us-west-2.amazonaws.com",
+  "https://a.usbrowserspeed.com",
+  "https://alocdn.com",
+  "https://pro.ip-api.com",
+  "https://*.liadm.com",
+];
+
 const rehypePrettyCodeOptions = {
   theme: "github-dark-dimmed",
   keepBackground: false,
@@ -95,12 +109,26 @@ const nextConfig = {
             key: "Content-Security-Policy",
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live",
+              [
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+                "https://vercel.live",
+                ...RB2B_HOSTS,
+              ].join(" "),
               "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: blob:",
+              [
+                "img-src 'self' data: blob:",
+                // Blog posts embed images hosted on Framer.
+                "https://framerusercontent.com",
+                ...RB2B_HOSTS,
+              ].join(" "),
               "font-src 'self' data:",
               "media-src 'self'",
-              "connect-src 'self' https://*.vercel.app https://vitals.vercel-insights.com",
+              [
+                "connect-src 'self' https://*.vercel.app",
+                "https://vitals.vercel-insights.com",
+                ...RB2B_HOSTS,
+              ].join(" "),
+              ["frame-src 'self'", ...RB2B_HOSTS].join(" "),
               "frame-ancestors 'none'",
             ].join("; "),
           },


### PR DESCRIPTION
Follow-up to #2683. The RB2B snippet merged, but CSP blocked it, so the tracker never actually ran:

```
Loading the script 'https://ddwl4m2hdecbv.cloudfront.net/b/4N210HX5V56Z/...'
violates the following Content Security Policy directive:
"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://vercel.live"
```

## RB2B hosts

The loader is obfuscated and hides its URLs behind `atob`. Decoding its string table shows it fans out well beyond its own CDN, and `b-code.liadm.com/lc2.js` is a second script that calls four more `*.liadm.com` hosts of its own:

| Host | Role |
|---|---|
| `ddwl4m2hdecbv.cloudfront.net` | loader |
| `s3-us-west-2.amazonaws.com`, `b2bjsstore.s3…` | loader mirrors |
| `app.rb2b.com` | `/script/browser_verification` |
| `*.liadm.com` | LiveIntent — second script, plus `idx`/`rp`/`rpr`/`i` sync hosts |
| `a.usbrowserspeed.com` | identity resolution |
| `alocdn.com` | third-party data |
| `pro.ip-api.com` | IP geolocation |

Rather than map each host to one directive by reverse-engineering a 158 KB minified bundle, every host is allowed on each directive the chain touches. `frame-src` is new — `i.liadm.com/sync-container` is an iframe that `default-src 'self'` was silently blocking.

## Framer images (unrelated, pre-existing)

`img-src` has always been `'self' data: blob:`, but blog posts embed images from `framerusercontent.com` — 21 references across 8 posts. They are blocked on production today:

```
useautumn.com/blog/component-fail
  img-src 'self' data: blob:         <- framerusercontent absent
  28 framerusercontent refs in HTML  <- all blocked
```

Happy to split this into its own PR if preferred.

## Verification

Note that `next.config.mjs` returns `[]` from `headers()` when not in production, so **no dev-server test can catch CSP issues**. Verified against a real `next build && next start`:

- Script loads: full response body from `ddwl4m2hdecbv.cloudfront.net`, no longer `blocked:csp`.
- Zero CSP violations in console.

Not verifiable locally: the downstream fan-out. The bundle carries `'domains': Object.freeze(['useautumn.com'])`, so it no-ops off its registered domain — including on Vercel preview URLs. Those hosts are pre-allowlisted, but the chain can only be confirmed on production after deploy.

## Note

This is a real widening of a previously tight policy — 8 hosts plus a wildcard across four directives. Worth a look from whoever owns security. The privacy point from #2683 also still stands: RB2B resolves visitors to named people and companies, and currently fires with no consent gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CSP to allow the RB2B tracker and Framer-hosted images. This unblocks the RB2B script and fixes broken blog images in production.

- **Bug Fixes**
  - Allowed RB2B loader and fan-out hosts across `script-src`, `connect-src`, and `img-src`, and added `frame-src` for the LiveIntent iframe.
  - Added `https://framerusercontent.com` to `img-src` for blog posts.

<sup>Written for commit 4f2d4a64bbea2abddd5b3917b6566621a78755fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the production website CSP so the existing RB2B tracker and Framer-hosted blog images can load.

- **Bug fixes:** Allows the RB2B loader and its downstream identity-provider resources across the script, image, connection, and frame directives they use.
- **Bug fixes:** Allows existing blog images served from `framerusercontent.com`.
- **Improvements:** Adds an explicit `frame-src` policy for the RB2B synchronization iframe.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intentionally broader third-party CSP access clearly scoped and documented.

The generated CSP remains a correctly serialized string, covers the statically visible RB2B loader and all current Framer image origins, and no reachable blocking or security failure was established.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/next.config.mjs | Expands the production CSP with the external origins required by RB2B and existing Framer-hosted blog images; no concrete defect was identified. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Page[Autumn website] -->|script-src| RB2B[RB2B and provider scripts]
  Page -->|connect-src| APIs[RB2B provider APIs]
  Page -->|frame-src| Sync[LiveIntent sync iframe]
  Page -->|img-src| Tracking[RB2B tracking resources]
  Page -->|img-src| Framer[Framer blog images]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(website): allow RB2B and Framer host..."](https://github.com/useautumn/autumn/commit/4f2d4a64bbea2abddd5b3917b6566621a78755fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51356588)</sub>

**Context used:**

- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)

<!-- /greptile_comment -->