### PR TITLE
fix: preserve variant filter interval count on pull

### DIFF
--- a/packages/atmn/src/lib/transforms/apiToSdk/plan.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/plan.ts
@@ -106,7 +106,7 @@ const transformApiPlanItemFilter = (
 		? { billingMethod: filter.billing_method }
 		: {}),
 	...(filter.interval !== undefined ? { interval: filter.interval } : {}),
-	...(filter.interval_count !== undefined && filter.interval_count !== 1
+	...(filter.interval_count !== undefined
 		? { intervalCount: filter.interval_count }
 		: {}),
 });

--- a/packages/atmn/test/integration/pull/variants-pull.test.ts
+++ b/packages/atmn/test/integration/pull/variants-pull.test.ts
@@ -158,6 +158,7 @@ test(`${chalk.yellowBright("atmn pull variants: method exports, boolean items, c
 		{
 			featureId: "automation_runs",
 			interval: BillingInterval.Month,
+			intervalCount: 1,
 		},
 	]);
 	expect(variant.customize?.addItems).toEqual([
@@ -184,6 +185,93 @@ test(`${chalk.yellowBright("atmn pull variants: method exports, boolean items, c
 
 	expect(inPlaceConfig.match(variantExportPattern)).toHaveLength(1);
 	expect(inPlaceConfig).toContain("price: { amount: 510, interval: 'year' }");
+});
+
+/** Red: pull drops an explicit interval_count of 1 from a variant removal filter.
+ * Green: the generated config preserves intervalCount: 1 for an exact round trip. */
+test(`${chalk.yellowBright("atmn pull variants: preserves interval count 1 in removal filters")}`, async () => {
+	const ctx = await createCleanAtmnIntegrationContext();
+	const rpc = new AutumnRpcCli({
+		secretKey: ctx.orgSecretKey,
+		version: ApiVersion.V2_1,
+	});
+	const featureId = "variant_interval_count";
+	const basePlanId = "interval-count-base";
+	const variantPlanId = "interval-count-variant";
+	const monthlyItem = ({
+		included,
+		intervalCount,
+	}: {
+		included: number;
+		intervalCount: number;
+	}) => ({
+		feature_id: featureId,
+		included,
+		reset: { interval: ResetInterval.Month, interval_count: intervalCount },
+	});
+
+	await rpc.post("/features.create", {
+		feature_id: featureId,
+		name: "Variant interval count",
+		type: "metered",
+		consumable: true,
+	});
+	await rpc.plans.create<ApiPlanV1, CreatePlanParamsV2Input>({
+		plan_id: basePlanId,
+		name: "Interval count base",
+		items: [
+			monthlyItem({ included: 100, intervalCount: 1 }),
+			monthlyItem({ included: 200, intervalCount: 2 }),
+		],
+	});
+	await rpc.post("/plans.create_variant", {
+		base_plan_id: basePlanId,
+		variant_plan_id: variantPlanId,
+		name: "Interval count variant",
+	});
+	await rpc.plans.update<ApiPlanV1>(variantPlanId, {
+		items: [
+			monthlyItem({ included: 150, intervalCount: 1 }),
+			monthlyItem({ included: 200, intervalCount: 2 }),
+		],
+		disable_version: true,
+	});
+
+	const apiVariant = await rpc.plans.get<ApiPlanV1>(variantPlanId);
+	expect(apiVariant.variant_details?.customize?.remove_items).toContainEqual({
+		feature_id: featureId,
+		interval: ResetInterval.Month,
+		interval_count: 1,
+	});
+
+	const workspace = await pullConfig({ secretKey: ctx.orgSecretKey });
+	const config = await readFile(workspace.configPath, "utf8");
+	const mod = await loadConfigModule(workspace.configPath);
+	const variant = mod.intervalCountVariant as {
+		customize?: { removeItems?: unknown[] };
+	};
+
+	expect(config).toContain("intervalCount: 1");
+	expect(variant.customize?.removeItems).toContainEqual({
+		featureId,
+		interval: ResetInterval.Month,
+		intervalCount: 1,
+	});
+
+	await runAtmnWorkspaceCli({
+		args: ["--yes"],
+		command: "push",
+		headless: true,
+		workspace,
+	});
+	const roundTrippedVariant = await rpc.plans.get<ApiPlanV1>(variantPlanId);
+	expect(
+		roundTrippedVariant.variant_details?.customize?.remove_items,
+	).toContainEqual({
+		feature_id: featureId,
+		interval: ResetInterval.Month,
+		interval_count: 1,
+	});
 });
 
 test(`${chalk.yellowBright("atmn pull variants: variable names handle collisions and numeric prefixes")}`, async () => {


### PR DESCRIPTION
## Summary

- preserve an explicit `interval_count`, including `1`, when transforming API variant removal filters into generated atmn config
- add server-backed regression coverage for API state → CLI pull → generated config → CLI push

## Testing

- `cd server && bunx tsgo --build --noEmit`
- `cd packages/atmn && bun run ts`
- `cd packages/atmn && bun test test/codegen/variants.test.ts` (7 passed)
- focused `atmn pull variants: preserves interval count 1 in removal filters` integration test (pull→push, 1 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicit interval_count in variant removal filters during pull (including 1) so the generated config keeps intervalCount and round-trips correctly on push.

- **Bug Fixes**
  - Always map API `interval_count` to SDK `intervalCount` in `packages/atmn` transform (`apiToSdk/plan.ts`).
  - Added server-backed integration test to verify API → pull → generated config → push keeps `intervalCount: 1`.

<sup>Written for commit c72275041d1f25fcf1bed1e6ebfbcc94ac39f497. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes variant configuration round trips by retaining an explicitly supplied interval count of `1`. It also adds server-backed integration coverage for the complete API-to-pull-to-push flow.

- **[Bug fixes]** Preserve `interval_count: 1` when converting API variant removal filters into generated camel-case configuration.
- **[Improvements]** Verify that pulling, generating, loading, and pushing a variant retains the exact removal filter.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The API-to-config transform, generated code, config type, push transform, and API contract consistently support an explicit interval count of `1`, and the integration test covers the complete round trip.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/lib/transforms/apiToSdk/plan.ts | Correctly preserves every defined removal-filter interval count, including the explicit value `1`. |
| packages/atmn/test/integration/pull/variants-pull.test.ts | Adds full pull-to-push regression coverage and updates the existing expected generated filter. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as Autumn API
  participant Pull as atmn pull
  participant Config as Generated config
  participant Push as atmn push
  API->>Pull: Removal filter with interval_count: 1
  Pull->>Config: Emit intervalCount: 1
  Config->>Push: Load preserved filter
  Push->>API: Submit interval_count: 1
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 preserve variant filter interval..."](https://github.com/useautumn/autumn/commit/c72275041d1f25fcf1bed1e6ebfbcc94ac39f497) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51753853)</sub>

**Context used:**

- Knowledge Base — [`atmn` Catalog Configuration CLI](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/atmn-cli.md)

<!-- /greptile_comment -->