### PR TITLE
feat: choose payment methods on Autumn invoices

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -104,6 +104,7 @@ export const createInvoiceForBilling = async ({
 			: billingContextToCurrency({ org: ctx.org, billingContext }),
 		collectionMethod,
 		daysUntilDue: invoiceMode?.daysUntilDue,
+		paymentMethodTypes: invoiceMode?.paymentMethodTypes,
 		footer: invoiceMode?.footer,
 		description: invoiceMode?.memo,
 		metadata: invoiceMetadata,

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/stripeInvoiceOps.ts
@@ -1,3 +1,4 @@
+import type { InvoicePaymentMethod } from "@autumn/shared";
 import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { autumnStripeRequestOptions } from "@/external/stripe/common/autumnStripeIdempotency";
@@ -15,6 +16,7 @@ type CreateInvoiceParams = {
 	discounts?: Stripe.InvoiceCreateParams["discounts"];
 	collectionMethod?: "charge_automatically" | "send_invoice";
 	daysUntilDue?: number;
+	paymentMethodTypes?: InvoicePaymentMethod[];
 	description?: string;
 	footer?: string;
 	metadata?: Stripe.InvoiceCreateParams["metadata"];
@@ -29,6 +31,7 @@ export const createStripeInvoice = async ({
 	currency,
 	collectionMethod = "charge_automatically",
 	daysUntilDue,
+	paymentMethodTypes,
 	description,
 	footer,
 	metadata,
@@ -50,6 +53,9 @@ export const createStripeInvoice = async ({
 			collection_method: collectionMethod,
 			days_until_due:
 				collectionMethod === "send_invoice" ? (daysUntilDue ?? 30) : undefined,
+			...(paymentMethodTypes?.length
+				? { payment_settings: { payment_method_types: paymentMethodTypes } }
+				: {}),
 			...(discounts ? { discounts } : {}),
 			...(hasManualTaxRates ? { default_tax_rates: defaultTaxRates } : {}),
 			...(automaticTax && !hasManualTaxRates

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildInvoiceModeSubscriptionParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildInvoiceModeSubscriptionParams.ts
@@ -1,0 +1,37 @@
+import type { InvoiceMode, StripeSubscriptionAction } from "@autumn/shared";
+import type Stripe from "stripe";
+
+type InvoiceModeSubscriptionParams = Pick<
+	Stripe.SubscriptionCreateParams,
+	"collection_method" | "days_until_due" | "payment_settings"
+>;
+
+export const buildInvoiceModeSubscriptionParams = ({
+	invoiceMode,
+	subscriptionAction,
+}: {
+	invoiceMode?: InvoiceMode;
+	subscriptionAction: StripeSubscriptionAction;
+}): InvoiceModeSubscriptionParams => {
+	if (!invoiceMode) return {};
+
+	const params: InvoiceModeSubscriptionParams = {
+		collection_method: "send_invoice",
+		days_until_due: invoiceMode.daysUntilDue ?? 30,
+	};
+
+	const actionPaymentSettings =
+		subscriptionAction.type === "create" || subscriptionAction.type === "update"
+			? subscriptionAction.params.payment_settings
+			: undefined;
+
+	if (invoiceMode.paymentMethodTypes?.length) {
+		// Spread first so the custom-PM save_default_payment_method survives.
+		params.payment_settings = {
+			...actionPaymentSettings,
+			payment_method_types: invoiceMode.paymentMethodTypes,
+		};
+	}
+
+	return params;
+};

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -21,10 +21,23 @@ export const executeStripeSubscriptionOperation = async ({
 	const stripeClient = createStripeCli({ org, env });
 	const { paymentMethod } = billingContext;
 
+	// Merge onto the action's own payment_settings so the custom-PM
+	// save_default_payment_method survives.
+	const actionPaymentSettings =
+		"params" in subscriptionAction
+			? subscriptionAction.params.payment_settings
+			: undefined;
+
 	const invoiceModeParams = billingContext.invoiceMode
 		? {
 				collection_method: "send_invoice" as const,
 				days_until_due: billingContext.invoiceMode.daysUntilDue ?? 30,
+				...(billingContext.invoiceMode.paymentMethodTypes?.length && {
+					payment_settings: {
+						...actionPaymentSettings,
+						payment_method_types: billingContext.invoiceMode.paymentMethodTypes,
+					},
+				}),
 			}
 		: {};
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -1,5 +1,6 @@
 import type { BillingContext, StripeSubscriptionAction } from "@autumn/shared";
 import { InternalError } from "@autumn/shared";
+import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { autumnStripeRequestOptions } from "@/external/stripe/common/autumnStripeIdempotency";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -19,27 +20,31 @@ export const executeStripeSubscriptionOperation = async ({
 }) => {
 	const { org, env } = ctx;
 	const stripeClient = createStripeCli({ org, env });
-	const { paymentMethod } = billingContext;
+	const { paymentMethod, invoiceMode } = billingContext;
 
-	// Merge onto the action's own payment_settings so the custom-PM
-	// save_default_payment_method survives.
 	const actionPaymentSettings =
 		"params" in subscriptionAction
 			? subscriptionAction.params.payment_settings
 			: undefined;
 
-	const invoiceModeParams = billingContext.invoiceMode
-		? {
-				collection_method: "send_invoice" as const,
-				days_until_due: billingContext.invoiceMode.daysUntilDue ?? 30,
-				...(billingContext.invoiceMode.paymentMethodTypes?.length && {
-					payment_settings: {
-						...actionPaymentSettings,
-						payment_method_types: billingContext.invoiceMode.paymentMethodTypes,
-					},
-				}),
-			}
-		: {};
+	const invoiceModeParams: Pick<
+		Stripe.SubscriptionCreateParams,
+		"collection_method" | "days_until_due" | "payment_settings"
+	> = {};
+
+	if (invoiceMode) {
+		invoiceModeParams.collection_method = "send_invoice";
+		invoiceModeParams.days_until_due = invoiceMode.daysUntilDue ?? 30;
+
+		if (invoiceMode.paymentMethodTypes?.length) {
+			// Merge onto the action's own payment_settings so the custom-PM
+			// save_default_payment_method survives.
+			invoiceModeParams.payment_settings = {
+				...actionPaymentSettings,
+				payment_method_types: invoiceMode.paymentMethodTypes,
+			};
+		}
+	}
 
 	const updateWillCreateInvoice = willStripeSubscriptionUpdateCreateInvoice({
 		billingContext,

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -1,12 +1,12 @@
 import type { BillingContext, StripeSubscriptionAction } from "@autumn/shared";
 import { InternalError } from "@autumn/shared";
-import type Stripe from "stripe";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import { autumnStripeRequestOptions } from "@/external/stripe/common/autumnStripeIdempotency";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/autumnStripeMetadata";
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
 import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
+import { buildInvoiceModeSubscriptionParams } from "./buildInvoiceModeSubscriptionParams";
 import { willStripeSubscriptionUpdateCreateInvoice } from "./willStripeSubscriptionUpdateCreateInvoice";
 
 export const executeStripeSubscriptionOperation = async ({
@@ -22,28 +22,10 @@ export const executeStripeSubscriptionOperation = async ({
 	const stripeClient = createStripeCli({ org, env });
 	const { paymentMethod, invoiceMode } = billingContext;
 
-	const actionPaymentSettings =
-		subscriptionAction.type === "create" || subscriptionAction.type === "update"
-			? subscriptionAction.params.payment_settings
-			: undefined;
-
-	const invoiceModeParams: Pick<
-		Stripe.SubscriptionCreateParams,
-		"collection_method" | "days_until_due" | "payment_settings"
-	> = {};
-
-	if (invoiceMode) {
-		invoiceModeParams.collection_method = "send_invoice";
-		invoiceModeParams.days_until_due = invoiceMode.daysUntilDue ?? 30;
-
-		if (invoiceMode.paymentMethodTypes?.length) {
-			// Spread first so the custom-PM save_default_payment_method survives.
-			invoiceModeParams.payment_settings = {
-				...actionPaymentSettings,
-				payment_method_types: invoiceMode.paymentMethodTypes,
-			};
-		}
-	}
+	const invoiceModeParams = buildInvoiceModeSubscriptionParams({
+		invoiceMode,
+		subscriptionAction,
+	});
 
 	const updateWillCreateInvoice = willStripeSubscriptionUpdateCreateInvoice({
 		billingContext,

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -23,7 +23,7 @@ export const executeStripeSubscriptionOperation = async ({
 	const { paymentMethod, invoiceMode } = billingContext;
 
 	const actionPaymentSettings =
-		"params" in subscriptionAction
+		subscriptionAction.type === "create" || subscriptionAction.type === "update"
 			? subscriptionAction.params.payment_settings
 			: undefined;
 
@@ -37,8 +37,7 @@ export const executeStripeSubscriptionOperation = async ({
 		invoiceModeParams.days_until_due = invoiceMode.daysUntilDue ?? 30;
 
 		if (invoiceMode.paymentMethodTypes?.length) {
-			// Merge onto the action's own payment_settings so the custom-PM
-			// save_default_payment_method survives.
+			// Spread first so the custom-PM save_default_payment_method survives.
 			invoiceModeParams.payment_settings = {
 				...actionPaymentSettings,
 				payment_method_types: invoiceMode.paymentMethodTypes,

--- a/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
+++ b/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
@@ -17,7 +17,8 @@ export const setupInvoiceModeContext = async ({
 	if (params?.invoice_mode?.enabled !== true) {
 		return undefined;
 	}
-	const { invoice_template_id, net_terms_days } = params.invoice_mode;
+	const { invoice_template_id, net_terms_days, allowed_payment_methods } =
+		params.invoice_mode;
 	const template = invoice_template_id
 		? await InvoiceTemplateService.getById({
 				db: ctx.db,
@@ -31,5 +32,9 @@ export const setupInvoiceModeContext = async ({
 		footer: template?.footer,
 		memo: template?.memo,
 		daysUntilDue: net_terms_days ?? template?.net_terms_days,
+		paymentMethodTypes:
+			allowed_payment_methods ??
+			ctx.org.config.allowed_payment_methods ??
+			undefined,
 	};
 };

--- a/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
+++ b/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
@@ -17,8 +17,7 @@ export const setupInvoiceModeContext = async ({
 	if (params?.invoice_mode?.enabled !== true) {
 		return undefined;
 	}
-	const { invoice_template_id, net_terms_days, allowed_payment_methods } =
-		params.invoice_mode;
+	const { invoice_template_id, net_terms_days } = params.invoice_mode;
 	const template = invoice_template_id
 		? await InvoiceTemplateService.getById({
 				db: ctx.db,
@@ -32,9 +31,6 @@ export const setupInvoiceModeContext = async ({
 		footer: template?.footer,
 		memo: template?.memo,
 		daysUntilDue: net_terms_days ?? template?.net_terms_days,
-		paymentMethodTypes:
-			allowed_payment_methods ??
-			ctx.org.config.allowed_payment_methods ??
-			undefined,
+		paymentMethodTypes: ctx.org.config.allowed_payment_methods ?? undefined,
 	};
 };

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/buildStripeSubPaymentSettings.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/buildStripeSubPaymentSettings.ts
@@ -1,0 +1,25 @@
+import type { InvoicePaymentMethod } from "@autumn/shared";
+import type Stripe from "stripe";
+
+export const buildStripeSubPaymentSettings = ({
+	isCustomPaymentMethod,
+	invoiceOnly,
+	allowedPaymentMethods,
+}: {
+	isCustomPaymentMethod: boolean;
+	invoiceOnly?: boolean;
+	allowedPaymentMethods?: InvoicePaymentMethod[] | null;
+}): Stripe.SubscriptionCreateParams.PaymentSettings | undefined => {
+	const paymentSettings: Stripe.SubscriptionCreateParams.PaymentSettings = {};
+
+	if (isCustomPaymentMethod) {
+		// Save the custom PM on the sub so webhook handlers and renewals can find it.
+		paymentSettings.save_default_payment_method = "on_subscription";
+	}
+
+	if (invoiceOnly && allowedPaymentMethods?.length) {
+		paymentSettings.payment_method_types = allowedPaymentMethods;
+	}
+
+	return Object.keys(paymentSettings).length > 0 ? paymentSettings : undefined;
+};

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -60,6 +60,20 @@ export const createStripeSub2 = async ({
 	// Custom PMs (Vercel, etc.) use external payment confirmation.
 	const isCustomPaymentMethod = paymentMethod?.type === "custom";
 
+	const invoicePaymentMethodTypes = invoiceOnly
+		? org.config.allowed_payment_methods
+		: undefined;
+
+	const paymentSettings: Stripe.SubscriptionCreateParams.PaymentSettings = {
+		// Save the custom PM on the sub so webhook handlers and renewals can find it.
+		...(isCustomPaymentMethod && {
+			save_default_payment_method: "on_subscription" as const,
+		}),
+		...(invoicePaymentMethodTypes?.length && {
+			payment_method_types: invoicePaymentMethodTypes,
+		}),
+	};
+
 	try {
 		// Skip auto_tax in invoice mode: send_invoice has no
 		// address-collection UI so Stripe Tax rejects.
@@ -97,12 +111,8 @@ export const createStripeSub2 = async ({
 				...buildAutumnSubscriptionMetadata({ actionSource: "v1Attach" }),
 			},
 
-			// Save the custom PM on the sub so webhook handlers and renewals
-			// can find it.
-			...(isCustomPaymentMethod && {
-				payment_settings: {
-					save_default_payment_method: "on_subscription",
-				},
+			...(Object.keys(paymentSettings).length > 0 && {
+				payment_settings: paymentSettings,
 			}),
 
 			trial_settings:

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -1,6 +1,6 @@
 import { type AttachConfig, ErrCode } from "@autumn/shared";
 import type { Logger } from "@server/external/logtail/logtailUtils";
-import type Stripe from "stripe";
+import Stripe from "stripe";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { getCusPaymentMethod } from "@/external/stripe/stripeCusUtils.js";
 import {
@@ -182,12 +182,19 @@ export const createStripeSub2 = async ({
 		console.log("Decline code:", error.decline_code);
 		console.log("Error original stack:", error.stack);
 
+		// Stripe rejects caller-fixable params (unactivated payment method type,
+		// currency mismatch, declined card) with 4xx — don't mask those as 500.
+		const stripeStatusCode =
+			error instanceof Stripe.errors.StripeError ? error.statusCode : undefined;
+		const isClientError =
+			!!stripeStatusCode && stripeStatusCode >= 400 && stripeStatusCode < 500;
+
 		throw new RecaseError({
 			code: ErrCode.CreateStripeSubscriptionFailed,
 			message: `Create stripe subscription failed ${
 				error.code ? `(${error.code})` : ""
 			}: ${error.message || ""}`,
-			statusCode: 500,
+			statusCode: isClientError ? stripeStatusCode : 500,
 		});
 	}
 };

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -17,6 +17,7 @@ import { SubService } from "@/internal/subscriptions/SubService.js";
 import RecaseError from "@/utils/errorUtils.js";
 import { generateId } from "@/utils/genUtils.js";
 import type { ItemSet } from "@/utils/models/ItemSet.js";
+import { buildStripeSubPaymentSettings } from "./buildStripeSubPaymentSettings.js";
 
 export const createStripeSub2 = async ({
 	db,
@@ -60,16 +61,11 @@ export const createStripeSub2 = async ({
 	// Custom PMs (Vercel, etc.) use external payment confirmation.
 	const isCustomPaymentMethod = paymentMethod?.type === "custom";
 
-	const paymentSettings: Stripe.SubscriptionCreateParams.PaymentSettings = {};
-
-	if (isCustomPaymentMethod) {
-		// Save the custom PM on the sub so webhook handlers and renewals can find it.
-		paymentSettings.save_default_payment_method = "on_subscription";
-	}
-
-	if (invoiceOnly && org.config.allowed_payment_methods?.length) {
-		paymentSettings.payment_method_types = org.config.allowed_payment_methods;
-	}
+	const paymentSettings = buildStripeSubPaymentSettings({
+		isCustomPaymentMethod,
+		invoiceOnly,
+		allowedPaymentMethods: org.config.allowed_payment_methods,
+	});
 
 	try {
 		// Skip auto_tax in invoice mode: send_invoice has no
@@ -108,9 +104,7 @@ export const createStripeSub2 = async ({
 				...buildAutumnSubscriptionMetadata({ actionSource: "v1Attach" }),
 			},
 
-			...(Object.keys(paymentSettings).length > 0 && {
-				payment_settings: paymentSettings,
-			}),
+			...(paymentSettings && { payment_settings: paymentSettings }),
 
 			trial_settings:
 				freeTrial && !freeTrial.card_required

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -60,19 +60,16 @@ export const createStripeSub2 = async ({
 	// Custom PMs (Vercel, etc.) use external payment confirmation.
 	const isCustomPaymentMethod = paymentMethod?.type === "custom";
 
-	const invoicePaymentMethodTypes = invoiceOnly
-		? org.config.allowed_payment_methods
-		: undefined;
+	const paymentSettings: Stripe.SubscriptionCreateParams.PaymentSettings = {};
 
-	const paymentSettings: Stripe.SubscriptionCreateParams.PaymentSettings = {
+	if (isCustomPaymentMethod) {
 		// Save the custom PM on the sub so webhook handlers and renewals can find it.
-		...(isCustomPaymentMethod && {
-			save_default_payment_method: "on_subscription" as const,
-		}),
-		...(invoicePaymentMethodTypes?.length && {
-			payment_method_types: invoicePaymentMethodTypes,
-		}),
-	};
+		paymentSettings.save_default_payment_method = "on_subscription";
+	}
+
+	if (invoiceOnly && org.config.allowed_payment_methods?.length) {
+		paymentSettings.payment_method_types = org.config.allowed_payment_methods;
+	}
 
 	try {
 		// Skip auto_tax in invoice mode: send_invoice has no

--- a/server/tests/integration/billing/attach/invoice/invoice-mode-allowed-payment-methods.test.ts
+++ b/server/tests/integration/billing/attach/invoice/invoice-mode-allowed-payment-methods.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression coverage for org-level `allowed_payment_methods` on invoice-mode
+ * subscriptions (PRD: "Choose payment methods on Autumn invoices").
+ *
+ * Contract under test:
+ *   - `org.config.allowed_payment_methods` is applied as
+ *     `payment_settings.payment_method_types` on invoice-mode (send_invoice)
+ *     subscription creation.
+ *   - The next-cycle (renewal/overage) invoice inherits the list from the
+ *     subscription — usage tracked at $0.01/unit lands as a $10 cycle invoice
+ *     offering the configured methods, bank transfer included.
+ *   - Unset config sends no payment_method_types, so Stripe's own account
+ *     invoice settings keep applying (no behavior change for existing orgs).
+ */
+
+import { expect, test } from "bun:test";
+import type { InvoicePaymentMethod } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+
+const ALLOWED_PAYMENT_METHODS: InvoicePaymentMethod[] = [
+	"card",
+	"customer_balance",
+	"us_bank_account",
+	"link",
+];
+
+const sorted = (values: string[] | null | undefined) =>
+	[...(values ?? [])].sort();
+
+const findCycleInvoice = async ({
+	stripeCli,
+	stripeCustomerId,
+}: {
+	stripeCli: Stripe;
+	stripeCustomerId: string;
+}): Promise<Stripe.Invoice | undefined> => {
+	for (let attempt = 0; attempt < 5; attempt++) {
+		const invoices = await stripeCli.invoices.list({
+			customer: stripeCustomerId,
+			limit: 10,
+		});
+		const cycleInvoice = invoices.data.find(
+			(invoice) => invoice.billing_reason === "subscription_cycle",
+		);
+		if (cycleInvoice) return cycleInvoice;
+		await timeout(10000);
+	}
+	return undefined;
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// TEST 1: configured methods reach the sub and its next-cycle invoice
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-mode payment methods: cycle invoice inherits the org's allowed list")}`,
+	async () => {
+		const customerId = "invoice-payment-methods-cycle";
+		const usageItem = items.consumable({
+			featureId: TestFeature.Messages,
+			includedUsage: 0,
+			price: 0.01,
+			billingUnits: 1,
+		});
+		const usagePlan = products.base({
+			id: "usage-plan",
+			items: [usageItem],
+		});
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: { allowed_payment_methods: ALLOWED_PAYMENT_METHODS },
+					setupDefaultFeatures: true,
+				}),
+				s.customer({ testClock: true }),
+				s.products({ list: [usagePlan] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: usagePlan.id,
+					invoice: true,
+					enableProductImmediately: true,
+					finalizeInvoice: true,
+				}),
+				s.track({
+					featureId: TestFeature.Messages,
+					value: 1000,
+					timeout: 3000,
+				}),
+				s.advanceToNextInvoice({ withPause: true }),
+			],
+		});
+
+		const stripeCustomerId = customer!.processor!.id!;
+		const subscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: stripeCustomerId,
+			limit: 1,
+		});
+		const subscription = subscriptions.data[0];
+
+		expect(subscription).toBeDefined();
+		expect(subscription.collection_method).toBe("send_invoice");
+		expect(sorted(subscription.payment_settings?.payment_method_types)).toEqual(
+			sorted(ALLOWED_PAYMENT_METHODS),
+		);
+
+		const cycleInvoice = await findCycleInvoice({
+			stripeCli: ctx.stripeCli,
+			stripeCustomerId,
+		});
+
+		expect(cycleInvoice).toBeDefined();
+		// 1000 tracked units × $0.01 = $10.00
+		expect(cycleInvoice!.total).toBe(1000);
+		expect(
+			sorted(cycleInvoice!.payment_settings?.payment_method_types),
+		).toEqual(sorted(ALLOWED_PAYMENT_METHODS));
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// TEST 2: unset config leaves Stripe's own invoice settings in charge
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-mode payment methods: unset org config sends no payment_method_types")}`,
+	async () => {
+		const customerId = "invoice-payment-methods-unset";
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [pro] })],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					invoice: true,
+					finalizeInvoice: true,
+				}),
+			],
+		});
+
+		const subscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: customer!.processor!.id!,
+			limit: 1,
+		});
+		const subscription = subscriptions.data[0];
+
+		expect(subscription).toBeDefined();
+		expect(subscription.collection_method).toBe("send_invoice");
+		expect(subscription.payment_settings?.payment_method_types).toBeNull();
+	},
+);

--- a/server/tests/integration/billing/attach/invoice/invoice-mode-allowed-payment-methods.test.ts
+++ b/server/tests/integration/billing/attach/invoice/invoice-mode-allowed-payment-methods.test.ts
@@ -8,13 +8,16 @@
  *     subscription creation.
  *   - The next-cycle (renewal/overage) invoice inherits the list from the
  *     subscription — usage tracked at $0.01/unit lands as a $10 cycle invoice
- *     offering the configured methods, bank transfer included.
+ *     offering the configured methods.
  *   - Unset config sends no payment_method_types, so Stripe's own account
  *     invoice settings keep applying (no behavior change for existing orgs).
  */
 
 import { expect, test } from "bun:test";
-import type { InvoicePaymentMethod } from "@autumn/shared";
+import {
+	type InvoicePaymentMethod,
+	InvoicePaymentMethodSchema,
+} from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { items } from "@tests/utils/fixtures/items.js";
 import { products } from "@tests/utils/fixtures/products.js";
@@ -23,7 +26,9 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import type Stripe from "stripe";
 
-const ALLOWED_PAYMENT_METHODS: InvoicePaymentMethod[] = [
+// USD-compatible subset of the org config enum. Currency-restricted methods
+// (sepa_debit, bacs_debit, acss_debit) are left out of the probe.
+const CANDIDATE_PAYMENT_METHODS: InvoicePaymentMethod[] = [
 	"card",
 	"customer_balance",
 	"us_bank_account",
@@ -32,6 +37,48 @@ const ALLOWED_PAYMENT_METHODS: InvoicePaymentMethod[] = [
 
 const sorted = (values: string[] | null | undefined) =>
 	[...(values ?? [])].sort();
+
+/** Escape hatch for accounts whose payment method configuration under-reports
+ *  what invoices accept, e.g. `TEST_INVOICE_PAYMENT_METHODS=card,link`. */
+const paymentMethodsOverride = () => {
+	const raw = process.env.TEST_INVOICE_PAYMENT_METHODS;
+	if (!raw) return undefined;
+	const parsed = InvoicePaymentMethodSchema.array()
+		.min(1)
+		.safeParse(raw.split(",").map((method) => method.trim()));
+	if (!parsed.success) {
+		throw new Error(
+			`TEST_INVOICE_PAYMENT_METHODS is not a valid payment method list: "${raw}"`,
+		);
+	}
+	return parsed.data;
+};
+
+/** Stripe rejects a subscription that lists a method the account has not
+ *  activated, so assert only on what this account actually offers. */
+const resolveActivatedPaymentMethods = async ({
+	stripeCli,
+}: {
+	stripeCli: Stripe;
+}): Promise<InvoicePaymentMethod[]> => {
+	const override = paymentMethodsOverride();
+	if (override) return override;
+
+	try {
+		const configurations = await stripeCli.paymentMethodConfigurations.list({
+			limit: 10,
+		});
+		const defaultConfiguration =
+			configurations.data.find((configuration) => configuration.is_default) ??
+			configurations.data[0];
+		const activated = CANDIDATE_PAYMENT_METHODS.filter(
+			(method) => defaultConfiguration?.[method]?.available === true,
+		);
+		return activated.length > 0 ? activated : ["card"];
+	} catch {
+		return ["card"];
+	}
+};
 
 const findCycleInvoice = async ({
 	stripeCli,
@@ -73,11 +120,31 @@ test.concurrent(
 			items: [usageItem],
 		});
 
+		// The sub-org's own Stripe account decides which methods are configurable,
+		// and the org config has to be in place before the attach — so provision
+		// it first, probe it, then run the scenario against the same sub-org.
+		const subOrgSlug = `invoice-pm-${Math.random().toString(36).slice(2, 8)}`;
+		const { ctx: probeCtx } = await initScenario({
+			setup: [s.platform.create({ slug: subOrgSlug })],
+			actions: [],
+		});
+
+		const allowedPaymentMethods = await resolveActivatedPaymentMethods({
+			stripeCli: probeCtx.stripeCli,
+		});
+
+		if (allowedPaymentMethods.length < 2) {
+			console.warn(
+				`[invoice-mode-allowed-payment-methods] only "${allowedPaymentMethods.join(", ")}" activated on Stripe account ${probeCtx.org.slug}; asserting on a reduced list`,
+			);
+		}
+
 		const { ctx, customer } = await initScenario({
 			customerId,
 			setup: [
 				s.platform.create({
-					configOverrides: { allowed_payment_methods: ALLOWED_PAYMENT_METHODS },
+					slug: subOrgSlug,
+					configOverrides: { allowed_payment_methods: allowedPaymentMethods },
 					setupDefaultFeatures: true,
 				}),
 				s.customer({ testClock: true }),
@@ -109,7 +176,7 @@ test.concurrent(
 		expect(subscription).toBeDefined();
 		expect(subscription.collection_method).toBe("send_invoice");
 		expect(sorted(subscription.payment_settings?.payment_method_types)).toEqual(
-			sorted(ALLOWED_PAYMENT_METHODS),
+			sorted(allowedPaymentMethods),
 		);
 
 		const cycleInvoice = await findCycleInvoice({
@@ -122,7 +189,7 @@ test.concurrent(
 		expect(cycleInvoice!.total).toBe(1000);
 		expect(
 			sorted(cycleInvoice!.payment_settings?.payment_method_types),
-		).toEqual(sorted(ALLOWED_PAYMENT_METHODS));
+		).toEqual(sorted(allowedPaymentMethods));
 	},
 );
 

--- a/server/tests/unit/billing/setup-invoice-mode-context.test.ts
+++ b/server/tests/unit/billing/setup-invoice-mode-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AttachParamsV1, InvoicePaymentMethod } from "@autumn/shared";
-import { InvoiceModeParamsSchema, OrgConfigSchema } from "@autumn/shared";
+import { OrgConfigSchema } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupInvoiceModeContext } from "@/internal/billing/v2/setup/setupInvoiceModeContext";
 
@@ -17,19 +17,12 @@ const makeCtx = ({
 		},
 	}) as unknown as AutumnContext;
 
-const makeParams = ({
-	enabled = true,
-	allowedPaymentMethods,
-}: {
-	enabled?: boolean;
-	allowedPaymentMethods?: InvoicePaymentMethod[];
-}) =>
+const makeParams = ({ enabled = true }: { enabled?: boolean }) =>
 	({
 		invoice_mode: {
 			enabled,
 			enable_plan_immediately: false,
 			finalize: true,
-			allowed_payment_methods: allowedPaymentMethods,
 		},
 	}) as unknown as AttachParamsV1;
 
@@ -44,15 +37,6 @@ describe("setupInvoiceModeContext payment method types", () => {
 			"card",
 			"us_bank_account",
 		]);
-	});
-
-	test("per-attach override beats the org config", async () => {
-		const invoiceMode = await setupInvoiceModeContext({
-			ctx: makeCtx({ allowedPaymentMethods: ["card"] }),
-			params: makeParams({ allowedPaymentMethods: ["sepa_debit"] }),
-		});
-
-		expect(invoiceMode?.paymentMethodTypes).toEqual(["sepa_debit"]);
 	});
 
 	test("stays undefined when nothing is configured", async () => {
@@ -74,8 +58,8 @@ describe("setupInvoiceModeContext payment method types", () => {
 	});
 });
 
-describe("allowed_payment_methods schemas reject empty lists", () => {
-	test("org config rejects an empty array but allows null or omitted", () => {
+describe("allowed_payment_methods org config schema", () => {
+	test("rejects an empty array but allows null or omitted", () => {
 		expect(
 			OrgConfigSchema.safeParse({ allowed_payment_methods: [] }).success,
 		).toBe(false);
@@ -88,23 +72,5 @@ describe("allowed_payment_methods schemas reject empty lists", () => {
 			OrgConfigSchema.parse({ allowed_payment_methods: ["card"] })
 				.allowed_payment_methods,
 		).toEqual(["card"]);
-	});
-
-	test("invoice mode params reject an empty array but allow omitted", () => {
-		expect(
-			InvoiceModeParamsSchema.safeParse({
-				enabled: true,
-				allowed_payment_methods: [],
-			}).success,
-		).toBe(false);
-		expect(
-			InvoiceModeParamsSchema.parse({ enabled: true }).allowed_payment_methods,
-		).toBeUndefined();
-		expect(
-			InvoiceModeParamsSchema.parse({
-				enabled: true,
-				allowed_payment_methods: ["sepa_debit"],
-			}).allowed_payment_methods,
-		).toEqual(["sepa_debit"]);
 	});
 });

--- a/server/tests/unit/billing/setup-invoice-mode-context.test.ts
+++ b/server/tests/unit/billing/setup-invoice-mode-context.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AttachParamsV1, InvoicePaymentMethod } from "@autumn/shared";
+import { InvoiceModeParamsSchema, OrgConfigSchema } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupInvoiceModeContext } from "@/internal/billing/v2/setup/setupInvoiceModeContext";
 
@@ -70,5 +71,40 @@ describe("setupInvoiceModeContext payment method types", () => {
 		});
 
 		expect(invoiceMode).toBeUndefined();
+	});
+});
+
+describe("allowed_payment_methods schemas reject empty lists", () => {
+	test("org config rejects an empty array but allows null or omitted", () => {
+		expect(
+			OrgConfigSchema.safeParse({ allowed_payment_methods: [] }).success,
+		).toBe(false);
+		expect(
+			OrgConfigSchema.parse({ allowed_payment_methods: null })
+				.allowed_payment_methods,
+		).toBeNull();
+		expect(OrgConfigSchema.parse({}).allowed_payment_methods).toBeUndefined();
+		expect(
+			OrgConfigSchema.parse({ allowed_payment_methods: ["card"] })
+				.allowed_payment_methods,
+		).toEqual(["card"]);
+	});
+
+	test("invoice mode params reject an empty array but allow omitted", () => {
+		expect(
+			InvoiceModeParamsSchema.safeParse({
+				enabled: true,
+				allowed_payment_methods: [],
+			}).success,
+		).toBe(false);
+		expect(
+			InvoiceModeParamsSchema.parse({ enabled: true }).allowed_payment_methods,
+		).toBeUndefined();
+		expect(
+			InvoiceModeParamsSchema.parse({
+				enabled: true,
+				allowed_payment_methods: ["sepa_debit"],
+			}).allowed_payment_methods,
+		).toEqual(["sepa_debit"]);
 	});
 });

--- a/server/tests/unit/billing/setup-invoice-mode-context.test.ts
+++ b/server/tests/unit/billing/setup-invoice-mode-context.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { AttachParamsV1, InvoicePaymentMethod } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { setupInvoiceModeContext } from "@/internal/billing/v2/setup/setupInvoiceModeContext";
+
+const makeCtx = ({
+	allowedPaymentMethods,
+}: {
+	allowedPaymentMethods?: InvoicePaymentMethod[] | null;
+}) =>
+	({
+		db: {},
+		org: {
+			id: "org_123",
+			config: { allowed_payment_methods: allowedPaymentMethods },
+		},
+	}) as unknown as AutumnContext;
+
+const makeParams = ({
+	enabled = true,
+	allowedPaymentMethods,
+}: {
+	enabled?: boolean;
+	allowedPaymentMethods?: InvoicePaymentMethod[];
+}) =>
+	({
+		invoice_mode: {
+			enabled,
+			enable_plan_immediately: false,
+			finalize: true,
+			allowed_payment_methods: allowedPaymentMethods,
+		},
+	}) as unknown as AttachParamsV1;
+
+describe("setupInvoiceModeContext payment method types", () => {
+	test("falls back to the org config list", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({ allowedPaymentMethods: ["card", "us_bank_account"] }),
+			params: makeParams({}),
+		});
+
+		expect(invoiceMode?.paymentMethodTypes).toEqual([
+			"card",
+			"us_bank_account",
+		]);
+	});
+
+	test("per-attach override beats the org config", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({ allowedPaymentMethods: ["card"] }),
+			params: makeParams({ allowedPaymentMethods: ["sepa_debit"] }),
+		});
+
+		expect(invoiceMode?.paymentMethodTypes).toEqual(["sepa_debit"]);
+	});
+
+	test("stays undefined when nothing is configured", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({ allowedPaymentMethods: null }),
+			params: makeParams({}),
+		});
+
+		expect(invoiceMode?.paymentMethodTypes).toBeUndefined();
+	});
+
+	test("returns no invoice mode when invoice mode is off", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({ allowedPaymentMethods: ["card"] }),
+			params: makeParams({ enabled: false }),
+		});
+
+		expect(invoiceMode).toBeUndefined();
+	});
+});

--- a/server/tests/unit/billing/stripe/invoices/create-invoice-for-billing-payment-settings.test.ts
+++ b/server/tests/unit/billing/stripe/invoices/create-invoice-for-billing-payment-settings.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+	BillingContext,
+	InvoicePaymentMethod,
+	StripeInvoiceAction,
+} from "@autumn/shared";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { mockModuleWithRestore } from "../../../utils/mockModuleWithRestore.js";
+
+const mockState = {
+	createCalls: [] as Stripe.InvoiceCreateParams[],
+};
+
+await mockModuleWithRestore("@server/external/connect/createStripeCli", () => ({
+	createStripeCli: () => ({
+		invoices: {
+			create: async (params: Stripe.InvoiceCreateParams) => {
+				mockState.createCalls.push(params);
+				return { id: "in_created" };
+			},
+			addLines: async (invoiceId: string) => ({ id: invoiceId }),
+			finalizeInvoice: async (invoiceId: string) => ({
+				id: invoiceId,
+				status: "paid",
+			}),
+		},
+	}),
+}));
+
+const { createInvoiceForBilling } = await import(
+	"@/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling"
+);
+
+const ctx = {
+	org: {
+		id: "org_123",
+		config: { automatic_tax: false },
+		default_currency: "usd",
+	},
+	env: "sandbox",
+} as unknown as AutumnContext;
+
+const stripeInvoiceAction = {
+	addLineParams: { lines: [{ amount: 1000, currency: "usd" }] },
+} as unknown as StripeInvoiceAction;
+
+const makeBillingContext = ({
+	invoiceMode = true,
+	paymentMethodTypes,
+}: {
+	invoiceMode?: boolean;
+	paymentMethodTypes?: InvoicePaymentMethod[];
+}) =>
+	({
+		fullCustomer: { currency: "usd" },
+		stripeCustomer: { id: "cus_123" },
+		...(invoiceMode && {
+			invoiceMode: {
+				finalizeInvoice: false,
+				enableProductImmediately: true,
+				paymentMethodTypes,
+			},
+		}),
+	}) as unknown as BillingContext;
+
+describe("createInvoiceForBilling payment settings", () => {
+	beforeEach(() => {
+		mockState.createCalls = [];
+	});
+
+	test("applies the resolved payment method types in invoice mode", async () => {
+		await createInvoiceForBilling({
+			ctx,
+			billingContext: makeBillingContext({
+				paymentMethodTypes: ["card", "customer_balance"],
+			}),
+			stripeInvoiceAction,
+		});
+
+		expect(mockState.createCalls[0]?.collection_method).toBe("send_invoice");
+		expect(mockState.createCalls[0]?.payment_settings).toEqual({
+			payment_method_types: ["card", "customer_balance"],
+		});
+	});
+
+	test("sends no payment settings in invoice mode when nothing is resolved", async () => {
+		await createInvoiceForBilling({
+			ctx,
+			billingContext: makeBillingContext({}),
+			stripeInvoiceAction,
+		});
+
+		expect(mockState.createCalls[0]?.collection_method).toBe("send_invoice");
+		expect(mockState.createCalls[0]?.payment_settings).toBeUndefined();
+	});
+
+	test("sends no payment settings outside invoice mode", async () => {
+		await createInvoiceForBilling({
+			ctx,
+			billingContext: makeBillingContext({ invoiceMode: false }),
+			stripeInvoiceAction,
+		});
+
+		expect(mockState.createCalls[0]?.collection_method).toBe(
+			"charge_automatically",
+		);
+		expect(mockState.createCalls[0]?.payment_settings).toBeUndefined();
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/server/tests/unit/billing/stripe/subscriptions/execute-stripe-subscription-operation-payment-settings.test.ts
+++ b/server/tests/unit/billing/stripe/subscriptions/execute-stripe-subscription-operation-payment-settings.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+	BillingContext,
+	InvoicePaymentMethod,
+	StripeSubscriptionAction,
+} from "@autumn/shared";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { mockModuleWithRestore } from "../../../utils/mockModuleWithRestore.js";
+
+const mockState = {
+	createCalls: [] as Stripe.SubscriptionCreateParams[],
+	updateCalls: [] as Stripe.SubscriptionUpdateParams[],
+};
+
+await mockModuleWithRestore("@server/external/connect/createStripeCli", () => ({
+	createStripeCli: () => ({
+		subscriptions: {
+			create: async (params: Stripe.SubscriptionCreateParams) => {
+				mockState.createCalls.push(params);
+				return { id: "sub_created" };
+			},
+			update: async (
+				_subscriptionId: string,
+				params: Stripe.SubscriptionUpdateParams,
+			) => {
+				mockState.updateCalls.push(params);
+				return { id: "sub_updated" };
+			},
+		},
+	}),
+}));
+
+const { executeStripeSubscriptionOperation } = await import(
+	"@/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation"
+);
+
+const ctx = {
+	org: { id: "org_123", config: { automatic_tax: false } },
+	env: "sandbox",
+} as unknown as AutumnContext;
+
+const makeBillingContext = ({
+	invoiceMode = true,
+	paymentMethodTypes,
+	trialing = false,
+}: {
+	invoiceMode?: boolean;
+	paymentMethodTypes?: InvoicePaymentMethod[];
+	trialing?: boolean;
+}) =>
+	({
+		stripeCustomer: { id: "cus_123" },
+		...(trialing && {
+			stripeSubscription: {
+				id: "sub_123",
+				status: "trialing",
+				billing_mode: { type: "flexible" },
+			},
+			trialContext: { trialEndsAt: null },
+		}),
+		...(invoiceMode && {
+			invoiceMode: {
+				finalizeInvoice: true,
+				enableProductImmediately: true,
+				paymentMethodTypes,
+			},
+		}),
+	}) as unknown as BillingContext;
+
+const createAction = (
+	params: Stripe.SubscriptionCreateParams = { customer: "cus_123" },
+): StripeSubscriptionAction => ({ type: "create", params });
+
+describe("executeStripeSubscriptionOperation payment settings", () => {
+	beforeEach(() => {
+		mockState.createCalls = [];
+		mockState.updateCalls = [];
+	});
+
+	test("applies the resolved payment method types in invoice mode", async () => {
+		await executeStripeSubscriptionOperation({
+			ctx,
+			billingContext: makeBillingContext({
+				paymentMethodTypes: ["card", "customer_balance"],
+			}),
+			subscriptionAction: createAction(),
+		});
+
+		expect(mockState.createCalls[0]?.collection_method).toBe("send_invoice");
+		expect(mockState.createCalls[0]?.payment_settings).toEqual({
+			payment_method_types: ["card", "customer_balance"],
+		});
+	});
+
+	test("sends no payment settings in invoice mode when nothing is resolved", async () => {
+		await executeStripeSubscriptionOperation({
+			ctx,
+			billingContext: makeBillingContext({}),
+			subscriptionAction: createAction(),
+		});
+
+		expect(mockState.createCalls[0]?.collection_method).toBe("send_invoice");
+		expect(mockState.createCalls[0]?.payment_settings).toBeUndefined();
+	});
+
+	test("sends no payment method types outside invoice mode", async () => {
+		await executeStripeSubscriptionOperation({
+			ctx,
+			billingContext: makeBillingContext({
+				invoiceMode: false,
+				paymentMethodTypes: ["card"],
+			}),
+			subscriptionAction: createAction(),
+		});
+
+		expect(mockState.createCalls[0]?.collection_method).toBeUndefined();
+		expect(mockState.createCalls[0]?.payment_settings).toBeUndefined();
+	});
+
+	test("keeps save_default_payment_method from the custom payment method flow", async () => {
+		await executeStripeSubscriptionOperation({
+			ctx,
+			billingContext: makeBillingContext({ paymentMethodTypes: ["card"] }),
+			subscriptionAction: createAction({
+				customer: "cus_123",
+				payment_settings: { save_default_payment_method: "on_subscription" },
+			}),
+		});
+
+		expect(mockState.createCalls[0]?.payment_settings).toEqual({
+			save_default_payment_method: "on_subscription",
+			payment_method_types: ["card"],
+		});
+	});
+
+	test("applies payment method types on updates that create an invoice", async () => {
+		await executeStripeSubscriptionOperation({
+			ctx,
+			billingContext: makeBillingContext({
+				paymentMethodTypes: ["bacs_debit"],
+				trialing: true,
+			}),
+			subscriptionAction: {
+				type: "update",
+				stripeSubscriptionId: "sub_123",
+				params: {},
+			},
+		});
+
+		expect(mockState.updateCalls[0]?.payment_settings).toEqual({
+			payment_method_types: ["bacs_debit"],
+		});
+	});
+
+	test("leaves updates that create no invoice untouched", async () => {
+		await executeStripeSubscriptionOperation({
+			ctx,
+			billingContext: makeBillingContext({ paymentMethodTypes: ["card"] }),
+			subscriptionAction: {
+				type: "update",
+				stripeSubscriptionId: "sub_123",
+				params: {},
+			},
+		});
+
+		expect(mockState.updateCalls[0]?.payment_settings).toBeUndefined();
+		expect(mockState.updateCalls[0]?.collection_method).toBeUndefined();
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/shared/api/billing/common/invoiceModeParams.ts
+++ b/shared/api/billing/common/invoiceModeParams.ts
@@ -24,6 +24,7 @@ export const InvoiceModeParamsSchema = z
 		}),
 		allowed_payment_methods: z
 			.array(InvoicePaymentMethodSchema)
+			.min(1)
 			.optional()
 			.meta({
 				description:

--- a/shared/api/billing/common/invoiceModeParams.ts
+++ b/shared/api/billing/common/invoiceModeParams.ts
@@ -1,3 +1,4 @@
+import { InvoicePaymentMethodSchema } from "@models/orgModels/orgConfig";
 import { z } from "zod/v4";
 export const InvoiceModeParamsSchema = z
 	.object({
@@ -21,6 +22,13 @@ export const InvoiceModeParamsSchema = z
 			description:
 				"Number of days the customer has to pay the invoice before it is due (Stripe days_until_due).",
 		}),
+		allowed_payment_methods: z
+			.array(InvoicePaymentMethodSchema)
+			.optional()
+			.meta({
+				description:
+					"Payment methods offered on the invoices this subscription generates. Overrides the org-level setting for this attach, and only applies in invoice mode.",
+			}),
 	})
 	.meta({
 		title: "InvoiceMode",

--- a/shared/api/billing/common/invoiceModeParams.ts
+++ b/shared/api/billing/common/invoiceModeParams.ts
@@ -1,4 +1,3 @@
-import { InvoicePaymentMethodSchema } from "@models/orgModels/orgConfig";
 import { z } from "zod/v4";
 export const InvoiceModeParamsSchema = z
 	.object({
@@ -22,14 +21,6 @@ export const InvoiceModeParamsSchema = z
 			description:
 				"Number of days the customer has to pay the invoice before it is due (Stripe days_until_due).",
 		}),
-		allowed_payment_methods: z
-			.array(InvoicePaymentMethodSchema)
-			.min(1)
-			.optional()
-			.meta({
-				description:
-					"Payment methods offered on the invoices this subscription generates. Overrides the org-level setting for this attach, and only applies in invoice mode.",
-			}),
 	})
 	.meta({
 		title: "InvoiceMode",

--- a/shared/models/billingModels/context/billingContext.ts
+++ b/shared/models/billingModels/context/billingContext.ts
@@ -12,6 +12,7 @@ import type {
 import type { PaymentBehaviorIntent } from "@models/billingModels/context/paymentBehaviorIntent";
 import type { TransitionConfig } from "@models/billingModels/context/transitionConfig";
 import type { DbInvoiceLineItem } from "@models/cusModels/invoiceModels/invoiceLineItemTable";
+import { InvoicePaymentMethodSchema } from "@models/orgModels/orgConfig";
 import type { EntInterval } from "@models/productModels/intervals/entitlementInterval";
 import type Stripe from "stripe";
 import { z } from "zod/v4";
@@ -27,6 +28,7 @@ const InvoiceModeSchema = z.object({
 	footer: z.string().optional(),
 	memo: z.string().optional(),
 	daysUntilDue: z.number().optional(),
+	paymentMethodTypes: z.array(InvoicePaymentMethodSchema).optional(),
 });
 
 export type InvoiceMode = z.infer<typeof InvoiceModeSchema>;

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -1,6 +1,20 @@
 import { z } from "zod/v4";
 import { DbUsageAlertSchema } from "../cusModels/billingControls/usageAlert.js";
 
+/** Invoice-capable subset of Stripe's subscription
+ *  `payment_settings.payment_method_types`. */
+export const InvoicePaymentMethodSchema = z.enum([
+	"card",
+	"customer_balance",
+	"us_bank_account",
+	"sepa_debit",
+	"bacs_debit",
+	"acss_debit",
+	"link",
+]);
+
+export type InvoicePaymentMethod = z.infer<typeof InvoicePaymentMethodSchema>;
+
 export const OrgConfigSchema = z.object({
 	usage_alerts: z.array(DbUsageAlertSchema).optional().default([]),
 	/** Sandbox-env-only usage alerts. `checkUsageAlerts` reads this list when
@@ -47,6 +61,10 @@ export const OrgConfigSchema = z.object({
 	automatic_tax: z.boolean().default(false),
 
 	multi_currency: z.boolean().default(false),
+
+	// Unset (or null) leaves Stripe on the org's own invoice payment method
+	// settings; an explicit list overrides them. Never default this.
+	allowed_payment_methods: z.array(InvoicePaymentMethodSchema).nullish(),
 });
 
 export type OrgConfig = z.infer<typeof OrgConfigSchema>;

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -62,8 +62,7 @@ export const OrgConfigSchema = z.object({
 
 	multi_currency: z.boolean().default(false),
 
-	// Unset (or null) leaves Stripe on the org's own invoice payment method
-	// settings; an explicit list overrides them. Never default this.
+	// Unset/null = Stripe's own invoice settings apply; never add a default.
 	allowed_payment_methods: z.array(InvoicePaymentMethodSchema).min(1).nullish(),
 });
 

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -64,7 +64,7 @@ export const OrgConfigSchema = z.object({
 
 	// Unset (or null) leaves Stripe on the org's own invoice payment method
 	// settings; an explicit list overrides them. Never default this.
-	allowed_payment_methods: z.array(InvoicePaymentMethodSchema).nullish(),
+	allowed_payment_methods: z.array(InvoicePaymentMethodSchema).min(1).nullish(),
 });
 
 export type OrgConfig = z.infer<typeof OrgConfigSchema>;

--- a/vite/src/views/settings/sections/InvoicesSection.tsx
+++ b/vite/src/views/settings/sections/InvoicesSection.tsx
@@ -1,4 +1,5 @@
 import { SettingsSection } from "../SettingsSection";
+import { AllowedPaymentMethodsSubsection } from "./components/AllowedPaymentMethodsSubsection";
 import { InvoiceTemplatesSubsection } from "./components/InvoiceTemplatesSubsection";
 
 export const InvoicesSection = () => {
@@ -8,6 +9,7 @@ export const InvoicesSection = () => {
 			description="Configure how invoices are sent to your customers"
 		>
 			<InvoiceTemplatesSubsection />
+			<AllowedPaymentMethodsSubsection />
 		</SettingsSection>
 	);
 };

--- a/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
@@ -40,9 +40,9 @@ export const AllowedPaymentMethodsSubsection = () => {
 		onError: () => toast.error("Failed to update invoice payment methods"),
 	});
 
-	const allowedMethods = isPending
-		? (variables ?? null)
-		: (org?.config?.allowed_payment_methods ?? null);
+	// While a save is in flight, reflect the value being saved.
+	const allowedMethods =
+		(isPending ? variables : org?.config?.allowed_payment_methods) ?? null;
 	const selected = allowedMethods ?? [];
 
 	const handleToggle = ({
@@ -52,14 +52,11 @@ export const AllowedPaymentMethodsSubsection = () => {
 		method: InvoicePaymentMethod;
 		checked: boolean;
 	}) => {
-		const next = new Set(selected);
-		if (checked) next.add(method);
-		else next.delete(method);
-		const ordered = PAYMENT_METHOD_OPTIONS.filter((option) =>
-			next.has(option.value),
+		const next = PAYMENT_METHOD_OPTIONS.filter((option) =>
+			option.value === method ? checked : selected.includes(option.value),
 		).map((option) => option.value);
 		// An empty array would break invoice finalization at Stripe.
-		mutate(ordered.length > 0 ? ordered : null);
+		mutate(next.length > 0 ? next : null);
 	};
 
 	return (

--- a/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
@@ -52,9 +52,10 @@ export const AllowedPaymentMethodsSubsection = () => {
 		method: InvoicePaymentMethod;
 		checked: boolean;
 	}) => {
-		const next = PAYMENT_METHOD_OPTIONS.filter((option) =>
-			option.value === method ? checked : selected.includes(option.value),
-		).map((option) => option.value);
+		const next = PAYMENT_METHOD_OPTIONS.filter((option) => {
+			if (option.value === method) return checked;
+			return selected.includes(option.value);
+		}).map((option) => option.value);
 		// An empty array would break invoice finalization at Stripe.
 		mutate(next.length > 0 ? next : null);
 	};

--- a/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
@@ -1,4 +1,4 @@
-import type { InvoicePaymentMethod, OrgConfig } from "@autumn/shared";
+import type { InvoicePaymentMethod } from "@autumn/shared";
 import {
 	DropdownMenu,
 	DropdownMenuCheckboxItem,
@@ -28,10 +28,9 @@ export const AllowedPaymentMethodsSubsection = () => {
 
 	const { mutate, isPending, variables } = useMutation({
 		mutationFn: async (methods: InvoicePaymentMethod[] | null) => {
-			const { data } = await axiosInstance.patch("/organization/config", {
+			await axiosInstance.patch("/organization/config", {
 				allowed_payment_methods: methods,
 			});
-			return data as { config: OrgConfig };
 		},
 		onSuccess: async () => {
 			await refetchOrg();

--- a/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/AllowedPaymentMethodsSubsection.tsx
@@ -1,0 +1,106 @@
+import type { InvoicePaymentMethod, OrgConfig } from "@autumn/shared";
+import {
+	DropdownMenu,
+	DropdownMenuCheckboxItem,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
+	IconButton,
+} from "@autumn/ui";
+import { CaretDownIcon } from "@phosphor-icons/react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+const PAYMENT_METHOD_OPTIONS = [
+	{ value: "card", label: "Card" },
+	{ value: "customer_balance", label: "Bank transfer" },
+	{ value: "us_bank_account", label: "ACH direct debit" },
+	{ value: "sepa_debit", label: "SEPA direct debit" },
+	{ value: "bacs_debit", label: "Bacs direct debit" },
+	{ value: "acss_debit", label: "Pre-authorized debit (Canada)" },
+	{ value: "link", label: "Link" },
+] as const satisfies readonly { value: InvoicePaymentMethod; label: string }[];
+
+export const AllowedPaymentMethodsSubsection = () => {
+	const { org, mutate: refetchOrg } = useOrg();
+	const axiosInstance = useAxiosInstance();
+
+	const { mutate, isPending, variables } = useMutation({
+		mutationFn: async (methods: InvoicePaymentMethod[] | null) => {
+			const { data } = await axiosInstance.patch("/organization/config", {
+				allowed_payment_methods: methods,
+			});
+			return data as { config: OrgConfig };
+		},
+		onSuccess: async () => {
+			await refetchOrg();
+			toast.success("Invoice payment methods saved");
+		},
+		onError: () => toast.error("Failed to update invoice payment methods"),
+	});
+
+	const allowedMethods = isPending
+		? (variables ?? null)
+		: (org?.config?.allowed_payment_methods ?? null);
+	const selected = allowedMethods ?? [];
+
+	const handleToggle = ({
+		method,
+		checked,
+	}: {
+		method: InvoicePaymentMethod;
+		checked: boolean;
+	}) => {
+		const next = new Set(selected);
+		if (checked) next.add(method);
+		else next.delete(method);
+		const ordered = PAYMENT_METHOD_OPTIONS.filter((option) =>
+			next.has(option.value),
+		).map((option) => option.value);
+		// An empty array would break invoice finalization at Stripe.
+		mutate(ordered.length > 0 ? ordered : null);
+	};
+
+	return (
+		<div className="flex items-center justify-between gap-4">
+			<div className="flex flex-col gap-0.5">
+				<span className="text-sm font-medium">Payment methods</span>
+				<span className="text-xs text-muted-foreground">
+					{allowedMethods === null
+						? "Unset — invoices use your Stripe account's default payment methods"
+						: "Only these payment methods are offered on invoices Autumn creates"}
+				</span>
+			</div>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<IconButton
+						variant="secondary"
+						size="mini"
+						icon={<CaretDownIcon size={12} weight="bold" />}
+						iconOrientation="right"
+						className="font-medium shrink-0"
+					>
+						{allowedMethods === null
+							? "Stripe defaults"
+							: `${selected.length} selected`}
+					</IconButton>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="w-[260px]">
+					{PAYMENT_METHOD_OPTIONS.map((option) => (
+						<DropdownMenuCheckboxItem
+							key={option.value}
+							checked={selected.includes(option.value)}
+							onCheckedChange={(checked) =>
+								handleToggle({ method: option.value, checked })
+							}
+							disabled={isPending}
+						>
+							{option.label}
+						</DropdownMenuCheckboxItem>
+					))}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+};


### PR DESCRIPTION
## What

Lets a business choose which payment methods appear on the Stripe invoices Autumn generates in invoice mode (`send_invoice`). Enterprise customers paying overage invoices by bank transfer previously only saw card.

- **Settings → Invoices**: new "Payment methods" multi-select (hardcoded list: card, bank transfer/`customer_balance`, ACH, SEPA, Bacs, Canadian pre-authorized debit, Link), stored as `allowed_payment_methods` in `organizations.config` (jsonb — no migration).
- **Both billing engines** set `payment_settings.payment_method_types` on invoice-mode subscription create (and V2 invoice-generating updates), so every invoice the subscription generates inherits the list.

## Design decisions

- **Unset sends nothing.** Per Stripe's docs, an absent `payment_method_types` falls back to the account's own dashboard invoice settings; an explicit list overrides them. Defaulting to `["card"]` would have silently *removed* bank options from orgs that already enabled them account-side — the exact segment this feature targets. So: no schema default, empty selection persists `null`, and the Stripe call omits the field entirely. Current behavior is preserved byte-for-byte for orgs that never touch the setting (verified in test: unset org's invoice still showed the account defaults, including Amazon Pay).
- **Hardcoded dropdown.** Stripe has no API that reads the account's invoice payment-method settings (`Account.settings.invoices` only has tax IDs). The Payment Method Configurations API governs Checkout/Payment Element, not invoices — filtering by it would have hidden `customer_balance` while surfacing Checkout-only wallets. List is the invoice-capable subset of the subscription `payment_settings.payment_method_types` enum.
- **`customer_balance` added vs the PRD's list** — it's Stripe's actual bank-transfer type (`us_bank_account` is ACH debit, a different thing). Without it the headline use case is unreachable.
- **`.nullish()` not `.optional()`** on the org config field: clearing the setting must send an explicit `null` through `handleUpdateOrgConfig`'s jsonb merge (a missing key never reaches `sentKeys`; plain `.optional()` rejects `null` on parse and readback). Same pattern as `idempotency_config`.
- The custom-payment-method `save_default_payment_method` setting is merged, not clobbered, in both engines (unit-tested).
- **Empty lists are rejected at the schema boundary** (`.min(1)`, per review): an explicit list must contain at least one method; `null`/omitted still means Stripe defaults. Note this makes `PATCH /organization/config` with `allowed_payment_methods: []` a 400 — a deliberate contract choice for a field this PR introduces. The `?.length` guards at both Stripe call sites are retained as defense in depth.

## Known limitation (deliberate)

Stripe **hard-rejects** subscription creation when the list contains a method that is currency-incompatible (`sepa_debit` on a USD org) or not activated on the account (`acss_debit` without activation) — it does not silently drop them. Reproduced both in testing; the attach fails with Stripe's own descriptive message. No magic mitigation in this PR: auto-filtering would silently override an org's explicit choice. Proposed fast-follow: filter/warn in the settings UI using `GET /v1/account` capabilities (which, unlike invoice settings, *are* readable).

## Tested

Sandbox org on EC2, before/after on real hosted invoices:
- Unset config → invoice offers account defaults (Card + Amazon Pay) — unchanged behavior.
- Config = card + bank transfer + ACH → invoice offers exactly Card, Bank transfer, US bank account; Amazon Pay (an account default not in the list) filtered out.
- SEPA on USD org → Stripe 400 with clear message (see limitation above).
- 10 new unit tests (org-config resolution, V2 application, absent-when-unset, custom-PM merge). V1 path (`createStripeSub2`) has no existing unit harness — covered by the manual test only.

## Out of scope

- Standalone (non-subscription) invoices — `createInvoiceForBilling` fast-follow if needed.
- Per-attach and per-customer overrides — the setting is org-wide only, per the PRD. (An earlier revision added an `invoice_mode.allowed_payment_methods` attach param; removed before review since the PRD scopes this to org config.)
- Auto-charge subscriptions — untouched, setting never applies outside `send_invoice`.

