### PR TITLE
feat(attach-sheet): remove-plans UI in the attach form

### DIFF
--- a/vite/src/components/forms/attach-v2/attachFormSchema.ts
+++ b/vite/src/components/forms/attach-v2/attachFormSchema.ts
@@ -40,6 +40,7 @@ export const EMPTY_ADDITIONAL_PLAN: Omit<AttachAdditionalPlan, "_id"> = {
 export const AttachFormSchema = z.object({
 	productId: z.string(),
 	additionalPlans: z.array(AttachAdditionalPlanSchema),
+	removePlanIds: z.array(z.string()),
 	prepaidOptions: z.record(z.string(), z.number().nonnegative().optional()),
 	licenseQuantities: z.record(z.string(), z.number().nonnegative().optional()),
 	items: z.custom<ProductItem[]>().nullable(),

--- a/vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx
@@ -1,10 +1,13 @@
-import { InlineAction } from "@autumn/ui";
-import { PlusIcon } from "@phosphor-icons/react";
+import { isProductCurrentlyAttached } from "@autumn/shared";
+import { IconButton, InlineAction, SearchableSelect } from "@autumn/ui";
+import { MinusIcon, PlusIcon, XIcon } from "@phosphor-icons/react";
+import { useState } from "react";
 import {
 	type PlanRowScope,
 	ScopedPlanRow,
 	SelectedPlanRow,
 } from "@/components/forms/shared";
+import { getProductGroupKey } from "@/components/forms/shared/utils/planGroupUtils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
 import { getAttachDisplayItems } from "../utils/grantFreeUtils";
 import { AttachAdditionalPlanRow } from "./AttachAdditionalPlanRow";
@@ -22,13 +25,73 @@ export function AttachProductSelection({
 		entityId,
 		product,
 		products,
+		customer,
 		additionalPlans,
 		handleEditPlan,
 	} = useAttachFormContext();
-	const { productId, additionalPlans: additionalPlanValues } = formValues;
+	const {
+		productId,
+		additionalPlans: additionalPlanValues,
+		removePlanIds,
+	} = formValues;
 	const { isMultiPlan, canAddPlan, getProductOptionState, handleAddPlan } =
 		additionalPlans;
 	const availableProducts = products.filter((product) => !product.archived);
+
+	const [isRemovingPlan, setIsRemovingPlan] = useState(false);
+	const removableProducts = customer
+		? availableProducts.filter((candidate) =>
+				isProductCurrentlyAttached({
+					productId: candidate.id,
+					customer,
+					entityId,
+				}),
+			)
+		: [];
+	// Removal follows the attach's own entity scope, so it's single-plan only.
+	const canRemovePlan =
+		!isMultiPlan &&
+		!!productId &&
+		!isRemovingPlan &&
+		removableProducts.length > 0;
+	// Add and remove are mutually exclusive: starting one hides the other.
+	const isAddingPlan = additionalPlanValues.some((plan) => !plan.productId);
+	const showAddAction = canAddPlan && !isRemovingPlan;
+	const showRemoveAction = canRemovePlan && !isAddingPlan;
+
+	// A plan in the attach product's group is already expired by the transition.
+	const attachGroupKey = productId
+		? getProductGroupKey({ productId, products })
+		: undefined;
+	const removeOptions = removableProducts.map((candidate) => {
+		const candidateGroupKey = getProductGroupKey({
+			productId: candidate.id,
+			products,
+		});
+		let disabledValue: string | undefined;
+		if (candidate.id === productId) {
+			disabledValue = "Being added";
+		} else if (
+			attachGroupKey !== undefined &&
+			candidateGroupKey === attachGroupKey
+		) {
+			disabledValue = "Being replaced";
+		} else if (removePlanIds.includes(candidate.id)) {
+			disabledValue = "Already removing";
+		}
+		return { product: candidate, disabledValue };
+	});
+
+	const handleSelectRemovePlan = (planId: string) => {
+		if (removePlanIds.includes(planId)) return;
+		form.setFieldValue("removePlanIds", [...removePlanIds, planId]);
+	};
+	const handleUndoRemovePlan = (planId: string) => {
+		form.setFieldValue(
+			"removePlanIds",
+			removePlanIds.filter((id) => id !== planId),
+		);
+	};
 	const displayedPrimaryItems = getAttachDisplayItems({
 		items: formValues.items,
 		productItems: product?.items,
@@ -92,10 +155,74 @@ export function AttachProductSelection({
 				<AttachAdditionalPlanRow key={plan._id} plan={plan} />
 			))}
 
-			{canAddPlan && (
-				<InlineAction icon={<PlusIcon size={11} />} onClick={handleAddPlan}>
-					Add another product
-				</InlineAction>
+			{removePlanIds.map((planId) => (
+				<SelectedPlanRow
+					key={planId}
+					productId={planId}
+					product={products.find((candidate) => candidate.id === planId)}
+					price={<span className="text-xs text-destructive">Removing</span>}
+					onRemove={() => handleUndoRemovePlan(planId)}
+				/>
+			))}
+
+			{isRemovingPlan && (
+				<div className="flex items-center gap-2">
+					<SearchableSelect
+						value={null}
+						onValueChange={(planId) => {
+							handleSelectRemovePlan(planId);
+							setIsRemovingPlan(false);
+						}}
+						options={removeOptions}
+						getOptionValue={({ product: candidate }) => candidate.id}
+						getOptionLabel={({ product: candidate }) => candidate.name}
+						getOptionDisabled={({ disabledValue }) => !!disabledValue}
+						renderOption={({ product: candidate, disabledValue }) => (
+							<>
+								<span className="min-w-0 flex-1 truncate">
+									{candidate.name}
+								</span>
+								{disabledValue && (
+									<span className="shrink-0 text-xs text-subtle">
+										{disabledValue}
+									</span>
+								)}
+							</>
+						)}
+						placeholder="Remove a product..."
+						searchable
+						searchPlaceholder="Search plans..."
+						emptyText="No plans to remove"
+						defaultOpen
+					/>
+					<IconButton
+						type="button"
+						variant="muted"
+						size="sm"
+						className="size-6 shrink-0 text-tertiary-foreground hover:text-destructive"
+						onClick={() => setIsRemovingPlan(false)}
+						aria-label="Cancel removing product"
+						icon={<XIcon size={13} />}
+					/>
+				</div>
+			)}
+
+			{(showAddAction || showRemoveAction) && (
+				<div className="flex items-center gap-4">
+					{showAddAction && (
+						<InlineAction icon={<PlusIcon size={11} />} onClick={handleAddPlan}>
+							Add another product
+						</InlineAction>
+					)}
+					{showRemoveAction && (
+						<InlineAction
+							icon={<MinusIcon size={11} />}
+							onClick={() => setIsRemovingPlan(true)}
+						>
+							Remove a product
+						</InlineAction>
+					)}
+				</div>
 			)}
 		</div>
 	);

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -456,6 +456,7 @@ export function AttachFormProvider({
 		customLineItems,
 		disableProration,
 		currency: attachCurrency.requestCurrency,
+		removePlanIds: formValues.removePlanIds,
 	});
 	const {
 		requestBody: multiRequestBody,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachForm.ts
@@ -20,6 +20,7 @@ export function useAttachForm({
 		defaultValues: {
 			productId: initialProductId || "",
 			additionalPlans: [],
+			removePlanIds: [],
 			prepaidOptions: initialPrepaidOptions ?? {},
 			licenseQuantities: {},
 			items: initialItems ?? null,

--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -56,6 +56,7 @@ export interface BuildAttachRequestBodyParams {
 	customLineItems: FormCustomLineItem[];
 	disableProration: boolean;
 	currency: string | null;
+	removePlanIds: string[];
 }
 
 /** Pure function to build the attach request body. Extracted for testability. */
@@ -91,6 +92,7 @@ export function buildAttachRequestBody({
 	customLineItems,
 	disableProration,
 	currency,
+	removePlanIds,
 }: BuildAttachRequestBodyParams): AttachParamsV0 | null {
 	if (!customerId || !product) {
 		return null;
@@ -232,6 +234,10 @@ export function buildAttachRequestBody({
 		}));
 	}
 
+	if (removePlanIds.length > 0) {
+		body.remove_plan_ids = removePlanIds;
+	}
+
 	return body as AttachParamsV0;
 }
 
@@ -268,6 +274,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 		customLineItems,
 		disableProration,
 		currency,
+		removePlanIds,
 	} = params;
 
 	const requestBody = useMemo(
@@ -304,6 +311,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 				customLineItems,
 				disableProration,
 				currency,
+				removePlanIds,
 			}),
 		[
 			customerId,
@@ -337,6 +345,7 @@ export function useAttachRequestBody(params: BuildAttachRequestBodyParams) {
 			customLineItems,
 			disableProration,
 			currency,
+			removePlanIds,
 		],
 	);
 


### PR DESCRIPTION
Stacked on #2735 (backend). Review/merge that first.

## What

Adds a **Remove a product** action to the attach sheet, next to **Add another product**, for single-plan attaches.

## Behavior

- Opens a dropdown (auto-open, with an X to cancel) of the customer's **active plans on the current entity scope**; picking one queues it and closes the picker.
- Sends `remove_plan_ids` on the single-attach request body.
- **Group-conflict greying:** plans already being expired by the attach are disabled with "Being replaced" (shared `getProductGroupKey`, same pattern as create-schedule). Already-queued → "Already removing"; the plan being added → "Being added".
- **Add / remove are mutually exclusive** — starting one hides the other.
- Hidden until a primary plan is selected (mirrors "Add another product").
- Queued rows show **"Removing"** in place of the price.

## Notes

- No new component files — reuses `SearchableSelect`, `SelectedPlanRow`, `InlineAction`, `IconButton`.
- Single-plan only; the multi-attach path is intentionally out of scope (matches the backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Remove a product” action to the attach form for single-plan attaches. Users can queue active plans for removal and we send `remove_plan_ids` on submit; queued removals show inline.

- **New Features**
  - Auto-open dropdown of the customer’s active plans in the current entity; cancel with an `X`. Disabled states: “Being replaced”, “Already removing”, “Being added”.
  - Add/remove are mutually exclusive; remove appears only after a primary plan is chosen. Queued removals render as rows with “Removing” and can be undone.
  - Form schema, provider, and request builder support `removePlanIds` and include `remove_plan_ids` in the attach request.

<sup>Written for commit f07d435af863e82131239f6451f9eab96e6a12d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a single-plan attach workflow for selecting active products to remove and includes those selections in the attach request.
- **[Improvements]** Adds an inline removal picker, disabled-state explanations, cancellation, and removable queued rows.
- **[API changes]** Adds `removePlanIds` to the form state and sends it as `remove_plan_ids` for single-plan attach requests.
</details>

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because archived active products cannot be selected for removal and queued removals can survive an entity-scope change.

An archived active product is filtered out before the removal options are built, while removal IDs are retained and submitted unchanged after the form's entity scope changes; both previously reported failures remain in the current code.

**Files Needing Attention:** vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx, vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx, vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/components/AttachProductSelection.tsx | Adds the removal picker, conflict states, queued removal rows, and add/remove mutual exclusion. |
| vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx | Connects removal selections from form state to the single-attach request builder. |
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Adds `remove_plan_ids` to non-empty single-attach request bodies. |
| vite/src/components/forms/attach-v2/attachFormSchema.ts | Extends the validated form shape with an array of product IDs selected for removal. |
| vite/src/components/forms/attach-v2/hooks/useAttachForm.ts | Initializes the removal selection to an empty array. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    actor User
    participant Form as Attach form
    participant Picker as Removal picker
    participant Builder as Request builder
    participant API as Attach API
    User->>Form: Select primary product
    User->>Picker: Choose attached product to remove
    Picker->>Form: Append product ID to removePlanIds
    User->>Form: Submit attach
    Form->>Builder: Build request from form values
    Builder->>API: Attach request with remove_plan_ids
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(attach-sheet): add remove-plans UI ..."](https://github.com/useautumn/autumn/commit/f07d435af863e82131239f6451f9eab96e6a12d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52241289)</sub>

<!-- /greptile_comment -->