### PR TITLE
fix(ui): align customer action controls

### DIFF
--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -152,7 +152,7 @@ function Calendar({
 				day_outside: "day-outside text-subtle aria-selected:text-subtle",
 				day_disabled: "text-subtle opacity-50",
 				day_range_middle:
-					"aria-selected:bg-accent aria-selected:text-accent-foreground",
+					"aria-selected:bg-accent aria-selected:!text-accent-foreground",
 				day_hidden: "invisible",
 				...classNames,
 			}}

--- a/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
@@ -129,12 +129,16 @@ export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 				if (open) setSelection(toJoinedSelection(bounds));
 			}}
 		>
-			<DropdownMenuSubTrigger className="flex items-center gap-2 cursor-pointer">
-				Created At
-				{label && (
+			<DropdownMenuSubTrigger
+				className="flex items-center gap-2 cursor-pointer"
+				aria-label="Filter customers by created date"
+			>
+				{label ? (
 					<span className="truncate text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
 						{label}
 					</span>
+				) : (
+					"Created At"
 				)}
 			</DropdownMenuSubTrigger>
 			<DropdownMenuSubContent className="p-0">

--- a/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/JoinedDateSubMenu.tsx
@@ -131,10 +131,10 @@ export const JoinedDateSubMenu = ({ onChange }: { onChange?: () => void }) => {
 		>
 			<DropdownMenuSubTrigger
 				className="flex items-center gap-2 cursor-pointer"
-				aria-label="Filter customers by created date"
+				aria-label={label ? `Created At: ${label}` : "Created At"}
 			>
 				{label ? (
-					<span className="truncate text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
+					<span className="flex-1 min-w-0 truncate text-xs text-tertiary-foreground bg-muted px-1 py-0 rounded-md">
 						{label}
 					</span>
 				) : (

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListExportMenu.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListExportMenu.tsx
@@ -1,9 +1,9 @@
 import {
-	Button,
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
+	IconButton,
 } from "@autumn/ui";
 import { EllipsisVertical } from "lucide-react";
 import { useState } from "react";
@@ -16,14 +16,15 @@ export function CustomerListExportMenu() {
 		<>
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
-					<Button
+					<IconButton
+						icon={<EllipsisVertical />}
 						variant="skeleton"
-						size="icon"
+						size="default"
+						iconOrientation="center"
+						className="!h-7"
 						type="button"
 						aria-label="More customer actions"
-					>
-						<EllipsisVertical size={16} />
-					</Button>
+					/>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align="end">
 					<DropdownMenuItem onClick={() => setIsSheetOpen(true)}>


### PR DESCRIPTION
## Summary\n- align the customer export menu trigger with shared list action styling\n- let an active created-date range use the full filter trigger width\n\n## Validation\n- bun -F @autumn/vite ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the customer export menu trigger with shared list action styling and improves the created-date filter for clarity and accessibility.

- **Bug Fixes**
  - Switched export menu trigger to `IconButton` from `@autumn/ui` to match shared control size/variant and center the ellipsis.
  - Updated created-date submenu: full-width range chip replaces the title when active, adds dynamic aria-label ("Created At: {range}"), and restores selected-range text contrast in the calendar.

<sup>Written for commit 67453e2ca2380870654e3af031c523f40b4d6430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

