### PR TITLE
fix: await Redis warmup before SQS polling

### DIFF
--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -171,6 +171,7 @@ export const startPollingLoop = async ({
 	shouldPoll = () => true,
 	visibilityTimeoutSeconds = 30,
 	receiveTimeoutMs = SQS_RECEIVE_TIMEOUT_MS,
+	maxMessagesBeforeRecycle = MAX_MESSAGES_BEFORE_RECYCLE,
 	workerActivity = createWorkerActivityTracker({
 		idleAfterMs: IDLE_SELF_KILL_MS,
 	}),
@@ -187,6 +188,7 @@ export const startPollingLoop = async ({
 	 * rows concurrently. */
 	visibilityTimeoutSeconds?: number;
 	receiveTimeoutMs?: number;
+	maxMessagesBeforeRecycle?: number;
 	workerActivity?: WorkerActivityTracker;
 }) => {
 	// Per-loop state
@@ -221,7 +223,7 @@ export const startPollingLoop = async ({
 	};
 
 	const recycleWorkerIfNeeded = () => {
-		if (totalMessagesProcessed < MAX_MESSAGES_BEFORE_RECYCLE) {
+		if (totalMessagesProcessed < maxMessagesBeforeRecycle) {
 			return;
 		}
 

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -603,8 +603,6 @@ export const initWorkers = async ({
 }) => {
 	const { db } = initDrizzle({ name: "worker", maxConnections: 40 });
 	startPgPoolMonitor();
-	const { warmupRegionalRedis } = await import("@/external/redis/initRedis.js");
-	await warmupRegionalRedis();
 
 	await initBlueGreen({ db, logger });
 

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -4,6 +4,7 @@ import { getAutumnEnv } from "@autumn/env";
 
 import { initInfisical } from "./external/infisical/initInfisical.js";
 import { logger } from "./external/logtail/logtailUtils.js";
+import { awaitBoundedWarmup } from "./external/redis/initUtils/boundedWarmup.js";
 import {
 	startAllEdgeConfigPolling,
 	stopAllEdgeConfigPolling,
@@ -114,25 +115,34 @@ if (cluster.isPrimary) {
 	);
 	const { primeRedisV2Monitor, startRedisV2Monitor, stopRedisV2Monitor } =
 		await import("./external/redis/availabilityMonitor/redisV2Availability.js");
-	const { startRedisMonitor, stopRedisMonitor } = await import(
-		"./external/redis/initRedis.js"
-	);
+	const { startRedisMonitor, stopRedisMonitor, warmupRegionalRedis } =
+		await import("./external/redis/initRedis.js");
 	const { preWarmOrgRedisConnections } = await import(
 		"./external/redis/orgRedisPool.js"
 	);
+
+	const redisWarmup = Promise.all([
+		warmupRegionalRedis(),
+		preWarmOrgRedisConnections({ db }).catch((error) => {
+			logger.warn("[OrgRedis] Warmup failed", { error });
+		}),
+	]);
+	void redisWarmup.catch(() => {});
 
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);
 	startRedisMonitor();
 	startRedisV2Monitor();
 
-	void preWarmOrgRedisConnections({ db }).catch((error) => {
-		logger.warn("[OrgRedis] Warmup failed", { error });
-	});
-
 	process.once("exit", () => {
 		stopAllEdgeConfigPolling();
 		stopRedisMonitor();
 		stopRedisV2Monitor();
+	});
+
+	await awaitBoundedWarmup({
+		warmup: redisWarmup,
+		timeoutMs: 10_000,
+		log: (message) => logger.warn(message),
 	});
 
 	const { initWorkers } = await import("./queue/initWorkers.js");

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -121,8 +121,12 @@ if (cluster.isPrimary) {
 		"./external/redis/orgRedisPool.js"
 	);
 
+	// Each arm catches its own failure: a regional rejection must not
+	// short-circuit the wait for healthy dedicated org connections.
 	const redisWarmup = Promise.all([
-		warmupRegionalRedis(),
+		warmupRegionalRedis().catch((error) => {
+			console.error("[Redis] regional warmup failed -", error);
+		}),
 		preWarmOrgRedisConnections({ db }).catch((error) => {
 			logger.warn("[OrgRedis] Warmup failed", { error });
 		}),

--- a/server/tests/unit/queue/fixtures/recycle-polling-worker.ts
+++ b/server/tests/unit/queue/fixtures/recycle-polling-worker.ts
@@ -1,0 +1,62 @@
+import { mock } from "bun:test";
+import {
+	DeleteMessageBatchCommand,
+	ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+mock.module("@/queue/processMessage.js", () => ({
+	processMessage: async () => {},
+}));
+mock.module(
+	"@/external/redis/actions/queueCapacityLease/queueCapacityLease.js",
+	() => ({
+		reserveQueueCapacity: async () => ({
+			capacity: 10,
+			isLimited: false,
+			assign: async (messages: unknown[]) =>
+				messages.map((item) => ({ item, release: async () => {} })),
+			release: async () => {},
+		}),
+	}),
+);
+
+const { startPollingLoop } = await import("@/queue/initWorkers.js");
+
+const messages = ["message-1", "message-2"].map((messageId) => ({
+	MessageId: messageId,
+	ReceiptHandle: `receipt-${messageId}`,
+	Body: JSON.stringify({ name: "recycle-test", data: {} }),
+}));
+
+let receiveCalls = 0;
+const sqs = {
+	send: async (command: unknown) => {
+		if (command instanceof ReceiveMessageCommand) {
+			receiveCalls++;
+			if (receiveCalls === 1) return { Messages: messages };
+			return new Promise(() => {});
+		}
+
+		if (command instanceof DeleteMessageBatchCommand) {
+			console.log(`DELETE_BATCH ${command.input.Entries?.length ?? 0}`);
+			return {
+				Successful: command.input.Entries?.map((entry) => ({ Id: entry.Id })),
+			};
+		}
+
+		throw new Error("Unexpected SQS command");
+	},
+};
+
+const pollingOptions = {
+	db: {} as never,
+	queueId: "primary",
+	queueUrl: "https://sqs.test/primary.fifo",
+	isFifo: true,
+	getSqsClientFn: () => sqs as never,
+	recreateSqsClientFn: () => sqs as never,
+	shouldPoll: () => true,
+	maxMessagesBeforeRecycle: 2,
+};
+
+await startPollingLoop(pollingOptions);

--- a/server/tests/unit/queue/queue-worker-recycle.test.ts
+++ b/server/tests/unit/queue/queue-worker-recycle.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+
+const FIXTURE_PATH = new URL(
+	"./fixtures/recycle-polling-worker.ts",
+	import.meta.url,
+).pathname;
+
+const waitForNaturalExit = async ({
+	child,
+	timeoutMs,
+}: {
+	child: ReturnType<typeof spawn>;
+	timeoutMs: number;
+}): Promise<boolean> => {
+	if (child.exitCode !== null || child.signalCode !== null) return true;
+
+	return await new Promise((resolve) => {
+		const timeout = setTimeout(() => resolve(false), timeoutMs);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolve(true);
+		});
+	});
+};
+
+// Queue workers previously had no process-level proof that their 50k threshold
+// ACKs the triggering batch before exiting for a cluster replacement.
+describe("SQS queue worker recycling", () => {
+	test("acknowledges the threshold batch before the worker exits", async () => {
+		const child = spawn("bun", [FIXTURE_PATH], {
+			cwd: process.cwd(),
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout?.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		const exitedNaturally = await waitForNaturalExit({
+			child,
+			timeoutMs: 2_500,
+		});
+		if (!exitedNaturally) {
+			child.kill("SIGKILL");
+			await new Promise((resolve) => child.once("exit", resolve));
+		}
+
+		expect(exitedNaturally, stderr).toBe(true);
+		expect(child.exitCode).toBe(0);
+
+		const deleteIndex = stdout.indexOf("DELETE_BATCH 2");
+		const recycleIndex = stdout.indexOf("Recycling after 2 messages");
+		expect(deleteIndex).toBeGreaterThanOrEqual(0);
+		expect(recycleIndex).toBeGreaterThan(deleteIndex);
+	});
+});

--- a/server/tests/unit/queue/queue-worker-recycle.test.ts
+++ b/server/tests/unit/queue/queue-worker-recycle.test.ts
@@ -41,9 +41,11 @@ describe("SQS queue worker recycling", () => {
 			stderr += chunk.toString();
 		});
 
+		// Generous: a cold-cache CI bun boot alone can take seconds; the wait
+		// resolves on exit, so healthy runs never pay the full bound.
 		const exitedNaturally = await waitForNaturalExit({
 			child,
-			timeoutMs: 2_500,
+			timeoutMs: 15_000,
 		});
 		if (!exitedNaturally) {
 			child.kill("SIGKILL");

--- a/server/tests/unit/queue/worker-redis-startup-gate.test.ts
+++ b/server/tests/unit/queue/worker-redis-startup-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 
 // Recycled SQS workers previously polled while dedicated Redis was connecting.
 // They now wait for bounded warmup before initializing queue consumers.
@@ -79,4 +79,8 @@ describe("queue worker Redis startup gate", () => {
 		await workerStartup;
 		expect(initWorkersCalled).toBe(true);
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });

--- a/server/tests/unit/queue/worker-redis-startup-gate.test.ts
+++ b/server/tests/unit/queue/worker-redis-startup-gate.test.ts
@@ -9,17 +9,33 @@ const orgRedisWarmup = new Promise<void>((resolve) => {
 	resolveOrgRedisWarmup = resolve;
 });
 
-mock.module("node:cluster", () => ({
+// Capture each real module before mocking so afterAll can restore it —
+// bun's mock.module leaks across test files otherwise. The preload has
+// already seeded these into the registry, so the imports are cheap.
+const realModules = new Map<string, Record<string, unknown>>();
+const mockModuleRestorable = async (
+	path: string,
+	factory: () => Record<string, unknown>,
+) => {
+	const real = await import(path).catch(() => null);
+	if (real) realModules.set(path, { ...real });
+	mock.module(path, factory);
+};
+
+await mockModuleRestorable("node:cluster", () => ({
 	default: { isPrimary: false },
 }));
 
-mock.module("@/external/infisical/initInfisical.js", () => ({
+await mockModuleRestorable("@/external/infisical/initInfisical.js", () => ({
 	initInfisical: async () => {},
 }));
-mock.module("@/internal/misc/edgeConfig/edgeConfigRegistry.js", () => ({
-	startAllEdgeConfigPolling: async () => {},
-	stopAllEdgeConfigPolling: () => {},
-}));
+await mockModuleRestorable(
+	"@/internal/misc/edgeConfig/edgeConfigRegistry.js",
+	() => ({
+		startAllEdgeConfigPolling: async () => {},
+		stopAllEdgeConfigPolling: () => {},
+	}),
+);
 
 for (const modulePath of [
 	"@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js",
@@ -32,21 +48,21 @@ for (const modulePath of [
 	"@/internal/misc/jobQueues/jobQueueStore.js",
 	"@/internal/misc/batchReset/batchResetConfigStore.js",
 ]) {
-	mock.module(modulePath, () => ({}));
+	await mockModuleRestorable(modulePath, () => ({}));
 }
 
-mock.module("@/utils/memoryMonitor.js", () => ({
+await mockModuleRestorable("@/utils/memoryMonitor.js", () => ({
 	startMemoryMonitor: () => {},
 }));
-mock.module("@/instrumentation.js", () => ({}));
-mock.module("@/db/initDrizzle.js", () => ({ db: {} }));
-mock.module(
+await mockModuleRestorable("@/instrumentation.js", () => ({}));
+await mockModuleRestorable("@/db/initDrizzle.js", () => ({ db: {} }));
+await mockModuleRestorable(
 	"@/external/redis/availabilityMonitor/redisAvailability.js",
 	() => ({
 		primeRedisMonitor: async () => {},
 	}),
 );
-mock.module(
+await mockModuleRestorable(
 	"@/external/redis/availabilityMonitor/redisV2Availability.js",
 	() => ({
 		primeRedisV2Monitor: async () => {},
@@ -54,15 +70,15 @@ mock.module(
 		stopRedisV2Monitor: () => {},
 	}),
 );
-mock.module("@/external/redis/initRedis.js", () => ({
+await mockModuleRestorable("@/external/redis/initRedis.js", () => ({
 	startRedisMonitor: () => {},
 	stopRedisMonitor: () => {},
 	warmupRegionalRedis: async () => {},
 }));
-mock.module("@/external/redis/orgRedisPool.js", () => ({
+await mockModuleRestorable("@/external/redis/orgRedisPool.js", () => ({
 	preWarmOrgRedisConnections: () => orgRedisWarmup,
 }));
-mock.module("@/queue/initWorkers.js", () => ({
+await mockModuleRestorable("@/queue/initWorkers.js", () => ({
 	initWorkers: async () => {
 		initWorkersCalled = true;
 	},
@@ -72,15 +88,22 @@ describe("queue worker Redis startup gate", () => {
 	test("does not initialize SQS polling until dedicated Redis is ready", async () => {
 		const workerStartup = import("@/workers.js");
 
-		await Bun.sleep(30);
-		expect(initWorkersCalled).toBe(false);
-
-		resolveOrgRedisWarmup();
+		// Release the warmup even when the first assertion throws, so a red
+		// run fails fast instead of waiting out the fail-open bound.
+		try {
+			await Bun.sleep(30);
+			expect(initWorkersCalled).toBe(false);
+		} finally {
+			resolveOrgRedisWarmup();
+		}
 		await workerStartup;
 		expect(initWorkersCalled).toBe(true);
 	});
 });
 
 afterAll(() => {
+	for (const [path, real] of realModules) {
+		mock.module(path, () => real);
+	}
 	mock.restore();
 });

--- a/server/tests/unit/queue/worker-redis-startup-gate.test.ts
+++ b/server/tests/unit/queue/worker-redis-startup-gate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Recycled SQS workers previously polled while dedicated Redis was connecting.
+// They now wait for bounded warmup before initializing queue consumers.
+let resolveOrgRedisWarmup = () => {};
+let initWorkersCalled = false;
+
+const orgRedisWarmup = new Promise<void>((resolve) => {
+	resolveOrgRedisWarmup = resolve;
+});
+
+mock.module("node:cluster", () => ({
+	default: { isPrimary: false },
+}));
+
+mock.module("@/external/infisical/initInfisical.js", () => ({
+	initInfisical: async () => {},
+}));
+mock.module("@/internal/misc/edgeConfig/edgeConfigRegistry.js", () => ({
+	startAllEdgeConfigPolling: async () => {},
+	stopAllEdgeConfigPolling: () => {},
+}));
+
+for (const modulePath of [
+	"@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js",
+	"@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js",
+	"@/internal/misc/requestBlocks/requestBlockStore.js",
+	"@/internal/misc/rollouts/rolloutConfigStore.js",
+	"@/internal/misc/redisV2Cache/redisV2CacheStore.js",
+	"@/internal/misc/miscRedisConfig/miscRedisConfigStore.js",
+	"@/internal/misc/cacheV2Ramp/cacheV2RampStore.js",
+	"@/internal/misc/jobQueues/jobQueueStore.js",
+	"@/internal/misc/batchReset/batchResetConfigStore.js",
+]) {
+	mock.module(modulePath, () => ({}));
+}
+
+mock.module("@/utils/memoryMonitor.js", () => ({
+	startMemoryMonitor: () => {},
+}));
+mock.module("@/instrumentation.js", () => ({}));
+mock.module("@/db/initDrizzle.js", () => ({ db: {} }));
+mock.module(
+	"@/external/redis/availabilityMonitor/redisAvailability.js",
+	() => ({
+		primeRedisMonitor: async () => {},
+	}),
+);
+mock.module(
+	"@/external/redis/availabilityMonitor/redisV2Availability.js",
+	() => ({
+		primeRedisV2Monitor: async () => {},
+		startRedisV2Monitor: () => {},
+		stopRedisV2Monitor: () => {},
+	}),
+);
+mock.module("@/external/redis/initRedis.js", () => ({
+	startRedisMonitor: () => {},
+	stopRedisMonitor: () => {},
+	warmupRegionalRedis: async () => {},
+}));
+mock.module("@/external/redis/orgRedisPool.js", () => ({
+	preWarmOrgRedisConnections: () => orgRedisWarmup,
+}));
+mock.module("@/queue/initWorkers.js", () => ({
+	initWorkers: async () => {
+		initWorkersCalled = true;
+	},
+}));
+
+describe("queue worker Redis startup gate", () => {
+	test("does not initialize SQS polling until dedicated Redis is ready", async () => {
+		const workerStartup = import("@/workers.js");
+
+		await Bun.sleep(30);
+		expect(initWorkersCalled).toBe(false);
+
+		resolveOrgRedisWarmup();
+		await workerStartup;
+		expect(initWorkersCalled).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- start regional and dedicated-org Redis warmups together in every SQS worker child
- wait on the same 10-second bounded startup barrier before calling `initWorkers()`
- keep fail-open startup behavior if Redis remains unavailable
- remove the duplicate regional warmup from `initWorkers()`
- add entrypoint coverage proving queue consumers do not initialize while dedicated Redis is connecting
- add a child-process queue-loop test proving the threshold batch is acknowledged before recycle exit

## Scope clarification

This is separate resilience hardening for the SQS worker service. SQS worker recycling was **not** the demonstrated cause of the observed HTTP 202 check fail-opens.

Those requests raced dedicated Redis readiness in HTTP server workers; #2700 gates the HTTP listener and addresses that observed startup race. This stacked PR applies the equivalent readiness barrier before SQS polling.

## Queue-worker issue

After an SQS worker processes 50,000 messages, the cluster primary forks a replacement child. Previously that child started `preWarmOrgRedisConnections()` without awaiting it, then immediately called `initWorkers()`, allowing queue processing to race dedicated Redis readiness.

The production threshold remains 50,000. The test supplies a threshold of 2 to exercise the same exit path quickly.

## Stacking

This PR is stacked on #2700 because it reuses that PR's bounded warmup helper and awaited per-org readiness. Retarget it to `dev` after #2700 merges.

## Validation

- regression startup test seen red before the fix and green afterward
- child-process recycle test seen red before the threshold override and green afterward
- recycle test proves two messages are processed and batch-deleted before the process exits
- complete queue unit surface: 41 tests passed across 14 files
- `bun ts`
- commit hooks: Knip and server typecheck passed

Scoped Biome reports only the pre-existing unused `hatchet` import in `initWorkers.ts`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents SQS consumers from starting until regional and organization-specific Redis warmups finish or the bounded startup timeout expires.

- **Bug fixes:** Starts both Redis warmups together and waits on a shared 10-second fail-open barrier before initializing queue consumers.
- **Improvements:** Removes the duplicate regional Redis warmup from `initWorkers()`.
- **Improvements:** Adds startup-gating and worker-recycling regression coverage, including proof that the threshold batch is acknowledged before exit.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/workers.ts | Starts both Redis warmups concurrently and gates queue initialization on a bounded fail-open wait. |
| server/src/queue/initWorkers.ts | Removes duplicate regional warmup and makes the recycle threshold injectable for process-level testing. |
| server/tests/unit/queue/worker-redis-startup-gate.test.ts | Verifies queue initialization waits for dedicated Redis and restores mocked modules after the test. |
| server/tests/unit/queue/queue-worker-recycle.test.ts | Verifies the threshold-triggering SQS batch is deleted before the worker exits. |
| server/tests/unit/queue/fixtures/recycle-polling-worker.ts | Provides an isolated child-process fixture exercising the queue-worker recycle path. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Worker as SQS Worker Child
  participant Regional as Regional Redis
  participant Org as Dedicated Org Redis
  participant Barrier as 10s Startup Barrier
  participant SQS as Queue Consumers
  Worker->>Regional: Start warmup
  Worker->>Org: Start warmup
  Worker->>Barrier: Await both warmups
  alt Warmups settle within 10 seconds
    Barrier-->>Worker: Continue
  else Timeout expires
    Barrier-->>Worker: Continue fail-open
  end
  Worker->>SQS: initWorkers()
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: catch warmup arms independently; re..."](https://github.com/useautumn/autumn/commit/c4b079a1f8c3cc9ae808c8b58d266957622bf3b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51815470)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->