### PR TITLE
fix: declare @typescript/native-preview in scripts so tsgo resolves in CI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -567,6 +567,7 @@
         "@types/bun": "^1.3.11",
         "@types/pg": "8.20.0",
         "@types/react": "^19.2.1",
+        "@typescript/native-preview": "7.0.0-dev.20260511.1",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
       },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -35,6 +35,7 @@
 		"@types/bun": "^1.3.11",
 		"@types/pg": "8.20.0",
 		"@types/react": "^19.2.1",
+		"@typescript/native-preview": "7.0.0-dev.20260511.1",
 		"tsx": "^4.19.2",
 		"typescript": "^5.7.3"
 	}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `@typescript/native-preview@7.0.0-dev.20260511.1` as a devDependency in `scripts` to provide the `tsgo` binary. This ensures `bunx tsgo` resolves in CI and fixes the failing type-check job.

<sup>Written for commit 7e06c51007ff246b22e46d0b1a1343d41db5b9d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR explicitly declares the package that provides `tsgo` in the scripts workspace, allowing CI type-check commands to resolve it reliably.

- **[Bug fixes]** Adds the pinned `@typescript/native-preview` development dependency to `scripts/package.json`.
- **[Improvements]** Updates `bun.lock` so frozen CI installations include the scripts workspace declaration.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the manifest and lockfile consistently declaring the required type-checking package.

The scripts workspace now directly declares the package providing `tsgo`, and the corresponding lockfile state supports the repository's frozen CI installation path without introducing a concrete failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/package.json | Declares the exact package version that supplies the `tsgo` executable used by the workspace's type-check script. |
| bun.lock | Records the matching scripts workspace dependency while retaining the existing resolved, integrity-checked package entry. |

<sub>Reviews (1): Last reviewed commit: ["fix: declare @typescript/native-preview ..."](https://github.com/useautumn/autumn/commit/7e06c51007ff246b22e46d0b1a1343d41db5b9d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51783382)</sub>

<!-- /greptile_comment -->