### PR TITLE
fix(website): add RB2B hosts missed by static analysis

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -20,7 +20,12 @@ const RB2B_HOSTS = [
   "https://a.usbrowserspeed.com",
   "https://alocdn.com",
   "https://pro.ip-api.com",
+  // *.liadm.com does not match the apex, which RB2B also calls.
+  "https://liadm.com",
   "https://*.liadm.com",
+  // Subdomain comes from the account's apiGateway config and is concatenated
+  // at runtime, so it never appears as a literal in the bundle.
+  "https://9xgnrndqve.execute-api.us-west-2.amazonaws.com",
 ];
 
 const rehypePrettyCodeOptions = {


### PR DESCRIPTION
RB2B's own installation checker flagged two gaps remaining after #2684.

## `9xgnrndqve.execute-api.us-west-2.amazonaws.com` (connect-src)

Explicitly reported as a missing domain. Static analysis of the bundle could not find it, because it is never a complete literal:

```
bundle contains only:  '.execute-api.us-west-2.amazonaws.com/b2b'
config supplies:       apiGateway -> '9xgnrndqve'
concatenated at runtime
```

Note this host comes from the account's own config, so if RB2B rotates their gateway this silently breaks again and needs updating. A `https://*.execute-api.us-west-2.amazonaws.com` wildcard would be robust to that, but allows any AWS API Gateway in the region, so the exact host is used here.

## `liadm.com` apex

`*.liadm.com` matches subdomains only, not the apex. RB2B's recommended list includes bare `liadm.com`, so the existing wildcard left it uncovered.

## On RB2B's suggested CSP

Their checker outputs a block that should **not** be pasted verbatim:

- `connect-src 'self' 'strict-dynamic'` — `'strict-dynamic'` is only meaningful in `script-src`; it does nothing in `connect-src`.
- `default-src 'self' strict-dynamic` — unquoted, so it parses as a *hostname* called `strict-dynamic` rather than a keyword.
- Their `script-src` omits `'unsafe-inline'`, which the inline loader added in #2683 requires.

Only the two host additions above are adopted.

## Still outstanding

The checker also reports **"No consent management platform found"**, which is not addressed here. RB2B resolves visitors to named individuals and shares data with LiveIntent and several data brokers, and currently fires with no consent gate. The bundle has `onConsentGranted` and `consentCheckInterval` hooks, so the integration can be gated without a heavyweight CMP. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing RB2B domains to our CSP to prevent blocked requests flagged by RB2B’s installation checker.

- **Bug Fixes**
  - Allow https://9xgnrndqve.execute-api.us-west-2.amazonaws.com for connect requests; the API gateway host is assembled at runtime, so we add the exact host.
  - Allow https://liadm.com; the existing wildcard (https://*.liadm.com) doesn’t cover the apex.

<sup>Written for commit 6147e411a1d3cc41375a39c8876df48d67879346. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two production CSP gaps reported by RB2B’s installation checker.
- **[Bug fixes]** Allows requests to the bare `liadm.com` domain, which is not covered by the existing subdomain wildcard.
- **[Bug fixes]** Allows requests to the account-specific AWS API Gateway hostname constructed by RB2B at runtime.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both additions correctly covering the reported production CSP gaps.

The new source expressions are valid, flow into the existing production CSP assembly, and match the two RB2B origins identified as previously blocked.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/next.config.mjs | Adds two valid HTTPS origins to the existing RB2B CSP allowlist, covering the liadm.com apex and the runtime-generated API Gateway endpoint without an identified regression. |

<sub>Reviews (1): Last reviewed commit: ["fix(website): add RB2B hosts missed by s..."](https://github.com/useautumn/autumn/commit/6147e411a1d3cc41375a39c8876df48d67879346) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51362584)</sub>

**Context used:**

- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)

<!-- /greptile_comment -->