### PR TITLE
fix(billing): charge full cycle on reset billing cycle (no proration credit)

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts
@@ -275,10 +275,7 @@ export const buildStripePhasesUpdate = ({
 					normalizedCustomerProducts.some(
 						(product) => product.starts_at >= endMs,
 					)));
-		if (
-			phaseItems.length === 0 &&
-			needsFreePhasePlaceholder
-		) {
+		if (phaseItems.length === 0 && needsFreePhasePlaceholder) {
 			const placeholderItem = buildFreeRecurringPlaceholderItem({
 				ctx,
 				customerProducts: normalizedCustomerProducts,
@@ -325,7 +322,13 @@ export const buildStripePhasesUpdate = ({
 			billing_cycle_anchor: isBillingCycleAnchorResetPhase
 				? "phase_start"
 				: undefined,
-			proration_behavior: shouldAlwaysInvoice ? "always_invoice" : undefined,
+			// A reset starts a fresh full cycle: charge the full amount and don't
+			// credit the old plan's leftover time.
+			proration_behavior: isBillingCycleAnchorResetPhase
+				? "none"
+				: shouldAlwaysInvoice
+					? "always_invoice"
+					: undefined,
 			discounts: stripeDiscountsToPhaseDiscounts({
 				stripeDiscounts: billingContext.stripeDiscounts,
 				phaseStartDateSeconds,

--- a/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts
@@ -161,6 +161,30 @@ export const billingPlanToNextCyclePreview = ({
 			customerProducts,
 			startsAtMs: event.startsAtMs - MS_PER_SECOND,
 		});
+		const chargeNewPlan = {
+			customerProducts: event.incomingCustomerProducts,
+			direction: "charge" as const,
+			billingCycleAnchorMs: event.resetsBillingCycle
+				? event.startsAtMs
+				: anchorMs,
+			filterBillingPeriodStart: false,
+			priceFilters: { excludeOneOffPrices: true },
+		};
+
+		const creditOldPlanUnusedTime = {
+			customerProducts: event.outgoingCustomerProducts,
+			direction: "refund" as const,
+			billingCycleAnchorMs: anchorMs,
+			filterBillingPeriodStart: false,
+			priceFilters: { excludeOneOffPrices: true },
+		};
+
+		// A reset starts a fresh full cycle, so we don't credit the old plan's
+		// leftover time — mirrors proration_behavior "none" on the Stripe phase.
+		const lineItemSpecs = event.resetsBillingCycle
+			? [chargeNewPlan]
+			: [chargeNewPlan, creditOldPlanUnusedTime];
+
 		const lineItemsResult = billingPlanToNextCycleLineItems({
 			ctx,
 			customerProducts: [
@@ -168,24 +192,7 @@ export const billingPlanToNextCyclePreview = ({
 				...event.outgoingCustomerProducts,
 			],
 			productsForUsageLineItems,
-			lineItemSpecs: [
-				{
-					customerProducts: event.incomingCustomerProducts,
-					direction: "charge",
-					billingCycleAnchorMs: event.resetsBillingCycle
-						? event.startsAtMs
-						: anchorMs,
-					filterBillingPeriodStart: false,
-					priceFilters: { excludeOneOffPrices: true },
-				},
-				{
-					customerProducts: event.outgoingCustomerProducts,
-					direction: "refund",
-					billingCycleAnchorMs: anchorMs,
-					filterBillingPeriodStart: false,
-					priceFilters: { excludeOneOffPrices: true },
-				},
-			],
+			lineItemSpecs,
 			autumnBillingPlan: billingPlan.autumn,
 			billingContext,
 			nextCycleStart: event.startsAtMs,

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts
@@ -1,10 +1,9 @@
-// Before: a future phase anchor reset previews a partial cycle from the saved schedule start.
-// After: it previews a full new cycle minus the unused current-plan credit.
+// A future phase anchor reset previews a fresh full cycle with no proration:
+// the new plan is charged in full and the old plan's leftover time isn't credited.
 
 import { expect, test } from "bun:test";
 import {
 	type AttachPreviewResponse,
-	applyProration,
 	type CreateScheduleParamsV0Input,
 	ms,
 	truncateMsToSecondPrecision,
@@ -60,18 +59,14 @@ test.concurrent(
 				],
 			},
 		);
-		const unusedCurrentPlan = applyProration({
-			now: transitionAt,
-			billingPeriod: { start: advancedTo, end: currentPlanEndsAt },
-			amount: 20,
-		});
 		const positiveTotal = preview.next_cycle?.line_items
 			.filter((lineItem) => lineItem.total > 0)
 			.reduce((total, lineItem) => total + lineItem.total, 0);
 
 		expect(preview.total).toBe(0);
 		expect(positiveTotal).toBeCloseTo(50, 2);
-		expect(preview.next_cycle?.total).toBeCloseTo(50 - unusedCurrentPlan, 2);
+		// Reset = fresh full cycle, no unused-current-plan credit netted in.
+		expect(preview.next_cycle?.total).toBeCloseTo(50, 2);
 		expect(preview.next_cycle?.starts_at).toBe(transitionAt);
 	},
 );

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-reset-cycle-same-plan-preview.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-reset-cycle-same-plan-preview.test.ts
@@ -1,0 +1,66 @@
+// A same-plan phase transition with a billing-cycle reset previews a fresh full
+// cycle: the plan is charged in full with no unused-time credit netted against it.
+
+import { expect, test } from "bun:test";
+import {
+	type AttachPreviewResponse,
+	type CreateScheduleParamsV0Input,
+	ms,
+	truncateMsToSecondPrecision,
+} from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { addMonths } from "date-fns";
+
+test.concurrent(
+	"create-schedule preview: same-plan reset-billing-cycle charges the full base",
+	async () => {
+		const plan = products.pro({
+			id: "reset-cycle-same-plan-preview",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { customerId, autumnV1, advancedTo } = await initScenario({
+			customerId: "create-schedule-reset-cycle-same-plan",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [],
+		});
+
+		const currentPlanEndsAt = truncateMsToSecondPrecision(
+			addMonths(advancedTo, 1).getTime(),
+		);
+		// Transition a sliver before the natural period end, which previously left
+		// a small unused-current-plan credit despite the reset.
+		const transitionAt = currentPlanEndsAt - ms.hours(16);
+
+		const phases: CreateScheduleParamsV0Input["phases"] = [
+			{ starts_at: advancedTo, plans: [{ plan_id: plan.id }] },
+			{
+				starts_at: transitionAt,
+				plans: [{ plan_id: plan.id }],
+				billing_cycle_anchor: "phase_start",
+			},
+		];
+
+		const preview: AttachPreviewResponse = await autumnV1.post(
+			"/billing.preview_create_schedule",
+			{
+				customer_id: customerId,
+				billing_behavior: "none",
+				phases,
+			},
+		);
+
+		const fullBase = 20;
+		const hasCreditLine = (preview.next_cycle?.line_items ?? []).some(
+			(lineItem) => lineItem.total < 0,
+		);
+
+		expect(preview.next_cycle?.starts_at).toBe(transitionAt);
+		expect(hasCreditLine).toBe(false);
+		expect(preview.next_cycle?.total).toBeCloseTo(fullBase, 2);
+	},
+);

--- a/server/tests/integration/billing/create-schedule/preview/create-schedule-reset-cycle-stripe-clock.test.ts
+++ b/server/tests/integration/billing/create-schedule/preview/create-schedule-reset-cycle-stripe-clock.test.ts
@@ -1,0 +1,73 @@
+// Advancing Stripe's test clock through a same-plan reset-billing-cycle
+// transition charges the full base on a single invoice, with no unused-time
+// proration credit — matching the next-cycle preview.
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type CreateScheduleParamsV0Input,
+	ms,
+	truncateMsToSecondPrecision,
+} from "@autumn/shared";
+import { hoursToFinalizeInvoice } from "@tests/utils/constants";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { advanceTestClock } from "@tests/utils/stripeUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import { addHours, addMonths } from "date-fns";
+
+test.concurrent(
+	"create-schedule Stripe clock: same-plan reset-billing-cycle charges the full base",
+	async () => {
+		const plan = products.pro({
+			id: "reset-cycle-clock-plan",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { customerId, autumnV1, ctx, testClockId, advancedTo } =
+			await initScenario({
+				customerId: "create-schedule-reset-cycle-clock",
+				setup: [
+					s.customer({ paymentMethod: "success" }),
+					s.products({ list: [plan] }),
+				],
+				actions: [],
+			});
+
+		const currentPlanEndsAt = truncateMsToSecondPrecision(
+			addMonths(advancedTo, 1).getTime(),
+		);
+		const transitionAt = currentPlanEndsAt - ms.hours(16);
+
+		const phases: CreateScheduleParamsV0Input["phases"] = [
+			{ starts_at: advancedTo, plans: [{ plan_id: plan.id }] },
+			{
+				starts_at: transitionAt,
+				plans: [{ plan_id: plan.id }],
+				billing_cycle_anchor: "phase_start",
+			},
+		];
+
+		await autumnV1.billing.createSchedule({
+			customer_id: customerId,
+			billing_behavior: "none",
+			phases,
+		});
+
+		await advanceTestClock({
+			stripeCli: ctx.stripeCli,
+			testClockId: testClockId!,
+			advanceTo: addHours(transitionAt, hoursToFinalizeInvoice).getTime(),
+			waitForSeconds: 30,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		const latestInvoiceStripeId = customer.invoices?.[0]?.stripe_id;
+		if (!latestInvoiceStripeId) {
+			throw new Error("Expected the reset transition to create an invoice");
+		}
+
+		const transitionInvoice =
+			await ctx.stripeCli.invoices.retrieve(latestInvoiceStripeId);
+		expect(transitionInvoice.total / 100).toBeCloseTo(20, 2);
+	},
+);


### PR DESCRIPTION
## Problem

A `create_schedule` phase with `billing_cycle_anchor: "phase_start"` (reset billing cycle) is meant to start a **clean, full billing cycle**. But it was quietly knocking off a small "unused old-plan time" credit.

Real example from a customer: an Enterprise → Enterprise schedule at **$31,000/yr** with reset billing cycle previewed and billed as **$30,944.22** — the full amount minus a ~$55.78 credit for the ~16 hours of old-plan time between the phase start and the old plan's natural period end. Disabling prorations didn't help, because `billing_behavior: "none"` only governs the immediate phase, not the future phase.

## Fix

Two sides, kept in sync:

| File | Before | After |
|---|---|---|
| `buildStripePhasesUpdate.ts` (real Stripe) | reset phase → `proration_behavior: "always_invoice"` (prorates) | reset phase → `proration_behavior: "none"` (full charge) |
| `billingPlanToNextCyclePreview.ts` (preview) | always adds the old-plan refund line | skips it when the phase resets the cycle |

Both must change together — otherwise the preview and the real invoice disagree.

## Verified with a Stripe test clock

Same-plan reset, transition 16h before period end:

```
Preview next-cycle total:   was 19.57  →  now 20.00   (full)
Real Stripe invoice total:  was 19.56  →  now 20.00   (full)
```

## Tests

- Added `create-schedule-reset-cycle-same-plan-preview.test.ts` — preview charges full base, no credit line.
- Added `create-schedule-reset-cycle-stripe-clock.test.ts` — advances Stripe's clock through the transition and asserts the real invoice is the full base.
- Updated `create-schedule-phase-anchor-reset-preview.test.ts` — its old assertion baked in the "full minus credit" behavior; now expects the full amount.

## Note on scope

This changes billing behavior for **all** reset-billing-cycle phases: on a downgrade with reset, the customer no longer gets a refund for unused expensive-plan time (reset = clean slate). Only the three directly-related tests were run; a full create-schedule suite run is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns reset-cycle previews with Stripe execution so a reset begins a clean billing period without crediting unused time from the previous period.
- **[Bug fixes]** Configures reset phases to disable proration, producing a full-cycle Stripe charge.
- **[Bug fixes]** Removes the outgoing-plan credit from reset-cycle previews.
- **[Improvements]** Adds preview and Stripe test-clock coverage for same-plan reset transitions.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/subscriptionSchedules/buildStripePhasesUpdate.ts | Reset phases now disable Stripe proration while other invoice-triggering phases retain existing behavior. |
| server/src/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCyclePreview.ts | Reset-cycle previews now charge the incoming plan without adding an unused-time credit for the outgoing plan. |
| server/tests/integration/billing/create-schedule/preview/create-schedule-phase-anchor-reset-preview.test.ts | Updates the reset-preview expectation from a prorated net amount to the full new-plan amount. |
| server/tests/integration/billing/create-schedule/preview/create-schedule-reset-cycle-same-plan-preview.test.ts | Adds coverage confirming that a same-plan reset preview contains no credit and charges the full base price. |
| server/tests/integration/billing/create-schedule/preview/create-schedule-reset-cycle-stripe-clock.test.ts | Adds Stripe test-clock coverage confirming the actual transition invoice charges the full base price. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Preview as Autumn Preview
    participant Schedule as Stripe Schedule
    participant Stripe
    Client->>Preview: Preview reset-cycle transition
    Preview->>Preview: Charge incoming plan in full
    Preview->>Preview: Skip outgoing-plan credit
    Preview-->>Client: Full-cycle total
    Client->>Schedule: Create reset-cycle schedule
    Schedule->>Stripe: phase_start anchor + proration none
    Stripe-->>Client: Full-cycle invoice
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(billing): charge full cycle on reset..."](https://github.com/useautumn/autumn/commit/f782222000e8f5ac9281c410369cbecd2ba8aaf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52186006)</sub>

<!-- /greptile_comment -->