### PR TITLE
Render flags as a label without a catalog tab

### DIFF
--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -223,7 +223,6 @@ export function CustomerFeatureUsageTable() {
 			</Table.Provider>
 			{!isLoading && hasFlagsSection && (
 				<CustomerFlagsSection
-					key={availableBooleanFeatures.length > 0 ? "catalog" : "flags"}
 					booleanEnts={booleanEnts}
 					availableFeatures={availableBooleanFeatures}
 				/>

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFeatureUsageTable.tsx
@@ -223,6 +223,7 @@ export function CustomerFeatureUsageTable() {
 			</Table.Provider>
 			{!isLoading && hasFlagsSection && (
 				<CustomerFlagsSection
+					key={availableBooleanFeatures.length > 0 ? "catalog" : "flags"}
 					booleanEnts={booleanEnts}
 					availableFeatures={availableBooleanFeatures}
 				/>

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
@@ -35,6 +35,7 @@ export function CustomerFlagsSection({
 	availableFeatures: Feature[];
 }) {
 	const reduceMotion = useReducedMotion() ?? false;
+	const hasCatalog = availableFeatures.length > 0;
 	const {
 		showingCatalog,
 		expanded,
@@ -48,7 +49,7 @@ export function CustomerFlagsSection({
 		rowRef,
 		setShowingCatalog,
 		toggleExpanded,
-	} = useFlagsView({ booleanEnts });
+	} = useFlagsView({ booleanEnts, hasCatalog });
 
 	// Pills keep their slot across views — only trailing ones are added or
 	// removed — so a plain fade reads calmer than layout animation plus scale.
@@ -64,7 +65,7 @@ export function CustomerFlagsSection({
 
 	return (
 		<div className="flex flex-col">
-			{availableFeatures.length > 0 ? (
+			{hasCatalog ? (
 				<div className="flex items-center mb-3">
 					<Tabs
 						value={showingCatalog ? "catalog" : "enabled"}

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
@@ -7,8 +7,9 @@ import { useFlagsView } from "./useFlagsView";
 
 type FlagsView = "enabled" | "catalog";
 
+const FLAGS_LABEL = "Flags";
 const FLAG_VIEWS: { value: FlagsView; label: string }[] = [
-	{ value: "enabled", label: "Flags" },
+	{ value: "enabled", label: FLAGS_LABEL },
 	{ value: "catalog", label: "Full Catalog" },
 ];
 
@@ -83,7 +84,7 @@ export function CustomerFlagsSection({
 					</Tabs>
 				</div>
 			) : (
-				<SectionTag>Flags</SectionTag>
+				<SectionTag>{FLAGS_LABEL}</SectionTag>
 			)}
 
 			<div ref={containerRef} className="relative">

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
@@ -7,9 +7,8 @@ import { useFlagsView } from "./useFlagsView";
 
 type FlagsView = "enabled" | "catalog";
 
-const FLAGS_LABEL = "Flags";
 const FLAG_VIEWS: { value: FlagsView; label: string }[] = [
-	{ value: "enabled", label: FLAGS_LABEL },
+	{ value: "enabled", label: "Flags" },
 	{ value: "catalog", label: "Full Catalog" },
 ];
 
@@ -85,7 +84,7 @@ export function CustomerFlagsSection({
 					</Tabs>
 				</div>
 			) : (
-				<SectionTag>{FLAGS_LABEL}</SectionTag>
+				<SectionTag>{FLAG_VIEWS[0].label}</SectionTag>
 			)}
 
 			<div ref={containerRef} className="relative">

--- a/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx
@@ -1,5 +1,5 @@
 import type { Feature, FullCusEntWithFullCusProduct } from "@autumn/shared";
-import { Tabs, TabsList, TabsTrigger } from "@autumn/ui";
+import { SectionTag, Tabs, TabsList, TabsTrigger } from "@autumn/ui";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { cn } from "@/lib/utils";
 import { flagPillClassName, OVERFLOW_PILL_CLASSNAME } from "./FlagPill";
@@ -63,14 +63,14 @@ export function CustomerFlagsSection({
 
 	return (
 		<div className="flex flex-col">
-			<div className="flex items-center mb-3">
-				<Tabs
-					value={showingCatalog ? "catalog" : "enabled"}
-					onValueChange={(value) => setShowingCatalog(value === "catalog")}
-				>
-					<TabsList className="h-auto gap-0.5 p-0.5 rounded-lg bg-muted dark:bg-muted">
-						{FLAG_VIEWS.map(({ value, label }) =>
-							value === "catalog" && availableFeatures.length === 0 ? null : (
+			{availableFeatures.length > 0 ? (
+				<div className="flex items-center mb-3">
+					<Tabs
+						value={showingCatalog ? "catalog" : "enabled"}
+						onValueChange={(value) => setShowingCatalog(value === "catalog")}
+					>
+						<TabsList className="h-auto gap-0.5 p-0.5 rounded-lg bg-muted dark:bg-muted">
+							{FLAG_VIEWS.map(({ value, label }) => (
 								<TabsTrigger
 									key={value}
 									value={value}
@@ -78,11 +78,13 @@ export function CustomerFlagsSection({
 								>
 									{label}
 								</TabsTrigger>
-							),
-						)}
-					</TabsList>
-				</Tabs>
-			</div>
+							))}
+						</TabsList>
+					</Tabs>
+				</div>
+			) : (
+				<SectionTag>Flags</SectionTag>
+			)}
 
 			<div ref={containerRef} className="relative">
 				{/* Always mounted — gating this on the view would leave the count stale

--- a/vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts
@@ -8,8 +8,10 @@ type FlagsViewState = { showingCatalog: boolean; expanded: boolean };
 
 export function useFlagsView({
 	booleanEnts,
+	hasCatalog,
 }: {
 	booleanEnts: FullCusEntWithFullCusProduct[];
+	hasCatalog: boolean;
 }) {
 	// Expansion survives a trip through the catalog, so the two axes are
 	// independent rather than one enum.
@@ -17,7 +19,8 @@ export function useFlagsView({
 		showingCatalog: false,
 		expanded: false,
 	});
-	const { showingCatalog, expanded } = state;
+	const { showingCatalog: catalogSelected, expanded } = state;
+	const showingCatalog = hasCatalog && catalogSelected;
 
 	// Measures a hidden layer, so it can always run — the count stays correct
 	// across every view instead of lagging a frame behind a toggle.

--- a/vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts
+++ b/vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts
@@ -19,8 +19,10 @@ export function useFlagsView({
 		showingCatalog: false,
 		expanded: false,
 	});
-	const { showingCatalog: catalogSelected, expanded } = state;
-	const showingCatalog = hasCatalog && catalogSelected;
+	const { showingCatalog, expanded } = state;
+	if (!hasCatalog && showingCatalog) {
+		setState({ ...state, showingCatalog: false });
+	}
 
 	// Measures a hidden layer, so it can always run — the count stays correct
 	// across every view instead of lagging a frame behind a toggle.


### PR DESCRIPTION
## Summary
- render Flags as a standard section label when every boolean entitlement is granted
- keep the Flags / Full Catalog tabs when catalog options remain

## Validation
- Vite TypeScript check
- focused ESLint check
- React Doctor changed-file scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render Flags as a label when the catalog is empty; keep tabs when options exist. The view resets to Flags if the catalog disappears, and expansion is preserved.

- **Bug Fixes**
  - Use `@autumn/ui` `SectionTag` for "Flags" with no catalog; keep "Flags/Full Catalog" tabs when features exist; reuse the existing label.
  - Clear any "Full Catalog" selection when the catalog becomes unavailable to prevent stale state.

<sup>Written for commit 65322402ae5d3a33aabd7ec1aba390a015610ea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes how the Flags section is labeled when no catalog options exist and resets catalog selection when those options disappear.
- **Improvements:** Replaces the one-option tab control with a standard “Flags” section label.
- **Bug fixes:** Clears an unavailable catalog selection, although the prior expansion state is still retained.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until catalog disappearance reliably restores the normal collapsed Flags view.

The prior reply, shown without an author name, says catalog availability now remounts the section and resets both catalog and expansion state, but current code has no such key and explicitly preserves `expanded`, leaving the previously reported state-restoration issue reachable.

**Files Needing Attention:** vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/table/customer-feature-usage/CustomerFlagsSection.tsx | Conditionally renders either catalog tabs or a standard Flags label and passes catalog availability into the view hook. |
| vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts | Clears catalog selection when unavailable, but preserves expansion and therefore does not always restore the normal collapsed view. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/customers2/components/table/customer-feature-usage/useFlagsView.ts:23-25
**Expansion survives catalog reset**

When a user expands Flags, switches to Full Catalog, and refreshed data removes every catalog option, this reset clears only `showingCatalog` and preserves `expanded: true`, causing all flags to remain expanded with “Show less” instead of restoring the normal collapsed view.

```suggestion
	if (!hasCatalog && showingCatalog) {
		setState({ showingCatalog: false, expanded: false });
	}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: 🐛 clear unavailable catalog select..."](https://github.com/useautumn/autumn/commit/65322402ae5d3a33aabd7ec1aba390a015610ea7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51761984)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->