### PR TITLE
fix: await redis warmup (bounded) before listening

### DIFF
--- a/server/src/external/redis/initUtils/boundedWarmup.ts
+++ b/server/src/external/redis/initUtils/boundedWarmup.ts
@@ -1,0 +1,40 @@
+export type BoundedWarmupResult = "warm" | "timeout" | "failed";
+
+/** Await a warmup with a hard bound: serve warm when redis is reachable, but
+ *  never let an unreachable redis block boot — fail-open covers the gap. */
+export const awaitBoundedWarmup = async ({
+	warmup,
+	timeoutMs,
+	log,
+}: {
+	warmup: Promise<unknown>;
+	timeoutMs: number;
+	log: (message: string) => void;
+}): Promise<BoundedWarmupResult> => {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const bound = new Promise<"timeout">((resolve) => {
+		timer = setTimeout(() => resolve("timeout"), timeoutMs);
+		timer.unref?.();
+	});
+
+	try {
+		const result = await Promise.race([
+			warmup.then(
+				() => "warm" as const,
+				() => "failed" as const,
+			),
+			bound,
+		]);
+		if (result === "timeout") {
+			log(
+				`[Redis] warmup still pending after ${timeoutMs}ms; serving with fail-open`,
+			);
+		}
+		if (result === "failed") {
+			log("[Redis] warmup failed; serving with fail-open");
+		}
+		return result;
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+};

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -167,7 +167,7 @@ export const preWarmOrgRedisConnections = async ({
 		`[OrgRedis] Pre-warming connections for ${orgsWithRedis.length} orgs in ${currentRegion}...`,
 	);
 
-	for (const org of orgsWithRedis) {
-		getOrgRedis({ org });
-	}
+	// Await readiness (bounded per org, never throws) so callers can gate
+	// listen on it — an open-but-handshaking client still times out ops.
+	await Promise.all(orgsWithRedis.map((org) => warmOrgRedis({ org })));
 };

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -99,8 +99,12 @@ const init = async ({
 
 	// Kicked off early, awaited (bounded) just before listen: a fork must not
 	// serve its first requests against still-connecting redis clients.
+	// Each arm catches its own failure: a regional rejection must not
+	// short-circuit the wait for healthy dedicated org connections.
 	const redisWarmup = Promise.all([
-		warmupRegionalRedis(),
+		warmupRegionalRedis().catch((error) => {
+			console.error("[Redis] regional warmup failed -", error);
+		}),
 		preWarmOrgRedisConnections({ db }).catch((error) => {
 			logger.warn("[OrgRedis] Warmup failed", { error });
 		}),

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -105,6 +105,9 @@ const init = async ({
 			logger.warn("[OrgRedis] Warmup failed", { error });
 		}),
 	]);
+	// Observed immediately: awaits run before the bounded wait consumes it, and
+	// an early rejection would otherwise hit the fatal unhandledRejection exit.
+	void redisWarmup.catch(() => {});
 
 	await startAllEdgeConfigPolling({ logger });
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -99,10 +99,12 @@ const init = async ({
 
 	// Kicked off early, awaited (bounded) just before listen: a fork must not
 	// serve its first requests against still-connecting redis clients.
-	const regionalRedisWarmup = warmupRegionalRedis();
-	void preWarmOrgRedisConnections({ db }).catch((error) => {
-		logger.warn("[OrgRedis] Warmup failed", { error });
-	});
+	const redisWarmup = Promise.all([
+		warmupRegionalRedis(),
+		preWarmOrgRedisConnections({ db }).catch((error) => {
+			logger.warn("[OrgRedis] Warmup failed", { error });
+		}),
+	]);
 
 	await startAllEdgeConfigPolling({ logger });
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);
@@ -143,7 +145,7 @@ const init = async ({
 	};
 
 	await awaitBoundedWarmup({
-		warmup: regionalRedisWarmup,
+		warmup: redisWarmup,
 		timeoutMs: 10_000,
 		log: (message) => console.warn(message),
 	});

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -53,6 +53,7 @@ import {
 	stopRedisMonitor,
 	warmupRegionalRedis,
 } from "./external/redis/initRedis.js";
+import { awaitBoundedWarmup } from "./external/redis/initUtils/boundedWarmup.js";
 import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
@@ -96,9 +97,9 @@ const init = async ({
 	// `db` is the general pool — the probe must never occupy a critical-pool slot.
 	startReplicaRoutingProber({ db });
 
-	void warmupRegionalRedis().catch((error) => {
-		logger.warn("[Redis] Warmup failed", { error });
-	});
+	// Kicked off early, awaited (bounded) just before listen: a fork must not
+	// serve its first requests against still-connecting redis clients.
+	const regionalRedisWarmup = warmupRegionalRedis();
 	void preWarmOrgRedisConnections({ db }).catch((error) => {
 		logger.warn("[OrgRedis] Warmup failed", { error });
 	});
@@ -140,6 +141,12 @@ const init = async ({
 		const idleSweep = setInterval(() => server.closeIdleConnections?.(), 1_000);
 		idleSweep.unref?.();
 	};
+
+	await awaitBoundedWarmup({
+		warmup: regionalRedisWarmup,
+		timeoutMs: 10_000,
+		log: (message) => console.warn(message),
+	});
 
 	await new Promise<void>((resolve) => {
 		server.listen(PORT, "0.0.0.0", () => {

--- a/server/tests/unit/memory/boundedWarmup.test.ts
+++ b/server/tests/unit/memory/boundedWarmup.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { awaitBoundedWarmup } from "@/external/redis/initUtils/boundedWarmup.js";
+
+describe("awaitBoundedWarmup", () => {
+	test("returns 'warm' when the warmup resolves within the bound", async () => {
+		const result = await awaitBoundedWarmup({
+			warmup: Promise.resolve(),
+			timeoutMs: 1_000,
+			log: () => {},
+		});
+		expect(result).toBe("warm");
+	});
+
+	test("proceeds at the bound when the warmup hangs, and logs", async () => {
+		const logs: string[] = [];
+		const never = new Promise<void>(() => {});
+		const started = Date.now();
+		const result = await awaitBoundedWarmup({
+			warmup: never,
+			timeoutMs: 50,
+			log: (message) => logs.push(message),
+		});
+		expect(result).toBe("timeout");
+		expect(Date.now() - started).toBeGreaterThanOrEqual(45);
+		expect(logs.length).toBe(1);
+	});
+
+	test("proceeds without throwing when the warmup rejects", async () => {
+		const logs: string[] = [];
+		const result = await awaitBoundedWarmup({
+			warmup: Promise.reject(new Error("redis down")),
+			timeoutMs: 1_000,
+			log: (message) => logs.push(message),
+		});
+		expect(result).toBe("failed");
+		expect(logs.length).toBe(1);
+	});
+});

--- a/server/tests/unit/memory/boundedWarmup.test.ts
+++ b/server/tests/unit/memory/boundedWarmup.test.ts
@@ -35,4 +35,28 @@ describe("awaitBoundedWarmup", () => {
 		expect(result).toBe("failed");
 		expect(logs.length).toBe(1);
 	});
+
+	// The init path observes the warmup with a no-op catch, then consumes it
+	// ticks later — that must still report "failed", never unhandledRejection.
+	test("pre-observed early rejection still reports 'failed' when consumed late", async () => {
+		let unhandled = 0;
+		const onUnhandled = () => {
+			unhandled += 1;
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const warmup = Promise.reject(new Error("bad redis config"));
+			void warmup.catch(() => {});
+			await Bun.sleep(20);
+			const result = await awaitBoundedWarmup({
+				warmup,
+				timeoutMs: 1_000,
+				log: () => {},
+			});
+			expect(result).toBe("failed");
+			expect(unhandled).toBe(0);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
 });

--- a/server/tests/unit/redis/orgRedisPrewarm.test.ts
+++ b/server/tests/unit/redis/orgRedisPrewarm.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 
 class FakeRedis extends EventEmitter {
@@ -18,6 +18,21 @@ const fakeOrg = (id: string) => ({
 	},
 });
 
+// Capture the real modules before mocking so afterAll can restore them —
+// bun's mock.module leaks across test files otherwise.
+const realOrgService = {
+	...(await import("@/internal/orgs/OrgService.js")),
+};
+const realEncryptUtils = {
+	...(await import("@/utils/encryptUtils.js")),
+};
+const realResolveRedisV2 = {
+	...(await import("@/external/redis/resolveRedisV2.js")),
+};
+const realInitRedis = {
+	...(await import("@/external/redis/initRedis.js")),
+};
+
 mock.module("@/internal/orgs/OrgService.js", () => ({
 	OrgService: {
 		listWithRedisConfig: async () => [fakeOrg("org-a"), fakeOrg("org-b")],
@@ -26,9 +41,6 @@ mock.module("@/internal/orgs/OrgService.js", () => ({
 mock.module("@/utils/encryptUtils.js", () => ({
 	decryptData: (value: string) => value,
 	encryptData: (value: string) => value,
-}));
-mock.module("@/external/aws/ecs/onAwsEcs.js", () => ({
-	onAwsEcs: () => false,
 }));
 mock.module("@/external/redis/resolveRedisV2.js", () => ({
 	resolveRedisV2: () => new FakeRedis(),
@@ -41,6 +53,13 @@ mock.module("@/external/redis/initRedis.js", () => ({
 		return instance;
 	},
 }));
+
+afterAll(() => {
+	mock.module("@/internal/orgs/OrgService.js", () => realOrgService);
+	mock.module("@/utils/encryptUtils.js", () => realEncryptUtils);
+	mock.module("@/external/redis/resolveRedisV2.js", () => realResolveRedisV2);
+	mock.module("@/external/redis/initRedis.js", () => realInitRedis);
+});
 
 describe("preWarmOrgRedisConnections", () => {
 	test("resolves only once every dedicated connection is ready", async () => {

--- a/server/tests/unit/redis/orgRedisPrewarm.test.ts
+++ b/server/tests/unit/redis/orgRedisPrewarm.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+class FakeRedis extends EventEmitter {
+	status = "connecting";
+	disconnect() {}
+}
+
+const instances: FakeRedis[] = [];
+
+const fakeOrg = (id: string) => ({
+	id,
+	slug: id,
+	redis_config: {
+		url: `redis://${id}.internal:6379`,
+		connectionString: `redis://${id}.internal:6379`,
+		publicConnectionString: `redis://${id}.public:6379`,
+	},
+});
+
+mock.module("@/internal/orgs/OrgService.js", () => ({
+	OrgService: {
+		listWithRedisConfig: async () => [fakeOrg("org-a"), fakeOrg("org-b")],
+	},
+}));
+mock.module("@/utils/encryptUtils.js", () => ({
+	decryptData: (value: string) => value,
+	encryptData: (value: string) => value,
+}));
+mock.module("@/external/aws/ecs/onAwsEcs.js", () => ({
+	onAwsEcs: () => false,
+}));
+mock.module("@/external/redis/resolveRedisV2.js", () => ({
+	resolveRedisV2: () => new FakeRedis(),
+}));
+mock.module("@/external/redis/initRedis.js", () => ({
+	currentRegion: "test",
+	createStandbyRedisConnection: () => {
+		const instance = new FakeRedis();
+		instances.push(instance);
+		return instance;
+	},
+}));
+
+describe("preWarmOrgRedisConnections", () => {
+	test("resolves only once every dedicated connection is ready", async () => {
+		const { preWarmOrgRedisConnections } = await import(
+			"@/external/redis/orgRedisPool.js"
+		);
+
+		let settled = false;
+		const warmup = preWarmOrgRedisConnections({ db: {} as never }).then(() => {
+			settled = true;
+		});
+
+		await Bun.sleep(30);
+		expect(instances.length).toBe(2);
+		expect(settled).toBe(false);
+
+		for (const instance of instances) {
+			instance.status = "ready";
+			instance.emit("ready");
+		}
+		await warmup;
+		expect(settled).toBe(true);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for Redis warmup (10s bound) before starting the server so first requests don’t hit still-connecting clients, and gate listen on per-org Redis readiness. Early warmup rejections are observed and each warmup arm is caught; if Redis is unreachable, we log and serve fail-open.

- **Bug Fixes**
  - Added bounded warmup helper with timeout and logging; never blocks boot.
  - Start warmup early and await regional and per-org readiness right before listen; catch each arm so a regional failure doesn’t hide healthy org connections.
  - Observe warmup rejections immediately to avoid unhandledRejection; tests cover warm/timeout/failure/pre-observed rejection and restore shared module mocks in org prewarm tests.

<sup>Written for commit fccaac5b72bf3a57d94dd0ec75474e942fa40998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR ensures Redis warmup begins early and is awaited for at most 10 seconds before the HTTP server starts, while preserving fail-open startup when Redis is unavailable.

- **Bug fixes:** Immediately observes Redis warmup failures so an early rejection cannot terminate the worker before the bounded wait.
- **Improvements:** Waits for regional and per-organization Redis connections before listening, with a fixed timeout to prevent Redis outages from blocking startup.
- **Improvements:** Adds unit coverage for successful, failed, timed-out, and early-rejected warmups.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/init.ts | Starts Redis warmup early, observes rejection immediately, and performs the bounded wait before opening the HTTP listener. |
| server/src/external/redis/initUtils/boundedWarmup.ts | Adds a bounded promise race that reports warm, timeout, or failure without blocking server startup indefinitely. |
| server/src/external/redis/orgRedisPool.ts | Changes organization Redis prewarming to await each connection's bounded readiness. |
| server/tests/unit/memory/boundedWarmup.test.ts | Covers successful, timed-out, rejected, and immediately observed rejection behavior. |
| server/tests/unit/redis/orgRedisPrewarm.test.ts | Verifies organization prewarming remains pending until every dedicated connection reports readiness. |

<sub>Reviews (4): Last reviewed commit: ["fix: restore shared module mocks after p..."](https://github.com/useautumn/autumn/commit/fccaac5b72bf3a57d94dd0ec75474e942fa40998) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51797420)</sub>

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->