### PR TITLE
fix: batch flushes settle all executions before propagating failures

### DIFF
--- a/server/src/internal/balances/events/EventBatchingManager.ts
+++ b/server/src/internal/balances/events/EventBatchingManager.ts
@@ -36,8 +36,14 @@ class BatchingManager {
 
 	/** Deliver pending AND already-executing batches (shutdown path). */
 	async flush(): Promise<void> {
-		await this.runBatch();
-		await Promise.all(Array.from(this.inFlightBatches));
+		// Settle everything before returning: a fail-fast await would abandon
+		// tracked in-flight batches on the first rejection.
+		const results = await Promise.allSettled([
+			this.runBatch(),
+			...Array.from(this.inFlightBatches),
+		]);
+		const failure = results.find((r) => r.status === "rejected");
+		if (failure && failure.status === "rejected") throw failure.reason;
 	}
 
 	private runBatch(): Promise<void> {

--- a/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
+++ b/server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts
@@ -187,12 +187,15 @@ export class SyncBatchingManagerV3 {
 
 	async flush(): Promise<void> {
 		const batchKeys = Array.from(this.customerBatches.keys());
-		await Promise.all(
-			batchKeys.map((batchKey) => this.runCustomerBatch({ batchKey })),
-		);
-		// Batches delete their map entry before awaiting Redis/queue work, so
-		// also await executions that were already mid-flight.
-		await Promise.all(Array.from(this.inFlightExecutions));
+		// Settle pending and mid-flight executions together: batches delete
+		// their map entry before awaiting Redis/queue work, and a fail-fast
+		// await would abandon the rest on the first rejection.
+		const results = await Promise.allSettled([
+			...batchKeys.map((batchKey) => this.runCustomerBatch({ batchKey })),
+			...Array.from(this.inFlightExecutions),
+		]);
+		const failure = results.find((r) => r.status === "rejected");
+		if (failure && failure.status === "rejected") throw failure.reason;
 	}
 
 	private inFlightExecutions = new Set<Promise<void>>();


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure batch flushes wait for all pending and in-flight executions, then rethrow the first error. Prevents abandoned work during shutdown and avoids races with the accumulator close.

- **Bug Fixes**
  - Switched `flush()` in `EventBatchingManager` and `SyncBatchingManagerV3` to `Promise.allSettled` over pending and in-flight tasks.
  - After settling, rethrow the first rejection to preserve failure signaling.
  - Handles transient backend failures (e.g., SQS/Tinybird) without dropping in-flight executions.

<sup>Written for commit 0474a470fde26f6dde3190e795b17ff24427e07b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ensures batch flushes wait for every captured execution to settle before propagating a failure.
- **Bug fixes:** Replaces fail-fast event-batch flushing with `Promise.allSettled`, then rethrows the first recorded failure.
- **Bug fixes:** Applies the same settlement behavior to pending and in-flight customer synchronization executions.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable changed-code defects identified.

Both flush implementations now wait for every captured promise to settle and preserve failure propagation after settlement.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/events/EventBatchingManager.ts | Event flushing now settles the captured pending and in-flight batches before returning or propagating the first failure. |
| server/src/internal/balances/utils/sync/SyncBatchingManagerV3.ts | Customer sync flushing now settles all captured executions together before propagating the first failure. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Flush
  participant Pending as Pending batches
  participant Active as In-flight executions
  Caller->>Flush: flush()
  Flush->>Pending: start pending work
  Flush->>Active: capture tracked work
  par Settle pending work
    Pending-->>Flush: fulfilled or rejected
  and Settle active work
    Active-->>Flush: fulfilled or rejected
  end
  alt At least one rejection
    Flush-->>Caller: throw first failure
  else All fulfilled
    Flush-->>Caller: return
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: batch flushes settle all executions..."](https://github.com/useautumn/autumn/commit/0474a470fde26f6dde3190e795b17ff24427e07b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51783056)</sub>

<!-- /greptile_comment -->