### PR TITLE
feat: env-driven server fork count

### DIFF
--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -125,8 +125,8 @@ const REPLICA_PGBOUNCER_MAX_CLIENT_CONN = 1_000;
  *  many clients onto far fewer of these. Kept for sizing, not for this guard. */
 const POSTGRES_MAX_SERVER_CONNECTIONS = 7_600;
 
-/** Request-serving processes: 20 tasks (fleet runs pinned at 20; revisit if
- *  autoscaling headroom to 30 is used) x configured forks per task. */
+/** 20 pinned tasks x forks. Recycles transiently add +1 fork/task — headroom
+ *  absorbs that at <=4 forks; at 5+ also lower REPLICA_DB_POOL_MAX. */
 const BUDGETED_FLEET_PROCESSES = 20 * getServerForkCount();
 
 /** Dedicated worker/cron pools that exist outside the three exported ones. */

--- a/server/src/db/initDrizzle.ts
+++ b/server/src/db/initDrizzle.ts
@@ -9,6 +9,7 @@ import type { SQLWrapper } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg, { type PoolConfig } from "pg";
 import { logger } from "../external/logtail/logtailUtils.js";
+import { getServerForkCount } from "../utils/memory/forkRecycling/recyclePolicy.js";
 import { otelConfig } from "../utils/otel/otelConfig.js";
 import { applyConnectRefusedRetry } from "./connectRetry.js";
 import { attachPoolErrorHandlers, registerPool } from "./pgPoolMonitor.js";
@@ -124,9 +125,9 @@ const REPLICA_PGBOUNCER_MAX_CLIENT_CONN = 1_000;
  *  many clients onto far fewer of these. Kept for sizing, not for this guard. */
 const POSTGRES_MAX_SERVER_CONNECTIONS = 7_600;
 
-/** Request-serving processes: 30 tasks x 3 cluster workers. Primaries hold pool
- *  objects but never query, and `min` doesn't pre-create, so they contribute 0. */
-const BUDGETED_FLEET_PROCESSES = 90;
+/** Request-serving processes: 20 tasks (fleet runs pinned at 20; revisit if
+ *  autoscaling headroom to 30 is used) x configured forks per task. */
+const BUDGETED_FLEET_PROCESSES = 20 * getServerForkCount();
 
 /** Dedicated worker/cron pools that exist outside the three exported ones. */
 const BUDGETED_NON_SERVER_CONNECTIONS = 362;
@@ -158,16 +159,17 @@ export const computePoolBudgetWarnings = ({
 	criticalPoolMax: critical,
 	generalPoolMax: general,
 	replicaPoolMax: replica,
+	fleetProcesses = BUDGETED_FLEET_PROCESSES,
 }: {
 	criticalPoolMax: number;
 	generalPoolMax: number;
 	replicaPoolMax: number;
+	fleetProcesses?: number;
 }): string[] => {
 	const warnings: string[] = [];
 
 	const primaryFleetConnections =
-		BUDGETED_FLEET_PROCESSES * (critical + general) +
-		BUDGETED_NON_SERVER_CONNECTIONS;
+		fleetProcesses * (critical + general) + BUDGETED_NON_SERVER_CONNECTIONS;
 	if (
 		primaryFleetConnections >
 		PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM
@@ -177,7 +179,7 @@ export const computePoolBudgetWarnings = ({
 		);
 	}
 
-	const replicaFleetConnections = BUDGETED_FLEET_PROCESSES * replica;
+	const replicaFleetConnections = fleetProcesses * replica;
 	if (
 		replicaFleetConnections >
 		REPLICA_PGBOUNCER_MAX_CLIENT_CONN * POOL_BUDGET_HEADROOM

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -65,6 +65,7 @@ import {
 	attachPrimaryForkRecycling,
 	startWorkerForkRecycling,
 } from "./utils/memory/forkRecycling/attachForkRecycling.js";
+import { getServerForkCount } from "./utils/memory/forkRecycling/recyclePolicy.js";
 import { listInFlightRequests } from "./utils/memory/inFlightRequests.js";
 import {
 	startMemorySpikeProbe,
@@ -183,7 +184,8 @@ if (process.env.NODE_ENV === "development") {
 		console.log(`Master ${process.pid} is running`);
 		console.log("Number of CPUs", numCPUs);
 
-		const numWorkers = 3;
+		const numWorkers = getServerForkCount();
+		console.log(`Forking ${numWorkers} workers`);
 
 		for (let i = 0; i < numWorkers; i++) {
 			cluster.fork();

--- a/server/src/utils/memory/forkRecycling/recyclePolicy.ts
+++ b/server/src/utils/memory/forkRecycling/recyclePolicy.ts
@@ -82,6 +82,14 @@ const nonNegativeOr = (raw: string | undefined, fallback: number): number => {
 	return Number.isFinite(value) && value >= 0 ? value : fallback;
 };
 
+/** Serving forks per task — single-threaded loops, so this is capacity.
+ *  Cap 8: worst-case forks x ~2.3GB (threshold+overshoot) must fit 16GB. */
+export const getServerForkCount = (): number => {
+	const value = Number(process.env.SERVER_FORK_COUNT);
+	if (!Number.isFinite(value) || value < 1) return 3;
+	return Math.min(8, Math.floor(value));
+};
+
 export const getForkRecycleConfig = () => {
 	return {
 		enabled: process.env.FORK_RECYCLE_DISABLED !== "true",

--- a/server/src/utils/memory/forkRecycling/recyclePolicy.ts
+++ b/server/src/utils/memory/forkRecycling/recyclePolicy.ts
@@ -83,11 +83,12 @@ const nonNegativeOr = (raw: string | undefined, fallback: number): number => {
 };
 
 /** Serving forks per task — single-threaded loops, so this is capacity.
- *  Cap 8: worst-case forks x ~2.3GB (threshold+overshoot) must fit 16GB. */
+ *  Cap 6: above it, forks x ~2.3GB worst case (default 2000MB threshold +
+ *  overshoot) + primary can OOM a 16GB task; revisit if the threshold drops. */
 export const getServerForkCount = (): number => {
 	const value = Number(process.env.SERVER_FORK_COUNT);
-	if (!Number.isFinite(value) || value < 1) return 3;
-	return Math.min(8, Math.floor(value));
+	if (!Number.isInteger(value) || value < 1) return 3;
+	return Math.min(6, value);
 };
 
 export const getForkRecycleConfig = () => {

--- a/server/tests/unit/db/poolBudgetGuard.test.ts
+++ b/server/tests/unit/db/poolBudgetGuard.test.ts
@@ -7,6 +7,9 @@ const prodDefaults = {
 	replicaPoolMax: 9,
 };
 
+// Historical 30-task x 3-fork fleet — keeps the boundary arithmetic exact.
+const NINETY = { fleetProcesses: 90 };
+
 describe("computePoolBudgetWarnings", () => {
 	test("prod defaults stay inside both bouncer budgets", () => {
 		expect(computePoolBudgetWarnings(prodDefaults)).toEqual([]);
@@ -16,6 +19,7 @@ describe("computePoolBudgetWarnings", () => {
 		// 90 x (60 + 60) + 362 = 11,162 > 0.85 x 12,000 = 10,200
 		const warnings = computePoolBudgetWarnings({
 			...prodDefaults,
+			...NINETY,
 			criticalPoolMax: 60,
 			generalPoolMax: 60,
 		});
@@ -27,6 +31,7 @@ describe("computePoolBudgetWarnings", () => {
 		// 90 x 12 = 1,080 > 0.85 x 1,000 = 850
 		const warnings = computePoolBudgetWarnings({
 			...prodDefaults,
+			...NINETY,
 			replicaPoolMax: 12,
 		});
 		expect(warnings).toHaveLength(1);
@@ -36,19 +41,34 @@ describe("computePoolBudgetWarnings", () => {
 	test("replica budget boundary: 9 per process fits, 10 does not", () => {
 		// 90 x 9 = 810 <= 850, but 90 x 10 = 900 > 850
 		expect(
-			computePoolBudgetWarnings({ ...prodDefaults, replicaPoolMax: 9 }),
+			computePoolBudgetWarnings({
+				...prodDefaults,
+				...NINETY,
+				replicaPoolMax: 9,
+			}),
 		).toEqual([]);
 		expect(
-			computePoolBudgetWarnings({ ...prodDefaults, replicaPoolMax: 10 }),
+			computePoolBudgetWarnings({
+				...prodDefaults,
+				...NINETY,
+				replicaPoolMax: 10,
+			}),
 		).toHaveLength(1);
 	});
 
 	test("both guards fire when both budgets are blown", () => {
 		const warnings = computePoolBudgetWarnings({
+			...NINETY,
 			criticalPoolMax: 80,
 			generalPoolMax: 80,
 			replicaPoolMax: 20,
 		});
 		expect(warnings).toHaveLength(2);
+	});
+
+	test("default fleet size derives from fork count: prod pools fit at 20 tasks x 4 forks", () => {
+		expect(
+			computePoolBudgetWarnings({ ...prodDefaults, fleetProcesses: 80 }),
+		).toEqual([]);
 	});
 });

--- a/server/tests/unit/memory/forkCount.test.ts
+++ b/server/tests/unit/memory/forkCount.test.ts
@@ -29,6 +29,11 @@ describe("getServerForkCount", () => {
 		process.env.SERVER_FORK_COUNT = "not-a-number";
 		expect(getServerForkCount()).toBe(3);
 		process.env.SERVER_FORK_COUNT = "64";
-		expect(getServerForkCount()).toBe(8);
+		expect(getServerForkCount()).toBe(6);
+	});
+
+	test("fractional values fall back to the default", () => {
+		process.env.SERVER_FORK_COUNT = "2.9";
+		expect(getServerForkCount()).toBe(3);
 	});
 });

--- a/server/tests/unit/memory/forkCount.test.ts
+++ b/server/tests/unit/memory/forkCount.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { getServerForkCount } from "@/utils/memory/forkRecycling/recyclePolicy.js";
+
+describe("getServerForkCount", () => {
+	let saved: string | undefined;
+	beforeEach(() => {
+		saved = process.env.SERVER_FORK_COUNT;
+		delete process.env.SERVER_FORK_COUNT;
+	});
+	afterEach(() => {
+		if (saved === undefined) delete process.env.SERVER_FORK_COUNT;
+		else process.env.SERVER_FORK_COUNT = saved;
+	});
+
+	test("defaults to 3", () => {
+		expect(getServerForkCount()).toBe(3);
+	});
+
+	test("honors a valid override", () => {
+		process.env.SERVER_FORK_COUNT = "6";
+		expect(getServerForkCount()).toBe(6);
+	});
+
+	test("clamps garbage, zero, negatives, and absurd values to sane bounds", () => {
+		process.env.SERVER_FORK_COUNT = "0";
+		expect(getServerForkCount()).toBe(3);
+		process.env.SERVER_FORK_COUNT = "-2";
+		expect(getServerForkCount()).toBe(3);
+		process.env.SERVER_FORK_COUNT = "not-a-number";
+		expect(getServerForkCount()).toBe(3);
+		process.env.SERVER_FORK_COUNT = "64";
+		expect(getServerForkCount()).toBe(8);
+	});
+});


### PR DESCRIPTION
SERVER_FORK_COUNT controls forks per task (default 3, cap 8 — worst-case forks x ~2.3GB must fit the 16GB task). Pool budget guard derives fleet process count from the configured value. Deploy pairing: SERVER_FORK_COUNT=4 requires REPLICA_DB_POOL_MAX=6 (5 forks: =5) to stay inside the replica bouncer's 1,000-client ceiling at scale-max.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the server worker count configurable via `SERVER_FORK_COUNT` and align DB pool budgeting to the configured fleet size. Defaults to 3, caps at 6, rejects fractional values; used for cluster forks and fleet-wide pool budgeting.

- **New Features**
  - Added `getServerForkCount()` to read `SERVER_FORK_COUNT`, default to 3, require an integer ≥1, and cap at 6.
  - Cluster now forks `getServerForkCount()` workers and logs the count.
  - DB pool-budget guard scales with a 20-task fleet: `BUDGETED_FLEET_PROCESSES = 20 * getServerForkCount()`; `computePoolBudgetWarnings` accepts an optional `fleetProcesses` override. Notes transient +1 fork during recycle; at 5+ forks, lower `REPLICA_DB_POOL_MAX`.
  - Unit tests cover defaults, integer parsing, cap behavior, fractional rejection, and budget boundaries with overrides.

- **Migration**
  - Set `SERVER_FORK_COUNT` to an integer between 1 and 6 (leave unset to keep 3).
  - If you increase forks, review `REPLICA_DB_POOL_MAX` (and primary pool sizes) so total clients stay under pgBouncer limits; at 5+ forks, reduce replica pool max to absorb recycle headroom.

<sup>Written for commit 547fe42d29e620d626b90dfbc6b42a11e9447878. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the number of server workers configurable and uses that value when estimating fleet-wide database pool usage.

- **[Improvements, API changes]** Adds `SERVER_FORK_COUNT` parsing with a default of three and an upper cap of six.
- **[Improvements]** Uses the configured worker count for cluster startup and database pool-budget calculations.
- **[Bug fixes]** Rejects fractional worker counts instead of silently rounding them down.
- **[Improvements]** Adds unit coverage for environment parsing and configurable fleet-size budget boundaries.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because six configured workers can exceed the task memory limit when recycling creates an overlapping replacement.

The replacement worker starts before the old worker drains, so a six-worker task can temporarily hold seven approximately 2.3 GB workers plus the primary process and be terminated for exceeding its documented 16 GB memory limit.

**Files Needing Attention:** server/src/utils/memory/forkRecycling/recyclePolicy.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/memory/forkRecycling/recyclePolicy.ts | Adds environment-driven fork-count parsing, but the cap can exceed the task memory limit during replacement-worker overlap. |
| server/src/init.ts | Replaces the fixed three-worker startup count with the shared environment-derived value. |
| server/src/db/initDrizzle.ts | Derives fleet process budgeting from the configured fork count and permits explicit fleet-size overrides in tests. |
| server/tests/unit/memory/forkCount.test.ts | Covers default, valid, invalid, capped, and fractional fork-count inputs. |
| server/tests/unit/db/poolBudgetGuard.test.ts | Preserves historical budget boundaries while adding coverage for configurable fleet sizes. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Primary as Cluster primary
  participant Old as Existing worker
  participant New as Replacement worker
  Primary->>Old: Run six configured workers
  Old->>Primary: Request recycling near RSS threshold
  Primary->>New: Fork replacement
  Note over Old,New: Seven workers temporarily coexist
  New-->>Primary: Listening
  Primary->>Old: Begin drain
  Old-->>Primary: Exit after draining
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/utils/memory/forkRecycling/recyclePolicy.ts:91
**Recycle overlap exceeds memory cap**

If a 16 GB task sets `SERVER_FORK_COUNT=6`, recycling starts a seventh worker before draining the old one. Seven workers at the documented approximately 2.3 GB worst-case RSS consume about 16.1 GB before the primary process is counted, causing the task to be terminated for exceeding its memory limit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: cap fork count at 6, reject fractio..."](https://github.com/useautumn/autumn/commit/547fe42d29e620d626b90dfbc6b42a11e9447878) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51863819)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)

<!-- /greptile_comment -->