### PR TITLE
Release 11/08/2026

### DIFF
--- a/server/src/external/redis/utils/runRedisOp.ts
+++ b/server/src/external/redis/utils/runRedisOp.ts
@@ -107,8 +107,8 @@ export const runRedisOp = async <T>({
 	/** Select the least-busy read lane. Requires `retryOnStandby` so only
 	 *  operations already declared idempotent can enter the pool. */
 	useReadPool?: boolean;
-	/** Opt-in bound, tighter than the client's `commandTimeout`. Reads only —
-	 *  the race abandons the promise but the command still reaches Redis. */
+	/** Opt-in planned budget, tighter than the client's `commandTimeout`. Reads
+	 *  only — the race abandons the promise but the command still reaches Redis. */
 	timeoutMs?: number;
 }): Promise<T> => {
 	const readLaneLease =
@@ -125,8 +125,8 @@ export const runRedisOp = async <T>({
 			throw new RedisUnavailableError({ source, reason });
 		}
 
-		// One budget for the whole op, not one per attempt: a retry must not double
-		// the ceiling the caller sized against its non-Redis fallback.
+		// Plan one budget for the whole op, not one per attempt: a retry must not
+		// double the ceiling the caller sized against its non-Redis fallback.
 		const deadlineAt = timeoutMs ? Date.now() + timeoutMs : undefined;
 		const runAttempt = (redis: Redis, budgetMs?: number) => {
 			const attempt = operation(redis);
@@ -152,6 +152,10 @@ export const runRedisOp = async <T>({
 			const preferredAttemptBudgetMs = router.isUsable(alternate)
 				? getPreferredAttemptBudgetMs({ timeoutMs })
 				: timeoutMs;
+			const reservedRetryBudgetMs =
+				timeoutMs !== undefined && preferredAttemptBudgetMs !== undefined
+					? timeoutMs - preferredAttemptBudgetMs
+					: 0;
 
 			try {
 				const value = await runAttempt(preferred, preferredAttemptBudgetMs);
@@ -161,14 +165,20 @@ export const runRedisOp = async <T>({
 				router.recordOutcome({ connection: preferred, error: firstError });
 
 				const remainingMs = deadlineAt ? deadlineAt - Date.now() : undefined;
+				// A delayed timeout callback must not consume the budget deliberately
+				// reserved for the alternate connection.
+				const retryBudgetMs =
+					remainingMs === undefined
+						? undefined
+						: Math.max(remainingMs, reservedRetryBudgetMs);
 				const canRetry =
 					alternate.status === "ready" &&
 					isConnectionLevelRedisError({ error: firstError }) &&
-					(remainingMs === undefined || remainingMs >= MIN_RETRY_BUDGET_MS);
+					(retryBudgetMs === undefined || retryBudgetMs >= MIN_RETRY_BUDGET_MS);
 				if (!canRetry) throw firstError;
 
 				try {
-					const value = await runAttempt(alternate, remainingMs);
+					const value = await runAttempt(alternate, retryBudgetMs);
 					router.recordOutcome({ connection: alternate });
 					logger.info(
 						{ source, type: "redis_standby_failover" },

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -171,6 +171,7 @@ export const startPollingLoop = async ({
 	shouldPoll = () => true,
 	visibilityTimeoutSeconds = 30,
 	receiveTimeoutMs = SQS_RECEIVE_TIMEOUT_MS,
+	maxMessagesBeforeRecycle = MAX_MESSAGES_BEFORE_RECYCLE,
 	workerActivity = createWorkerActivityTracker({
 		idleAfterMs: IDLE_SELF_KILL_MS,
 	}),
@@ -187,6 +188,7 @@ export const startPollingLoop = async ({
 	 * rows concurrently. */
 	visibilityTimeoutSeconds?: number;
 	receiveTimeoutMs?: number;
+	maxMessagesBeforeRecycle?: number;
 	workerActivity?: WorkerActivityTracker;
 }) => {
 	// Per-loop state
@@ -221,7 +223,7 @@ export const startPollingLoop = async ({
 	};
 
 	const recycleWorkerIfNeeded = () => {
-		if (totalMessagesProcessed < MAX_MESSAGES_BEFORE_RECYCLE) {
+		if (totalMessagesProcessed < maxMessagesBeforeRecycle) {
 			return;
 		}
 

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -603,8 +603,6 @@ export const initWorkers = async ({
 }) => {
 	const { db } = initDrizzle({ name: "worker", maxConnections: 40 });
 	startPgPoolMonitor();
-	const { warmupRegionalRedis } = await import("@/external/redis/initRedis.js");
-	await warmupRegionalRedis();
 
 	await initBlueGreen({ db, logger });
 

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -4,6 +4,7 @@ import { getAutumnEnv } from "@autumn/env";
 
 import { initInfisical } from "./external/infisical/initInfisical.js";
 import { logger } from "./external/logtail/logtailUtils.js";
+import { awaitBoundedWarmup } from "./external/redis/initUtils/boundedWarmup.js";
 import {
 	startAllEdgeConfigPolling,
 	stopAllEdgeConfigPolling,
@@ -114,25 +115,34 @@ if (cluster.isPrimary) {
 	);
 	const { primeRedisV2Monitor, startRedisV2Monitor, stopRedisV2Monitor } =
 		await import("./external/redis/availabilityMonitor/redisV2Availability.js");
-	const { startRedisMonitor, stopRedisMonitor } = await import(
-		"./external/redis/initRedis.js"
-	);
+	const { startRedisMonitor, stopRedisMonitor, warmupRegionalRedis } =
+		await import("./external/redis/initRedis.js");
 	const { preWarmOrgRedisConnections } = await import(
 		"./external/redis/orgRedisPool.js"
 	);
+
+	const redisWarmup = Promise.all([
+		warmupRegionalRedis(),
+		preWarmOrgRedisConnections({ db }).catch((error) => {
+			logger.warn("[OrgRedis] Warmup failed", { error });
+		}),
+	]);
+	void redisWarmup.catch(() => {});
 
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);
 	startRedisMonitor();
 	startRedisV2Monitor();
 
-	void preWarmOrgRedisConnections({ db }).catch((error) => {
-		logger.warn("[OrgRedis] Warmup failed", { error });
-	});
-
 	process.once("exit", () => {
 		stopAllEdgeConfigPolling();
 		stopRedisMonitor();
 		stopRedisV2Monitor();
+	});
+
+	await awaitBoundedWarmup({
+		warmup: redisWarmup,
+		timeoutMs: 10_000,
+		log: (message) => logger.warn(message),
 	});
 
 	const { initWorkers } = await import("./queue/initWorkers.js");

--- a/server/src/workers.ts
+++ b/server/src/workers.ts
@@ -121,8 +121,12 @@ if (cluster.isPrimary) {
 		"./external/redis/orgRedisPool.js"
 	);
 
+	// Each arm catches its own failure: a regional rejection must not
+	// short-circuit the wait for healthy dedicated org connections.
 	const redisWarmup = Promise.all([
-		warmupRegionalRedis(),
+		warmupRegionalRedis().catch((error) => {
+			console.error("[Redis] regional warmup failed -", error);
+		}),
 		preWarmOrgRedisConnections({ db }).catch((error) => {
 			logger.warn("[OrgRedis] Warmup failed", { error });
 		}),

--- a/server/tests/unit/queue/fixtures/recycle-polling-worker.ts
+++ b/server/tests/unit/queue/fixtures/recycle-polling-worker.ts
@@ -1,0 +1,62 @@
+import { mock } from "bun:test";
+import {
+	DeleteMessageBatchCommand,
+	ReceiveMessageCommand,
+} from "@aws-sdk/client-sqs";
+
+mock.module("@/queue/processMessage.js", () => ({
+	processMessage: async () => {},
+}));
+mock.module(
+	"@/external/redis/actions/queueCapacityLease/queueCapacityLease.js",
+	() => ({
+		reserveQueueCapacity: async () => ({
+			capacity: 10,
+			isLimited: false,
+			assign: async (messages: unknown[]) =>
+				messages.map((item) => ({ item, release: async () => {} })),
+			release: async () => {},
+		}),
+	}),
+);
+
+const { startPollingLoop } = await import("@/queue/initWorkers.js");
+
+const messages = ["message-1", "message-2"].map((messageId) => ({
+	MessageId: messageId,
+	ReceiptHandle: `receipt-${messageId}`,
+	Body: JSON.stringify({ name: "recycle-test", data: {} }),
+}));
+
+let receiveCalls = 0;
+const sqs = {
+	send: async (command: unknown) => {
+		if (command instanceof ReceiveMessageCommand) {
+			receiveCalls++;
+			if (receiveCalls === 1) return { Messages: messages };
+			return new Promise(() => {});
+		}
+
+		if (command instanceof DeleteMessageBatchCommand) {
+			console.log(`DELETE_BATCH ${command.input.Entries?.length ?? 0}`);
+			return {
+				Successful: command.input.Entries?.map((entry) => ({ Id: entry.Id })),
+			};
+		}
+
+		throw new Error("Unexpected SQS command");
+	},
+};
+
+const pollingOptions = {
+	db: {} as never,
+	queueId: "primary",
+	queueUrl: "https://sqs.test/primary.fifo",
+	isFifo: true,
+	getSqsClientFn: () => sqs as never,
+	recreateSqsClientFn: () => sqs as never,
+	shouldPoll: () => true,
+	maxMessagesBeforeRecycle: 2,
+};
+
+await startPollingLoop(pollingOptions);

--- a/server/tests/unit/queue/queue-worker-recycle.test.ts
+++ b/server/tests/unit/queue/queue-worker-recycle.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+
+const FIXTURE_PATH = new URL(
+	"./fixtures/recycle-polling-worker.ts",
+	import.meta.url,
+).pathname;
+
+const waitForNaturalExit = async ({
+	child,
+	timeoutMs,
+}: {
+	child: ReturnType<typeof spawn>;
+	timeoutMs: number;
+}): Promise<boolean> => {
+	if (child.exitCode !== null || child.signalCode !== null) return true;
+
+	return await new Promise((resolve) => {
+		const timeout = setTimeout(() => resolve(false), timeoutMs);
+		child.once("exit", () => {
+			clearTimeout(timeout);
+			resolve(true);
+		});
+	});
+};
+
+// Queue workers previously had no process-level proof that their 50k threshold
+// ACKs the triggering batch before exiting for a cluster replacement.
+describe("SQS queue worker recycling", () => {
+	test("acknowledges the threshold batch before the worker exits", async () => {
+		const child = spawn("bun", [FIXTURE_PATH], {
+			cwd: process.cwd(),
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout?.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+
+		const exitedNaturally = await waitForNaturalExit({
+			child,
+			timeoutMs: 2_500,
+		});
+		if (!exitedNaturally) {
+			child.kill("SIGKILL");
+			await new Promise((resolve) => child.once("exit", resolve));
+		}
+
+		expect(exitedNaturally, stderr).toBe(true);
+		expect(child.exitCode).toBe(0);
+
+		const deleteIndex = stdout.indexOf("DELETE_BATCH 2");
+		const recycleIndex = stdout.indexOf("Recycling after 2 messages");
+		expect(deleteIndex).toBeGreaterThanOrEqual(0);
+		expect(recycleIndex).toBeGreaterThan(deleteIndex);
+	});
+});

--- a/server/tests/unit/queue/queue-worker-recycle.test.ts
+++ b/server/tests/unit/queue/queue-worker-recycle.test.ts
@@ -41,9 +41,11 @@ describe("SQS queue worker recycling", () => {
 			stderr += chunk.toString();
 		});
 
+		// Generous: a cold-cache CI bun boot alone can take seconds; the wait
+		// resolves on exit, so healthy runs never pay the full bound.
 		const exitedNaturally = await waitForNaturalExit({
 			child,
-			timeoutMs: 2_500,
+			timeoutMs: 15_000,
 		});
 		if (!exitedNaturally) {
 			child.kill("SIGKILL");

--- a/server/tests/unit/queue/worker-redis-startup-gate.test.ts
+++ b/server/tests/unit/queue/worker-redis-startup-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, describe, expect, mock, test } from "bun:test";
 
 // Recycled SQS workers previously polled while dedicated Redis was connecting.
 // They now wait for bounded warmup before initializing queue consumers.
@@ -79,4 +79,8 @@ describe("queue worker Redis startup gate", () => {
 		await workerStartup;
 		expect(initWorkersCalled).toBe(true);
 	});
+});
+
+afterAll(() => {
+	mock.restore();
 });

--- a/server/tests/unit/queue/worker-redis-startup-gate.test.ts
+++ b/server/tests/unit/queue/worker-redis-startup-gate.test.ts
@@ -9,17 +9,33 @@ const orgRedisWarmup = new Promise<void>((resolve) => {
 	resolveOrgRedisWarmup = resolve;
 });
 
-mock.module("node:cluster", () => ({
+// Capture each real module before mocking so afterAll can restore it —
+// bun's mock.module leaks across test files otherwise. The preload has
+// already seeded these into the registry, so the imports are cheap.
+const realModules = new Map<string, Record<string, unknown>>();
+const mockModuleRestorable = async (
+	path: string,
+	factory: () => Record<string, unknown>,
+) => {
+	const real = await import(path).catch(() => null);
+	if (real) realModules.set(path, { ...real });
+	mock.module(path, factory);
+};
+
+await mockModuleRestorable("node:cluster", () => ({
 	default: { isPrimary: false },
 }));
 
-mock.module("@/external/infisical/initInfisical.js", () => ({
+await mockModuleRestorable("@/external/infisical/initInfisical.js", () => ({
 	initInfisical: async () => {},
 }));
-mock.module("@/internal/misc/edgeConfig/edgeConfigRegistry.js", () => ({
-	startAllEdgeConfigPolling: async () => {},
-	stopAllEdgeConfigPolling: () => {},
-}));
+await mockModuleRestorable(
+	"@/internal/misc/edgeConfig/edgeConfigRegistry.js",
+	() => ({
+		startAllEdgeConfigPolling: async () => {},
+		stopAllEdgeConfigPolling: () => {},
+	}),
+);
 
 for (const modulePath of [
 	"@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js",
@@ -32,21 +48,21 @@ for (const modulePath of [
 	"@/internal/misc/jobQueues/jobQueueStore.js",
 	"@/internal/misc/batchReset/batchResetConfigStore.js",
 ]) {
-	mock.module(modulePath, () => ({}));
+	await mockModuleRestorable(modulePath, () => ({}));
 }
 
-mock.module("@/utils/memoryMonitor.js", () => ({
+await mockModuleRestorable("@/utils/memoryMonitor.js", () => ({
 	startMemoryMonitor: () => {},
 }));
-mock.module("@/instrumentation.js", () => ({}));
-mock.module("@/db/initDrizzle.js", () => ({ db: {} }));
-mock.module(
+await mockModuleRestorable("@/instrumentation.js", () => ({}));
+await mockModuleRestorable("@/db/initDrizzle.js", () => ({ db: {} }));
+await mockModuleRestorable(
 	"@/external/redis/availabilityMonitor/redisAvailability.js",
 	() => ({
 		primeRedisMonitor: async () => {},
 	}),
 );
-mock.module(
+await mockModuleRestorable(
 	"@/external/redis/availabilityMonitor/redisV2Availability.js",
 	() => ({
 		primeRedisV2Monitor: async () => {},
@@ -54,15 +70,15 @@ mock.module(
 		stopRedisV2Monitor: () => {},
 	}),
 );
-mock.module("@/external/redis/initRedis.js", () => ({
+await mockModuleRestorable("@/external/redis/initRedis.js", () => ({
 	startRedisMonitor: () => {},
 	stopRedisMonitor: () => {},
 	warmupRegionalRedis: async () => {},
 }));
-mock.module("@/external/redis/orgRedisPool.js", () => ({
+await mockModuleRestorable("@/external/redis/orgRedisPool.js", () => ({
 	preWarmOrgRedisConnections: () => orgRedisWarmup,
 }));
-mock.module("@/queue/initWorkers.js", () => ({
+await mockModuleRestorable("@/queue/initWorkers.js", () => ({
 	initWorkers: async () => {
 		initWorkersCalled = true;
 	},
@@ -72,15 +88,22 @@ describe("queue worker Redis startup gate", () => {
 	test("does not initialize SQS polling until dedicated Redis is ready", async () => {
 		const workerStartup = import("@/workers.js");
 
-		await Bun.sleep(30);
-		expect(initWorkersCalled).toBe(false);
-
-		resolveOrgRedisWarmup();
+		// Release the warmup even when the first assertion throws, so a red
+		// run fails fast instead of waiting out the fail-open bound.
+		try {
+			await Bun.sleep(30);
+			expect(initWorkersCalled).toBe(false);
+		} finally {
+			resolveOrgRedisWarmup();
+		}
 		await workerStartup;
 		expect(initWorkersCalled).toBe(true);
 	});
 });
 
 afterAll(() => {
+	for (const [path, real] of realModules) {
+		mock.module(path, () => real);
+	}
 	mock.restore();
 });

--- a/server/tests/unit/queue/worker-redis-startup-gate.test.ts
+++ b/server/tests/unit/queue/worker-redis-startup-gate.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Recycled SQS workers previously polled while dedicated Redis was connecting.
+// They now wait for bounded warmup before initializing queue consumers.
+let resolveOrgRedisWarmup = () => {};
+let initWorkersCalled = false;
+
+const orgRedisWarmup = new Promise<void>((resolve) => {
+	resolveOrgRedisWarmup = resolve;
+});
+
+mock.module("node:cluster", () => ({
+	default: { isPrimary: false },
+}));
+
+mock.module("@/external/infisical/initInfisical.js", () => ({
+	initInfisical: async () => {},
+}));
+mock.module("@/internal/misc/edgeConfig/edgeConfigRegistry.js", () => ({
+	startAllEdgeConfigPolling: async () => {},
+	stopAllEdgeConfigPolling: () => {},
+}));
+
+for (const modulePath of [
+	"@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js",
+	"@/internal/misc/asyncBalanceUpdate/asyncBalanceUpdateStore.js",
+	"@/internal/misc/requestBlocks/requestBlockStore.js",
+	"@/internal/misc/rollouts/rolloutConfigStore.js",
+	"@/internal/misc/redisV2Cache/redisV2CacheStore.js",
+	"@/internal/misc/miscRedisConfig/miscRedisConfigStore.js",
+	"@/internal/misc/cacheV2Ramp/cacheV2RampStore.js",
+	"@/internal/misc/jobQueues/jobQueueStore.js",
+	"@/internal/misc/batchReset/batchResetConfigStore.js",
+]) {
+	mock.module(modulePath, () => ({}));
+}
+
+mock.module("@/utils/memoryMonitor.js", () => ({
+	startMemoryMonitor: () => {},
+}));
+mock.module("@/instrumentation.js", () => ({}));
+mock.module("@/db/initDrizzle.js", () => ({ db: {} }));
+mock.module(
+	"@/external/redis/availabilityMonitor/redisAvailability.js",
+	() => ({
+		primeRedisMonitor: async () => {},
+	}),
+);
+mock.module(
+	"@/external/redis/availabilityMonitor/redisV2Availability.js",
+	() => ({
+		primeRedisV2Monitor: async () => {},
+		startRedisV2Monitor: () => {},
+		stopRedisV2Monitor: () => {},
+	}),
+);
+mock.module("@/external/redis/initRedis.js", () => ({
+	startRedisMonitor: () => {},
+	stopRedisMonitor: () => {},
+	warmupRegionalRedis: async () => {},
+}));
+mock.module("@/external/redis/orgRedisPool.js", () => ({
+	preWarmOrgRedisConnections: () => orgRedisWarmup,
+}));
+mock.module("@/queue/initWorkers.js", () => ({
+	initWorkers: async () => {
+		initWorkersCalled = true;
+	},
+}));
+
+describe("queue worker Redis startup gate", () => {
+	test("does not initialize SQS polling until dedicated Redis is ready", async () => {
+		const workerStartup = import("@/workers.js");
+
+		await Bun.sleep(30);
+		expect(initWorkersCalled).toBe(false);
+
+		resolveOrgRedisWarmup();
+		await workerStartup;
+		expect(initWorkersCalled).toBe(true);
+	});
+});

--- a/server/tests/unit/redis/standby-redis-routing.test.ts
+++ b/server/tests/unit/redis/standby-redis-routing.test.ts
@@ -464,6 +464,61 @@ describe("runRedisOp standby failover", () => {
 		expect(Date.now() - startedAt).toBeLessThan(390);
 	});
 
+	test("uses the reserved retry budget when timeout delivery is late", async () => {
+		const { primary, standby, redis } = createPair();
+		const startedAt = Date.now();
+		primary.get = async (key) => {
+			primary.calls.push(`get:${key}`);
+			setSystemTime(new Date(startedAt + 500));
+			throw new Error("[redis] standby-test timeout after 300ms");
+		};
+
+		try {
+			const result = await runRedisOp({
+				redisInstance: redis,
+				source: "standby-test",
+				retryOnStandby: true,
+				timeoutMs: 400,
+				operation: (connection) => connection.get("subject"),
+			});
+
+			expect(result).toBe("standby");
+			expect(primary.calls).toEqual(["get:subject"]);
+			expect(standby.calls).toEqual(["get:subject"]);
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	test("bounds a late standby retry to the reserved budget", async () => {
+		const { primary, standby, redis } = createPair();
+		const startedAt = Date.now();
+		primary.get = async (key) => {
+			primary.calls.push(`get:${key}`);
+			setSystemTime(new Date(startedAt + 500));
+			throw new Error("[redis] standby-test timeout after 300ms");
+		};
+		standby.hangGetForMs = 5_000;
+		const attemptStartedAt = performance.now();
+
+		try {
+			await expect(
+				runRedisOp({
+					redisInstance: redis,
+					source: "standby-test",
+					retryOnStandby: true,
+					timeoutMs: 400,
+					operation: (connection) => connection.get("subject"),
+				}),
+			).rejects.toBeInstanceOf(RedisUnavailableError);
+
+			expect(standby.calls).toEqual(["get:subject"]);
+			expect(performance.now() - attemptStartedAt).toBeLessThan(250);
+		} finally {
+			setSystemTime();
+		}
+	});
+
 	// The reserve has to fit inside the headroom each deadline was sized with,
 	// not eat into the tail it was sized to cover. Feature balances measure a
 	// p99.9 of 297ms, so the preferred attempt must stay clear of that.


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Queue workers now wait for a bounded Redis warmup before polling. Redis standby failover now uses a reserved retry budget when the primary timeout fires late, preventing overrun of caller timeouts.

- **Bug Fixes**
  - Gate worker startup on Redis warmup (regional + org). Wait up to 10s, then warn-and-continue; monitors still start.
  - Move Redis warmup from `initWorkers` to the top-level `workers` bootstrap so all workers respect the gate.
  - In `runRedisOp`, reserve and enforce retry budget for standby attempts. Late primary timeouts no longer consume the standby budget.

- **New Features**
  - `startPollingLoop` adds `maxMessagesBeforeRecycle`. Lets us recycle workers after a set count while ensuring the triggering batch is ACKed first.

<sup>Written for commit 55182ba3dfdea9fbb075733c9413ac641b4e8ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release improves Redis and queue-worker resilience during failover, startup, and process recycling.

- **[Bug fixes]** Preserves a reserved Redis standby-attempt budget when timeout delivery is delayed.
- **[Improvements]** Starts regional and organization Redis warmups together and gives them a bounded startup window before SQS polling begins.
- **[Improvements]** Makes the worker recycle threshold configurable for process-level testing and verifies that the triggering SQS batch is acknowledged before exit.
- **[Improvements]** Adds focused tests for delayed Redis failover, worker Redis startup gating, and safe worker recycling.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The Redis retry, bounded startup warmup, and worker recycling changes preserve their relevant fallback, acknowledgement, and lifecycle behavior, with targeted tests covering the newly introduced paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/redis/utils/runRedisOp.ts | Preserves the intentionally reserved standby budget when timeout callbacks arrive late while continuing to bound the retry attempt itself. |
| server/src/workers.ts | Moves regional and organization Redis warmups into the worker bootstrap and waits for them through a bounded, fail-open startup gate. |
| server/src/queue/initWorkers.ts | Removes the redundant regional warmup and exposes the recycle threshold for deterministic process-level testing. |
| server/tests/unit/redis/standby-redis-routing.test.ts | Adds coverage for delayed timeout delivery and verifies that the standby attempt remains bounded. |
| server/tests/unit/queue/worker-redis-startup-gate.test.ts | Verifies that queue initialization waits for Redis warmup completion. |
| server/tests/unit/queue/queue-worker-recycle.test.ts | Verifies in a subprocess that the threshold-triggering batch is deleted before the worker exits. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Worker as Worker process
  participant Regional as Regional Redis
  participant Org as Organization Redis
  participant Monitor as Redis monitors
  participant SQS as SQS pollers
  Worker->>Regional: Start warmup
  Worker->>Org: Start warmup
  Worker->>Monitor: Prime and start monitors
  Worker->>Worker: Wait for combined warmup (up to 10s)
  Worker->>SQS: Initialize queue polling
  SQS->>SQS: Process and acknowledge messages
  SQS->>Worker: Recycle after message threshold
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/5a7ef29da2e975396e5315436e0a09e739b39cc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52259684)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->