### PR TITLE
feat: flag Stripe customers shared across Autumn customers

### DIFF
--- a/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSharedStripeCustomer.ts
+++ b/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSharedStripeCustomer.ts
@@ -1,0 +1,40 @@
+import {
+	type FullCustomer,
+	notNullish,
+	type SubscriptionMismatch,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { CusService } from "@/internal/customers/CusService";
+
+/** Flags a Stripe customer that more than one Autumn customer points at, and
+ * lists the other customers so the collision can be untangled. */
+export const evaluateSharedStripeCustomer = async ({
+	ctx,
+	fullCustomer,
+}: {
+	ctx: AutumnContext;
+	fullCustomer: FullCustomer;
+}): Promise<SubscriptionMismatch[]> => {
+	const stripeCustomerId = fullCustomer.processor?.id;
+	if (!stripeCustomerId) return [];
+
+	const linkedCustomers = await CusService.getAllByStripeId({
+		ctx,
+		stripeId: stripeCustomerId,
+	});
+
+	const otherCustomerIds = linkedCustomers
+		.filter((customer) => customer.internal_id !== fullCustomer.internal_id)
+		.map((customer) => customer.id ?? customer.internal_id)
+		.filter(notNullish);
+
+	if (otherCustomerIds.length === 0) return [];
+
+	return [
+		{
+			type: "shared_stripe_customer",
+			stripe_customer_id: stripeCustomerId,
+			other_customer_ids: otherCustomerIds,
+		},
+	];
+};

--- a/server/src/internal/billing/v2/actions/verify/format/verifyMismatchToMessage.ts
+++ b/server/src/internal/billing/v2/actions/verify/format/verifyMismatchToMessage.ts
@@ -116,6 +116,8 @@ const describe = (mismatch: SubscriptionMismatch): string => {
 			return "Autumn products link to a Stripe subscription that is not in the customer's active set";
 		case "expected_state_error":
 			return `Could not compute Autumn's expected Stripe state — ${mismatch.error}`;
+		case "shared_stripe_customer":
+			return `Stripe customer ${mismatch.stripe_customer_id} is also linked to Autumn customer(s): ${mismatch.other_customer_ids.join(", ")}`;
 		case "base_price_mismatch": {
 			const { reason, expected_amount, actual_amount } = mismatch;
 			const label = planPriceLabel(mismatch);

--- a/server/src/internal/billing/v2/actions/verify/verify.ts
+++ b/server/src/internal/billing/v2/actions/verify/verify.ts
@@ -11,6 +11,7 @@ import { computeExpectedSubscriptionState } from "./compute/computeExpectedSubsc
 import { evaluateCancelState } from "./evaluate/evaluateCancelState";
 import { evaluateItems } from "./evaluate/evaluateItems";
 import { evaluateSchedulePhases } from "./evaluate/evaluateSchedulePhases";
+import { evaluateSharedStripeCustomer } from "./evaluate/evaluateSharedStripeCustomer";
 import { verifyMismatchToMessage } from "./format/verifyMismatchToMessage";
 import {
 	setupVerifyContext,
@@ -21,6 +22,7 @@ import {
  * else defaults to error. */
 const WARNING_MISMATCH_TYPES = new Set<SubscriptionMismatch["type"]>([
 	"stripe_sub_not_in_autumn",
+	"shared_stripe_customer",
 ]);
 
 const stampMessages = (
@@ -78,6 +80,10 @@ export const verify = async ({
 
 	const stripeCli =
 		stripeCliOverride ?? createStripeCli({ org: ctx.org, env: ctx.env });
+
+	const customerMismatches = stampMessages(
+		await evaluateSharedStripeCustomer({ ctx, fullCustomer }),
+	);
 
 	const subscriptions: VerifyResponse["subscriptions"] = [];
 
@@ -166,5 +172,9 @@ export const verify = async ({
 		});
 	}
 
-	return { customer_id: customerId, subscriptions };
+	return {
+		customer_id: customerId,
+		customer_mismatches: customerMismatches,
+		subscriptions,
+	};
 };

--- a/server/src/internal/customers/CusService.ts
+++ b/server/src/internal/customers/CusService.ts
@@ -478,6 +478,25 @@ export class CusService {
 		return customer as Customer;
 	}
 
+	static async getAllByStripeId({
+		ctx,
+		stripeId,
+	}: {
+		ctx: AutumnContext;
+		stripeId: string;
+	}) {
+		const { db, org, env } = ctx;
+		const results = await db.query.customers.findMany({
+			where: and(
+				eq(sql`processor->>'id'`, stripeId),
+				eq(customers.org_id, org.id),
+				eq(customers.env, env),
+			),
+		});
+
+		return results as Customer[];
+	}
+
 	static async insert({ db, data }: { db: DrizzleCli; data: Customer }) {
 		const results = await db.insert(customers).values(data).returning();
 

--- a/server/src/internal/customers/actions/update/updateCustomer.ts
+++ b/server/src/internal/customers/actions/update/updateCustomer.ts
@@ -83,15 +83,19 @@ export const updateCustomer = async ({
 		}
 	}
 
-	// Try to update stripe ID
+	// Try to update stripe ID. Distinguish omitted (undefined -> leave as is)
+	// from explicitly cleared (null/"" -> unlink the Stripe customer).
 	let stripeId = originalCustomer.processor?.id;
 	const newStripeId = newCusData.stripe_id;
+	const clearStripeId = newStripeId === null || newStripeId === "";
 
-	if (notNullish(newStripeId) && stripeId !== newStripeId) {
+	if (clearStripeId) {
+		stripeId = undefined;
+	} else if (newStripeId && stripeId !== newStripeId) {
 		const stripeCli = createStripeCli({ org, env });
 		await stripeCli.customers.retrieve(newStripeId);
 
-		stripeId = newCusData.stripe_id;
+		stripeId = newStripeId;
 		logger.info(
 			`Updating customer's Stripe ID from ${originalCustomer.processor?.id} to ${stripeId}`,
 		);
@@ -184,8 +188,9 @@ export const updateCustomer = async ({
 	};
 
 	if (newStripeId) {
-		// Only set processor if newStripeId is provided
 		updateData.processor = { id: newStripeId, type: ProcessorType.Stripe };
+	} else if (clearStripeId) {
+		updateData.processor = null;
 	}
 
 	if (!notNullish(newCustomerId) || originalCustomer.id === newCustomerId) {

--- a/shared/api/billing/verify/verifyParamsV1.ts
+++ b/shared/api/billing/verify/verifyParamsV1.ts
@@ -174,6 +174,19 @@ export type ExpectedStateErrorMismatch = z.infer<
 	typeof ExpectedStateErrorMismatchSchema
 >;
 
+/** More than one Autumn customer points at the same Stripe customer — invoices
+ * and subscriptions from different Autumn customers collide on one Stripe account. */
+export const SharedStripeCustomerMismatchSchema = z.object({
+	type: z.literal("shared_stripe_customer"),
+	message,
+	severity,
+	stripe_customer_id: z.string(),
+	other_customer_ids: z.array(z.string()),
+});
+export type SharedStripeCustomerMismatch = z.infer<
+	typeof SharedStripeCustomerMismatchSchema
+>;
+
 export const SubscriptionMismatchSchema = z.discriminatedUnion("type", [
 	BasePriceMismatchSchema,
 	ItemMismatchSchema,
@@ -185,6 +198,7 @@ export const SubscriptionMismatchSchema = z.discriminatedUnion("type", [
 	StripeSubNotInAutumnMismatchSchema,
 	StaleSubscriptionLinkMismatchSchema,
 	ExpectedStateErrorMismatchSchema,
+	SharedStripeCustomerMismatchSchema,
 ]);
 export type SubscriptionMismatch = z.infer<typeof SubscriptionMismatchSchema>;
 
@@ -199,6 +213,8 @@ export type SubscriptionVerifyResult = z.infer<
 
 export const VerifyResponseSchema = z.object({
 	customer_id: z.string(),
+	/** Account-level findings not tied to a single subscription. */
+	customer_mismatches: z.array(SubscriptionMismatchSchema),
 	subscriptions: z.array(SubscriptionVerifyResultSchema),
 });
 export type VerifyResponse = z.infer<typeof VerifyResponseSchema>;

--- a/vite/src/views/customers/customer/components/UpdateCustomerDialog.tsx
+++ b/vite/src/views/customers/customer/components/UpdateCustomerDialog.tsx
@@ -9,7 +9,7 @@ import {
 	Input,
 	ShortcutButton,
 } from "@autumn/ui";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { CusService } from "@/services/customers/CusService";
@@ -22,6 +22,7 @@ import { CustomerConfig } from "./CustomerConfig";
 
 const UpdateCustomerDialog = ({
 	selectedCustomer,
+	open,
 	setOpen,
 }: {
 	selectedCustomer: Customer;
@@ -33,6 +34,14 @@ const UpdateCustomerDialog = ({
 	const [stripeId, setStripeId] = useState(
 		selectedCustomer.processor?.id ?? "",
 	);
+
+	// Dialog stays mounted across customer navigation, so reseed the form each open.
+	useEffect(() => {
+		if (open) {
+			setCustomer(curCustomer);
+			setStripeId(selectedCustomer.processor?.id ?? "");
+		}
+	}, [open, curCustomer, selectedCustomer]);
 
 	const [loading, setLoading] = useState(false);
 	const env = useEnv();

--- a/vite/src/views/customers2/components/verify-stripe/MismatchTable.tsx
+++ b/vite/src/views/customers2/components/verify-stripe/MismatchTable.tsx
@@ -1,0 +1,41 @@
+import type { SubscriptionMismatch } from "@autumn/shared";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { useMemo } from "react";
+import { Table } from "@/components/general/table";
+import { createVerifyMismatchColumns } from "./VerifyStripeColumns";
+
+export function MismatchTable({
+	mismatches,
+}: {
+	mismatches: SubscriptionMismatch[];
+}) {
+	const columns = useMemo(() => createVerifyMismatchColumns(), []);
+
+	const table = useReactTable({
+		data: mismatches,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		enableSorting: false,
+	});
+
+	return (
+		<div className="rounded-lg border shadow-card overflow-hidden">
+			<Table.Provider
+				config={{
+					table,
+					numberOfColumns: columns.length,
+					isLoading: false,
+					enableSorting: false,
+					flexibleTableColumns: true,
+				}}
+			>
+				<Table.Container>
+					<Table.Content className="!rounded-none !border-0 !shadow-none">
+						<Table.Header />
+						<Table.Body />
+					</Table.Content>
+				</Table.Container>
+			</Table.Provider>
+		</div>
+	);
+}

--- a/vite/src/views/customers2/components/verify-stripe/SubscriptionVerifyGroup.tsx
+++ b/vite/src/views/customers2/components/verify-stripe/SubscriptionVerifyGroup.tsx
@@ -1,9 +1,6 @@
 import type { SubscriptionVerifyResult } from "@autumn/shared";
 import { CheckCircleIcon } from "@phosphor-icons/react";
-import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
-import { useMemo } from "react";
-import { Table } from "@/components/general/table";
-import { createVerifyMismatchColumns } from "./VerifyStripeColumns";
+import { MismatchTable } from "./MismatchTable";
 import {
 	resultToDisplayStatus,
 	VerifyStripeStatusBadge,
@@ -14,15 +11,6 @@ export function SubscriptionVerifyGroup({
 }: {
 	result: SubscriptionVerifyResult;
 }) {
-	const columns = useMemo(() => createVerifyMismatchColumns(), []);
-
-	const table = useReactTable({
-		data: result.mismatches,
-		columns,
-		getCoreRowModel: getCoreRowModel(),
-		enableSorting: false,
-	});
-
 	return (
 		<div>
 			<div className="flex items-center justify-between gap-3 pb-2">
@@ -44,24 +32,7 @@ export function SubscriptionVerifyGroup({
 					Matches Autumn's expected state
 				</div>
 			) : (
-				<div className="rounded-lg border shadow-card overflow-hidden">
-					<Table.Provider
-						config={{
-							table,
-							numberOfColumns: columns.length,
-							isLoading: false,
-							enableSorting: false,
-							flexibleTableColumns: true,
-						}}
-					>
-						<Table.Container>
-							<Table.Content className="!rounded-none !border-0 !shadow-none">
-								<Table.Header />
-								<Table.Body />
-							</Table.Content>
-						</Table.Container>
-					</Table.Provider>
-				</div>
+				<MismatchTable mismatches={result.mismatches} />
 			)}
 		</div>
 	);

--- a/vite/src/views/customers2/components/verify-stripe/VerifyStripeColumns.tsx
+++ b/vite/src/views/customers2/components/verify-stripe/VerifyStripeColumns.tsx
@@ -14,51 +14,7 @@ const ISSUE_LABELS: Record<SubscriptionMismatch["type"], string> = {
 	stripe_sub_not_in_autumn: "Unlinked",
 	stale_subscription_link: "Stale link",
 	expected_state_error: "Unknown state",
-};
-
-const NO_VALUE = "–";
-
-/** Comparable expected/actual pair for the mismatch, when the type carries one. */
-const mismatchToExpectedActual = (
-	mismatch: SubscriptionMismatch,
-): { expected: string; actual: string } => {
-	switch (mismatch.type) {
-		case "item_mismatch":
-			return {
-				expected: mismatch.expected_quantity?.toString() ?? NO_VALUE,
-				actual: mismatch.actual_quantity?.toString() ?? NO_VALUE,
-			};
-		case "base_price_mismatch":
-			return {
-				expected:
-					mismatch.expected_amount ??
-					mismatch.expected_quantity?.toString() ??
-					NO_VALUE,
-				actual: mismatch.actual_amount ?? NO_VALUE,
-			};
-		case "prepaid_quantity_mismatch":
-			return {
-				expected: mismatch.expected_quantity.toString(),
-				actual: mismatch.actual_quantity.toString(),
-			};
-		case "prepaid_price_mismatch":
-			return {
-				expected: mismatch.expected_unit_amount,
-				actual: mismatch.actual_unit_amount,
-			};
-		case "schedule_mismatch":
-			return {
-				expected: mismatch.expected_phase_count?.toString() ?? NO_VALUE,
-				actual: mismatch.actual_phase_count?.toString() ?? NO_VALUE,
-			};
-		case "cancel_state_mismatch":
-			return {
-				expected: mismatch.expected_canceling ? "Canceling" : "Active",
-				actual: mismatch.actual_canceling ? "Canceling" : "Active",
-			};
-		default:
-			return { expected: NO_VALUE, actual: NO_VALUE };
-	}
+	shared_stripe_customer: "Shared customer",
 };
 
 export const createVerifyMismatchColumns = (): ColumnDef<
@@ -68,7 +24,7 @@ export const createVerifyMismatchColumns = (): ColumnDef<
 	{
 		header: "Issue",
 		id: "issue",
-		size: 130,
+		size: 90,
 		cell: ({ row }: { row: Row<SubscriptionMismatch> }) => {
 			const mismatch = row.original;
 			const isWarning = mismatch.severity === "warning";
@@ -93,26 +49,6 @@ export const createVerifyMismatchColumns = (): ColumnDef<
 		cell: ({ row }: { row: Row<SubscriptionMismatch> }) => (
 			<span className="block whitespace-normal break-words text-tertiary-foreground py-2">
 				{row.original.message}
-			</span>
-		),
-	},
-	{
-		header: "Expected",
-		id: "expected",
-		size: 90,
-		cell: ({ row }: { row: Row<SubscriptionMismatch> }) => (
-			<span className="text-tertiary-foreground tabular-nums">
-				{mismatchToExpectedActual(row.original).expected}
-			</span>
-		),
-	},
-	{
-		header: "Actual",
-		id: "actual",
-		size: 90,
-		cell: ({ row }: { row: Row<SubscriptionMismatch> }) => (
-			<span className="text-tertiary-foreground tabular-nums">
-				{mismatchToExpectedActual(row.original).actual}
 			</span>
 		),
 	},

--- a/vite/src/views/customers2/components/verify-stripe/VerifyStripeSheet.tsx
+++ b/vite/src/views/customers2/components/verify-stripe/VerifyStripeSheet.tsx
@@ -2,12 +2,13 @@ import { Button, SmallSpinner } from "@autumn/ui";
 import { SheetHeader } from "@/components/v2/sheets/SharedSheetComponents";
 import { getBackendErr } from "@/utils/genUtils";
 import { useVerifyStripeQuery } from "./hooks/useVerifyStripeQuery";
+import { MismatchTable } from "./MismatchTable";
 import { SubscriptionVerifyGroup } from "./SubscriptionVerifyGroup";
 
 export function VerifyStripeSheet() {
 	const {
 		subscriptions,
-		mismatchCount,
+		customerMismatches,
 		isLoading,
 		error,
 		refetch,
@@ -45,9 +46,23 @@ export function VerifyStripeSheet() {
 					</div>
 				)}
 
-				{!isLoading && !error && subscriptions.length === 0 && (
-					<div className="rounded-lg border border-border border-dashed px-4 py-6 text-center text-sm text-tertiary-foreground">
-						No Stripe subscriptions to verify for this customer.
+				{!isLoading &&
+					!error &&
+					subscriptions.length === 0 &&
+					customerMismatches.length === 0 && (
+						<div className="rounded-lg border border-border border-dashed px-4 py-6 text-center text-sm text-tertiary-foreground">
+							No Stripe subscriptions to verify for this customer.
+						</div>
+					)}
+
+				{!isLoading && !error && customerMismatches.length > 0 && (
+					<div>
+						<div className="flex items-center gap-3 pb-2">
+							<span className="text-xs font-medium text-tertiary-foreground">
+								Account
+							</span>
+						</div>
+						<MismatchTable mismatches={customerMismatches} />
 					</div>
 				)}
 
@@ -57,11 +72,6 @@ export function VerifyStripeSheet() {
 							{subscriptions.length}{" "}
 							{subscriptions.length === 1 ? "subscription" : "subscriptions"}{" "}
 							checked
-						</span>
-						<span className="tabular-nums">
-							{mismatchCount === 0
-								? "No drift found"
-								: `${mismatchCount} ${mismatchCount === 1 ? "issue" : "issues"} found`}
 						</span>
 					</div>
 				)}

--- a/vite/src/views/customers2/components/verify-stripe/hooks/useVerifyStripeQuery.ts
+++ b/vite/src/views/customers2/components/verify-stripe/hooks/useVerifyStripeQuery.ts
@@ -30,16 +30,24 @@ export const useVerifyStripeQuery = () => {
 	});
 
 	const subscriptions = query.data?.subscriptions ?? [];
-	const mismatchCount = subscriptions.reduce(
-		(count, subscription) => count + subscription.mismatches.length,
-		0,
-	);
-	const hasErrorMismatch = subscriptions.some((subscription) =>
-		subscription.mismatches.some((mismatch) => mismatch.severity !== "warning"),
-	);
+	const customerMismatches = query.data?.customer_mismatches ?? [];
+	const mismatchCount =
+		customerMismatches.length +
+		subscriptions.reduce(
+			(count, subscription) => count + subscription.mismatches.length,
+			0,
+		);
+	const hasErrorMismatch =
+		customerMismatches.some((mismatch) => mismatch.severity !== "warning") ||
+		subscriptions.some((subscription) =>
+			subscription.mismatches.some(
+				(mismatch) => mismatch.severity !== "warning",
+			),
+		);
 
 	return {
 		subscriptions,
+		customerMismatches,
 		mismatchCount,
 		hasErrorMismatch,
 		isLoading: query.isLoading,

--- a/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
+++ b/vite/src/views/customers2/customer/components/CustomerHeaderActions.tsx
@@ -51,7 +51,7 @@ export function CustomerHeaderActions() {
 
 	const [showObjectOpen, setShowObjectOpen] = useState(false);
 	const setSheet = useSheetStore((s) => s.setSheet);
-	const { mismatchCount, hasErrorMismatch } = useVerifyStripeQuery();
+	const { mismatchCount } = useVerifyStripeQuery();
 
 	const stripeCustomerId = customer?.processor?.id;
 	const showStripe =
@@ -109,7 +109,7 @@ export function CustomerHeaderActions() {
 						<WarningCircleIcon
 							size={14}
 							weight="fill"
-							className={hasErrorMismatch ? "text-red-500" : "text-amber-500"}
+							className="text-yellow-400"
 						/>
 					}
 					onClick={() => setSheet({ type: "verify-stripe" })}


### PR DESCRIPTION
## What

Verify now surfaces an **account-level warning** when more than one Autumn customer points at the same Stripe customer, listing the colliding customer IDs so the overlap can be untangled. Also includes two independent fixes.

## Commits

- **fix(customers): allow clearing a customer's Stripe ID** — passing `null`/`""` now unlinks the Stripe customer instead of being ignored.
- **fix(dashboard): reseed UpdateCustomerDialog form when reopened** — dialog stays mounted across customer navigation, so the name/Stripe ID fields are reset on each open.
- **feat: flag Stripe customers shared across Autumn customers** — adds `CusService.getAllByStripeId`, an `evaluateSharedStripeCustomer` check wired into verify as a warning, a `customer_mismatches` field on the verify response, and an Account section in the verify sheet. Extracts the mismatch table into `MismatchTable` and drops the unused expected/actual columns.

## Notes

- The shared-customer finding is a **warning**, not an error.
- MismatchTable extraction + header icon color are folded into the feature commit (they share hunks with the verify rework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds account-level verification warnings for Autumn customers sharing one Stripe customer, supports explicitly unlinking Stripe customers, and refreshes the customer-edit form when reopened.

- **[Improvements, API changes]** Adds shared-Stripe-customer detection, human-readable mismatch data, and an account section in the verification sheet.
- **[Bug fixes, API changes]** Allows `null` or an empty Stripe customer ID to unlink a customer.
- **[Bug fixes]** Reseeds the update dialog when opened, though the current effect can also erase edits during an open session.
- **[Improvements]** Extracts a reusable mismatch table and simplifies verification details.
</details>

<h3>Confidence Score: 4/5</h3>

The dialog state-reset behavior should be fixed before merging because routine customer-query refreshes can erase a user's unsaved edits.

The verification and unlinking changes are internally consistent, but the new form synchronization effect remains active throughout the open session and overwrites local edits whenever the live customer object refreshes.

**Files Needing Attention:** vite/src/views/customers/customer/components/UpdateCustomerDialog.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/verify/evaluate/evaluateSharedStripeCustomer.ts | Adds an organization- and environment-scoped lookup that reports other Autumn customers sharing the current Stripe customer. |
| server/src/internal/billing/v2/actions/verify/verify.ts | Evaluates and returns account-level mismatches alongside existing subscription results. |
| server/src/internal/customers/actions/update/updateCustomer.ts | Distinguishes omitted Stripe IDs from explicit unlink requests and persists a null processor. |
| shared/api/billing/verify/verifyParamsV1.ts | Adds the shared-customer mismatch type and required account-level mismatch array to the verification response. |
| vite/src/views/customers/customer/components/UpdateCustomerDialog.tsx | Reseeds values when opened, but live query updates while open can overwrite unsaved user input. |
| vite/src/views/customers2/components/verify-stripe/VerifyStripeSheet.tsx | Displays account-level mismatches separately from subscription verification results. |
| vite/src/views/customers2/components/verify-stripe/hooks/useVerifyStripeQuery.ts | Includes account-level findings in mismatch counts and error classification. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Verify Stripe UI
  participant API as billing.verify
  participant DB as Customer Store
  participant Stripe as Stripe Reader
  UI->>API: Verify Autumn customer
  API->>DB: Find same-org/environment customers by Stripe ID
  DB-->>API: Linked Autumn customers
  API->>Stripe: Read subscriptions
  Stripe-->>API: Subscription state
  API-->>UI: customer_mismatches + subscriptions
  UI->>UI: Render Account and subscription findings
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/customers/customer/components/UpdateCustomerDialog.tsx:36-42
**Open dialog resets active edits**

When the customer query refreshes while this dialog is open, the effect reseeds both form states because `curCustomer` or `selectedCustomer` changes, causing the user's unsaved name, email, Stripe ID, or configuration edits to be erased.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: flag Stripe customers shared acros..."](https://github.com/useautumn/autumn/commit/ff0382b3c470212570734e8a5dc632c56bcb4db7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52194367)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->