### PR TITLE
fix: settle in-flight requests before SQS batcher teardown; recycle at 1.5GB

### DIFF
--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -271,8 +271,14 @@ function registerFatalErrorHandlers() {
 }
 
 function registerShutdownHandlers() {
-	process.on("SIGTERM", gracefulShutdown);
-	process.on("SIGINT", gracefulShutdown);
+	// Same 30s bound as recycle exits: no shutdown path may hang unbounded.
+	const shutdownWithBackstop = () => {
+		const forceExit = setTimeout(() => process.exit(0), 30_000);
+		forceExit.unref?.();
+		void gracefulShutdown();
+	};
+	process.on("SIGTERM", shutdownWithBackstop);
+	process.on("SIGINT", shutdownWithBackstop);
 	// Do NOT use process.on("exit", ...) for async cleanup!
 }
 

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -209,13 +209,14 @@ if (process.env.NODE_ENV === "development") {
 			const workersAlive = () =>
 				Object.values(cluster.workers ?? {}).filter((w) => w && !w.isDead())
 					.length;
-			const deadline = Date.now() + 20_000;
+			// Must exceed the workers' own 30s shutdown backstop.
+			const deadline = Date.now() + 35_000;
 			while (workersAlive() > 0 && Date.now() < deadline) {
 				await new Promise((resolve) => setTimeout(resolve, 200));
 			}
 			if (workersAlive() > 0) {
 				console.warn(
-					`[Shutdown] ${workersAlive()} worker(s) still alive after 20s; exiting anyway`,
+					`[Shutdown] ${workersAlive()} worker(s) still alive after 35s; exiting anyway`,
 				);
 			}
 			await gracefulShutdown();
@@ -323,12 +324,15 @@ async function gracefulShutdown() {
 		// App-level batch windows (events 350ms, balance sync 1s) hold work in
 		// timers that process.exit would silently kill: deliver them, then close
 		// the SQS batchers at the last possible moment.
-		await Promise.all([
+		const flushResults = await Promise.allSettled([
 			globalEventBatchingManager.flush(),
 			globalSyncBatchingManagerV3.flush(),
-		]).catch((error) => {
-			console.warn("[Shutdown] app-level batch flush failed:", error);
-		});
+		]);
+		for (const result of flushResults) {
+			if (result.status === "rejected") {
+				console.warn("[Shutdown] app-level batch flush failed:", result.reason);
+			}
+		}
 		await shutdownSqsSendBatchers();
 		await Promise.all([
 			client.end(),

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -56,6 +56,8 @@ import {
 import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
+import { globalEventBatchingManager } from "./internal/balances/events/EventBatchingManager.js";
+import { globalSyncBatchingManagerV3 } from "./internal/balances/utils/sync/SyncBatchingManagerV3.js";
 import { shutdownSqsSendBatchers } from "./queue/queueUtils.js";
 import { checkEnvVars } from "./utils/initUtils.js";
 import {
@@ -192,7 +194,34 @@ if (process.env.NODE_ENV === "development") {
 			});
 		});
 
-		registerShutdownHandlers();
+		// Container init delivers SIGTERM to this primary only; without
+		// forwarding, workers never run their graceful shutdown and ECS
+		// SIGKILLs them mid-request at stopTimeout.
+		const shutdownPrimary = async () => {
+			if (shuttingDown) return;
+			shuttingDown = true;
+			console.log("[Shutdown] primary forwarding SIGTERM to workers");
+			for (const worker of Object.values(cluster.workers ?? {})) {
+				try {
+					worker?.process.kill("SIGTERM");
+				} catch {}
+			}
+			const workersAlive = () =>
+				Object.values(cluster.workers ?? {}).filter((w) => w && !w.isDead())
+					.length;
+			const deadline = Date.now() + 20_000;
+			while (workersAlive() > 0 && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, 200));
+			}
+			if (workersAlive() > 0) {
+				console.warn(
+					`[Shutdown] ${workersAlive()} worker(s) still alive after 20s; exiting anyway`,
+				);
+			}
+			await gracefulShutdown();
+		};
+		process.on("SIGTERM", () => void shutdownPrimary());
+		process.on("SIGINT", () => void shutdownPrimary());
 	} else {
 		registerFatalErrorHandlers();
 		const server = await init({ startupStartedAt: Date.now() });
@@ -251,11 +280,18 @@ async function waitForInFlightRequestsToSettle({
 }: {
 	timeoutMs: number;
 }) {
+	// Streamed bodies outlive the request registry, so wait on open sockets
+	// too (idle keep-alives clear within a sweep once accepting stopped).
+	const activeWork = () =>
+		Math.max(
+			listInFlightRequests({ now: Date.now() }).length,
+			drainState.getActiveConnectionCount(),
+		);
 	const deadline = Date.now() + timeoutMs;
-	while (listInFlightRequests({ now: Date.now() }).length > 0) {
+	while (activeWork() > 0) {
 		if (Date.now() > deadline) {
 			console.warn(
-				`[Shutdown] proceeding with ${listInFlightRequests({ now: Date.now() }).length} request(s) still in flight after ${timeoutMs}ms`,
+				`[Shutdown] proceeding with ${listInFlightRequests({ now: Date.now() }).length} request(s) / ${drainState.getActiveConnectionCount()} connection(s) still active after ${timeoutMs}ms`,
 			);
 			return;
 		}
@@ -284,8 +320,15 @@ async function gracefulShutdown() {
 		stopRedisV2Monitor();
 		stopMemorySpikeProbe();
 		stopAllEdgeConfigPolling();
-		// Request-scheduled timers may have enqueued during teardown: deliver
-		// those, then close the batchers at the last possible moment.
+		// App-level batch windows (events 350ms, balance sync 1s) hold work in
+		// timers that process.exit would silently kill: deliver them, then close
+		// the SQS batchers at the last possible moment.
+		await Promise.all([
+			globalEventBatchingManager.flush(),
+			globalSyncBatchingManagerV3.flush(),
+		]).catch((error) => {
+			console.warn("[Shutdown] app-level batch flush failed:", error);
+		});
 		await shutdownSqsSendBatchers();
 		await Promise.all([
 			client.end(),

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -236,9 +236,9 @@ if (process.env.NODE_ENV === "development") {
 				drainState.draining = true;
 			},
 			exitGracefully: () => {
-				// Backstop: a hung flush must not strand a drained fork. Sized above
-				// the in-flight settle window inside gracefulShutdown.
-				const forceExit = setTimeout(() => process.exit(0), 15_000);
+				// Backstop: a hung flush must not strand a drained fork. Sized so a
+				// full 10s settle still leaves teardown ample time.
+				const forceExit = setTimeout(() => process.exit(0), 30_000);
 				forceExit.unref?.();
 				void gracefulShutdown();
 			},

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -72,6 +72,9 @@ import { startMemoryMonitor } from "./utils/memoryMonitor.js";
 checkEnvVars();
 
 let shuttingDown = false;
+// Set once the worker's HTTP server exists; SIGTERM shutdown uses it to stop
+// accepting before any teardown, mirroring the fork-recycle drain shape.
+let stopAcceptingRequests: (() => void) | null = null;
 const drainState: {
 	draining: boolean;
 	getActiveConnectionCount: () => number;
@@ -128,6 +131,13 @@ const init = async ({
 
 	server.keepAliveTimeout = 120000;
 	server.headersTimeout = 120000;
+
+	stopAcceptingRequests = () => {
+		drainState.draining = true;
+		server.close(() => {});
+		const idleSweep = setInterval(() => server.closeIdleConnections?.(), 1_000);
+		idleSweep.unref?.();
+	};
 
 	await new Promise<void>((resolve) => {
 		server.listen(PORT, "0.0.0.0", () => {
@@ -257,11 +267,11 @@ async function gracefulShutdown() {
 	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
-		// Requests still executing enqueue SQS work (track fallbacks, async
-		// track); closing the batchers under them rejects those sends. Give
-		// in-flight requests a bounded window to finish first.
+		// Stop taking new requests first (SIGTERM path: ALB keeps routing
+		// through deregistration), then let in-flight work finish. Requests and
+		// their delayed timers enqueue SQS work, so the batchers close LAST.
+		stopAcceptingRequests?.();
 		await waitForInFlightRequestsToSettle({ timeoutMs: 10_000 });
-		await shutdownSqsSendBatchers();
 
 		// Flush any buffered OTel spans before shutting down
 		if (otelSdk) {
@@ -274,6 +284,9 @@ async function gracefulShutdown() {
 		stopRedisV2Monitor();
 		stopMemorySpikeProbe();
 		stopAllEdgeConfigPolling();
+		// Request-scheduled timers may have enqueued during teardown: deliver
+		// those, then close the batchers at the last possible moment.
+		await shutdownSqsSendBatchers();
 		await Promise.all([
 			client.end(),
 			clientCritical.end(),

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -197,8 +197,9 @@ if (process.env.NODE_ENV === "development") {
 				drainState.draining = true;
 			},
 			exitGracefully: () => {
-				// Backstop: a hung flush must not strand a drained fork.
-				const forceExit = setTimeout(() => process.exit(0), 5_000);
+				// Backstop: a hung flush must not strand a drained fork. Sized above
+				// the in-flight settle window inside gracefulShutdown.
+				const forceExit = setTimeout(() => process.exit(0), 15_000);
 				forceExit.unref?.();
 				void gracefulShutdown();
 			},
@@ -235,10 +236,31 @@ function registerShutdownHandlers() {
 	// Do NOT use process.on("exit", ...) for async cleanup!
 }
 
+async function waitForInFlightRequestsToSettle({
+	timeoutMs,
+}: {
+	timeoutMs: number;
+}) {
+	const deadline = Date.now() + timeoutMs;
+	while (listInFlightRequests({ now: Date.now() }).length > 0) {
+		if (Date.now() > deadline) {
+			console.warn(
+				`[Shutdown] proceeding with ${listInFlightRequests({ now: Date.now() }).length} request(s) still in flight after ${timeoutMs}ms`,
+			);
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 200));
+	}
+}
+
 async function gracefulShutdown() {
 	shuttingDown = true;
 	console.log("Shutting down worker, flushing telemetry and closing DB...");
 	try {
+		// Requests still executing enqueue SQS work (track fallbacks, async
+		// track); closing the batchers under them rejects those sends. Give
+		// in-flight requests a bounded window to finish first.
+		await waitForInFlightRequestsToSettle({ timeoutMs: 10_000 });
 		await shutdownSqsSendBatchers();
 
 		// Flush any buffered OTel spans before shutting down

--- a/server/src/internal/balances/events/EventBatchingManager.ts
+++ b/server/src/internal/balances/events/EventBatchingManager.ts
@@ -7,6 +7,9 @@ import { addTaskToQueue } from "@server/queue/queueUtils.js";
 class BatchingManager {
 	private events: Map<string, EventInsert> = new Map();
 	private timer: NodeJS.Timeout | null = null;
+	// Batches clear the map before their sends complete, so shutdown flushes
+	// must await these, not just the pending map.
+	private inFlightBatches = new Set<Promise<void>>();
 	private readonly batchWindow = 350; // 100ms batching window
 	private readonly maxBatchSize = 200; // Max events per batch (~200kb per event, keep batches under 10MB for Tinybird)
 
@@ -17,7 +20,7 @@ class BatchingManager {
 
 		// Auto-execute if batch size is reached
 		if (this.events.size >= this.maxBatchSize) {
-			this.executeBatch();
+			void this.runBatch();
 			return;
 		}
 
@@ -27,13 +30,22 @@ class BatchingManager {
 		}
 
 		this.timer = setTimeout(() => {
-			this.executeBatch();
+			void this.runBatch();
 		}, this.batchWindow);
 	}
 
-	/** Deliver anything still waiting on the batch timer (shutdown path). */
+	/** Deliver pending AND already-executing batches (shutdown path). */
 	async flush(): Promise<void> {
-		await this.executeBatch();
+		await this.runBatch();
+		await Promise.all(Array.from(this.inFlightBatches));
+	}
+
+	private runBatch(): Promise<void> {
+		const batchPromise = this.executeBatch().finally(() => {
+			this.inFlightBatches.delete(batchPromise);
+		});
+		this.inFlightBatches.add(batchPromise);
+		return batchPromise;
 	}
 
 	/** Execute the current batch - queue to SQS for Postgres and send to Tinybird */

--- a/server/src/internal/balances/events/EventBatchingManager.ts
+++ b/server/src/internal/balances/events/EventBatchingManager.ts
@@ -31,6 +31,11 @@ class BatchingManager {
 		}, this.batchWindow);
 	}
 
+	/** Deliver anything still waiting on the batch timer (shutdown path). */
+	async flush(): Promise<void> {
+		await this.executeBatch();
+	}
+
 	/** Execute the current batch - queue to SQS for Postgres and send to Tinybird */
 	private async executeBatch(): Promise<void> {
 		if (this.timer) {

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -163,7 +163,7 @@ export class SyncBatchingManagerV3 {
 		const totalSize =
 			batch.context.cusEntIds.size + batch.context.rolloverIds.size;
 		if (totalSize >= this.MAX_BATCH_SIZE) {
-			this.executeCustomerBatch({ batchKey });
+			void this.runCustomerBatch({ batchKey });
 		}
 	}
 
@@ -188,8 +188,23 @@ export class SyncBatchingManagerV3 {
 	async flush(): Promise<void> {
 		const batchKeys = Array.from(this.customerBatches.keys());
 		await Promise.all(
-			batchKeys.map((batchKey) => this.executeCustomerBatch({ batchKey })),
+			batchKeys.map((batchKey) => this.runCustomerBatch({ batchKey })),
 		);
+		// Batches delete their map entry before awaiting Redis/queue work, so
+		// also await executions that were already mid-flight.
+		await Promise.all(Array.from(this.inFlightExecutions));
+	}
+
+	private inFlightExecutions = new Set<Promise<void>>();
+
+	private runCustomerBatch({ batchKey }: { batchKey: string }): Promise<void> {
+		const executionPromise = this.executeCustomerBatch({ batchKey }).finally(
+			() => {
+				this.inFlightExecutions.delete(executionPromise);
+			},
+		);
+		this.inFlightExecutions.add(executionPromise);
+		return executionPromise;
 	}
 
 	private buildBatchKey({
@@ -260,7 +275,7 @@ export class SyncBatchingManagerV3 {
 		if (!batch) return;
 
 		batch.timer = setTimeout(() => {
-			this.executeCustomerBatch({ batchKey });
+			void this.runCustomerBatch({ batchKey });
 		}, this.BATCH_WINDOW_MS);
 
 		if (batch.timer.unref) {

--- a/server/src/queue/SqsBatchAccumulator.ts
+++ b/server/src/queue/SqsBatchAccumulator.ts
@@ -54,8 +54,16 @@ export class SqsBatchAccumulator<TEntry extends SqsBatchAccumulatorEntry> {
 		this.sendBatch = sendBatch;
 	}
 
+	private rejectedDuringShutdown = 0;
+
 	enqueue(entry: TEntry): Promise<void> {
 		if (!this.acceptingEntries) {
+			// Every rejection here is a dropped send from a request that outlived
+			// teardown — must stay visible and countable.
+			this.rejectedDuringShutdown++;
+			console.warn(
+				`[SqsBatch] enqueue rejected during shutdown (#${this.rejectedDuringShutdown}, queue=${entry.queueUrl.split("/").pop()})`,
+			);
 			return Promise.reject(
 				new Error("SQS batch accumulator is shutting down"),
 			);

--- a/server/src/utils/memory/forkRecycling/recyclePolicy.ts
+++ b/server/src/utils/memory/forkRecycling/recyclePolicy.ts
@@ -3,7 +3,7 @@ const MB = 1024 * 1024;
 /** JSC never returns allocator-retained pages, so forks only shed memory by
  *  dying; recycling above this RSS is the bound the engine cannot provide. */
 export const FORK_RECYCLE_DEFAULTS = {
-	rssThresholdBytes: 3072 * MB,
+	rssThresholdBytes: 1536 * MB,
 	minAgeMs: 30 * 60_000,
 	checkIntervalMs: 30_000,
 	drainTimeoutMs: 30_000,

--- a/server/tests/unit/memory/forkRecycling.test.ts
+++ b/server/tests/unit/memory/forkRecycling.test.ts
@@ -60,15 +60,15 @@ describe("getForkRecycleConfig", () => {
 	test("defaults apply when nothing is set", () => {
 		const config = getForkRecycleConfig();
 		expect(config.enabled).toBe(true);
-		expect(config.rssThresholdBytes).toBe(3072 * MB);
+		expect(config.rssThresholdBytes).toBe(1536 * MB);
 		expect(config.minAgeMs).toBe(30 * 60_000);
 	});
 
 	test("valid overrides are honored", () => {
-		process.env.FORK_RECYCLE_RSS_MB = "1536";
+		process.env.FORK_RECYCLE_RSS_MB = "2048";
 		process.env.FORK_RECYCLE_CHECK_INTERVAL_MS = "5000";
 		const config = getForkRecycleConfig();
-		expect(config.rssThresholdBytes).toBe(1536 * MB);
+		expect(config.rssThresholdBytes).toBe(2048 * MB);
 		expect(config.checkIntervalMs).toBe(5000);
 	});
 
@@ -79,7 +79,7 @@ describe("getForkRecycleConfig", () => {
 		const config = getForkRecycleConfig();
 		expect(config.checkIntervalMs).toBe(30_000);
 		expect(config.drainTimeoutMs).toBe(30_000);
-		expect(config.rssThresholdBytes).toBe(3072 * MB);
+		expect(config.rssThresholdBytes).toBe(1536 * MB);
 	});
 
 	test("FORK_RECYCLE_DISABLED=true turns recycling off", () => {


### PR DESCRIPTION
Two changes:

## Don't close SQS batchers under live requests

The weekend's failed track fallbacks (`SQS batch accumulator is shutting down` rejections) came from teardown ordering: `gracefulShutdown` closed the send batchers immediately, while requests were still executing — on fork-recycle deadline exits, and on **every deploy's SIGTERM** (the server keeps receiving ALB traffic through target deregistration, so this predates recycling).

- `gracefulShutdown` now waits up to 10s for the in-flight request registry to empty before closing batchers (bounded, logs if it proceeds with stragglers).
- The recycle exit backstop widens 5s → 15s to fit the settle window.
- `SqsBatchAccumulator.enqueue` rejections during shutdown are now counted and logged (`[SqsBatch] enqueue rejected during shutdown (#N, queue=…)`) so any residue is measurable.

## Default recycle threshold 3072MB → 1536MB

Prod data from the first recycle waves: fork live sets are ~600-900MB, recycling was traffic-invisible at the 3GB threshold (and at 30x prod cadence in drills), and the lower ceiling (theoretical worst ~8GB/task with drain extension + serialization overshoot) clears the path to the 10GB task resize. Env `FORK_RECYCLE_RSS_MB` still overrides.

57 tests pass, typecheck + lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dropped SQS sends during deploys and recycling by stopping new requests, waiting up to 10s for in-flight requests and open sockets to settle, flushing app-level batches (awaiting mid-flight executions), then closing SQS batchers last. All shutdown paths (SIGTERM/SIGINT and recycle) use a 30s backstop; the primary forwards signals to workers, and the default fork recycle threshold drops to 1536MB.

- **Bug Fixes**
  - Stop accepting requests first; wait up to 10s for requests/sockets; flush event and balance-sync batches; await in-flight; close SQS batchers last.
  - Primary forwards SIGTERM/SIGINT to all workers and waits up to 35s so each runs graceful shutdown.
  - Signal-driven shutdowns are bounded with the same 30s backstop as recycle exits.
  - `SqsBatchAccumulator.enqueue` rejections during shutdown are counted and logged.

- **Refactors**
  - Default recycle RSS threshold changed from 3072MB to 1536MB; `FORK_RECYCLE_RSS_MB` still overrides.
  - Tests updated for the new defaults.

<sup>Written for commit 949eb6336e69f4b7b4370f3082a5f21aafb3d602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Prevents SQS batching teardown from immediately racing active server work and lowers the default worker recycle threshold.
- **Bug fixes:** Stops accepting new HTTP work, waits for active work, flushes application batches, and closes SQS batchers last; however, requests surviving the bounded wait can still create work after the final flush.
- **Improvements:** Tracks in-progress event and balance-sync batches during explicit flushes and logs SQS enqueue attempts rejected during teardown.
- **Improvements:** Forwards shutdown signals from the cluster primary to workers and increases worker shutdown backstops to thirty seconds.
- **Improvements:** Lowers the default fork recycle threshold from 3072 MB to 1536 MB while retaining the environment override.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because shutdown can still discard work created by requests surviving the settle timeout, and its fixed backstop can terminate pending SQS sends.

Shutdown performs only one application-batch flush after a bounded request wait even though surviving handlers can still add work, while the unconditional process-exit deadline can interrupt serial network-bound flush stages and active SQS sends.

**Files Needing Attention:** server/src/init.ts, server/src/internal/balances/events/EventBatchingManager.ts, server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts, server/src/queue/SqsBatchAccumulator.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/init.ts | Reorders clustered and worker shutdown around request settling and queue flushing, but bounded settling and the fixed exit deadline still permit side-effect loss. |
| server/src/internal/balances/events/EventBatchingManager.ts | Tracks active event deliveries for flush, while still allowing new batches to be added concurrently with teardown. |
| server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts | Tracks active synchronization executions for flush, while still allowing new customer batches during teardown. |
| server/src/queue/SqsBatchAccumulator.ts | Adds observable counting and logging for enqueue attempts rejected after accumulator shutdown. |
| server/src/utils/memory/forkRecycling/recyclePolicy.ts | Lowers the default worker RSS recycle threshold to 1536 MB while preserving configuration overrides. |
| server/tests/unit/memory/forkRecycling.test.ts | Updates recycle-policy expectations for the new default and verifies a distinct environment override. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Signal
  participant Server
  participant Request
  participant AppBatch as Event/Sync Batches
  participant SQS
  Signal->>Server: SIGTERM or recycle exit
  Server->>Server: Stop accepting connections
  Server->>Request: Wait up to 10 seconds
  alt Request finishes
    Request->>AppBatch: Add final work
  else Request remains active
    Server-->>Server: Continue after timeout
  end
  Server->>AppBatch: Flush current work once
  Server->>SQS: Close and flush accumulators
  Request-->>AppBatch: Possible late addition
  Note over AppBatch,SQS: Late work is not covered by the completed flush
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/init.ts:300-303
**Late batches escape shutdown flush**

When an in-flight request remains active beyond the ten-second settling window, shutdown performs its one-time application-batch flush while that request can still add an event or balance-sync item. The late work is then rejected during SQS teardown or left pending until process exit, dropping the side effect.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: bound signal-driven shutdowns with ..."](https://github.com/useautumn/autumn/commit/949eb6336e69f4b7b4370f3082a5f21aafb3d602) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51768160)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->