### PR TITLE
Clear Stripe mappings on disconnect

### DIFF
--- a/server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts
+++ b/server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts
@@ -1,7 +1,7 @@
 import {
 	type ApiPlanItemV1,
-	FixedPriceConfigSchema,
 	type Feature,
+	FixedPriceConfigSchema,
 	type FullProduct,
 	getProductItemDisplay,
 	isFeaturePriceItem,
@@ -165,7 +165,9 @@ export const buildProductMappingContext = ({
 		product: { items: sortedItems } as any,
 	});
 	const basePrice = basePriceItem?.price_id
-		? (product.prices ?? []).find((price) => price.id === basePriceItem.price_id)
+		? (product.prices ?? []).find(
+				(price) => price.id === basePriceItem.price_id,
+			)
 		: undefined;
 
 	const featureItems = productV2ToFeatureItems({
@@ -204,6 +206,25 @@ export const buildProductMappingContext = ({
 	};
 };
 
+const clearCurrencyStripePriceFields = (
+	currencies: Price["config"]["currencies"],
+) => {
+	if (!currencies) return currencies;
+
+	return Object.fromEntries(
+		Object.entries(currencies).map(([currency, config]) => [
+			currency,
+			{
+				...config,
+				stripe_price_id: null,
+				stripe_empty_price_id: null,
+				stripe_placeholder_price_id: null,
+				stripe_prepaid_price_v2_id: null,
+			},
+		]),
+	);
+};
+
 export const clearDependentStripePriceFields = ({
 	price,
 	stripeProductId,
@@ -219,6 +240,7 @@ export const clearDependentStripePriceFields = ({
 		const config = FixedPriceConfigSchema.parse(price.config);
 		return {
 			...config,
+			currencies: clearCurrencyStripePriceFields(config.currencies),
 			stripe_product_id: stripeProductId,
 			stripe_price_id: stripePriceId ?? null,
 			stripe_empty_price_id: null,
@@ -228,6 +250,7 @@ export const clearDependentStripePriceFields = ({
 	const config = UsagePriceConfigSchema.parse(price.config);
 	return {
 		...config,
+		currencies: clearCurrencyStripePriceFields(config.currencies),
 		stripe_product_id: stripeProductId,
 		stripe_price_id: stripePriceId ?? null,
 		stripe_empty_price_id: null,

--- a/server/src/internal/catalog/actions/catalogMappings/clearStripeCatalogMappings.ts
+++ b/server/src/internal/catalog/actions/catalogMappings/clearStripeCatalogMappings.ts
@@ -1,0 +1,50 @@
+import {
+	type AppEnv,
+	type Price,
+	ProcessorType,
+	prices,
+	products,
+} from "@autumn/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { clearDependentStripePriceFields } from "./catalogMappingUtils.js";
+
+export const clearStripeCatalogMappings = async ({
+	db,
+	orgId,
+	env,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+}) => {
+	const catalogProducts = await db.query.products.findMany({
+		where: and(eq(products.org_id, orgId), eq(products.env, env)),
+		with: { prices: true },
+	});
+
+	await db
+		.update(products)
+		.set({ processor: null })
+		.where(
+			and(
+				eq(products.org_id, orgId),
+				eq(products.env, env),
+				sql`${products.processor} ->> 'type' = ${ProcessorType.Stripe}`,
+			),
+		);
+
+	for (const product of catalogProducts) {
+		for (const price of product.prices) {
+			await db
+				.update(prices)
+				.set({
+					config: clearDependentStripePriceFields({
+						price: price as Price,
+						stripeProductId: null,
+					}),
+				})
+				.where(eq(prices.id, price.id));
+		}
+	}
+};

--- a/server/src/internal/orgs/handlers/stripeHandlers/handleDeleteStripe.ts
+++ b/server/src/internal/orgs/handlers/stripeHandlers/handleDeleteStripe.ts
@@ -8,12 +8,15 @@ import {
 	type StripeConnectConfig,
 } from "@autumn/shared";
 import { z } from "zod/v4";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { orgToAccountId } from "@/external/connect/connectUtils.js";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { initMasterStripe } from "@/external/connect/initStripeCli.js";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
 import { createWebhookEndpoint } from "@/external/stripe/stripeOnboardingUtils.js";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { clearStripeCatalogMappings } from "@/internal/catalog/actions/catalogMappings/clearStripeCatalogMappings.js";
 import { decryptData, encryptData } from "@/utils/encryptUtils.js";
 import { OrgService } from "../../OrgService.js";
 import { clearOrgCache } from "../../orgUtils/clearOrgCache.js";
@@ -48,10 +51,14 @@ export const resolveDisconnectChannels = ({
 		orgToAccountId({ org, env, noDefaultAccount: true }),
 	);
 
-	return {
-		clearSecretKey: channel === "oauth" ? false : hasSecretKey,
-		clearOauth: channel === "secret_key" ? false : hasOauth,
-	};
+	const clearSecretKey = channel === "oauth" ? false : hasSecretKey;
+	const clearOauth = channel === "secret_key" ? false : hasOauth;
+	const clearCatalogMappings =
+		(clearSecretKey || clearOauth) &&
+		(!hasSecretKey || clearSecretKey) &&
+		(!hasOauth || clearOauth);
+
+	return { clearSecretKey, clearOauth, clearCatalogMappings };
 };
 
 export const computeClearedStripeConfig = ({
@@ -243,11 +250,12 @@ export const handleDeleteStripe = createRoute({
 		await clearOrgCache({ db, orgId: org.id, logger });
 
 		// 1. Resolve which channels to disconnect
-		const { clearSecretKey, clearOauth } = resolveDisconnectChannels({
-			org,
-			env,
-			channel,
-		});
+		const { clearSecretKey, clearOauth, clearCatalogMappings } =
+			resolveDisconnectChannels({
+				org,
+				env,
+				channel,
+			});
 
 		// 2. Disconnect each channel, collecting the org updates it produces
 		const updates: Partial<Organization> = {};
@@ -268,7 +276,21 @@ export const handleDeleteStripe = createRoute({
 
 		// 3. Persist (nothing to clear if neither channel was connected for this env)
 		if (Object.keys(updates).length > 0) {
-			await OrgService.update({ db, orgId: org.id, updates });
+			await db.transaction(async (tx) => {
+				const txDb = tx as unknown as DrizzleCli;
+				await OrgService.update({ db: txDb, orgId: org.id, updates });
+				if (clearCatalogMappings) {
+					await clearStripeCatalogMappings({
+						db: txDb,
+						orgId: org.id,
+						env,
+					});
+				}
+			});
+		}
+
+		if (clearCatalogMappings) {
+			await invalidateProductsCache({ orgId: org.id, env });
 		}
 
 		return c.json({});

--- a/server/tests/integration/stripe/disconnect-clears-catalog-mappings.test.ts
+++ b/server/tests/integration/stripe/disconnect-clears-catalog-mappings.test.ts
@@ -1,0 +1,244 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	type Organization,
+	organizations,
+	PriceType,
+	ProcessorType,
+	prices as pricesTable,
+	products as productsTable,
+} from "@autumn/shared";
+import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
+import type { User } from "better-auth";
+import { and, eq } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { deletePlatformSubOrg } from "@/internal/orgs/deleteOrg/deletePlatformSubOrg.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { createSandboxForOrg } from "@/internal/sandboxes/createSandbox.js";
+import { encryptData } from "@/utils/encryptUtils.js";
+
+// Disconnecting the last Stripe channel clears every catalog mapping in that org/environment.
+// Active, archived, versioned, variant, auxiliary, and currency-specific mappings are covered.
+
+const { db } = initDrizzle();
+const apiBase = `${(process.env.AUTUMN_TEST_BASE_URL ?? "http://localhost:8080").replace(/\/$/, "")}/v1`;
+const createdOrgs: Organization[] = [];
+
+const stripeResourceFields = [
+	"stripe_product_id",
+	"stripe_price_id",
+	"stripe_empty_price_id",
+	"stripe_placeholder_price_id",
+	"stripe_prepaid_price_v2_id",
+	"stripe_meter_id",
+	"stripe_event_name",
+] as const;
+
+const priceResourceFields = [
+	"stripe_price_id",
+	"stripe_empty_price_id",
+	"stripe_placeholder_price_id",
+	"stripe_prepaid_price_v2_id",
+] as const;
+
+const mappedUsageConfig = (suffix: string) => ({
+	type: PriceType.Usage,
+	bill_when: BillWhen.EndOfPeriod,
+	billing_units: 1,
+	internal_feature_id: `feature_internal_${suffix}`,
+	feature_id: `feature_${suffix}`,
+	usage_tiers: [{ to: "inf" as const, amount: 1 }],
+	interval: BillingInterval.Month,
+	stripe_product_id: `prod_${suffix}`,
+	stripe_price_id: `price_${suffix}`,
+	stripe_empty_price_id: `price_empty_${suffix}`,
+	stripe_placeholder_price_id: `price_placeholder_${suffix}`,
+	stripe_prepaid_price_v2_id: `price_prepaid_v2_${suffix}`,
+	stripe_meter_id: `mtr_${suffix}`,
+	stripe_event_name: `event_${suffix}`,
+	currencies: {
+		eur: {
+			amount: 2,
+			stripe_price_id: `price_eur_${suffix}`,
+			stripe_empty_price_id: `price_empty_eur_${suffix}`,
+			stripe_placeholder_price_id: `price_placeholder_eur_${suffix}`,
+			stripe_prepaid_price_v2_id: `price_prepaid_v2_eur_${suffix}`,
+		},
+	},
+});
+
+const expectStripeResourcesCleared = (config: Record<string, unknown>) => {
+	for (const field of stripeResourceFields) {
+		expect(config[field] ?? null).toBeNull();
+	}
+
+	const currencies = config.currencies as Record<
+		string,
+		Record<string, unknown>
+	>;
+	for (const currencyConfig of Object.values(currencies ?? {})) {
+		for (const field of priceResourceFields) {
+			expect(currencyConfig[field] ?? null).toBeNull();
+		}
+	}
+};
+
+afterAll(async () => {
+	for (const org of createdOrgs) {
+		await deletePlatformSubOrg({
+			db,
+			org,
+			logger,
+			skipLiveCustomerCheck: true,
+		});
+	}
+});
+
+describe("Stripe disconnect catalog cleanup", () => {
+	test("clears every sandbox catalog mapping when the secret key is the last channel", async () => {
+		const actorUser = (await db.query.user.findFirst()) as unknown as User;
+		const { org, secret_key } = await createSandboxForOrg({
+			db,
+			masterOrg: defaultCtx.org,
+			actorUser,
+			name: "QA Disconnect Catalog Mappings",
+		});
+		createdOrgs.push(org);
+
+		await OrgService.update({
+			db,
+			orgId: org.id,
+			updates: {
+				stripe_config: {
+					...(org.stripe_config ?? {}),
+					test_api_key: encryptData("sk_test_disconnect_catalog"),
+				},
+			},
+		});
+
+		const productRows = [
+			{
+				internal_id: `${org.id}_plan_v1`,
+				id: `${org.id}_plan`,
+				name: "Mapped plan v1",
+				org_id: org.id,
+				env: AppEnv.Sandbox,
+				version: 1,
+				processor: {
+					type: ProcessorType.Stripe,
+					id: "prod_plan_v1",
+					additional_ids: ["prod_plan_v1_alias"],
+				},
+			},
+			{
+				internal_id: `${org.id}_plan_v2`,
+				id: `${org.id}_plan`,
+				name: "Mapped plan v2",
+				org_id: org.id,
+				env: AppEnv.Sandbox,
+				version: 2,
+				processor: {
+					type: ProcessorType.Stripe,
+					id: "prod_plan_v2",
+				},
+			},
+			{
+				internal_id: `${org.id}_variant`,
+				id: `${org.id}_variant`,
+				name: "Archived mapped variant",
+				org_id: org.id,
+				env: AppEnv.Sandbox,
+				archived: true,
+				base_internal_product_id: `${org.id}_plan_v2`,
+				processor: {
+					type: ProcessorType.Stripe,
+					id: "prod_variant",
+				},
+			},
+			{
+				internal_id: `${org.id}_live_plan`,
+				id: `${org.id}_live_plan`,
+				name: "Live mapped plan",
+				org_id: org.id,
+				env: AppEnv.Live,
+				processor: {
+					type: ProcessorType.Stripe,
+					id: "prod_live",
+				},
+			},
+		];
+		await db.insert(productsTable).values(productRows);
+
+		await db.insert(pricesTable).values(
+			productRows.map((product, index) => ({
+				id: `${org.id}_price_${index}`,
+				org_id: org.id,
+				internal_product_id: product.internal_id,
+				created_at: Date.now(),
+				billing_type: "usage_in_arrear",
+				config: mappedUsageConfig(`${index}`),
+			})),
+		);
+
+		await ProductService.listFull({
+			db,
+			orgId: org.id,
+			env: AppEnv.Sandbox,
+		});
+
+		const response = await fetch(`${apiBase}/organization/stripe`, {
+			method: "DELETE",
+			headers: {
+				Authorization: `Bearer ${secret_key}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ channel: "secret_key" }),
+		});
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({});
+
+		const sandboxProducts = await db.query.products.findMany({
+			where: and(
+				eq(productsTable.org_id, org.id),
+				eq(productsTable.env, AppEnv.Sandbox),
+			),
+			with: { prices: true },
+		});
+		expect(sandboxProducts).toHaveLength(3);
+		for (const product of sandboxProducts) {
+			expect(product.processor).toBeNull();
+			for (const price of product.prices) {
+				expectStripeResourcesCleared(price.config as Record<string, unknown>);
+			}
+		}
+
+		const cachedProducts = await ProductService.listFull({
+			db,
+			orgId: org.id,
+			env: AppEnv.Sandbox,
+		});
+		for (const product of cachedProducts) {
+			expect(product.processor).toBeNull();
+		}
+
+		const [liveProduct] = await db.query.products.findMany({
+			where: and(
+				eq(productsTable.org_id, org.id),
+				eq(productsTable.env, AppEnv.Live),
+			),
+			with: { prices: true },
+		});
+		expect(liveProduct?.processor?.id).toBe("prod_live");
+		expect(liveProduct?.prices[0]?.config?.stripe_price_id).toBe("price_3");
+
+		const [updatedOrg] = await db
+			.select()
+			.from(organizations)
+			.where(eq(organizations.id, org.id));
+		expect(updatedOrg?.stripe_config?.test_api_key ?? null).toBeNull();
+	}, 120_000);
+});

--- a/server/tests/integration/stripe/dual-auth-disconnect.test.ts
+++ b/server/tests/integration/stripe/dual-auth-disconnect.test.ts
@@ -1,23 +1,8 @@
-/**
- * TDD test for Stripe dual-auth channel-specific disconnect.
- *
- * Contract under test:
- *   resolveDisconnectChannels({ org, env, channel }) -> { clearSecretKey, clearOauth }
- *     - channel "secret_key": clearSecretKey true, clearOauth false (leaves oauth intact)
- *     - channel "oauth": clearOauth true, clearSecretKey false (leaves key + direct webhook intact)
- *     - channel undefined (legacy): clears whichever channel(s) are present for the env
- *
- *   computeClearedStripeConfig / computeClearedStripeConnect (pure field mutators):
- *     - clearing secret key nulls *_api_key + *_webhook_secret, leaves *_connect_webhook_secret + account_id
- *     - clearing oauth deletes account_id, leaves stripe_config untouched
- *
- * Pre-impl red: these helpers do not exist; disconnect is all-or-nothing branched on
- * throughSecretKey.
- * Post-impl green: disconnect is channel-scoped and never clears the other channel.
- */
+/** Channel resolution clears catalog mappings only when the last Stripe channel is removed.
+ * Channel-specific config mutation must continue preserving the other channel. */
 
 import { describe, expect, test } from "bun:test";
-import { AppEnv, type Organization } from "@autumn/shared";
+import { AppEnv, type Organization, type StripeConfig } from "@autumn/shared";
 import {
 	computeClearedStripeConfig,
 	computeClearedStripeConnect,
@@ -41,7 +26,7 @@ const dualOrg = () =>
 			test_api_key: encryptData("sk_test"),
 			test_webhook_secret: encryptData("whsec_direct"),
 			test_connect_webhook_secret: encryptData("whsec_connect"),
-		} as any,
+		} satisfies StripeConfig,
 		test_stripe_connect: { account_id: "acct_dual" },
 	});
 
@@ -53,18 +38,47 @@ describe("dual-auth: resolveDisconnectChannels", () => {
 		const res = resolveDisconnectChannels({ org, env, channel: "secret_key" });
 		expect(res.clearSecretKey).toBe(true);
 		expect(res.clearOauth).toBe(false);
+		expect(res.clearCatalogMappings).toBe(false);
 	});
 
 	test("channel oauth clears only oauth", () => {
 		const res = resolveDisconnectChannels({ org, env, channel: "oauth" });
 		expect(res.clearOauth).toBe(true);
 		expect(res.clearSecretKey).toBe(false);
+		expect(res.clearCatalogMappings).toBe(false);
 	});
 
 	test("no channel (legacy) clears both present channels", () => {
 		const res = resolveDisconnectChannels({ org, env, channel: undefined });
 		expect(res.clearSecretKey).toBe(true);
 		expect(res.clearOauth).toBe(true);
+		expect(res.clearCatalogMappings).toBe(true);
+	});
+
+	test("clearing the only connected channel clears catalog mappings", () => {
+		const secretOnly = buildOrg({
+			stripe_config: {
+				test_api_key: encryptData("sk_test"),
+			} satisfies StripeConfig,
+		});
+		const oauthOnly = buildOrg({
+			test_stripe_connect: { account_id: "acct_oauth" },
+		});
+
+		expect(
+			resolveDisconnectChannels({
+				org: secretOnly,
+				env,
+				channel: "secret_key",
+			}).clearCatalogMappings,
+		).toBe(true);
+		expect(
+			resolveDisconnectChannels({
+				org: oauthOnly,
+				env,
+				channel: "oauth",
+			}).clearCatalogMappings,
+		).toBe(true);
 	});
 });
 

--- a/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
+++ b/vite/src/views/developer/configure-stripe/ConfigureStripe.tsx
@@ -30,8 +30,8 @@ import {
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useMasterStripeAccount } from "@/views/admin/hooks/useMasterStripeAccount";
 import ConnectStripeDialog from "@/views/onboarding2/ConnectStripeDialog";
-import { CatalogMappingsCard } from "./mappings/CatalogMappingsCard";
 import { DisconnectStripeDialog } from "./DisconnectStripeDialog";
+import { CatalogMappingsCard } from "./mappings/CatalogMappingsCard";
 import { StripeAccountMismatchBanner } from "./StripeAccountMismatchBanner";
 import { StripeChannelCell } from "./StripeChannelCell";
 import { StripeCheckoutSettings } from "./StripeCheckoutSettings";
@@ -186,6 +186,7 @@ export const ConfigureStripe = () => {
 								oauthConnected ? (
 									<DisconnectStripeDialog
 										channel="oauth"
+										willRemoveCatalogMappings={!secretKeyConnected}
 										label="Disconnect"
 										icon={<LinkBreakIcon />}
 										onSuccess={mutate}
@@ -221,6 +222,7 @@ export const ConfigureStripe = () => {
 								secretKeyConnected ? (
 									<DisconnectStripeDialog
 										channel="secret_key"
+										willRemoveCatalogMappings={!oauthConnected}
 										label="Disconnect"
 										icon={<LinkBreakIcon />}
 										onSuccess={mutate}

--- a/vite/src/views/developer/configure-stripe/DisconnectStripeDialog.tsx
+++ b/vite/src/views/developer/configure-stripe/DisconnectStripeDialog.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 import { OrgService } from "@/services/OrgService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
+import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
 
 const CONFIRM_TEXT = "disconnect";
 
@@ -25,11 +26,13 @@ const CHANNEL_LABEL: Record<"secret_key" | "oauth", string> = {
 export const DisconnectStripeDialog = ({
 	onSuccess,
 	channel,
+	willRemoveCatalogMappings = false,
 	label = "Disconnect Stripe",
 	icon,
 }: {
 	onSuccess: () => Promise<void>;
 	channel?: "secret_key" | "oauth";
+	willRemoveCatalogMappings?: boolean;
 	label?: string;
 	icon?: React.ReactNode;
 }) => {
@@ -88,6 +91,14 @@ export const DisconnectStripeDialog = ({
 						Stripe operations.
 					</DialogDescription>
 				</DialogHeader>
+
+				{willRemoveCatalogMappings && (
+					<InfoBox variant="warning">
+						This will remove all existing, active and archived product and price
+						mappings to Autumn plans. This will break any links existing
+						customers have.
+					</InfoBox>
+				)}
 
 				<Input
 					autoFocus


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clears all Stripe catalog mappings when the last Stripe channel is disconnected for an environment. Adds a UI warning for this case and invalidates product caches.

- **Bug Fixes**
  - When the final connected Stripe channel (secret key or OAuth) is removed, clear `products.processor` and all Stripe price fields (including currency-level IDs) for all products/prices in that org/env.
  - Run catalog clearing in the same DB transaction as the org update and invalidate the products cache afterward.
  - Do not clear mappings if the other Stripe channel remains connected.

- **New Features**
  - Disconnect dialog shows a warning when the action will remove catalog mappings, based on whether it’s the last connected channel.

<sup>Written for commit 037f750566cef7cc53a99d3bfe24aa33fbaa72ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR clears Stripe product and price mappings when an organization disconnects its final Stripe authentication channel, while preserving mappings when another Stripe channel remains connected.
- **Bug fixes:** Remove active, archived, versioned, and currency-specific Stripe catalog identifiers after the final Stripe channel is disconnected.
- **Improvements:** Perform credential and catalog cleanup in one database transaction, then invalidate the product cache.
- **Improvements:** Warn users when a disconnect will remove catalog mappings, and add integration coverage for cleanup and dual-channel behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with final-channel cleanup correctly scoped to the organization and environment and protected by a database transaction.

The changed flow preserves catalog mappings while another Stripe authentication channel remains, clears them when the final channel is removed, and invalidates product caches only after the database work completes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/catalog/actions/catalogMappings/catalogMappingUtils.ts | Extends Stripe mapping cleanup to null currency-specific price identifiers while preserving other currency configuration. |
| server/src/internal/catalog/actions/catalogMappings/clearStripeCatalogMappings.ts | Adds environment-scoped cleanup for Stripe product processors and all Stripe fields stored in associated price configurations. |
| server/src/internal/orgs/handlers/stripeHandlers/handleDeleteStripe.ts | Detects final-channel disconnects, transactionally clears credentials and mappings, and invalidates product caches after commit. |
| server/tests/integration/stripe/disconnect-clears-catalog-mappings.test.ts | Verifies cleanup across archived, versioned, variant, currency-specific, and environment-scoped catalog records. |
| server/tests/integration/stripe/dual-auth-disconnect.test.ts | Verifies catalog mappings remain until the last available Stripe authentication channel is removed. |
| vite/src/views/developer/configure-stripe/ConfigureStripe.tsx | Determines whether each channel disconnect will remove catalog mappings based on the other channel's connection state. |
| vite/src/views/developer/configure-stripe/DisconnectStripeDialog.tsx | Displays a warning when disconnecting Stripe will remove product and price mappings. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant API as Stripe Disconnect API
  participant DB as PostgreSQL
  participant Cache as Product Cache

  User->>API: Disconnect Stripe channel
  API->>API: Check remaining authentication channels
  alt Another Stripe channel remains
    API->>DB: Remove selected channel credentials
  else Final Stripe channel removed
    API->>DB: Begin transaction
    API->>DB: Remove channel credentials
    API->>DB: Clear Stripe product and price mappings
    DB-->>API: Commit
    API->>Cache: Invalidate org/environment products
  end
  API-->>User: Success
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 clear stripe mappings on disconn..."](https://github.com/useautumn/autumn/commit/037f750566cef7cc53a99d3bfe24aa33fbaa72ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51844396)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->