### PR TITLE
fix(vercel): unblock marketplace get-resource and pre-install plan list

### DIFF
--- a/server/src/external/vercel/handlers/handleListBillingPlans.ts
+++ b/server/src/external/vercel/handlers/handleListBillingPlans.ts
@@ -240,7 +240,7 @@ export const handleVercelListBillingPlans = createRoute({
 		metadata: z.string().optional(),
 	}),
 	handler: async (c) => {
-		let { env, integrationConfigurationId, productId } = c.req.param() as {
+		const { env, integrationConfigurationId, productId } = c.req.param() as {
 			env: AppEnv;
 			integrationConfigurationId?: string;
 			productId?: string;
@@ -252,28 +252,6 @@ export const handleVercelListBillingPlans = createRoute({
 			return c.json(
 				{
 					error: "Missing integration configuration ID or product ID",
-				},
-				400,
-			);
-		}
-
-		if (productId && !integrationConfigurationId) {
-			const claims = c.get("vercelClaims");
-			if (!claims) {
-				return c.json(
-					{
-						error: "Missing installation ID",
-					},
-					400,
-				);
-			}
-			integrationConfigurationId = claims.installation_id ?? "";
-		}
-
-		if (!integrationConfigurationId) {
-			return c.json(
-				{
-					error: "Missing installation ID",
 				},
 				400,
 			);

--- a/server/src/external/vercel/handlers/resources/handleGetResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleGetResource.ts
@@ -60,7 +60,6 @@ export const handleGetResource = createRoute({
 			metadata: resource.metadata,
 			status: resource.status,
 			...(billingPlan ? { billingPlan } : {}),
-			notification: null,
 		});
 	},
 });


### PR DESCRIPTION
Two independent fixes to the Vercel Marketplace partner API, both surfaced by a week of Firecrawl integration logs (Aug 3–10) and both confirmed against our own Axiom data.

---

## 1. `get-resource` returned `notification: null`

Vercel rejected **every** `get-resource` response — 337 failures out of 337 calls, zero successes.

`handleGetResource` ended its response body with a hardcoded `notification: null`. Vercel's partner `get-resource` schema types `notification` as an *optional object* with required `level` and `title`, so an explicit null fails validation:

```
Failed to parse response body: $.notification: Expected object, received null
```

Confirmed against real response bodies in Axiom — every one ends `..."name":"…","notification":null`.

Note `null` *is* valid on Vercel's `update-resource` PATCH (their schema has a `oneOf` there, where null clears an existing notification), which is likely how the field ended up mirrored into the GET response as a placeholder.

The field was unconditional and never carried a real notification on this endpoint, so removing it is behaviour-preserving for anything that tolerated the null.

**Impact:** restores the resource detail view in the Vercel dashboard. Over the reported week this hit 36 distinct Vercel accounts, 37 installations and 44 resources — every customer opening their resource, 83 times on Aug 10 alone.

---

## 2. Product-level plan list required an installation

`GET /v1/products/:productId/plans` 400'd with `{"error":"Missing installation ID"}` whenever `claims.installation_id` was null — which is exactly the pre-install case Vercel calls this route in. 8 occurrences in the week, against 76 successful calls that happened to carry an installation.

The resolved `integrationConfigurationId` was never actually used to select plans: `listVercelPlansForOrg` keys off `org` / `env` and `allowed_product_ids_{live,sandbox}`, both of which come from the URL path. So the two guards rejected requests that would have returned the correct list anyway. They're removed; nothing downstream reads the variable.

The route already skips installation-id validation in `vercelOidcAuthMiddleware` (`vercelAuth.ts:282`) and never had `vercelCustomerMiddleware` attached, so anonymous callers were already expected here — only the handler disagreed.

**Impact:** prospects browsing the marketplace listing pre-install can see pricing.

---

## Not included

- `handleGetInstallation.ts:38` has the same `notification: null`. Vercel's get-installation schema appears to tolerate it — that endpoint sees far more traffic without being flagged — but it's the same latent shape.
- `secrets/rotate` rejects anything without `user_role === "admin"` (`handleRotateResourceSecret.ts:19`), which excludes all system-auth tokens since `user_role` is an optional claim.
- Plan upgrades/downgrades returning 400 is intentional and out of scope.

## Testing

`bun ts` clean, Biome clean on both touched files. No new tests — the Vercel suite has no coverage of either read endpoint today, and both changes are deletions of guards/fields that fail 100% of the time in production, so the Vercel integration log is the verification signal.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR corrects two Vercel Marketplace endpoint behaviors.
- **[Bug fixes, API changes]** Omits the invalid `notification: null` value from get-resource responses so Vercel accepts them.
- **[Bug fixes, Improvements]** Allows product-level billing-plan requests before an installation exists; plan selection remains scoped to the requested organization and environment.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/vercel/handlers/resources/handleGetResource.ts | Removes an invalid optional response field without changing resource lookup or billing-plan selection. |
| server/src/external/vercel/handlers/handleListBillingPlans.ts | Removes an unused installation requirement so authenticated pre-install product requests can list organization-scoped plans. |

<sub>Reviews (2): Last reviewed commit: ["fix(vercel): serve product-level plan li..."](https://github.com/useautumn/autumn/commit/c7e1fbc5ed5a85b0bc26f4008e90bd32c67dad4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51887115)</sub>

<!-- /greptile_comment -->