### PR TITLE
feat(attach): add remove_plan_ids to expire extra plans on attach

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
@@ -71,7 +71,13 @@ export const computeAttachNewCustomerProduct = ({
 		processorTypeOverride,
 	} = attachBillingContext;
 
-	const currentCustomerEntitlements = carryOverSourceCustomerProduct?.customer_entitlements ?? [];
+	// multiAttach / scheduled-activation contexts don't set the carry-over source;
+	// fall back to the same-group product so their carry-over is preserved.
+	const carryOverSource =
+		carryOverSourceCustomerProduct ?? currentCustomerProduct;
+
+	const currentCustomerEntitlements =
+		carryOverSource?.customer_entitlements ?? [];
 	const carryOverUsages = params.carry_over_usages;
 
 	// LEGACY: carry_from_previous flag on entitlements
@@ -94,25 +100,25 @@ export const computeAttachNewCustomerProduct = ({
 		: undefined;
 
 	let existingUsagesConfig: ExistingUsagesConfig | undefined =
-		!isScheduled && carryOverSourceCustomerProduct
+		!isScheduled && carryOverSource
 			? {
-					fromCustomerProduct: carryOverSourceCustomerProduct,
+					fromCustomerProduct: carryOverSource,
 					consumableFeatureIdsToCarry: featuresToCarryUsagesFor,
 				}
 			: undefined;
 
 	const existingRolloversConfig =
-		!isScheduled && carryOverSourceCustomerProduct
+		!isScheduled && carryOverSource
 			? {
-					fromCustomerProduct: carryOverSourceCustomerProduct,
+					fromCustomerProduct: carryOverSource,
 				}
 			: undefined;
 
-	if (!isScheduled && carryOverSourceCustomerProduct && carryOverUsages?.enabled) {
+	if (!isScheduled && carryOverSource && carryOverUsages?.enabled) {
 		existingUsagesConfig = carryOverUsagesToExistingUsagesConfig({
 			ctx,
 			params,
-			currentCustomerProduct: carryOverSourceCustomerProduct,
+			currentCustomerProduct: carryOverSource,
 		});
 	}
 

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
@@ -50,6 +50,7 @@ export const computeAttachNewCustomerProduct = ({
 		attachProduct,
 		fullCustomer,
 		currentCustomerProduct,
+		carryOverSourceCustomerProduct,
 		planTiming,
 		endOfCycleMs,
 		stripeSubscription,
@@ -70,8 +71,7 @@ export const computeAttachNewCustomerProduct = ({
 		processorTypeOverride,
 	} = attachBillingContext;
 
-	const currentCustomerEntitlements =
-		currentCustomerProduct?.customer_entitlements ?? [];
+	const currentCustomerEntitlements = carryOverSourceCustomerProduct?.customer_entitlements ?? [];
 	const carryOverUsages = params.carry_over_usages;
 
 	// LEGACY: carry_from_previous flag on entitlements
@@ -94,25 +94,25 @@ export const computeAttachNewCustomerProduct = ({
 		: undefined;
 
 	let existingUsagesConfig: ExistingUsagesConfig | undefined =
-		!isScheduled && currentCustomerProduct
+		!isScheduled && carryOverSourceCustomerProduct
 			? {
-					fromCustomerProduct: currentCustomerProduct,
+					fromCustomerProduct: carryOverSourceCustomerProduct,
 					consumableFeatureIdsToCarry: featuresToCarryUsagesFor,
 				}
 			: undefined;
 
 	const existingRolloversConfig =
-		!isScheduled && currentCustomerProduct
+		!isScheduled && carryOverSourceCustomerProduct
 			? {
-					fromCustomerProduct: currentCustomerProduct,
+					fromCustomerProduct: carryOverSourceCustomerProduct,
 				}
 			: undefined;
 
-	if (!isScheduled && currentCustomerProduct && carryOverUsages?.enabled) {
+	if (!isScheduled && carryOverSourceCustomerProduct && carryOverUsages?.enabled) {
 		existingUsagesConfig = carryOverUsagesToExistingUsagesConfig({
 			ctx,
 			params,
-			currentCustomerProduct,
+			currentCustomerProduct: carryOverSourceCustomerProduct,
 		});
 	}
 

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -29,6 +29,7 @@ export const computeAttachPlan = ({
 }): AutumnBillingPlan => {
 	const {
 		currentCustomerProduct,
+		carryOverSourceCustomerProduct,
 		scheduledCustomerProduct,
 		planTiming,
 		customPrices,
@@ -83,9 +84,9 @@ export const computeAttachPlan = ({
 	// expires. Skipped on scheduled transitions — the outgoing product remains
 	// active until end-of-cycle and the preservation runs at activation time.
 	const oneOffPrepaidCarryOvers =
-		planTiming === "immediate" && currentCustomerProduct
+		planTiming === "immediate" && carryOverSourceCustomerProduct
 			? cusProductToOneOffPrepaidCarryOvers({
-					currentCustomerProduct,
+					currentCustomerProduct: carryOverSourceCustomerProduct,
 					fullCustomer: attachBillingContext.fullCustomer,
 				})
 			: { entitlements: [], customerEntitlements: [] };

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -11,6 +11,7 @@ import { computeAttachPooledBalancePlan } from "@/internal/billing/v2/pooledBala
 import { cusProductToExistingBalanceCarryOvers } from "@/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers";
 import { cusProductToOneOffPrepaidCarryOvers } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
 import { computeAttachNewCustomerProduct } from "./computeAttachNewCustomerProduct";
+import { computeAttachRemovals } from "./computeAttachRemovals";
 import { computeAttachTransitionUpdates } from "./computeAttachTransitionUpdates";
 import { computeOneOffPurchaseRebalance } from "./computeOneOffPurchaseRebalance";
 import { finalizeAttachPlan } from "./finalizeAttachPlan";
@@ -46,6 +47,11 @@ export const computeAttachPlan = ({
 	});
 
 	const updateCustomerProduct = computeAttachTransitionUpdates({
+		attachBillingContext,
+		params,
+	});
+
+	const removeCustomerProducts = computeAttachRemovals({
 		attachBillingContext,
 		params,
 	});
@@ -131,6 +137,7 @@ export const computeAttachPlan = ({
 		insertCustomerProducts: [preparedNewCustomerProduct],
 		lockCustomerCurrency,
 		updateCustomerProduct,
+		updateCustomerProducts: removeCustomerProducts,
 		deleteCustomerProduct: scheduledCustomerProduct,
 		customPrices,
 		customEntitlements: [

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachRemovals.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachRemovals.ts
@@ -34,6 +34,24 @@ export const computeAttachRemovals = ({
 	);
 	if (removePlanIds.length === 0) return [];
 
+	// Carry-over reads a single source. With no same-group product to carry from,
+	// removing multiple plans is ambiguous — there is no merge rule.
+	const carryOverRequested = Boolean(
+		params.carry_over_usages?.enabled || params.carry_over_balances?.enabled,
+	);
+	if (
+		!currentCustomerProduct &&
+		carryOverRequested &&
+		removePlanIds.length > 1
+	) {
+		throw new RecaseError({
+			code: ErrCode.InvalidRequest,
+			message:
+				"Cannot carry over usage when removing multiple plans. Remove them one at a time.",
+			statusCode: 400,
+		});
+	}
+
 	return removePlanIds.map((productId) =>
 		computeRemovalUpdate({
 			productId,

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachRemovals.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachRemovals.ts
@@ -1,0 +1,105 @@
+import {
+	type AttachBillingContext,
+	type AttachParamsV1,
+	CusProductStatus,
+	type CustomerProductUpdate,
+	cp,
+	ErrCode,
+	findActiveCustomerProductById,
+	RecaseError,
+} from "@autumn/shared";
+
+/**
+ * Expires the extra plans named in `remove_plan_ids` alongside the attach.
+ * Removal flows to Stripe declaratively: the expired plans drop out of the
+ * final customer state, so this only reconciles the attach's own subscription.
+ */
+export const computeAttachRemovals = ({
+	attachBillingContext,
+	params,
+}: {
+	attachBillingContext: AttachBillingContext;
+	params: AttachParamsV1;
+}): CustomerProductUpdate[] => {
+	const {
+		fullCustomer,
+		stripeSubscription,
+		currentCustomerProduct,
+		currentEpochMs,
+	} = attachBillingContext;
+
+	// The current product is already expired via the transition update.
+	const removePlanIds = (params.remove_plan_ids ?? []).filter(
+		(productId) => productId !== currentCustomerProduct?.product.id,
+	);
+	if (removePlanIds.length === 0) return [];
+
+	return removePlanIds.map((productId) =>
+		computeRemovalUpdate({
+			productId,
+			params,
+			fullCustomer,
+			stripeSubscription,
+			currentEpochMs,
+		}),
+	);
+};
+
+const computeRemovalUpdate = ({
+	productId,
+	params,
+	fullCustomer,
+	stripeSubscription,
+	currentEpochMs,
+}: {
+	productId: string;
+	params: AttachParamsV1;
+	fullCustomer: AttachBillingContext["fullCustomer"];
+	stripeSubscription: AttachBillingContext["stripeSubscription"];
+	currentEpochMs: number;
+}): CustomerProductUpdate => {
+	if (productId === params.plan_id) {
+		throw new RecaseError({
+			code: ErrCode.InvalidRequest,
+			message: `Cannot remove plan '${productId}' in the same attach that adds it`,
+			statusCode: 400,
+		});
+	}
+
+	const customerProduct = findActiveCustomerProductById({
+		fullCus: fullCustomer,
+		productId,
+	});
+	if (!customerProduct) {
+		throw new RecaseError({
+			code: ErrCode.ProductNotFound,
+			message: `No active plan '${productId}' found on the customer to remove`,
+			statusCode: 404,
+		});
+	}
+
+	// Removal only cancels the attach's own subscription, so a plan billed on a
+	// separate subscription would be expired in Autumn but left live in Stripe.
+	const removableInThisAttach = cp(customerProduct)
+		.free()
+		.or.onStripeSubscription({
+			stripeSubscriptionId: stripeSubscription?.id ?? "",
+		}).valid;
+	if (!removableInThisAttach) {
+		throw new RecaseError({
+			code: ErrCode.InvalidRequest,
+			message: `Plan '${productId}' is billed on a separate subscription and cannot be removed in this attach`,
+			statusCode: 400,
+		});
+	}
+
+	return {
+		customerProduct,
+		updates: {
+			status: CusProductStatus.Expired,
+			ended_at: currentEpochMs,
+			canceled: true,
+			canceled_at: currentEpochMs,
+		},
+	};
+};

--- a/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts
@@ -3,6 +3,7 @@ import {
 	type AttachParamsV1,
 	type BillingContextOverride,
 	BillingVersion,
+	findActiveCustomerProductById,
 	hasActivePaidSubscription,
 	hasCustomItems,
 	isCustomerProductFree,
@@ -82,6 +83,26 @@ export const setupAttachBillingContext = async ({
 			attachProduct,
 			planScheduleOverride: params.plan_schedule,
 		});
+
+	// No same-group product to carry from? When carry-over is explicitly
+	// requested, fall back to the single plan being removed in this attach.
+	// computeAttachRemovals throws if more than one is removed.
+	const carryOverRequested = Boolean(
+		params.carry_over_usages?.enabled || params.carry_over_balances?.enabled,
+	);
+	const removedCarrySourceId = carryOverRequested
+		? (params.remove_plan_ids ?? []).find(
+				(productId) => productId !== params.plan_id,
+			)
+		: undefined;
+	const removedCarrySource = removedCarrySourceId
+		? findActiveCustomerProductById({
+				fullCus: fullCustomer,
+				productId: removedCarrySourceId,
+			})
+		: undefined;
+	const carryOverSourceCustomerProduct =
+		currentCustomerProduct ?? removedCarrySource ?? undefined;
 
 	const isAttachPaidRecurring = isProductPaidAndRecurring(attachProduct);
 
@@ -281,6 +302,7 @@ export const setupAttachBillingContext = async ({
 
 		currentCustomerProduct,
 		scheduledCustomerProduct,
+		carryOverSourceCustomerProduct,
 		canceledStripeSubscriptionId,
 
 		planTiming,

--- a/server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts
+++ b/server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts
@@ -1,7 +1,7 @@
 import {
-	addCusProductToCusEnt,
 	type AttachBillingContext,
 	type AttachParamsV1,
+	addCusProductToCusEnt,
 	type Entitlement,
 	featureUtils,
 	type InsertCustomerEntitlement,
@@ -25,15 +25,18 @@ export const cusProductToExistingBalanceCarryOvers = ({
 	entitlements: Entitlement[];
 	customerEntitlements: InsertCustomerEntitlement[];
 } => {
-	const { currentCustomerProduct, planTiming, endOfCycleMs, fullCustomer } =
-		attachBillingContext;
+	const {
+		carryOverSourceCustomerProduct,
+		planTiming,
+		endOfCycleMs,
+		fullCustomer,
+	} = attachBillingContext;
 
 	const carryOverParams = params.carry_over_balances;
 
 	if (planTiming !== "immediate")
 		return { entitlements: [], customerEntitlements: [] };
-	if (!currentCustomerProduct)
-		return { entitlements: [], customerEntitlements: [] };
+	if (!carryOverSourceCustomerProduct) return { entitlements: [], customerEntitlements: [] };
 	if (!carryOverParams?.enabled)
 		return { entitlements: [], customerEntitlements: [] };
 
@@ -45,7 +48,7 @@ export const cusProductToExistingBalanceCarryOvers = ({
 	const entitlements: Entitlement[] = [];
 	const customerEntitlements: InsertCustomerEntitlement[] = [];
 
-	for (const cusEnt of currentCustomerProduct.customer_entitlements) {
+	for (const cusEnt of carryOverSourceCustomerProduct.customer_entitlements) {
 		if (isBooleanCusEnt({ cusEnt })) continue;
 		if (isUnlimitedCusEnt(cusEnt)) continue;
 		if (featureUtils.isAllocated(cusEnt.entitlement.feature)) continue;
@@ -55,7 +58,7 @@ export const cusProductToExistingBalanceCarryOvers = ({
 		// to avoid minting a second carry-over row for the same balance.
 		const cusEntWithCusProduct = addCusProductToCusEnt({
 			cusEnt,
-			cusProduct: currentCustomerProduct,
+			cusProduct: carryOverSourceCustomerProduct,
 		});
 		if (isOneOffPrepaidConsumableCustomerEntitlement(cusEntWithCusProduct))
 			continue;
@@ -106,7 +109,7 @@ export const cusProductToExistingBalanceCarryOvers = ({
 			entitlementId: ent.id,
 			internalCustomerId: customer.internal_id,
 			customerId: customer.id,
-			internalEntityId: currentCustomerProduct.internal_entity_id ?? null,
+			internalEntityId: carryOverSourceCustomerProduct.internal_entity_id ?? null,
 			balance,
 			expiresAt,
 		});

--- a/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-cross-group.test.ts
+++ b/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-cross-group.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Carry Over Usages - Cross-Group Tests
+ *
+ * carry_over_usages carries from the single same-group product being replaced.
+ * When there is NO same-group product, but the attach expires a DIFFERENT-group
+ * plan via remove_plan_ids, that removed plan becomes the carry-over source.
+ *
+ * Key behaviors:
+ * - One removed cross-group plan → its usage carries onto the attached plan.
+ * - Two removed plans that both hold usage → ambiguous (no merge rule), so the
+ *   attach is rejected with InvalidRequest.
+ */
+
+import { test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type AttachParamsV1Input,
+	ErrCode,
+} from "@autumn/shared";
+import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Usage carries from a removed cross-group plan
+//
+// Old plan (group "legacy"): 50 messages, 40 used (balance=10)
+// Attach New plan (group "current", 200 messages) with
+//   carry_over_usages: { enabled: true } and remove_plan_ids: [old]
+// Expected: New plan active, old plan gone, balance = 160 (200 - 40), usage = 40
+// Before the fix: balance = 200 (removed plan is never a carry source cross-group)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("carry-over-usage cross-group 1: usage carries from a removed different-group plan")}`,
+	async () => {
+		const oldMessages = items.monthlyMessages({ includedUsage: 50 });
+		const newMessages = items.monthlyMessages({ includedUsage: 200 });
+
+		const oldPlan = products.base({
+			id: "old-plan",
+			group: "legacy",
+			items: [oldMessages],
+		});
+		const newPlan = products.base({
+			id: "new-plan",
+			group: "current",
+			items: [newMessages],
+		});
+
+		const { customerId, autumnV2_1, autumnV2_2, autumnV1 } = await initScenario(
+			{
+				customerId: "carry-over-usage-cross-group-1",
+				setup: [s.customer({}), s.products({ list: [oldPlan, newPlan] })],
+				actions: [s.attach({ productId: oldPlan.id, timeout: 4000 })],
+			},
+		);
+
+		// Track 40 units on the old plan (balance: 50 → 10)
+		await autumnV2_1.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 40,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		// Attach the new plan, expiring the old (different-group) plan in the same go
+		await autumnV2_2.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: newPlan.id,
+			carry_over_usages: { enabled: true },
+			remove_plan_ids: [oldPlan.id],
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2000));
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		await expectCustomerProducts({
+			customer,
+			active: [newPlan.id],
+			notPresent: [oldPlan.id],
+		});
+
+		// Balance = 200 (new allowance) - 40 (carried usage) = 160
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			balance: 160,
+			usage: 40,
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: Two carryable removed plans is ambiguous → InvalidRequest
+//
+// Two active plans in different groups, both holding usage. Attaching a third
+// plan that removes BOTH has no single carry source and no merge rule.
+// Expected: InvalidRequest.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("carry-over-usage cross-group 2: two carryable removed plans throws InvalidRequest")}`,
+	async () => {
+		const messagesA = items.monthlyMessages({ includedUsage: 50 });
+		const messagesB = items.monthlyMessages({ includedUsage: 50 });
+		const newMessages = items.monthlyMessages({ includedUsage: 200 });
+
+		const oldPlanA = products.base({
+			id: "old-plan-a",
+			group: "group-a",
+			items: [messagesA],
+		});
+		const oldPlanB = products.base({
+			id: "old-plan-b",
+			group: "group-b",
+			items: [messagesB],
+		});
+		const newPlan = products.base({
+			id: "new-plan",
+			group: "current",
+			items: [newMessages],
+		});
+
+		const { customerId, autumnV2_2 } = await initScenario({
+			customerId: "carry-over-usage-cross-group-2",
+			setup: [
+				s.customer({}),
+				s.products({ list: [oldPlanA, oldPlanB, newPlan] }),
+			],
+			actions: [
+				s.attach({ productId: oldPlanA.id, timeout: 4000 }),
+				s.attach({ productId: oldPlanB.id, timeout: 4000 }),
+			],
+		});
+
+		await expectAutumnError({
+			errCode: ErrCode.InvalidRequest,
+			func: () =>
+				autumnV2_2.billing.attach<AttachParamsV1Input>({
+					customer_id: customerId,
+					plan_id: newPlan.id,
+					carry_over_usages: { enabled: true },
+					remove_plan_ids: [oldPlanA.id, oldPlanB.id],
+				}),
+		});
+	},
+);

--- a/shared/api/billing/attachV2/attachParamsV0.ts
+++ b/shared/api/billing/attachV2/attachParamsV0.ts
@@ -70,6 +70,8 @@ export const AttachParamsV0Schema = ExtAttachParamsV0Schema.extend({
 			feature_ids: z.array(z.string()).optional(),
 		})
 		.optional(),
+
+	remove_plan_ids: z.array(z.string()).optional(),
 });
 
 export type ExtAttachParamsV0 = z.input<typeof ExtAttachParamsV0Schema>;

--- a/shared/api/billing/attachV2/attachParamsV1.ts
+++ b/shared/api/billing/attachV2/attachParamsV1.ts
@@ -105,6 +105,11 @@ export const AttachParamsV1Schema = BillingParamsBaseV1Schema.extend({
 		description:
 			"Currency to bill this attach in (e.g. usd, eur). Must match the customer's currency if they are already locked to one, and the plan must offer a paid price in it. Defaults to the customer's currency, then the org default.",
 	}),
+
+	remove_plan_ids: z.array(z.string()).optional().meta({
+		description:
+			"Plan IDs to expire on the customer as part of this attach. Each must be an active plan billed on the same subscription as the attach (or a free plan); plans on a separate subscription are rejected.",
+	}),
 });
 
 export type AttachParamsV1 = z.infer<typeof AttachParamsV1Schema>;

--- a/shared/models/billingModels/context/attachBillingContext.ts
+++ b/shared/models/billingModels/context/attachBillingContext.ts
@@ -33,6 +33,10 @@ export interface AttachBillingContext extends BillingContext {
 	currentCustomerProduct?: FullCusProduct; // To transition from
 	scheduledCustomerProduct?: FullCusProduct; // To delete
 
+	// Source for usage/balance carry-over. Same as currentCustomerProduct for
+	// in-group transitions; falls back to a removed cross-group plan otherwise.
+	carryOverSourceCustomerProduct?: FullCusProduct;
+
 	// Timing
 	planTiming: PlanTiming;
 	endOfCycleMs?: number; // Only needed if planTiming === "end_of_cycle"


### PR DESCRIPTION
## What

Adds a `remove_plan_ids` field to the attach request so callers can expire active plans **alongside** an attach, in one call.

## How

- New `computeAttachRemovals` resolves each id to its active customer product and builds an `Expired` update, fed into the plan's `updateCustomerProducts` array.
- Removal flows to Stripe **declaratively** — expired plans drop out of the final customer state, and the existing Stripe reconciliation cancels/removes them. No separate cancel wiring.
- Field added to **both** `AttachParamsV0` and `AttachParamsV1` schemas so the dashboard's V0 body carries it through the version upgrade (`...input` spread in `V1.2_AttachParamsChange`).

## Validation (throws)

- Removing the plan being attached in the same call.
- A plan that isn't active / not found on the customer.
- A plan billed on a **separate** subscription — attach only reconciles its own subscription, so this would expire in Autumn but leave Stripe live.

## Entity scoping

Removal follows the attach's own entity scope (via `findActiveCustomerProductById`): an entity-scoped attach removes that entity's plan; a customer-level attach only matches non-entity plans.

## Notes

- Scope is **single-plan attach** (`/billing.attach`). The multi-attach endpoint is intentionally not wired.
- Frontend UI is stacked in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `remove_plan_ids` to single-plan `/billing.attach` so callers can expire extra plans in the same call, with optional carry-over from a removed cross‑group plan when there’s no same‑group source. Also fixes carry-over for multiAttach and scheduled activations by falling back to the current plan when a carry-over source isn’t set.

- **New Features**
  - Added `remove_plan_ids` to `AttachParamsV0` and `AttachParamsV1`.
  - Implemented `computeAttachRemovals` to emit Expired updates; Stripe cancels via existing reconciliation. Removals respect entity scope and must be on the same subscription.
  - Carry-over (usage/balances) prefers a same‑group product; if none exists, uses a single removed plan as the source. Fallbacks ensure carry-over also works for multiAttach and scheduled activations.

- **Validation**
  - Reject removing the plan being attached.
  - Reject plans that aren’t active/found or are billed on a different subscription.
  - Reject carry-over when multiple plans are removed (ambiguous source).

<sup>Written for commit 70b34ee03e79d8e64769d7f6a161dc7dbf2057a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds support for expiring extra plans during a single-plan attach and extends carry-over behavior to use a removed cross-group plan when needed.
- **[API changes]** Adds optional `remove_plan_ids` fields to both attach request versions.
- **[Improvements]** Resolves and validates requested removals, then includes their expiration in the attach billing plan.
- **[Bug fixes, Improvements]** Uses an explicit carry-over source so usage and balances can transfer from a removed cross-group plan and remain supported in scheduled or multi-attach contexts.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because skipped-billing attaches can revoke a plan in Autumn while leaving its Stripe subscription item active.

Removal updates are always executed against Autumn state, while `no_billing_changes` and `processor_subscription_id` bypass the Stripe reconciliation needed to remove the corresponding billed item.

**Files Needing Attention:** server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts, server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/compute/computeAttachRemovals.ts | Adds active-plan resolution, subscription-affinity validation, and expiration updates for requested removals. |
| server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts | Adds removal updates to the attach plan, but those local updates remain active when Stripe billing execution is skipped. |
| server/src/internal/billing/v2/actions/attach/setup/setupAttachBillingContext.ts | Selects the carry-over source and retains skip-billing modes that currently conflict with removal reconciliation. |
| server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts | Uses the selected carry-over source when constructing usage and rollover state for the new customer product. |
| server/src/internal/billing/v2/utils/handleCarryOvers/cusProductToExistingBalanceCarryOvers.ts | Transfers eligible balances from the selected carry-over source instead of requiring a same-group transition product. |
| shared/api/billing/attachV2/attachParamsV0.ts | Exposes `remove_plan_ids` through the legacy attach request schema. |
| shared/api/billing/attachV2/attachParamsV1.ts | Adds and documents `remove_plan_ids` on the current attach API contract. |

<sub>Reviews (4): Last reviewed commit: ["fix(attach): preserve carry-over source ..."](https://github.com/useautumn/autumn/commit/70b34ee03e79d8e64769d7f6a161dc7dbf2057a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52240864)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->