### PR TITLE
Pool Redis reads across multiple connections

### DIFF
--- a/server/src/external/redis/initRedis.ts
+++ b/server/src/external/redis/initRedis.ts
@@ -1,21 +1,23 @@
 import "./initUtils/redisTypes.js";
 
 export {
-	createRedisClient,
-	createRedisConnection,
-	createStandbyRedisConnection,
-} from "./initUtils/createRedisClient.js";
-export {
 	getRedisAvailability,
 	shouldUseRedis,
 	startRedisMonitor,
 	stopRedisMonitor,
 } from "./availabilityMonitor/redisAvailability.js";
 export {
+	createPooledStandbyRedisConnection,
+	createRedisClient,
+	createRedisConnection,
+	createStandbyRedisConnection,
+} from "./initUtils/createRedisClient.js";
+export {
 	currentRegion,
 	hasMiscRedisConfig,
 } from "./initUtils/redisConfig.js";
 export {
+	waitForRedisReadPoolReady,
 	waitForRedisReady,
 	warmupRegionalRedis,
 } from "./initUtils/redisWarmup.js";

--- a/server/src/external/redis/initRedisV2.ts
+++ b/server/src/external/redis/initRedisV2.ts
@@ -3,10 +3,10 @@ import { logger } from "@/external/logtail/logtailUtils.js";
 import type { RedisV2InstanceName } from "@/internal/misc/redisV2Cache/redisV2CacheSchemas.js";
 import { getReachableDragonflyUrl } from "./getReachableDragonflyUrl.js";
 import {
+	createPooledStandbyRedisConnection,
 	createRedisConnection,
-	createStandbyRedisConnection,
 	currentRegion,
-	waitForRedisReady,
+	waitForRedisReadPoolReady,
 } from "./initRedis.js";
 import { REDIS_V2_COMMAND_TIMEOUT_MS } from "./initUtils/createRedisClient.js";
 
@@ -18,7 +18,7 @@ const dragonflyUrl = rawDragonflyUrl
 export const hasRedisV2Config = Boolean(dragonflyUrl);
 
 export const redisV2: Redis = dragonflyUrl
-	? createStandbyRedisConnection({
+	? createPooledStandbyRedisConnection({
 			cacheUrl: dragonflyUrl,
 			region: `${currentRegion}:v2`,
 			redisType: "subject-primary",
@@ -70,5 +70,5 @@ export const getAlternateRedisV2Instance = (
 export const warmupRedisV2 = async (): Promise<void> => {
 	if (!hasRedisV2Config) return;
 
-	await waitForRedisReady(redisV2, "v2");
+	await waitForRedisReadPoolReady({ instance: redisV2, label: "v2" });
 };

--- a/server/src/external/redis/initUtils/createRedisClient.ts
+++ b/server/src/external/redis/initUtils/createRedisClient.ts
@@ -3,6 +3,7 @@ import {
 	instrumentRedis,
 	type RedisClientType,
 } from "../otel/instrumentRedis.js";
+import { createRedisReadPool } from "./createRedisReadPool.js";
 import { createStandbyRedisRouter } from "./createStandbyRedisRouter.js";
 import { redisDnsLookup } from "./redisDnsLookup.js";
 import { registerRedisCommands } from "./registerRedisCommands.js";
@@ -89,4 +90,19 @@ export const createStandbyRedisConnection = ({
 			autoResendUnfulfilledCommands: false,
 			maxRetriesPerRequest: 0,
 		}),
+	});
+
+/** Two read lanes, each retaining the preferred/standby failover pair. */
+export const createPooledStandbyRedisConnection = ({
+	region,
+	...options
+}: Parameters<typeof createRedisClient>[0]): Redis =>
+	createRedisReadPool({
+		lanes: [
+			createStandbyRedisConnection({ ...options, region }),
+			createStandbyRedisConnection({
+				...options,
+				region: `${region}:lane-1`,
+			}),
+		],
 	});

--- a/server/src/external/redis/initUtils/createRedisReadPool.ts
+++ b/server/src/external/redis/initUtils/createRedisReadPool.ts
@@ -42,8 +42,10 @@ export const acquireRedisReadLane = (
 	const candidateIndexes = readyIndexes.length > 0 ? readyIndexes : [0, 1];
 	let selectedIndex = candidateIndexes[0] ?? 0;
 
+	// Ties go to the highest lane: lane 0 also carries every unpooled op
+	// (writes, readMaster), so idle pooled reads defect to the quiet lane.
 	for (const candidateIndex of candidateIndexes.slice(1)) {
-		if (state.inFlight[candidateIndex] < state.inFlight[selectedIndex]) {
+		if (state.inFlight[candidateIndex] <= state.inFlight[selectedIndex]) {
 			selectedIndex = candidateIndex;
 		}
 	}

--- a/server/src/external/redis/initUtils/createRedisReadPool.ts
+++ b/server/src/external/redis/initUtils/createRedisReadPool.ts
@@ -1,0 +1,146 @@
+import type { Redis } from "ioredis";
+
+const REDIS_READ_POOL = Symbol("redisReadPool");
+
+const LISTENER_METHODS = new Set([
+	"addListener",
+	"off",
+	"on",
+	"once",
+	"prependListener",
+	"removeAllListeners",
+	"removeListener",
+]);
+
+type RedisReadPoolState = {
+	lanes: readonly [Redis, Redis];
+	inFlight: [number, number];
+};
+
+export type RedisReadLaneLease = {
+	redis: Redis;
+	release: () => void;
+};
+
+const getRedisReadPoolState = (redis: Redis): RedisReadPoolState | undefined =>
+	(Reflect.get(redis, REDIS_READ_POOL) as RedisReadPoolState | undefined) ??
+	undefined;
+
+export const getRedisReadPoolLanes = (redis: Redis): readonly Redis[] =>
+	getRedisReadPoolState(redis)?.lanes ?? [redis];
+
+export const acquireRedisReadLane = (
+	redis: Redis,
+): RedisReadLaneLease | undefined => {
+	const state = getRedisReadPoolState(redis);
+	if (!state) return undefined;
+
+	const readyIndexes = state.lanes
+		.map((lane, index) => ({ lane, index }))
+		.filter(({ lane }) => lane.status === "ready")
+		.map(({ index }) => index);
+	const candidateIndexes = readyIndexes.length > 0 ? readyIndexes : [0, 1];
+	let selectedIndex = candidateIndexes[0] ?? 0;
+
+	for (const candidateIndex of candidateIndexes.slice(1)) {
+		if (state.inFlight[candidateIndex] < state.inFlight[selectedIndex]) {
+			selectedIndex = candidateIndex;
+		}
+	}
+
+	state.inFlight[selectedIndex] += 1;
+	let released = false;
+	return {
+		redis: state.lanes[selectedIndex],
+		release: () => {
+			if (released) return;
+			released = true;
+			state.inFlight[selectedIndex] -= 1;
+		},
+	};
+};
+
+export const createRedisReadPool = ({
+	lanes,
+}: {
+	lanes: readonly [Redis, Redis];
+}): Redis => {
+	const state: RedisReadPoolState = {
+		lanes,
+		inFlight: [0, 0],
+	};
+	const laneZero = lanes[0];
+	const onceWrappers = new Map<
+		(...args: unknown[]) => void,
+		(...args: unknown[]) => void
+	>();
+	let proxy: Redis;
+
+	const fanOutListener = (property: string) => {
+		if (property === "once") {
+			return (event: string, handler: (...args: unknown[]) => void) => {
+				let fired = false;
+				const wrapped = (...args: unknown[]) => {
+					if (fired) return;
+					fired = true;
+					for (const lane of lanes) lane.off(event, wrapped);
+					onceWrappers.delete(handler);
+					handler(...args);
+				};
+				onceWrappers.set(handler, wrapped);
+				for (const lane of lanes) lane.once(event, wrapped);
+				return proxy;
+			};
+		}
+
+		return (...args: unknown[]) => {
+			const handler = args[1] as ((...inner: unknown[]) => void) | undefined;
+			const wrapped = handler && onceWrappers.get(handler);
+			const effective = wrapped ? [args[0], wrapped, ...args.slice(2)] : args;
+			if (wrapped) onceWrappers.delete(handler);
+
+			for (const lane of lanes) {
+				Reflect.apply(Reflect.get(lane, property, lane), lane, effective);
+			}
+			return proxy;
+		};
+	};
+
+	proxy = new Proxy(laneZero, {
+		get(target, property) {
+			if (property === REDIS_READ_POOL) return state;
+			if (property === "disconnect") {
+				return (...args: unknown[]) => {
+					for (const lane of lanes) {
+						Reflect.apply(lane.disconnect, lane, args);
+					}
+				};
+			}
+			if (property === "quit") {
+				return async (...args: unknown[]) => {
+					const [result] = await Promise.all(
+						lanes.map((lane) => Reflect.apply(lane.quit, lane, args)),
+					);
+					return result;
+				};
+			}
+			if (typeof property === "string" && LISTENER_METHODS.has(property)) {
+				return fanOutListener(property);
+			}
+
+			const value = Reflect.get(target, property, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+		set(target, property, value) {
+			return Reflect.set(target, property, value, target);
+		},
+		has(target, property) {
+			return property === REDIS_READ_POOL || Reflect.has(target, property);
+		},
+		getPrototypeOf(target) {
+			return Reflect.getPrototypeOf(target);
+		},
+	});
+
+	return proxy;
+};

--- a/server/src/external/redis/initUtils/createRedisReadPool.ts
+++ b/server/src/external/redis/initUtils/createRedisReadPool.ts
@@ -1,4 +1,5 @@
 import type { Redis } from "ioredis";
+import { getStandbyRedisRouter } from "./createStandbyRedisRouter.js";
 
 const REDIS_READ_POOL = Symbol("redisReadPool");
 
@@ -35,11 +36,24 @@ export const acquireRedisReadLane = (
 	const state = getRedisReadPoolState(redis);
 	if (!state) return undefined;
 
-	const readyIndexes = state.lanes
-		.map((lane, index) => ({ lane, index }))
+	const indexedLanes = state.lanes.map((lane, index) => ({ lane, index }));
+	const usableIndexes = indexedLanes
+		.filter(({ lane }) => {
+			const router = getStandbyRedisRouter(lane);
+			return router
+				? router.ordered().some((connection) => router.isUsable(connection))
+				: lane.status === "ready";
+		})
+		.map(({ index }) => index);
+	const readyIndexes = indexedLanes
 		.filter(({ lane }) => lane.status === "ready")
 		.map(({ index }) => index);
-	const candidateIndexes = readyIndexes.length > 0 ? readyIndexes : [0, 1];
+	const candidateIndexes =
+		usableIndexes.length > 0
+			? usableIndexes
+			: readyIndexes.length > 0
+				? readyIndexes
+				: [0, 1];
 	let selectedIndex = candidateIndexes[0] ?? 0;
 
 	// Ties go to the highest lane: lane 0 also carries every unpooled op

--- a/server/src/external/redis/initUtils/redisWarmup.ts
+++ b/server/src/external/redis/initUtils/redisWarmup.ts
@@ -1,6 +1,7 @@
 import type { Redis } from "ioredis";
 import { getMiscRedis } from "../miscCache/getMiscRedis.js";
 import { getMiscBackupRedis } from "../miscCache/miscRedisInstances.js";
+import { getRedisReadPoolLanes } from "./createRedisReadPool.js";
 
 /** Wait for a Redis instance to be ready */
 export const waitForRedisReady = (
@@ -35,6 +36,31 @@ export const waitForRedisReady = (
 			reject(err);
 		});
 	});
+};
+
+export const waitForRedisReadPoolReady = async ({
+	instance,
+	label,
+	timeoutMs = 10000,
+}: {
+	instance: Redis;
+	label: string;
+	timeoutMs?: number;
+}): Promise<void> => {
+	const lanes = getRedisReadPoolLanes(instance);
+	const results = await Promise.allSettled(
+		lanes.map((lane, index) =>
+			waitForRedisReady(
+				lane,
+				lanes.length === 1 ? label : `${label}:lane-${index}`,
+				timeoutMs,
+			),
+		),
+	);
+	const rejection = results.find(
+		(result): result is PromiseRejectedResult => result.status === "rejected",
+	);
+	if (rejection) throw rejection.reason;
 };
 
 /** Pre-warm the main + fallback + V2 Redis connections. Call on startup before processing requests. */

--- a/server/src/external/redis/orgRedisPool.ts
+++ b/server/src/external/redis/orgRedisPool.ts
@@ -6,9 +6,12 @@ import { logger } from "@/external/logtail/logtailUtils.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { decryptData } from "@/utils/encryptUtils.js";
 import { getReachableDragonflyUrl } from "./getReachableDragonflyUrl.js";
-import { createStandbyRedisConnection, currentRegion } from "./initRedis.js";
+import {
+	createPooledStandbyRedisConnection,
+	currentRegion,
+} from "./initRedis.js";
 import { REDIS_V2_COMMAND_TIMEOUT_MS } from "./initUtils/createRedisClient.js";
-import { waitForRedisReady } from "./initUtils/redisWarmup.js";
+import { waitForRedisReadPoolReady } from "./initUtils/redisWarmup.js";
 import { resolveRedisV2 } from "./resolveRedisV2.js";
 
 export type OrgWithRedisConfig = {
@@ -35,7 +38,7 @@ const createOrgRedisConnection = ({
 	orgId: string;
 	orgSlug: string;
 }): Redis => {
-	const instance = createStandbyRedisConnection({
+	const instance = createPooledStandbyRedisConnection({
 		cacheUrl: connectionString,
 		region: `org:${orgSlug}:v2:dragonfly`,
 		redisType: `subject-dedicated:${orgSlug}`,
@@ -130,14 +133,13 @@ export const warmOrgRedis = async ({
 	if (!org.redis_config) return;
 
 	const instance = getOrgRedis({ org });
-	if (instance.status === "ready") return;
 
 	try {
-		await waitForRedisReady(
+		await waitForRedisReadPoolReady({
 			instance,
-			`org:${org.slug ?? org.id}`,
-			ORG_REDIS_WARMUP_TIMEOUT_MS,
-		);
+			label: `org:${org.slug ?? org.id}`,
+			timeoutMs: ORG_REDIS_WARMUP_TIMEOUT_MS,
+		});
 	} catch (error) {
 		logger.warn(
 			`[OrgRedis] org=${org.id}: warmup failed (continuing): ${

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -116,6 +116,7 @@ export const runRedisOp = async <T>({
 			? acquireRedisReadLane(redisInstance)
 			: undefined;
 	const targetRedis = readLaneLease?.redis ?? redisInstance;
+	const redisAttempts: Promise<T>[] = [];
 
 	try {
 		if (!queueIfNotReady && targetRedis.status !== "ready") {
@@ -127,14 +128,17 @@ export const runRedisOp = async <T>({
 		// One budget for the whole op, not one per attempt: a retry must not double
 		// the ceiling the caller sized against its non-Redis fallback.
 		const deadlineAt = timeoutMs ? Date.now() + timeoutMs : undefined;
-		const runAttempt = (redis: Redis, budgetMs?: number) =>
-			budgetMs
+		const runAttempt = (redis: Redis, budgetMs?: number) => {
+			const attempt = operation(redis);
+			redisAttempts.push(attempt);
+			return budgetMs
 				? withTimeout({
 						timeoutMs: budgetMs,
-						fn: () => operation(redis),
+						fn: () => attempt,
 						timeoutMessage: `[redis] ${source} timeout after ${budgetMs}ms`,
 					})
-				: operation(redis);
+				: attempt;
+		};
 
 		try {
 			const router = retryOnStandby
@@ -183,7 +187,13 @@ export const runRedisOp = async <T>({
 			throw new RedisUnavailableError({ source, reason, cause: error });
 		}
 	} finally {
-		readLaneLease?.release();
+		if (readLaneLease && redisAttempts.length === 0) readLaneLease.release();
+		if (readLaneLease && redisAttempts.length > 0) {
+			// Caller deadlines must not make a running command look like spare capacity.
+			void Promise.allSettled(redisAttempts).then(() =>
+				readLaneLease.release(),
+			);
+		}
 	}
 };
 

--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -1,6 +1,7 @@
 import type { Redis } from "ioredis";
 import { logger } from "@/external/logtail/logtailUtils.js";
 import { withTimeout } from "@/utils/withTimeout.js";
+import { acquireRedisReadLane } from "../initUtils/createRedisReadPool.js";
 import { getStandbyRedisRouter } from "../initUtils/createStandbyRedisRouter.js";
 import { RedisUnavailableError } from "./errors.js";
 import { isConnectionLevelRedisError } from "./isTransientRedisError.js";
@@ -93,6 +94,7 @@ export const runRedisOp = async <T>({
 	redisInstance,
 	queueIfNotReady = false,
 	retryOnStandby = false,
+	useReadPool = false,
 	timeoutMs,
 }: {
 	operation: (redis: Redis) => Promise<T>;
@@ -102,78 +104,86 @@ export const runRedisOp = async <T>({
 	/** Retry a failed idempotent read once on the other connection. `operation`
 	 *  must use its injected `redis`; closing over the router re-runs the same one. */
 	retryOnStandby?: boolean;
+	/** Select the least-busy read lane. Requires `retryOnStandby` so only
+	 *  operations already declared idempotent can enter the pool. */
+	useReadPool?: boolean;
 	/** Opt-in bound, tighter than the client's `commandTimeout`. Reads only —
 	 *  the race abandons the promise but the command still reaches Redis. */
 	timeoutMs?: number;
 }): Promise<T> => {
-	const targetRedis = redisInstance;
-
-	if (!queueIfNotReady && targetRedis.status !== "ready") {
-		const reason: UnavailableReason = "not_ready";
-		warnRedisUnavailable({ source, reason });
-		throw new RedisUnavailableError({ source, reason });
-	}
-
-	// One budget for the whole op, not one per attempt: a retry must not double
-	// the ceiling the caller sized against its non-Redis fallback.
-	const deadlineAt = timeoutMs ? Date.now() + timeoutMs : undefined;
-
-	const runAttempt = (redis: Redis, budgetMs?: number) =>
-		budgetMs
-			? // The message must contain "timeout" so classifyErrorReason maps it to
-				// `timeout` rather than `other` — withTimeout's default says "timed out".
-				withTimeout({
-					timeoutMs: budgetMs,
-					fn: () => operation(redis),
-					timeoutMessage: `[redis] ${source} timeout after ${budgetMs}ms`,
-				})
-			: operation(redis);
+	const readLaneLease =
+		retryOnStandby && useReadPool
+			? acquireRedisReadLane(redisInstance)
+			: undefined;
+	const targetRedis = readLaneLease?.redis ?? redisInstance;
 
 	try {
-		const router = retryOnStandby
-			? getStandbyRedisRouter(targetRedis)
-			: undefined;
-		if (!router) return await runAttempt(targetRedis, timeoutMs);
+		if (!queueIfNotReady && targetRedis.status !== "ready") {
+			const reason: UnavailableReason = "not_ready";
+			warnRedisUnavailable({ source, reason });
+			throw new RedisUnavailableError({ source, reason });
+		}
 
-		const [preferred, alternate] = router.ordered();
-		// Only shorten the preferred attempt for an alternate worth retrying on.
-		// `canRetry` below stays broader on purpose: once the preferred has failed,
-		// a penalized alternate still beats falling open to the non-Redis path.
-		const preferredAttemptBudgetMs = router.isUsable(alternate)
-			? getPreferredAttemptBudgetMs({ timeoutMs })
-			: timeoutMs;
+		// One budget for the whole op, not one per attempt: a retry must not double
+		// the ceiling the caller sized against its non-Redis fallback.
+		const deadlineAt = timeoutMs ? Date.now() + timeoutMs : undefined;
+		const runAttempt = (redis: Redis, budgetMs?: number) =>
+			budgetMs
+				? withTimeout({
+						timeoutMs: budgetMs,
+						fn: () => operation(redis),
+						timeoutMessage: `[redis] ${source} timeout after ${budgetMs}ms`,
+					})
+				: operation(redis);
+
 		try {
-			const value = await runAttempt(preferred, preferredAttemptBudgetMs);
-			router.recordOutcome({ connection: preferred });
-			return value;
-		} catch (firstError) {
-			router.recordOutcome({ connection: preferred, error: firstError });
+			const router = retryOnStandby
+				? getStandbyRedisRouter(targetRedis)
+				: undefined;
+			if (!router) return await runAttempt(targetRedis, timeoutMs);
 
-			const remainingMs = deadlineAt ? deadlineAt - Date.now() : undefined;
-			const canRetry =
-				alternate.status === "ready" &&
-				isConnectionLevelRedisError({ error: firstError }) &&
-				(remainingMs === undefined || remainingMs >= MIN_RETRY_BUDGET_MS);
-			if (!canRetry) throw firstError;
+			const [preferred, alternate] = router.ordered();
+			// Only shorten the preferred attempt for an alternate worth retrying on.
+			// A penalized alternate still beats the non-Redis fallback after failure.
+			const preferredAttemptBudgetMs = router.isUsable(alternate)
+				? getPreferredAttemptBudgetMs({ timeoutMs })
+				: timeoutMs;
 
 			try {
-				const value = await runAttempt(alternate, remainingMs);
-				router.recordOutcome({ connection: alternate });
-				logger.info(
-					{ source, type: "redis_standby_failover" },
-					"[redis] standby served a read the preferred connection failed",
-				);
+				const value = await runAttempt(preferred, preferredAttemptBudgetMs);
+				router.recordOutcome({ connection: preferred });
 				return value;
-			} catch (retryError) {
-				router.recordOutcome({ connection: alternate, error: retryError });
-				throw retryError;
+			} catch (firstError) {
+				router.recordOutcome({ connection: preferred, error: firstError });
+
+				const remainingMs = deadlineAt ? deadlineAt - Date.now() : undefined;
+				const canRetry =
+					alternate.status === "ready" &&
+					isConnectionLevelRedisError({ error: firstError }) &&
+					(remainingMs === undefined || remainingMs >= MIN_RETRY_BUDGET_MS);
+				if (!canRetry) throw firstError;
+
+				try {
+					const value = await runAttempt(alternate, remainingMs);
+					router.recordOutcome({ connection: alternate });
+					logger.info(
+						{ source, type: "redis_standby_failover" },
+						"[redis] standby served a read the preferred connection failed",
+					);
+					return value;
+				} catch (retryError) {
+					router.recordOutcome({ connection: alternate, error: retryError });
+					throw retryError;
+				}
 			}
+		} catch (error) {
+			const classified = classifyErrorReason(targetRedis, error);
+			const reason: UnavailableReason = classified ?? "other";
+			warnRedisUnavailable({ source, reason, error });
+			throw new RedisUnavailableError({ source, reason, cause: error });
 		}
-	} catch (error) {
-		const classified = classifyErrorReason(targetRedis, error);
-		const reason: UnavailableReason = classified ?? "other";
-		warnRedisUnavailable({ source, reason, error });
-		throw new RedisUnavailableError({ source, reason, cause: error });
+	} finally {
+		readLaneLease?.release();
 	}
 };
 
@@ -188,6 +198,7 @@ export const tryRedisOp = async <T>({
 	redisInstance,
 	queueIfNotReady,
 	retryOnStandby,
+	useReadPool,
 	timeoutMs,
 	onError,
 }: {
@@ -196,6 +207,7 @@ export const tryRedisOp = async <T>({
 	redisInstance: Redis;
 	queueIfNotReady?: boolean;
 	retryOnStandby?: boolean;
+	useReadPool?: boolean;
 	timeoutMs?: number;
 	onError?: (error: unknown) => void;
 }): Promise<T | undefined> => {
@@ -206,6 +218,7 @@ export const tryRedisOp = async <T>({
 			redisInstance,
 			queueIfNotReady,
 			retryOnStandby,
+			useReadPool,
 			timeoutMs,
 		});
 	} catch (error) {

--- a/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/getCachedFullSubject.ts
@@ -73,6 +73,7 @@ export const getCachedFullSubject = async ({
 		source: "getCachedFullSubject:pipeline",
 		redisInstance: redisV2,
 		retryOnStandby: true,
+		useReadPool: true,
 		timeoutMs: REDIS_OP_TIMEOUT_MS.subjectPipeline,
 	});
 

--- a/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/partial/getCachedPartialFullSubject.ts
@@ -77,6 +77,7 @@ export const getCachedPartialFullSubject = async ({
 		source: "getCachedPartialFullSubject:pipeline",
 		redisInstance: redisV2,
 		retryOnStandby: true,
+		useReadPool: true,
 		timeoutMs: REDIS_OP_TIMEOUT_MS.subjectPipeline,
 	});
 

--- a/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
+++ b/server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts
@@ -110,6 +110,7 @@ export const getCachedFeatureBalance = async ({
 		// readMaster demands same-socket ordering: a standby retry could land
 		// before an in-flight write on the dying primary socket.
 		retryOnStandby: !readMaster,
+		useReadPool: !readMaster,
 		timeoutMs: REDIS_OP_TIMEOUT_MS.featureBalances,
 	});
 
@@ -189,6 +190,7 @@ export const getCachedFeatureBalancesBatch = async ({
 		source: "getCachedFeatureBalancesBatch",
 		redisInstance: redisV2,
 		retryOnStandby: true,
+		useReadPool: true,
 		timeoutMs: REDIS_OP_TIMEOUT_MS.featureBalancesBatch,
 	});
 

--- a/server/tests/unit/redis/orgRedisPrewarm.test.ts
+++ b/server/tests/unit/redis/orgRedisPrewarm.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, describe, expect, mock, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import type { Redis } from "ioredis";
+import { createRedisReadPool } from "@/external/redis/initUtils/createRedisReadPool.js";
 
 class FakeRedis extends EventEmitter {
 	status = "connecting";
@@ -7,6 +9,12 @@ class FakeRedis extends EventEmitter {
 }
 
 const instances: FakeRedis[] = [];
+
+const createFakeRedis = (): FakeRedis => {
+	const instance = new FakeRedis();
+	instances.push(instance);
+	return instance;
+};
 
 const fakeOrg = (id: string) => ({
 	id,
@@ -47,11 +55,14 @@ mock.module("@/external/redis/resolveRedisV2.js", () => ({
 }));
 mock.module("@/external/redis/initRedis.js", () => ({
 	currentRegion: "test",
-	createStandbyRedisConnection: () => {
-		const instance = new FakeRedis();
-		instances.push(instance);
-		return instance;
-	},
+	createStandbyRedisConnection: createFakeRedis,
+	createPooledStandbyRedisConnection: () =>
+		createRedisReadPool({
+			lanes: [
+				createFakeRedis() as unknown as Redis,
+				createFakeRedis() as unknown as Redis,
+			],
+		}),
 }));
 
 afterAll(() => {
@@ -73,13 +84,20 @@ describe("preWarmOrgRedisConnections", () => {
 		});
 
 		await Bun.sleep(30);
-		expect(instances.length).toBe(2);
+		expect(instances.length).toBe(4);
 		expect(settled).toBe(false);
 
-		for (const instance of instances) {
+		for (const instance of instances.slice(0, 3)) {
 			instance.status = "ready";
 			instance.emit("ready");
 		}
+		await Bun.sleep(10);
+		expect(settled).toBe(false);
+
+		const lastInstance = instances[3];
+		expect(lastInstance).toBeDefined();
+		lastInstance!.status = "ready";
+		lastInstance!.emit("ready");
 		await warmup;
 		expect(settled).toBe(true);
 	});

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -553,6 +553,31 @@ describe("runRedisOp standby failover", () => {
 });
 
 describe("Redis read pool", () => {
+	test("sends a lone pooled read to the high lane, away from unpooled traffic", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("lane-one-primary");
+		expect(laneZero.primary.calls).toEqual([]);
+	});
+
 	test("skips a lane whose preferred and standby connections are unavailable", async () => {
 		const laneZero = createNamedPair({
 			primaryName: "lane-zero-primary",
@@ -591,7 +616,7 @@ describe("Redis read pool", () => {
 			standbyName: "lane-one-standby",
 		});
 		let releaseFirstRead: (() => void) | undefined;
-		laneZero.primary.waitForGet = new Promise<void>((resolve) => {
+		laneOne.primary.waitForGet = new Promise<void>((resolve) => {
 			releaseFirstRead = resolve;
 		});
 		const redis = createRedisReadPool({
@@ -613,10 +638,10 @@ describe("Redis read pool", () => {
 			operation: (connection) => connection.get("second"),
 		});
 
-		expect(secondRead).toBe("lane-one-primary");
-		expect(laneOne.primary.calls).toEqual(["get:second"]);
+		expect(secondRead).toBe("lane-zero-primary");
+		expect(laneZero.primary.calls).toEqual(["get:second"]);
 		releaseFirstRead?.();
-		expect(await firstRead).toBe("lane-zero-primary");
+		expect(await firstRead).toBe("lane-one-primary");
 	});
 
 	test("keeps non-retry-safe operations pinned to lane zero", async () => {
@@ -629,7 +654,7 @@ describe("Redis read pool", () => {
 			standbyName: "lane-one-standby",
 		});
 		let releaseFirstRead: (() => void) | undefined;
-		laneZero.primary.waitForGet = new Promise<void>((resolve) => {
+		laneOne.primary.waitForGet = new Promise<void>((resolve) => {
 			releaseFirstRead = resolve;
 		});
 		const redis = createRedisReadPool({
@@ -650,8 +675,8 @@ describe("Redis read pool", () => {
 		});
 
 		expect(write).toBe("OK");
-		expect(laneZero.primary.calls).toContain("set:subject:value");
-		expect(laneOne.primary.calls).toEqual([]);
+		expect(laneZero.primary.calls).toEqual(["set:subject:value"]);
+		expect(laneOne.primary.calls).toEqual(["get:first"]);
 		releaseFirstRead?.();
 		await firstRead;
 	});
@@ -665,7 +690,7 @@ describe("Redis read pool", () => {
 			primaryName: "lane-one-primary",
 			standbyName: "lane-one-standby",
 		});
-		laneZero.primary.failGetWith = connectionError();
+		laneOne.primary.failGetWith = connectionError();
 		const redis = createRedisReadPool({
 			lanes: [laneZero.redis, laneOne.redis],
 		});
@@ -678,10 +703,10 @@ describe("Redis read pool", () => {
 			operation: (connection) => connection.get("subject"),
 		});
 
-		expect(result).toBe("lane-zero-standby");
-		expect(laneZero.standby.calls).toEqual(["get:subject"]);
-		expect(laneOne.primary.calls).toEqual([]);
-		expect(laneOne.standby.calls).toEqual([]);
+		expect(result).toBe("lane-one-standby");
+		expect(laneOne.standby.calls).toEqual(["get:subject"]);
+		expect(laneZero.primary.calls).toEqual([]);
+		expect(laneZero.standby.calls).toEqual([]);
 	});
 
 	test("fans connection listeners out across both lanes", () => {

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, setSystemTime, test } from "bun:test";
 import type { Redis } from "ioredis";
+import { createRedisReadPool } from "@/external/redis/initUtils/createRedisReadPool.js";
 import {
 	createStandbyRedisRouter,
 	getStandbyRedisRouter,
@@ -20,6 +21,7 @@ type FakeRedis = {
 	listeners: Map<string, Set<Listener>>;
 	failGetWith?: Error;
 	hangGetForMs?: number;
+	waitForGet?: Promise<void>;
 	pipelineError?: Error;
 	/** Resolve exec() with a per-command error tuple, as real ioredis does. */
 	pipelineCommandError?: Error;
@@ -98,6 +100,7 @@ const createFakeRedis = ({
 		},
 		async get(key) {
 			calls.push(`get:${key}`);
+			if (redis.waitForGet) await redis.waitForGet;
 			if (redis.hangGetForMs) {
 				await new Promise((resolve) => setTimeout(resolve, redis.hangGetForMs));
 			}
@@ -144,6 +147,22 @@ const createPair = (options?: {
 		name: "standby",
 		status: options?.standbyStatus,
 	});
+	const redis = createStandbyRedisRouter({
+		primary: asRedis(primary),
+		standby: asRedis(standby),
+	});
+	return { primary, standby, redis };
+};
+
+const createNamedPair = ({
+	primaryName,
+	standbyName,
+}: {
+	primaryName: string;
+	standbyName: string;
+}) => {
+	const primary = createFakeRedis({ name: primaryName });
+	const standby = createFakeRedis({ name: standbyName });
 	const redis = createStandbyRedisRouter({
 		primary: asRedis(primary),
 		standby: asRedis(standby),
@@ -530,6 +549,186 @@ describe("runRedisOp standby failover", () => {
 		).rejects.toBeInstanceOf(RedisUnavailableError);
 
 		expect(standby.calls).toEqual([]);
+	});
+});
+
+describe("Redis read pool", () => {
+	test("skips a lane whose preferred and standby connections are unavailable", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		laneZero.primary.status = "reconnecting";
+		laneZero.standby.status = "end";
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("lane-one-primary");
+		expect(laneZero.primary.calls).toEqual([]);
+		expect(laneZero.standby.calls).toEqual([]);
+	});
+
+	test("routes a concurrent retry-safe read to the least-busy lane", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		let releaseFirstRead: (() => void) | undefined;
+		laneZero.primary.waitForGet = new Promise<void>((resolve) => {
+			releaseFirstRead = resolve;
+		});
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+
+		const firstRead = runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: (connection) => connection.get("first"),
+		});
+		const secondRead = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: (connection) => connection.get("second"),
+		});
+
+		expect(secondRead).toBe("lane-one-primary");
+		expect(laneOne.primary.calls).toEqual(["get:second"]);
+		releaseFirstRead?.();
+		expect(await firstRead).toBe("lane-zero-primary");
+	});
+
+	test("keeps non-retry-safe operations pinned to lane zero", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		let releaseFirstRead: (() => void) | undefined;
+		laneZero.primary.waitForGet = new Promise<void>((resolve) => {
+			releaseFirstRead = resolve;
+		});
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+
+		const firstRead = runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: (connection) => connection.get("first"),
+		});
+		const write = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			operation: (connection) => connection.set("subject", "value"),
+		});
+
+		expect(write).toBe("OK");
+		expect(laneZero.primary.calls).toContain("set:subject:value");
+		expect(laneOne.primary.calls).toEqual([]);
+		releaseFirstRead?.();
+		await firstRead;
+	});
+
+	test("keeps standby failover inside the selected lane", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		laneZero.primary.failGetWith = connectionError();
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("lane-zero-standby");
+		expect(laneZero.standby.calls).toEqual(["get:subject"]);
+		expect(laneOne.primary.calls).toEqual([]);
+		expect(laneOne.standby.calls).toEqual([]);
+	});
+
+	test("fans connection listeners out across both lanes", () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+		const seen: string[] = [];
+
+		redis.on("error", (error) => seen.push((error as Error).message));
+		laneZero.primary.emit("error", new Error("lane zero"));
+		laneOne.primary.emit("error", new Error("lane one"));
+
+		expect(seen).toEqual(["lane zero", "lane one"]);
+	});
+
+	test("closes every primary and standby connection during teardown", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+
+		redis.disconnect();
+		expect(laneZero.primary.calls).toEqual(["disconnect"]);
+		expect(laneZero.standby.calls).toEqual(["disconnect"]);
+		expect(laneOne.primary.calls).toEqual(["disconnect"]);
+		expect(laneOne.standby.calls).toEqual(["disconnect"]);
+
+		await redis.quit();
+		expect(laneZero.primary.calls).toEqual(["disconnect", "quit"]);
+		expect(laneZero.standby.calls).toEqual(["disconnect", "quit"]);
+		expect(laneOne.primary.calls).toEqual(["disconnect", "quit"]);
+		expect(laneOne.standby.calls).toEqual(["disconnect", "quit"]);
 	});
 });
 

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -606,6 +606,47 @@ describe("Redis read pool", () => {
 		expect(laneZero.standby.calls).toEqual([]);
 	});
 
+	test("skips a lane whose ready connections are breaker-penalized", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		const laneOneRouter = getStandbyRedisRouter(laneOne.redis);
+		if (!laneOneRouter) throw new Error("Expected lane one to have a router");
+		const [laneOnePrimary, laneOneStandby] = laneOneRouter.ordered();
+
+		for (let attempt = 0; attempt < 3; attempt++) {
+			laneOneRouter.recordOutcome({
+				connection: laneOnePrimary,
+				error: connectionError(),
+			});
+			laneOneRouter.recordOutcome({
+				connection: laneOneStandby,
+				error: connectionError(),
+			});
+		}
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+
+		expect(laneOne.redis.status).toBe("ready");
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: (connection) => connection.get("subject"),
+		});
+
+		expect(result).toBe("lane-zero-primary");
+		expect(laneOne.primary.calls).toEqual([]);
+		expect(laneOne.standby.calls).toEqual([]);
+	});
+
 	test("routes a concurrent retry-safe read to the least-busy lane", async () => {
 		const laneZero = createNamedPair({
 			primaryName: "lane-zero-primary",
@@ -642,6 +683,69 @@ describe("Redis read pool", () => {
 		expect(laneZero.primary.calls).toEqual(["get:second"]);
 		releaseFirstRead?.();
 		expect(await firstRead).toBe("lane-one-primary");
+	});
+
+	test("keeps a timed-out lane busy after standby succeeds", async () => {
+		const laneZero = createNamedPair({
+			primaryName: "lane-zero-primary",
+			standbyName: "lane-zero-standby",
+		});
+		const laneOne = createNamedPair({
+			primaryName: "lane-one-primary",
+			standbyName: "lane-one-standby",
+		});
+		let releaseBlockedRead: (() => void) | undefined;
+		laneOne.primary.waitForGet = new Promise<void>((resolve) => {
+			releaseBlockedRead = resolve;
+		});
+		const redis = createRedisReadPool({
+			lanes: [laneZero.redis, laneOne.redis],
+		});
+		let blockedRead: Promise<string | null> | undefined;
+		const identifyLane = async (connection: Redis) =>
+			connection === asRedis(laneZero.primary)
+				? "lane-zero-primary"
+				: "lane-one-primary";
+
+		const result = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			timeoutMs: 400,
+			operation: (connection) => {
+				const command = connection.get("blocked");
+				if (connection === asRedis(laneOne.primary)) blockedRead = command;
+				return command;
+			},
+		});
+		expect(result).toBe("lane-one-standby");
+
+		try {
+			const whileCommandIsPending = await runRedisOp({
+				redisInstance: redis,
+				source: "read-pool-test",
+				retryOnStandby: true,
+				useReadPool: true,
+				operation: identifyLane,
+			});
+			expect(whileCommandIsPending).toBe("lane-zero-primary");
+		} finally {
+			releaseBlockedRead?.();
+		}
+
+		if (!blockedRead) throw new Error("Expected a blocked Redis command");
+		await blockedRead;
+		await Promise.resolve();
+
+		const afterCommandSettles = await runRedisOp({
+			redisInstance: redis,
+			source: "read-pool-test",
+			retryOnStandby: true,
+			useReadPool: true,
+			operation: identifyLane,
+		});
+		expect(afterCommandSettles).toBe("lane-one-primary");
 	});
 
 	test("keeps non-retry-safe operations pinned to lane zero", async () => {


### PR DESCRIPTION
## What changed

- add a fixed two-lane Redis read pool
- retain the existing primary/standby failover pair inside each lane
- route explicitly retry-safe FullSubject and balance reads to the least-busy ready lane
- keep writes and ordering-sensitive `readMaster` operations pinned to lane 0
- prewarm both lanes and fan out connection lifecycle handling across the pool

## Why

Each Bun process currently sends Redis work through one preferred connection. During bursts, unrelated reads can queue behind a slow command on that socket and hit their client-side deadline even when Dragonfly itself is healthy. A second independent read lane reduces that connection-level head-of-line blocking while preserving the existing standby behavior.

## Impact

Each Redis target now uses four sockets per process instead of two: two read lanes, each with a preferred and standby connection. The pool is deliberately opt-in for idempotent reads; mutation ordering is unchanged.

This is a draft pending review and production burst validation.

## Validation

- `bun test tests/unit/redis/standby-redis-routing.test.ts tests/unit/redis/orgRedisPrewarm.test.ts` — 42 passed
- `bun ts`
- scoped Biome check on all 12 changed files
- `git diff --check`
- commit hooks: Knip and `@autumn/server` typecheck passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pool Redis reads across two independent lanes to cut connection-level head-of-line blocking during bursts. Writes and ordering-sensitive reads stay on lane 0; retry-safe reads go to the least-busy usable lane with per-lane standby failover and avoidance of unhealthy lanes.

- **New Features**
  - Added a fixed two-lane read pool with per-lane primary/standby; new `createPooledStandbyRedisConnection`.
  - `runRedisOp` now supports `useReadPool` (requires `retryOnStandby`) and tracks in-flight per lane, keeping lanes “busy” until attempts settle to avoid over-admitting after timeouts.
  - Lane selection picks the least-busy ready/usable lane, skips lanes whose connections are down or breaker-penalized, and breaks ties to lane 1 to keep unpooled traffic on lane 0.
  - New `waitForRedisReadPoolReady` prewarms all lanes; applied to Redis V2 and per-org pools.
  - Connection listeners and teardown fan out across lanes. Each target now uses four sockets per process.

- **Migration**
  - Use `createPooledStandbyRedisConnection` for V2 and per-org Redis clients that will pool reads.
  - For retry-safe reads, call `runRedisOp` with `retryOnStandby: true` and `useReadPool: true`.
  - When using the pool, call `waitForRedisReadPoolReady` instead of `waitForRedisReady`.

<sup>Written for commit a911cdc56ea9de2635b75aa5a1df70b917759fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a two-lane Redis read pool while preserving per-lane primary/standby failover and keeping writes and ordering-sensitive reads on lane 0.

- **[Improvements, API changes]** Adds pooled Redis connection construction, lane selection, readiness handling, and lifecycle fan-out.
- **[Improvements]** Routes explicitly retry-safe FullSubject and balance reads to the least-busy usable lane.
- **[Improvements]** Prewarms both lanes for shared Redis V2 and organization-specific Redis clients.
- **[Improvements]** Expands unit coverage for balancing, failover, listener handling, teardown, and prewarming.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the reviewed follow-up scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/initUtils/createRedisReadPool.ts | Introduces the two-lane proxy, least-busy lane leasing, listener fan-out, and pooled teardown behavior. |
| server/src/external/redis/utils/runRedisOp.ts | Adds opt-in pooled routing for retry-safe reads and retains leases while underlying timed-out commands remain active. |
| server/src/external/redis/initUtils/createRedisClient.ts | Constructs two independent read lanes, each retaining the existing preferred/standby router. |
| server/src/external/redis/initUtils/redisWarmup.ts | Adds readiness checks across every lane in a pooled Redis instance. |
| server/src/external/redis/orgRedisPool.ts | Moves organization-specific Redis clients to pooled connections and prewarms both lanes. |
| server/src/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.ts | Enables pooled routing for retry-safe balance reads while keeping readMaster operations pinned to lane 0. |
| server/tests/unit/redis/standby-redis-routing.test.ts | Covers lane balancing, unavailable-lane avoidance, standby retry, lease retention, event fan-out, and teardown. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Caller[Redis operation] --> Safe{Retry-safe pooled read?}
  Safe -- No --> Lane0[Lane 0]
  Safe -- Yes --> Select[Choose least-busy usable lane]
  Select --> Lane0
  Select --> Lane1[Lane 1]
  Lane0 --> Pair0[Preferred / standby pair]
  Lane1 --> Pair1[Preferred / standby pair]
  Pair0 --> Redis[(Redis target)]
  Pair1 --> Redis
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: avoid reusing unhealthy Redis read ..."](https://github.com/useautumn/autumn/commit/a911cdc56ea9de2635b75aa5a1df70b917759fc9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51920817)</sub>

<!-- /greptile_comment -->