### PR TITLE
fix: reject rollover max of 0 on plan and catalog updates

### DIFF
--- a/server/src/internal/products/product-items/validateProductItems.ts
+++ b/server/src/internal/products/product-items/validateProductItems.ts
@@ -317,9 +317,9 @@ const validateProductItem = ({
 
 		// Validate rollover max amount
 		if (rollover.max !== null && typeof rollover.max === "number") {
-			if (rollover.max < 0) {
+			if (rollover.max <= 0) {
 				throw new RecaseError({
-					message: "Rollover maximum amount must be positive",
+					message: "Rollover maximum amount must be greater than 0",
 					code: ErrCode.InvalidInputs,
 					statusCode: StatusCodes.BAD_REQUEST,
 				});

--- a/server/src/internal/products/product-items/validateProductItems.ts
+++ b/server/src/internal/products/product-items/validateProductItems.ts
@@ -17,6 +17,7 @@ import {
 	RecaseError,
 	type RolloverConfig,
 	RolloverExpiryDurationType,
+	rolloverConfigToIssue,
 	TierBehavior,
 	UsageModel,
 } from "@autumn/shared";
@@ -315,34 +316,10 @@ const validateProductItem = ({
 	if (item.config?.rollover) {
 		const rollover = item.config.rollover as RolloverConfig;
 
-		// Validate rollover max amount
-		if (rollover.max !== null && typeof rollover.max === "number") {
-			if (rollover.max <= 0) {
-				throw new RecaseError({
-					message: "Rollover maximum amount must be greater than 0",
-					code: ErrCode.InvalidInputs,
-					statusCode: StatusCodes.BAD_REQUEST,
-				});
-			}
-		}
-
-		// Validate rollover max_percentage
-		if (notNullish(rollover.max_percentage)) {
-			if (rollover.max_percentage <= 0 || rollover.max_percentage > 100) {
-				throw new RecaseError({
-					message:
-						"Rollover max_percentage must be between 0 (exclusive) and 100 (inclusive)",
-					code: ErrCode.InvalidInputs,
-					statusCode: StatusCodes.BAD_REQUEST,
-				});
-			}
-		}
-
-		// max and max_percentage are mutually exclusive
-		if (notNullish(rollover.max) && notNullish(rollover.max_percentage)) {
+		const rolloverIssue = rolloverConfigToIssue({ rollover });
+		if (rolloverIssue) {
 			throw new RecaseError({
-				message:
-					"Rollover max and max_percentage are mutually exclusive. Set one or the other, not both.",
+				message: rolloverIssue,
 				code: ErrCode.InvalidInputs,
 				statusCode: StatusCodes.BAD_REQUEST,
 			});

--- a/server/tests/unit/products/validate-rollover-max.test.ts
+++ b/server/tests/unit/products/validate-rollover-max.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	type ProductItem,
+	ProductItemInterval,
+	type RolloverConfig,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { validateProductItems } from "@/internal/products/product-items/validateProductItems";
+
+const run = (rollover: RolloverConfig) =>
+	validateProductItems({
+		newItems: [
+			{
+				feature_id: "messages",
+				feature_type: "single_use",
+				included_usage: 100,
+				interval: ProductItemInterval.Month,
+				config: { rollover },
+			} as unknown as ProductItem,
+		],
+		features: [],
+		orgId: "org_1",
+		env: AppEnv.Sandbox,
+		multiCurrencyEnabled: false,
+	});
+
+const baseRollover: RolloverConfig = {
+	max: null,
+	max_percentage: null,
+	duration: RolloverExpiryDurationType.Month,
+	length: 1,
+};
+
+describe("validateProductItems rollover max", () => {
+	test("rejects rollover max of 0", () => {
+		expect(() => run({ ...baseRollover, max: 0 })).toThrow(/greater than 0/i);
+	});
+
+	test("rejects negative rollover max", () => {
+		expect(() => run({ ...baseRollover, max: -5 })).toThrow(/greater than 0/i);
+	});
+
+	test("accepts a positive rollover max", () => {
+		expect(() => run({ ...baseRollover, max: 100 })).not.toThrow();
+	});
+
+	test("accepts null rollover max", () => {
+		expect(() => run({ ...baseRollover })).not.toThrow();
+	});
+
+	test("accepts max_percentage without max", () => {
+		expect(() => run({ ...baseRollover, max_percentage: 50 })).not.toThrow();
+	});
+
+	test("rejects max_percentage of 0", () => {
+		expect(() => run({ ...baseRollover, max_percentage: 0 })).toThrow(
+			/between 0/i,
+		);
+	});
+});

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -64,6 +64,7 @@ export * from "./productV2Utils/productItemUtils/getItemType";
 export * from "./productV2Utils/productItemUtils/mapToItem";
 export * from "./productV2Utils/productItemUtils/matchPlanItem";
 export * from "./productV2Utils/productItemUtils/productItemUtils";
+export * from "./productV2Utils/productItemUtils/rolloverConfigToIssue";
 export * from "./productV2Utils/productItemUtils/sortPlanItems";
 export * from "./productV2Utils/productV2ToApiPlanV1";
 export * from "./productV2Utils/productV2ToFrontendProduct";

--- a/shared/utils/productV2Utils/productItemUtils/rolloverConfigToIssue.ts
+++ b/shared/utils/productV2Utils/productItemUtils/rolloverConfigToIssue.ts
@@ -1,0 +1,27 @@
+import type { RolloverConfig } from "../../../models/productV2Models/productItemModels/productItemModels.js";
+
+/** First validation issue with a rollover config's max settings, or null if valid. */
+export const rolloverConfigToIssue = ({
+	rollover,
+}: {
+	rollover?: RolloverConfig | null;
+}): string | null => {
+	if (rollover === null || rollover === undefined) return null;
+
+	if (rollover.max != null && rollover.max_percentage != null) {
+		return "Rollover max and max_percentage are mutually exclusive. Set one or the other, not both.";
+	}
+
+	if (rollover.max_percentage != null) {
+		if (rollover.max_percentage <= 0 || rollover.max_percentage > 100) {
+			return "Rollover max_percentage must be between 0 (exclusive) and 100 (inclusive)";
+		}
+		return null;
+	}
+
+	if (rollover.max != null && rollover.max <= 0) {
+		return "Rollover maximum amount must be greater than 0";
+	}
+
+	return null;
+};

--- a/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceCreateSheet.tsx
@@ -35,6 +35,7 @@ import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { RolloverConfigForm } from "@/views/products/plan/components/edit-plan-feature/advanced-settings/RolloverConfigForm";
+import { checkRolloverConfigValid } from "@/views/products/plan/utils/rolloverUtils";
 import { useCustomerContext } from "../../customer/CustomerContext";
 import { EntityScopeSelector } from "./EntityScopeSelector";
 
@@ -151,6 +152,7 @@ export function BalanceCreateSheet() {
 		}
 
 		if (rollover && canEnableRollover) {
+			if (!checkRolloverConfigValid(rollover)) return;
 			params.rollover = rollover;
 		}
 

--- a/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
@@ -5,7 +5,7 @@ import {
 import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
 import { checkItemCurrenciesValid } from "../../utils/currencyUtils";
-import { checkItemRolloverValid } from "../../utils/rolloverUtils";
+import { checkRolloverConfigValid } from "../../utils/rolloverUtils";
 
 export function SheetFooterActions({
 	isDirty,
@@ -32,7 +32,7 @@ export function SheetFooterActions({
 
 	const handleUpdateItem = async () => {
 		if (item && !checkItemCurrenciesValid(item)) return;
-		if (item && !checkItemRolloverValid(item)) return;
+		if (item && !checkRolloverConfigValid(item.config?.rollover)) return;
 		await onBeforeCommit?.();
 		await handleUpdateProductItem();
 	};

--- a/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/SheetFooterActions.tsx
@@ -5,6 +5,7 @@ import {
 import { PlanSheetFooter } from "@/components/v2/sheets/PlanSheetFooter";
 import { useProductItemContext } from "@/views/products/product/product-item/ProductItemContext";
 import { checkItemCurrenciesValid } from "../../utils/currencyUtils";
+import { checkItemRolloverValid } from "../../utils/rolloverUtils";
 
 export function SheetFooterActions({
 	isDirty,
@@ -31,6 +32,7 @@ export function SheetFooterActions({
 
 	const handleUpdateItem = async () => {
 		if (item && !checkItemCurrenciesValid(item)) return;
+		if (item && !checkItemRolloverValid(item)) return;
 		await onBeforeCommit?.();
 		await handleUpdateProductItem();
 	};

--- a/vite/src/views/products/plan/utils/rolloverUtils.ts
+++ b/vite/src/views/products/plan/utils/rolloverUtils.ts
@@ -1,0 +1,23 @@
+import type { ProductItem, RolloverConfig } from "@autumn/shared";
+import { toast } from "sonner";
+
+export const checkRolloverConfigValid = (
+	rollover: RolloverConfig | null | undefined,
+	showToast = true,
+) => {
+	if (!rollover) return true;
+	if (rollover.max_percentage != null) return true;
+	if (rollover.max != null && rollover.max <= 0) {
+		if (showToast) {
+			toast.error("Set a maximum rollover amount greater than 0");
+		}
+		return false;
+	}
+	return true;
+};
+
+export const checkItemRolloverValid = (item: ProductItem, showToast = true) =>
+	checkRolloverConfigValid(
+		item.config?.rollover as RolloverConfig | null | undefined,
+		showToast,
+	);

--- a/vite/src/views/products/plan/utils/rolloverUtils.ts
+++ b/vite/src/views/products/plan/utils/rolloverUtils.ts
@@ -1,7 +1,7 @@
-import type { ProductItem, RolloverConfig } from "@autumn/shared";
+import type { RolloverConfig } from "@autumn/shared";
 import { toast } from "sonner";
 
-// Mirrors the server's rollover rules in validateProductItems so saves fail fast.
+/** Mirrors the server's rollover rules in validateProductItems so saves fail fast. */
 export const checkRolloverConfigValid = (
 	rollover: RolloverConfig | null | undefined,
 	showToast = true,
@@ -32,9 +32,3 @@ export const checkRolloverConfigValid = (
 
 	return true;
 };
-
-export const checkItemRolloverValid = (item: ProductItem, showToast = true) =>
-	checkRolloverConfigValid(
-		item.config?.rollover as RolloverConfig | null | undefined,
-		showToast,
-	);

--- a/vite/src/views/products/plan/utils/rolloverUtils.ts
+++ b/vite/src/views/products/plan/utils/rolloverUtils.ts
@@ -1,18 +1,35 @@
 import type { ProductItem, RolloverConfig } from "@autumn/shared";
 import { toast } from "sonner";
 
+// Mirrors the server's rollover rules in validateProductItems so saves fail fast.
 export const checkRolloverConfigValid = (
 	rollover: RolloverConfig | null | undefined,
 	showToast = true,
 ) => {
 	if (!rollover) return true;
-	if (rollover.max_percentage != null) return true;
-	if (rollover.max != null && rollover.max <= 0) {
-		if (showToast) {
-			toast.error("Set a maximum rollover amount greater than 0");
-		}
+
+	const fail = (message: string) => {
+		if (showToast) toast.error(message);
 		return false;
+	};
+
+	if (rollover.max != null && rollover.max_percentage != null) {
+		return fail(
+			"Set either a maximum rollover amount or a percentage, not both",
+		);
 	}
+
+	if (rollover.max_percentage != null) {
+		if (rollover.max_percentage <= 0 || rollover.max_percentage > 100) {
+			return fail("Maximum rollover percentage must be between 1 and 100");
+		}
+		return true;
+	}
+
+	if (rollover.max != null && rollover.max <= 0) {
+		return fail("Set a maximum rollover amount greater than 0");
+	}
+
 	return true;
 };
 

--- a/vite/src/views/products/plan/utils/rolloverUtils.ts
+++ b/vite/src/views/products/plan/utils/rolloverUtils.ts
@@ -1,34 +1,12 @@
-import type { RolloverConfig } from "@autumn/shared";
+import { type RolloverConfig, rolloverConfigToIssue } from "@autumn/shared";
 import { toast } from "sonner";
 
-/** Mirrors the server's rollover rules in validateProductItems so saves fail fast. */
+/** Client-side gate running the same shared rules the server enforces. */
 export const checkRolloverConfigValid = (
 	rollover: RolloverConfig | null | undefined,
 	showToast = true,
 ) => {
-	if (!rollover) return true;
-
-	const fail = (message: string) => {
-		if (showToast) toast.error(message);
-		return false;
-	};
-
-	if (rollover.max != null && rollover.max_percentage != null) {
-		return fail(
-			"Set either a maximum rollover amount or a percentage, not both",
-		);
-	}
-
-	if (rollover.max_percentage != null) {
-		if (rollover.max_percentage <= 0 || rollover.max_percentage > 100) {
-			return fail("Maximum rollover percentage must be between 1 and 100");
-		}
-		return true;
-	}
-
-	if (rollover.max != null && rollover.max <= 0) {
-		return fail("Set a maximum rollover amount greater than 0");
-	}
-
-	return true;
+	const issue = rolloverConfigToIssue({ rollover });
+	if (issue && showToast) toast.error(issue);
+	return !issue;
 };


### PR DESCRIPTION
A rollover config with max: 0 passed validation but zeroed out every rolled-over credit at reset time, since performMaximumClearing treats 0 as a real cap. The dashboard produced this state silently: selecting "Absolute" rollover mode stores max: 0 and renders it as an empty input.

Server: tighten the validateProductItems check from max < 0 to max <= 0 so plans.update and catalog.update return a 400. Frontend: block save in the plan feature sheet and balance create sheet with a toast when the rollover has no percentage and max <= 0, mirroring the currency check pattern. Null max (unlimited) is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject rollover max of 0 and unify rollover validation across server and dashboard. Blocks invalid configs before save and returns clear 400s; null max (unlimited) is still allowed.

- **Bug Fixes**
  - Server: use shared validator and treat `rollover.max <= 0` as invalid; handle mutual exclusivity and percentage range; `plans.update` and `catalog.update` return 400 with clear messages.
  - Frontend: gate saves in plan feature and balance create using `checkRolloverConfigValid`; block invalid configs and show toasts.
  - Tests: add unit tests for 0/negative max, positive/null max, percentage-only, and 0% cases.

- **Refactors**
  - Extract `rolloverConfigToIssue` in `@autumn/shared` and use it on both server and client; remove the thin wrapper.

<sup>Written for commit 8b59ac75b40f2c4566b861d34f2d4fb43984c3d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

