### PR TITLE
Retry Redis standby after late timeout

### DIFF
--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -107,8 +107,8 @@ export const runRedisOp = async <T>({
 	/** Select the least-busy read lane. Requires `retryOnStandby` so only
 	 *  operations already declared idempotent can enter the pool. */
 	useReadPool?: boolean;
-	/** Opt-in bound, tighter than the client's `commandTimeout`. Reads only —
-	 *  the race abandons the promise but the command still reaches Redis. */
+	/** Opt-in planned budget, tighter than the client's `commandTimeout`. Reads
+	 *  only — the race abandons the promise but the command still reaches Redis. */
 	timeoutMs?: number;
 }): Promise<T> => {
 	const readLaneLease =
@@ -125,8 +125,8 @@ export const runRedisOp = async <T>({
 			throw new RedisUnavailableError({ source, reason });
 		}
 
-		// One budget for the whole op, not one per attempt: a retry must not double
-		// the ceiling the caller sized against its non-Redis fallback.
+		// Plan one budget for the whole op, not one per attempt: a retry must not
+		// double the ceiling the caller sized against its non-Redis fallback.
 		const deadlineAt = timeoutMs ? Date.now() + timeoutMs : undefined;
 		const runAttempt = (redis: Redis, budgetMs?: number) => {
 			const attempt = operation(redis);
@@ -152,6 +152,10 @@ export const runRedisOp = async <T>({
 			const preferredAttemptBudgetMs = router.isUsable(alternate)
 				? getPreferredAttemptBudgetMs({ timeoutMs })
 				: timeoutMs;
+			const reservedRetryBudgetMs =
+				timeoutMs !== undefined && preferredAttemptBudgetMs !== undefined
+					? timeoutMs - preferredAttemptBudgetMs
+					: 0;
 
 			try {
 				const value = await runAttempt(preferred, preferredAttemptBudgetMs);
@@ -161,14 +165,20 @@ export const runRedisOp = async <T>({
 				router.recordOutcome({ connection: preferred, error: firstError });
 
 				const remainingMs = deadlineAt ? deadlineAt - Date.now() : undefined;
+				// A delayed timeout callback must not consume the budget deliberately
+				// reserved for the alternate connection.
+				const retryBudgetMs =
+					remainingMs === undefined
+						? undefined
+						: Math.max(remainingMs, reservedRetryBudgetMs);
 				const canRetry =
 					alternate.status === "ready" &&
 					isConnectionLevelRedisError({ error: firstError }) &&
-					(remainingMs === undefined || remainingMs >= MIN_RETRY_BUDGET_MS);
+					(retryBudgetMs === undefined || retryBudgetMs >= MIN_RETRY_BUDGET_MS);
 				if (!canRetry) throw firstError;
 
 				try {
-					const value = await runAttempt(alternate, remainingMs);
+					const value = await runAttempt(alternate, retryBudgetMs);
 					router.recordOutcome({ connection: alternate });
 					logger.info(
 						{ source, type: "redis_standby_failover" },

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -464,6 +464,61 @@ describe("runRedisOp standby failover", () => {
 		expect(Date.now() - startedAt).toBeLessThan(390);
 	});
 
+	test("uses the reserved retry budget when timeout delivery is late", async () => {
+		const { primary, standby, redis } = createPair();
+		const startedAt = Date.now();
+		primary.get = async (key) => {
+			primary.calls.push(`get:${key}`);
+			setSystemTime(new Date(startedAt + 500));
+			throw new Error("[redis] standby-test timeout after 300ms");
+		};
+
+		try {
+			const result = await runRedisOp({
+				redisInstance: redis,
+				source: "standby-test",
+				retryOnStandby: true,
+				timeoutMs: 400,
+				operation: (connection) => connection.get("subject"),
+			});
+
+			expect(result).toBe("standby");
+			expect(primary.calls).toEqual(["get:subject"]);
+			expect(standby.calls).toEqual(["get:subject"]);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("bounds a late standby retry to the reserved budget", async () => {
+		const { primary, standby, redis } = createPair();
+		const startedAt = Date.now();
+		primary.get = async (key) => {
+			primary.calls.push(`get:${key}`);
+			setSystemTime(new Date(startedAt + 500));
+			throw new Error("[redis] standby-test timeout after 300ms");
+		};
+		standby.hangGetForMs = 5_000;
+		const attemptStartedAt = performance.now();
+
+		try {
+			await expect(
+				runRedisOp({
+					redisInstance: redis,
+					source: "standby-test",
+					retryOnStandby: true,
+					timeoutMs: 400,
+					operation: (connection) => connection.get("subject"),
+				}),
+			).rejects.toBeInstanceOf(RedisUnavailableError);
+
+			expect(standby.calls).toEqual(["get:subject"]);
+			expect(performance.now() - attemptStartedAt).toBeLessThan(250);
+		} finally {
+			setSystemTime();
+		}
+	});
+
 	// The reserve has to fit inside the headroom each deadline was sized with,
 	// not eat into the tail it was sized to cover. Feature balances measure a
 	// p99.9 of 297ms, so the preferred attempt must stay clear of that.


### PR DESCRIPTION
## Summary

- preserve the standby retry budget when Bun delivers the preferred Redis timeout callback after the operation deadline
- keep the alternate attempt capped to the original reserve
- add regression coverage for both successful recovery and a slow standby

## Why

During event-loop stalls, the preferred read can time out but its callback can run after the overall deadline. The existing remaining-budget check then becomes negative and skips the ready standby entirely, even though the preferred attempt was deliberately shortened to reserve time for it.

This restores only that reserved budget. Healthy reads remain single-shot, writes remain ineligible, connection-level errors are still required, and the alternate must still be ready.

## Testing

- `UNIT_TESTS=1 UNIT_TEST_FILES=tests/unit/redis/standby-redis-routing.test.ts bun test tests/unit/redis/standby-redis-routing.test.ts` — 46 passed
- `bun test tests/unit/utils/with-timeout.test.ts` — 2 passed
- `bun ts` — passed
- scoped Biome check — passed
- commit hooks: Knip and server typecheck — passed
- full `bun test:unit` attempted: 2,575 passed; 17 unrelated local-infrastructure/real-cluster tests failed with unavailable Postgres/Redis and cluster runtime

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes standby failover when the preferred Redis timeout callback arrives after the deadline. Preserves the reserved retry budget so we can still retry on standby within the planned time.

- **Bug Fixes**
  - Preserve the reserved retry budget when `timeoutMs` delivery is late (event-loop stalls).
  - Cap the standby attempt to the reserved share of the original budget, not the negative/remaining time.
  - Keep existing guards: reads only, `retryOnStandby` ops, connection-level errors, standby must be ready.
  - Add regression tests for successful recovery and a slow standby path.

<sup>Written for commit 21a6515f5a2ef48295b91122ba64066fe7d0f5fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores the Redis standby retry reserve when the preferred read’s timeout callback runs after the planned deadline, while keeping the alternate attempt bounded.

- **Bug fixes:** Retry an eligible, connection-level failed Redis read on a ready standby using the originally reserved time.
- **Improvements:** Add regression coverage for successful late-timeout recovery and for bounding a slow standby attempt.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The retry remains limited to eligible reads, connection-level failures, and ready standby connections, while the added tests cover both recovery and bounded failure behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/utils/runRedisOp.ts | Restores the precomputed standby reserve after delayed timeout delivery while preserving readiness, error-classification, and retry-budget guards. |
| server/tests/unit/redis/standby-redis-routing.test.ts | Adds focused regression tests proving successful late-timeout failover and bounding a slow standby to the reserved budget. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Preferred as Preferred Redis
  participant Router as Retry Router
  participant Standby as Standby Redis
  Caller->>Preferred: Read with shortened preferred budget
  Preferred-->>Router: Timeout callback delivered late
  Router->>Router: Restore reserved retry budget
  Router->>Standby: Retry eligible read within reserve
  Standby-->>Caller: Value or bounded timeout error
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Retry Redis standby after late timeout"](https://github.com/useautumn/autumn/commit/21a6515f5a2ef48295b91122ba64066fe7d0f5fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52244917)</sub>

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->