### PR TITLE
feat: default server fork count to 4

### DIFF
--- a/server/src/utils/memory/forkRecycling/recyclePolicy.ts
+++ b/server/src/utils/memory/forkRecycling/recyclePolicy.ts
@@ -87,7 +87,7 @@ const nonNegativeOr = (raw: string | undefined, fallback: number): number => {
  *  overshoot) + primary can OOM a 16GB task; revisit if the threshold drops. */
 export const getServerForkCount = (): number => {
 	const value = Number(process.env.SERVER_FORK_COUNT);
-	if (!Number.isInteger(value) || value < 1) return 3;
+	if (!Number.isInteger(value) || value < 1) return 4;
 	return Math.min(6, value);
 };
 

--- a/server/tests/unit/memory/forkCount.test.ts
+++ b/server/tests/unit/memory/forkCount.test.ts
@@ -12,8 +12,8 @@ describe("getServerForkCount", () => {
 		else process.env.SERVER_FORK_COUNT = saved;
 	});
 
-	test("defaults to 3", () => {
-		expect(getServerForkCount()).toBe(3);
+	test("defaults to 4", () => {
+		expect(getServerForkCount()).toBe(4);
 	});
 
 	test("honors a valid override", () => {
@@ -23,17 +23,17 @@ describe("getServerForkCount", () => {
 
 	test("clamps garbage, zero, negatives, and absurd values to sane bounds", () => {
 		process.env.SERVER_FORK_COUNT = "0";
-		expect(getServerForkCount()).toBe(3);
+		expect(getServerForkCount()).toBe(4);
 		process.env.SERVER_FORK_COUNT = "-2";
-		expect(getServerForkCount()).toBe(3);
+		expect(getServerForkCount()).toBe(4);
 		process.env.SERVER_FORK_COUNT = "not-a-number";
-		expect(getServerForkCount()).toBe(3);
+		expect(getServerForkCount()).toBe(4);
 		process.env.SERVER_FORK_COUNT = "64";
 		expect(getServerForkCount()).toBe(6);
 	});
 
 	test("fractional values fall back to the default", () => {
 		process.env.SERVER_FORK_COUNT = "2.9";
-		expect(getServerForkCount()).toBe(3);
+		expect(getServerForkCount()).toBe(4);
 	});
 });


### PR DESCRIPTION
Unset/invalid SERVER_FORK_COUNT now yields 4 forks per task (cap 6 unchanged). At 20 tasks x 16GB: 80 loops (vs 72 pre-resize), worst-case memory ~59%/task at the 2000MB recycle threshold, replica pool budget 720/850 with no env changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the default server fork count from 3 to 4 when SERVER_FORK_COUNT is unset or invalid to improve parallelism. The 6-fork cap stays the same; unit tests updated (default, clamping, fractional).

<sup>Written for commit 5f306c6013f91845d69b628f4f627ccb587967fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR raises the default server worker-fork count from three to four while retaining the existing maximum of six.
- **Improvements:** Use four workers when `SERVER_FORK_COUNT` is unset, invalid, fractional, zero, or negative.
- **Improvements:** Update unit tests to verify the new fallback while preserving valid overrides and the six-worker cap.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the new four-worker default remains within the documented memory and connection-budget constraints.

The implementation changes only the fallback value, preserves explicit valid overrides and the six-worker cap, and updates the relevant unit tests consistently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/memory/forkRecycling/recyclePolicy.ts | Raises the fallback worker count to four; existing memory guidance and pool-budget coverage support this value. |
| server/tests/unit/memory/forkCount.test.ts | Updates fallback expectations for unset and invalid values while retaining override and cap coverage. |

<sub>Reviews (1): Last reviewed commit: ["feat: default server fork count to 4"](https://github.com/useautumn/autumn/commit/5f306c6013f91845d69b628f4f627ccb587967fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51870752)</sub>

<!-- /greptile_comment -->