### PR TITLE
Release 10/08/2026

### DIFF
--- a/server/src/external/redis/initUtils/boundedWarmup.ts
+++ b/server/src/external/redis/initUtils/boundedWarmup.ts
@@ -1,0 +1,40 @@
+export type BoundedWarmupResult = "warm" | "timeout" | "failed";
+
+/** Await a warmup with a hard bound: serve warm when redis is reachable, but
+ *  never let an unreachable redis block boot — fail-open covers the gap. */
+export const awaitBoundedWarmup = async ({
+	warmup,
+	timeoutMs,
+	log,
+}: {
+	warmup: Promise<unknown>;
+	timeoutMs: number;
+	log: (message: string) => void;
+}): Promise<BoundedWarmupResult> => {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const bound = new Promise<"timeout">((resolve) => {
+		timer = setTimeout(() => resolve("timeout"), timeoutMs);
+		timer.unref?.();
+	});
+
+	try {
+		const result = await Promise.race([
+			warmup.then(
+				() => "warm" as const,
+				() => "failed" as const,
+			),
+			bound,
+		]);
+		if (result === "timeout") {
+			log(
+				`[Redis] warmup still pending after ${timeoutMs}ms; serving with fail-open`,
+			);
+		}
+		if (result === "failed") {
+			log("[Redis] warmup failed; serving with fail-open");
+		}
+		return result;
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+};

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -167,7 +167,7 @@ export const preWarmOrgRedisConnections = async ({
 		`[OrgRedis] Pre-warming connections for ${orgsWithRedis.length} orgs in ${currentRegion}...`,
 	);
 
-	for (const org of orgsWithRedis) {
-		getOrgRedis({ org });
-	}
+	// Await readiness (bounded per org, never throws) so callers can gate
+	// listen on it — an open-but-handshaking client still times out ops.
+	await Promise.all(orgsWithRedis.map((org) => warmOrgRedis({ org })));
 };

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
@@ -26,6 +26,11 @@ export const withClaimedCheckoutSessionMetadata = async ({
 	execute: () => Promise<void>;
 }): Promise<void> => {
 	const deferredData = metadata.data as DeferredAutumnBillingPlanData;
+
+	// Only the initiating org sends the webhook — handles when multiple Stripe
+	// orgs are linked to the same account and both receive this event.
+	if (deferredData.billingContext.fullCustomer.org_id !== ctx.org.id) return;
+
 	const lockCustomerId =
 		deferredData?.billingContext?.fullCustomer?.id ??
 		deferredData?.billingContext?.fullCustomer?.internal_id;

--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts
@@ -29,7 +29,8 @@ export const withClaimedCheckoutSessionMetadata = async ({
 
 	// Only the initiating org sends the webhook — handles when multiple Stripe
 	// orgs are linked to the same account and both receive this event.
-	if (deferredData.billingContext.fullCustomer.org_id !== ctx.org.id) return;
+	const owningOrgId = deferredData?.billingContext?.fullCustomer?.org_id;
+	if (owningOrgId && owningOrgId !== ctx.org.id) return;
 
 	const lockCustomerId =
 		deferredData?.billingContext?.fullCustomer?.id ??

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -99,8 +99,12 @@ const init = async ({
 
 	// Kicked off early, awaited (bounded) just before listen: a fork must not
 	// serve its first requests against still-connecting redis clients.
+	// Each arm catches its own failure: a regional rejection must not
+	// short-circuit the wait for healthy dedicated org connections.
 	const redisWarmup = Promise.all([
-		warmupRegionalRedis(),
+		warmupRegionalRedis().catch((error) => {
+			console.error("[Redis] regional warmup failed -", error);
+		}),
 		preWarmOrgRedisConnections({ db }).catch((error) => {
 			logger.warn("[OrgRedis] Warmup failed", { error });
 		}),

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -105,6 +105,9 @@ const init = async ({
 			logger.warn("[OrgRedis] Warmup failed", { error });
 		}),
 	]);
+	// Observed immediately: awaits run before the bounded wait consumes it, and
+	// an early rejection would otherwise hit the fatal unhandledRejection exit.
+	void redisWarmup.catch(() => {});
 
 	await startAllEdgeConfigPolling({ logger });
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -99,10 +99,12 @@ const init = async ({
 
 	// Kicked off early, awaited (bounded) just before listen: a fork must not
 	// serve its first requests against still-connecting redis clients.
-	const regionalRedisWarmup = warmupRegionalRedis();
-	void preWarmOrgRedisConnections({ db }).catch((error) => {
-		logger.warn("[OrgRedis] Warmup failed", { error });
-	});
+	const redisWarmup = Promise.all([
+		warmupRegionalRedis(),
+		preWarmOrgRedisConnections({ db }).catch((error) => {
+			logger.warn("[OrgRedis] Warmup failed", { error });
+		}),
+	]);
 
 	await startAllEdgeConfigPolling({ logger });
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);
@@ -143,7 +145,7 @@ const init = async ({
 	};
 
 	await awaitBoundedWarmup({
-		warmup: regionalRedisWarmup,
+		warmup: redisWarmup,
 		timeoutMs: 10_000,
 		log: (message) => console.warn(message),
 	});

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -53,6 +53,7 @@ import {
 	stopRedisMonitor,
 	warmupRegionalRedis,
 } from "./external/redis/initRedis.js";
+import { awaitBoundedWarmup } from "./external/redis/initUtils/boundedWarmup.js";
 import { preWarmOrgRedisConnections } from "./external/redis/orgRedisPool.js";
 import { createHonoApp } from "./initHono.js";
 import { otelSdk } from "./instrumentation.js";
@@ -96,9 +97,9 @@ const init = async ({
 	// `db` is the general pool — the probe must never occupy a critical-pool slot.
 	startReplicaRoutingProber({ db });
 
-	void warmupRegionalRedis().catch((error) => {
-		logger.warn("[Redis] Warmup failed", { error });
-	});
+	// Kicked off early, awaited (bounded) just before listen: a fork must not
+	// serve its first requests against still-connecting redis clients.
+	const regionalRedisWarmup = warmupRegionalRedis();
 	void preWarmOrgRedisConnections({ db }).catch((error) => {
 		logger.warn("[OrgRedis] Warmup failed", { error });
 	});
@@ -140,6 +141,12 @@ const init = async ({
 		const idleSweep = setInterval(() => server.closeIdleConnections?.(), 1_000);
 		idleSweep.unref?.();
 	};
+
+	await awaitBoundedWarmup({
+		warmup: regionalRedisWarmup,
+		timeoutMs: 10_000,
+		log: (message) => console.warn(message),
+	});
 
 	await new Promise<void>((resolve) => {
 		server.listen(PORT, "0.0.0.0", () => {

--- a/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts
@@ -94,6 +94,8 @@ export const executeStripeSubscriptionAction = async ({
 		latestStripeInvoice = await finalizeStripeInvoice({
 			stripeCli,
 			invoiceId: latestStripeInvoice.id,
+			// Invoice mode: let Stripe email the finalized invoice (fires invoice.sent).
+			autoAdvance: Boolean(billingContext.invoiceMode),
 		});
 	}
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts
@@ -127,6 +127,8 @@ export const createInvoiceForBilling = async ({
 	const finalizedInvoice = await finalizeStripeInvoice({
 		stripeCli,
 		invoiceId: invoiceWithLines.id,
+		// Invoice mode: let Stripe email the finalized invoice (fires invoice.sent).
+		autoAdvance: isInvoiceMode,
 	});
 
 	if (finalizedInvoice.status === "paid") {

--- a/server/tests/unit/memory/boundedWarmup.test.ts
+++ b/server/tests/unit/memory/boundedWarmup.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { awaitBoundedWarmup } from "@/external/redis/initUtils/boundedWarmup.js";
+
+describe("awaitBoundedWarmup", () => {
+	test("returns 'warm' when the warmup resolves within the bound", async () => {
+		const result = await awaitBoundedWarmup({
+			warmup: Promise.resolve(),
+			timeoutMs: 1_000,
+			log: () => {},
+		});
+		expect(result).toBe("warm");
+	});
+
+	test("proceeds at the bound when the warmup hangs, and logs", async () => {
+		const logs: string[] = [];
+		const never = new Promise<void>(() => {});
+		const started = Date.now();
+		const result = await awaitBoundedWarmup({
+			warmup: never,
+			timeoutMs: 50,
+			log: (message) => logs.push(message),
+		});
+		expect(result).toBe("timeout");
+		expect(Date.now() - started).toBeGreaterThanOrEqual(45);
+		expect(logs.length).toBe(1);
+	});
+
+	test("proceeds without throwing when the warmup rejects", async () => {
+		const logs: string[] = [];
+		const result = await awaitBoundedWarmup({
+			warmup: Promise.reject(new Error("redis down")),
+			timeoutMs: 1_000,
+			log: (message) => logs.push(message),
+		});
+		expect(result).toBe("failed");
+		expect(logs.length).toBe(1);
+	});
+});

--- a/server/tests/unit/memory/boundedWarmup.test.ts
+++ b/server/tests/unit/memory/boundedWarmup.test.ts
@@ -35,4 +35,28 @@ describe("awaitBoundedWarmup", () => {
 		expect(result).toBe("failed");
 		expect(logs.length).toBe(1);
 	});
+
+	// The init path observes the warmup with a no-op catch, then consumes it
+	// ticks later — that must still report "failed", never unhandledRejection.
+	test("pre-observed early rejection still reports 'failed' when consumed late", async () => {
+		let unhandled = 0;
+		const onUnhandled = () => {
+			unhandled += 1;
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			const warmup = Promise.reject(new Error("bad redis config"));
+			void warmup.catch(() => {});
+			await Bun.sleep(20);
+			const result = await awaitBoundedWarmup({
+				warmup,
+				timeoutMs: 1_000,
+				log: () => {},
+			});
+			expect(result).toBe("failed");
+			expect(unhandled).toBe(0);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
 });

--- a/server/tests/unit/redis/orgRedisPrewarm.test.ts
+++ b/server/tests/unit/redis/orgRedisPrewarm.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
 
 class FakeRedis extends EventEmitter {
@@ -18,6 +18,21 @@ const fakeOrg = (id: string) => ({
 	},
 });
 
+// Capture the real modules before mocking so afterAll can restore them —
+// bun's mock.module leaks across test files otherwise.
+const realOrgService = {
+	...(await import("@/internal/orgs/OrgService.js")),
+};
+const realEncryptUtils = {
+	...(await import("@/utils/encryptUtils.js")),
+};
+const realResolveRedisV2 = {
+	...(await import("@/external/redis/resolveRedisV2.js")),
+};
+const realInitRedis = {
+	...(await import("@/external/redis/initRedis.js")),
+};
+
 mock.module("@/internal/orgs/OrgService.js", () => ({
 	OrgService: {
 		listWithRedisConfig: async () => [fakeOrg("org-a"), fakeOrg("org-b")],
@@ -26,9 +41,6 @@ mock.module("@/internal/orgs/OrgService.js", () => ({
 mock.module("@/utils/encryptUtils.js", () => ({
 	decryptData: (value: string) => value,
 	encryptData: (value: string) => value,
-}));
-mock.module("@/external/aws/ecs/onAwsEcs.js", () => ({
-	onAwsEcs: () => false,
 }));
 mock.module("@/external/redis/resolveRedisV2.js", () => ({
 	resolveRedisV2: () => new FakeRedis(),
@@ -41,6 +53,13 @@ mock.module("@/external/redis/initRedis.js", () => ({
 		return instance;
 	},
 }));
+
+afterAll(() => {
+	mock.module("@/internal/orgs/OrgService.js", () => realOrgService);
+	mock.module("@/utils/encryptUtils.js", () => realEncryptUtils);
+	mock.module("@/external/redis/resolveRedisV2.js", () => realResolveRedisV2);
+	mock.module("@/external/redis/initRedis.js", () => realInitRedis);
+});
 
 describe("preWarmOrgRedisConnections", () => {
 	test("resolves only once every dedicated connection is ready", async () => {

--- a/server/tests/unit/redis/orgRedisPrewarm.test.ts
+++ b/server/tests/unit/redis/orgRedisPrewarm.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+class FakeRedis extends EventEmitter {
+	status = "connecting";
+	disconnect() {}
+}
+
+const instances: FakeRedis[] = [];
+
+const fakeOrg = (id: string) => ({
+	id,
+	slug: id,
+	redis_config: {
+		url: `redis://${id}.internal:6379`,
+		connectionString: `redis://${id}.internal:6379`,
+		publicConnectionString: `redis://${id}.public:6379`,
+	},
+});
+
+mock.module("@/internal/orgs/OrgService.js", () => ({
+	OrgService: {
+		listWithRedisConfig: async () => [fakeOrg("org-a"), fakeOrg("org-b")],
+	},
+}));
+mock.module("@/utils/encryptUtils.js", () => ({
+	decryptData: (value: string) => value,
+	encryptData: (value: string) => value,
+}));
+mock.module("@/external/aws/ecs/onAwsEcs.js", () => ({
+	onAwsEcs: () => false,
+}));
+mock.module("@/external/redis/resolveRedisV2.js", () => ({
+	resolveRedisV2: () => new FakeRedis(),
+}));
+mock.module("@/external/redis/initRedis.js", () => ({
+	currentRegion: "test",
+	createStandbyRedisConnection: () => {
+		const instance = new FakeRedis();
+		instances.push(instance);
+		return instance;
+	},
+}));
+
+describe("preWarmOrgRedisConnections", () => {
+	test("resolves only once every dedicated connection is ready", async () => {
+		const { preWarmOrgRedisConnections } = await import(
+			"@/external/redis/orgRedisPool.js"
+		);
+
+		let settled = false;
+		const warmup = preWarmOrgRedisConnections({ db: {} as never }).then(() => {
+			settled = true;
+		});
+
+		await Bun.sleep(30);
+		expect(instances.length).toBe(2);
+		expect(settled).toBe(false);
+
+		for (const instance of instances) {
+			instance.status = "ready";
+			instance.emit("ready");
+		}
+		await warmup;
+		expect(settled).toBe(true);
+	});
+});


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Wait for Redis to be ready (with a 10s bound) before the server starts listening, and guard Stripe checkout webhooks to prevent cross-org claims. Also enable invoice emails when invoice mode is on.

- **Bug Fixes**
  - Gate server listen on bounded Redis warmup; fall back to fail-open on timeout. Also wait for dedicated org Redis clients to be ready.
  - Add `awaitBoundedWarmup` utility and unit tests for warm/timeout/reject paths. Prewarm now awaits per-org readiness to avoid first-op timeouts.
  - Only process `checkout.session.completed` for the initiating org when multiple orgs share one Stripe account.
  - In invoice mode, pass `autoAdvance` on finalize so Stripe emails the invoice (fires `invoice.sent`).

<sup>Written for commit 5eb969fb876fa6e41d84016d84a91be27ac6959b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release improves Redis readiness during startup, prevents duplicate cross-organization checkout processing, and aligns invoice-mode finalization behavior across Stripe billing paths.
- **[Improvements, Bug fixes]** Waits for regional and organization-specific Redis connections before accepting traffic, while retaining a bounded fail-open startup.
- **[Bug fixes]** Restricts deferred checkout processing to the organization that owns the customer metadata.
- **[Improvements, API changes]** Enables Stripe automatic advancement when invoice-mode invoices are finalized, allowing Stripe to send them and emit the corresponding event.
- **[Improvements]** Updates the AI submodule revision and adds Redis warmup tests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable issues identified.

The Redis startup changes remain bounded and fail open, the checkout ownership check targets duplicate cross-organization handling, and Stripe auto-advance is consistent with the existing finalized invoice-mode contract.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/init.ts | Starts Redis warmups early and waits for them through a ten-second fail-open bound before listening. |
| server/src/external/redis/initUtils/boundedWarmup.ts | Adds a reusable bounded promise wait that reports success, failure, or timeout without blocking startup indefinitely. |
| server/src/external/redis/orgRedisPool.ts | Changes organization Redis prewarming to await each configured connection's bounded readiness check. |
| server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/tasks/handleCheckoutSessionMetadataV2/withClaimedCheckoutSessionMetadata.ts | Skips deferred checkout processing when serialized customer ownership points to another organization. |
| server/src/internal/billing/v2/providers/stripe/execute/executeStripeSubscriptionAction.ts | Enables Stripe auto-advance when finalizing subscription-action invoices in invoice mode. |
| server/src/internal/billing/v2/providers/stripe/utils/invoices/createInvoiceForBilling.ts | Enables Stripe auto-advance when finalizing directly created invoice-mode invoices. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Worker
  participant RegionalRedis
  participant OrgRedis
  participant HTTP
  Worker->>RegionalRedis: Start warmup
  Worker->>OrgRedis: Prewarm configured organizations
  alt Warmups finish within 10 seconds
    RegionalRedis-->>Worker: Ready or failed open
    OrgRedis-->>Worker: Ready or failed open
  else Warmup remains pending
    Worker->>Worker: Log timeout and fail open
  end
  Worker->>HTTP: Begin listening
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/b366133c475516f839deac898b4ce6ef58283059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51811759)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Stripe Integration](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-stripe-integration.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)
</details>

<!-- /greptile_comment -->