### PR TITLE
fix: settle all batch executions on flush; bound primary shutdown

### DIFF
--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -219,6 +219,10 @@ if (process.env.NODE_ENV === "development") {
 					`[Shutdown] ${workersAlive()} worker(s) still alive after 35s; exiting anyway`,
 				);
 			}
+			// Same bound as every other exit path: a hung pool close must not
+			// leave the primary for the platform SIGKILL.
+			const forceExit = setTimeout(() => process.exit(0), 30_000);
+			forceExit.unref?.();
 			await gracefulShutdown();
 		};
 		process.on("SIGTERM", () => void shutdownPrimary());


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a 30s force-exit timeout to the primary shutdown path so the process exits even if a pool close hangs. This aligns primary behavior with workers and avoids platform SIGKILLs.

<sup>Written for commit 36ad29b9e933d4031814ce6f292e686d1a445adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ensures the primary server process cannot remain stuck indefinitely during graceful shutdown.

- **[Bug fixes]** Adds a 30-second fallback exit after workers stop, matching the timeout already used by other shutdown paths.
- **[Improvements]** Prevents a hung database or service cleanup from leaving the process waiting for the platform to kill it.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the forced-exit behavior consistently bounding the existing graceful-shutdown path.

The new timer matches sibling shutdown paths and only terminates the primary when graceful cleanup has not completed within the intended bound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/init.ts | Adds an unreferenced 30-second forced-exit timer before the primary process begins graceful resource cleanup. |

<sub>Reviews (1): Last reviewed commit: ["fix: primary shutdown carries the same 3..."](https://github.com/useautumn/autumn/commit/36ad29b9e933d4031814ce6f292e686d1a445adc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51785205)</sub>

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)

<!-- /greptile_comment -->