### PR TITLE
feat: replay missing entity creation

### DIFF
--- a/server/src/internal/api/entities/EntityService.ts
+++ b/server/src/internal/api/entities/EntityService.ts
@@ -78,13 +78,24 @@ export class EntityService {
 				),
 		});
 	}
-	static async insert({ db, data }: { db: DrizzleCli; data: Entity[] }) {
+	static async insert({
+		db,
+		data,
+		ignoreConflicts = false,
+	}: {
+		db: DrizzleCli;
+		data: Entity[];
+		ignoreConflicts?: boolean;
+	}) {
 		if (data.length === 0) {
 			return [];
 		}
 
 		try {
-			const results = await db.insert(entities).values(data).returning();
+			const insert = db.insert(entities).values(data);
+			const results = await (ignoreConflicts
+				? insert.onConflictDoNothing().returning()
+				: insert.returning());
 
 			await markCustomersUpdatedAtByInternalIds({
 				db,

--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -4,7 +4,6 @@ import {
 	type Entity,
 	findFeatureById,
 } from "@autumn/shared";
-import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import { withLock } from "@/external/redis/utils/lockUtils/withLock.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -45,120 +44,100 @@ const createEntities = async ({
 		customerData,
 		createEntityData,
 	});
-	let canReplay = false;
-	const run = async () => {
-		for (const cusProduct of cusProducts) {
-			await createEntityForCusProduct({
-				ctx,
-				customer: fullCus,
-				cusProduct,
-				inputEntities,
-			});
-		}
 
-		let data = inputEntities.map((e) =>
-			constructEntity({
-				inputEntity: e,
-				feature: findFeatureById({
-					features,
-					featureId: e.feature_id,
-					errorOnNotFound: true,
-				}),
-				internalCustomerId: fullCus.internal_id,
-				orgId: org.id,
-				env,
+	for (const cusProduct of cusProducts) {
+		await createEntityForCusProduct({
+			ctx,
+			customer: fullCus,
+			cusProduct,
+			inputEntities,
+		});
+	}
+
+	let data = inputEntities.map((e) =>
+		constructEntity({
+			inputEntity: e,
+			feature: findFeatureById({
+				features,
+				featureId: e.feature_id,
+				errorOnNotFound: true,
 			}),
-		);
+			internalCustomerId: fullCus.internal_id,
+			orgId: org.id,
+			env,
+		}),
+	);
 
-		const newEntities: Entity[] = [];
+	const newEntities: Entity[] = [];
 
-		const noIdEntity = existingEntities.find((e) => e.id === null);
-		if (noIdEntity) {
-			const updatedEntity = await EntityService.update({
-				db,
-				internalId: noIdEntity.internal_id,
-				update: {
-					id: inputEntities[0].id,
-					name: inputEntities[0].name,
-					...(inputEntities[0].billing_controls && {
-						spend_limits: inputEntities[0].billing_controls.spend_limits,
-						usage_limits: inputEntities[0].billing_controls.usage_limits,
-						usage_alerts: inputEntities[0].billing_controls.usage_alerts,
-						overage_allowed: inputEntities[0].billing_controls.overage_allowed,
-					}),
-				},
-			});
+	const noIdEntity = existingEntities.find((e) => e.id === null);
+	if (noIdEntity) {
+		const updatedEntity = await EntityService.update({
+			db,
+			internalId: noIdEntity.internal_id,
+			update: {
+				id: inputEntities[0].id,
+				name: inputEntities[0].name,
+				...(inputEntities[0].billing_controls && {
+					spend_limits: inputEntities[0].billing_controls.spend_limits,
+					usage_limits: inputEntities[0].billing_controls.usage_limits,
+					usage_alerts: inputEntities[0].billing_controls.usage_alerts,
+					overage_allowed: inputEntities[0].billing_controls.overage_allowed,
+				}),
+			},
+		});
 
-			data = data.slice(1);
-			newEntities.push(updatedEntity);
-		}
+		data = data.slice(1);
+		newEntities.push(updatedEntity);
+	}
 
-		const insertAndAttach = async ({
-			transactionDb,
-		}: {
-			transactionDb: DrizzleCli;
-		}) => {
-			const transactionCtx = { ...ctx, db: transactionDb };
-			const insertedEntities = await EntityService.insert({
-				db: transactionDb,
-				data,
-			});
-			newEntities.push(...insertedEntities);
-			await attachDefaultProductsToEntities({
-				ctx: transactionCtx,
-				fullCustomer: fullCus,
-				entities: newEntities,
-				customerData,
-			});
-		};
+	let insertedEntities: Entity[];
+	if (inputEntities.some((entity) => !entity.id) || noIdEntity) {
+		insertedEntities = await EntityService.insert({ db, data });
+	} else {
+		insertedEntities = await shed503OnTransientError({
+			ctx,
+			source: "entities.create",
+			run: () => EntityService.insert({ db, data }),
+			onTransientError: async () => {
+				await queueFailedEntityCreation({
+					ctx,
+					params: {
+						customer_id: customerId,
+						create_entity_data: inputEntities,
+						customer_data: customerData,
+					},
+				});
+			},
+		});
+	}
 
-		if (inputEntities.some((entity) => !entity.id) || noIdEntity) {
-			await insertAndAttach({ transactionDb: db });
-		} else {
-			canReplay = true;
-			await db.transaction(
-				async (transactionDb) =>
-					await insertAndAttach({
-						transactionDb: transactionDb as unknown as DrizzleCli,
-					}),
-			);
-		}
+	newEntities.push(...insertedEntities);
 
-		// Get api entity for each entity...
-		const apiEntities = [];
-		for (const entity of newEntities) {
-			const clonedFullCus = structuredClone(fullCus);
-			clonedFullCus.entity = entity;
-
-			const apiEntity = await getApiEntity({
-				ctx,
-				customerId,
-				entityId: entity.id ?? entity.internal_id,
-				fullCus: clonedFullCus,
-				withAutumnId,
-			});
-			apiEntities.push(apiEntity);
-		}
-
-		return apiEntities;
-	};
-
-	return shed503OnTransientError({
+	await attachDefaultProductsToEntities({
 		ctx,
-		source: "entities.create",
-		run,
-		onTransientError: async () => {
-			if (!canReplay) return;
-			await queueFailedEntityCreation({
-				ctx,
-				params: {
-					customer_id: customerId,
-					create_entity_data: inputEntities,
-					customer_data: customerData,
-				},
-			});
-		},
+		fullCustomer: fullCus,
+		entities: newEntities,
+		customerData,
 	});
+
+	// Get api entity for each entity...
+	const apiEntities = [];
+	for (const entity of newEntities) {
+		const clonedFullCus = structuredClone(fullCus);
+		clonedFullCus.entity = entity;
+
+		const apiEntity = await getApiEntity({
+			ctx,
+			customerId,
+			entityId: entity.id ?? entity.internal_id,
+			fullCus: clonedFullCus,
+			withAutumnId,
+		});
+		apiEntities.push(apiEntity);
+	}
+
+	return apiEntities;
 };
 
 export const batchCreateEntities = async (

--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -4,9 +4,11 @@ import {
 	type Entity,
 	findFeatureById,
 } from "@autumn/shared";
+import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import { withLock } from "@/external/redis/utils/lockUtils/withLock.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { EntityService } from "@/internal/api/entities/EntityService";
+import { queueFailedEntityCreation } from "@/internal/entities/recovery/queueFailedEntityCreation.js";
 import { getApiEntity } from "../entityUtils/apiEntityUtils/getApiEntity";
 import { constructEntity } from "../entityUtils/entityUtils";
 import { createEntityForCusProduct } from "../handlers/handleCreateEntity/createEntityForCusProduct";
@@ -43,83 +45,102 @@ const createEntities = async ({
 		createEntityData,
 	});
 
-	for (const cusProduct of cusProducts) {
-		await createEntityForCusProduct({
-			ctx,
-			customer: fullCus,
-			cusProduct,
-			inputEntities,
-		});
-	}
+	const run = async () => {
+		for (const cusProduct of cusProducts) {
+			await createEntityForCusProduct({
+				ctx,
+				customer: fullCus,
+				cusProduct,
+				inputEntities,
+			});
+		}
 
-	let data = inputEntities.map((e) =>
-		constructEntity({
-			inputEntity: e,
-			feature: findFeatureById({
-				features,
-				featureId: e.feature_id,
-				errorOnNotFound: true,
-			}),
-			internalCustomerId: fullCus.internal_id,
-			orgId: org.id,
-			env,
-		}),
-	);
-
-	const newEntities: Entity[] = [];
-
-	const noIdEntity = existingEntities.find((e) => e.id === null);
-	if (noIdEntity) {
-		const updatedEntity = await EntityService.update({
-			db,
-			internalId: noIdEntity.internal_id,
-			update: {
-				id: inputEntities[0].id,
-				name: inputEntities[0].name,
-				...(inputEntities[0].billing_controls && {
-					spend_limits: inputEntities[0].billing_controls.spend_limits,
-					usage_limits: inputEntities[0].billing_controls.usage_limits,
-					usage_alerts: inputEntities[0].billing_controls.usage_alerts,
-					overage_allowed: inputEntities[0].billing_controls.overage_allowed,
+		let data = inputEntities.map((e) =>
+			constructEntity({
+				inputEntity: e,
+				feature: findFeatureById({
+					features,
+					featureId: e.feature_id,
+					errorOnNotFound: true,
 				}),
-			},
+				internalCustomerId: fullCus.internal_id,
+				orgId: org.id,
+				env,
+			}),
+		);
+
+		const newEntities: Entity[] = [];
+
+		const noIdEntity = existingEntities.find((e) => e.id === null);
+		if (noIdEntity) {
+			const updatedEntity = await EntityService.update({
+				db,
+				internalId: noIdEntity.internal_id,
+				update: {
+					id: inputEntities[0].id,
+					name: inputEntities[0].name,
+					...(inputEntities[0].billing_controls && {
+						spend_limits: inputEntities[0].billing_controls.spend_limits,
+						usage_limits: inputEntities[0].billing_controls.usage_limits,
+						usage_alerts: inputEntities[0].billing_controls.usage_alerts,
+						overage_allowed: inputEntities[0].billing_controls.overage_allowed,
+					}),
+				},
+			});
+
+			data = data.slice(1);
+			newEntities.push(updatedEntity);
+		}
+
+		const insertedEntities = await EntityService.insert({
+			db,
+			data,
 		});
 
-		data = data.slice(1);
-		newEntities.push(updatedEntity);
-	}
+		newEntities.push(...insertedEntities);
 
-	const insertedEntities = await EntityService.insert({
-		db,
-		data,
-	});
-
-	newEntities.push(...insertedEntities);
-
-	await attachDefaultProductsToEntities({
-		ctx,
-		fullCustomer: fullCus,
-		entities: newEntities,
-		customerData,
-	});
-
-	// Get api entity for each entity...
-	const apiEntities = [];
-	for (const entity of newEntities) {
-		const clonedFullCus = structuredClone(fullCus);
-		clonedFullCus.entity = entity;
-
-		const apiEntity = await getApiEntity({
+		await attachDefaultProductsToEntities({
 			ctx,
-			customerId,
-			entityId: entity.id ?? entity.internal_id,
-			fullCus: clonedFullCus,
-			withAutumnId,
+			fullCustomer: fullCus,
+			entities: newEntities,
+			customerData,
 		});
-		apiEntities.push(apiEntity);
-	}
 
-	return apiEntities;
+		// Get api entity for each entity...
+		const apiEntities = [];
+		for (const entity of newEntities) {
+			const clonedFullCus = structuredClone(fullCus);
+			clonedFullCus.entity = entity;
+
+			const apiEntity = await getApiEntity({
+				ctx,
+				customerId,
+				entityId: entity.id ?? entity.internal_id,
+				fullCus: clonedFullCus,
+				withAutumnId,
+			});
+			apiEntities.push(apiEntity);
+		}
+
+		return apiEntities;
+	};
+
+	if (inputEntities.some((entity) => !entity.id)) return run();
+	return shed503OnTransientError({
+		ctx,
+		source: "entities.create",
+		run,
+		onTransientError: async () => {
+			await queueFailedEntityCreation({
+				ctx,
+				params: {
+					customer_id: customerId,
+					create_entity_data: inputEntities,
+					customer_data: customerData,
+				},
+			});
+		},
+	});
 };
 
 export const batchCreateEntities = async (

--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -4,6 +4,7 @@ import {
 	type Entity,
 	findFeatureById,
 } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { shed503OnTransientError } from "@/db/shed503OnTransientError.js";
 import { withLock } from "@/external/redis/utils/lockUtils/withLock.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -45,102 +46,114 @@ const createEntities = async ({
 		createEntityData,
 	});
 
-	const run = async () => {
-		for (const cusProduct of cusProducts) {
-			await createEntityForCusProduct({
-				ctx,
-				customer: fullCus,
-				cusProduct,
-				inputEntities,
-			});
-		}
+	for (const cusProduct of cusProducts) {
+		await createEntityForCusProduct({
+			ctx,
+			customer: fullCus,
+			cusProduct,
+			inputEntities,
+		});
+	}
 
-		let data = inputEntities.map((e) =>
-			constructEntity({
-				inputEntity: e,
-				feature: findFeatureById({
-					features,
-					featureId: e.feature_id,
-					errorOnNotFound: true,
-				}),
-				internalCustomerId: fullCus.internal_id,
-				orgId: org.id,
-				env,
+	let data = inputEntities.map((e) =>
+		constructEntity({
+			inputEntity: e,
+			feature: findFeatureById({
+				features,
+				featureId: e.feature_id,
+				errorOnNotFound: true,
 			}),
-		);
+			internalCustomerId: fullCus.internal_id,
+			orgId: org.id,
+			env,
+		}),
+	);
 
-		const newEntities: Entity[] = [];
+	const newEntities: Entity[] = [];
 
-		const noIdEntity = existingEntities.find((e) => e.id === null);
-		if (noIdEntity) {
-			const updatedEntity = await EntityService.update({
-				db,
-				internalId: noIdEntity.internal_id,
-				update: {
-					id: inputEntities[0].id,
-					name: inputEntities[0].name,
-					...(inputEntities[0].billing_controls && {
-						spend_limits: inputEntities[0].billing_controls.spend_limits,
-						usage_limits: inputEntities[0].billing_controls.usage_limits,
-						usage_alerts: inputEntities[0].billing_controls.usage_alerts,
-						overage_allowed: inputEntities[0].billing_controls.overage_allowed,
-					}),
-				},
-			});
-
-			data = data.slice(1);
-			newEntities.push(updatedEntity);
-		}
-
-		const insertedEntities = await EntityService.insert({
+	const noIdEntity = existingEntities.find((e) => e.id === null);
+	if (noIdEntity) {
+		const updatedEntity = await EntityService.update({
 			db,
-			data,
+			internalId: noIdEntity.internal_id,
+			update: {
+				id: inputEntities[0].id,
+				name: inputEntities[0].name,
+				...(inputEntities[0].billing_controls && {
+					spend_limits: inputEntities[0].billing_controls.spend_limits,
+					usage_limits: inputEntities[0].billing_controls.usage_limits,
+					usage_alerts: inputEntities[0].billing_controls.usage_alerts,
+					overage_allowed: inputEntities[0].billing_controls.overage_allowed,
+				}),
+			},
 		});
 
-		newEntities.push(...insertedEntities);
+		data = data.slice(1);
+		newEntities.push(updatedEntity);
+	}
 
+	const insertAndAttach = async ({
+		transactionDb,
+	}: {
+		transactionDb: DrizzleCli;
+	}) => {
+		const transactionCtx = { ...ctx, db: transactionDb };
+		const insertedEntities = await EntityService.insert({
+			db: transactionDb,
+			data,
+		});
+		newEntities.push(...insertedEntities);
 		await attachDefaultProductsToEntities({
-			ctx,
+			ctx: transactionCtx,
 			fullCustomer: fullCus,
 			entities: newEntities,
 			customerData,
 		});
-
-		// Get api entity for each entity...
-		const apiEntities = [];
-		for (const entity of newEntities) {
-			const clonedFullCus = structuredClone(fullCus);
-			clonedFullCus.entity = entity;
-
-			const apiEntity = await getApiEntity({
-				ctx,
-				customerId,
-				entityId: entity.id ?? entity.internal_id,
-				fullCus: clonedFullCus,
-				withAutumnId,
-			});
-			apiEntities.push(apiEntity);
-		}
-
-		return apiEntities;
 	};
 
-	if (inputEntities.some((entity) => !entity.id)) return run();
-	return shed503OnTransientError({
-		ctx,
-		source: "entities.create",
-		run,
-		onTransientError: async () => {
-			await queueFailedEntityCreation({
-				ctx,
-				params: {
-					customer_id: customerId,
-					create_entity_data: inputEntities,
-					customer_data: customerData,
-				},
-			});
-		},
-	});
+	if (inputEntities.some((entity) => !entity.id) || noIdEntity) {
+		await insertAndAttach({ transactionDb: db });
+	} else {
+		await shed503OnTransientError({
+			ctx,
+			source: "entities.create",
+			run: async () =>
+				await db.transaction(
+					async (transactionDb) =>
+						await insertAndAttach({
+							transactionDb: transactionDb as unknown as DrizzleCli,
+						}),
+				),
+			onTransientError: async () => {
+				await queueFailedEntityCreation({
+					ctx,
+					params: {
+						customer_id: customerId,
+						create_entity_data: inputEntities,
+						customer_data: customerData,
+					},
+				});
+			},
+		});
+	}
+
+	// Get api entity for each entity...
+	const apiEntities = [];
+	for (const entity of newEntities) {
+		const clonedFullCus = structuredClone(fullCus);
+		clonedFullCus.entity = entity;
+
+		const apiEntity = await getApiEntity({
+			ctx,
+			customerId,
+			entityId: entity.id ?? entity.internal_id,
+			fullCus: clonedFullCus,
+			withAutumnId,
+		});
+		apiEntities.push(apiEntity);
+	}
+
+	return apiEntities;
 };
 
 export const batchCreateEntities = async (

--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -45,115 +45,120 @@ const createEntities = async ({
 		customerData,
 		createEntityData,
 	});
+	let canReplay = false;
+	const run = async () => {
+		for (const cusProduct of cusProducts) {
+			await createEntityForCusProduct({
+				ctx,
+				customer: fullCus,
+				cusProduct,
+				inputEntities,
+			});
+		}
 
-	for (const cusProduct of cusProducts) {
-		await createEntityForCusProduct({
-			ctx,
-			customer: fullCus,
-			cusProduct,
-			inputEntities,
-		});
-	}
-
-	let data = inputEntities.map((e) =>
-		constructEntity({
-			inputEntity: e,
-			feature: findFeatureById({
-				features,
-				featureId: e.feature_id,
-				errorOnNotFound: true,
-			}),
-			internalCustomerId: fullCus.internal_id,
-			orgId: org.id,
-			env,
-		}),
-	);
-
-	const newEntities: Entity[] = [];
-
-	const noIdEntity = existingEntities.find((e) => e.id === null);
-	if (noIdEntity) {
-		const updatedEntity = await EntityService.update({
-			db,
-			internalId: noIdEntity.internal_id,
-			update: {
-				id: inputEntities[0].id,
-				name: inputEntities[0].name,
-				...(inputEntities[0].billing_controls && {
-					spend_limits: inputEntities[0].billing_controls.spend_limits,
-					usage_limits: inputEntities[0].billing_controls.usage_limits,
-					usage_alerts: inputEntities[0].billing_controls.usage_alerts,
-					overage_allowed: inputEntities[0].billing_controls.overage_allowed,
+		let data = inputEntities.map((e) =>
+			constructEntity({
+				inputEntity: e,
+				feature: findFeatureById({
+					features,
+					featureId: e.feature_id,
+					errorOnNotFound: true,
 				}),
-			},
-		});
+				internalCustomerId: fullCus.internal_id,
+				orgId: org.id,
+				env,
+			}),
+		);
 
-		data = data.slice(1);
-		newEntities.push(updatedEntity);
-	}
+		const newEntities: Entity[] = [];
 
-	const insertAndAttach = async ({
-		transactionDb,
-	}: {
-		transactionDb: DrizzleCli;
-	}) => {
-		const transactionCtx = { ...ctx, db: transactionDb };
-		const insertedEntities = await EntityService.insert({
-			db: transactionDb,
-			data,
-		});
-		newEntities.push(...insertedEntities);
-		await attachDefaultProductsToEntities({
-			ctx: transactionCtx,
-			fullCustomer: fullCus,
-			entities: newEntities,
-			customerData,
-		});
+		const noIdEntity = existingEntities.find((e) => e.id === null);
+		if (noIdEntity) {
+			const updatedEntity = await EntityService.update({
+				db,
+				internalId: noIdEntity.internal_id,
+				update: {
+					id: inputEntities[0].id,
+					name: inputEntities[0].name,
+					...(inputEntities[0].billing_controls && {
+						spend_limits: inputEntities[0].billing_controls.spend_limits,
+						usage_limits: inputEntities[0].billing_controls.usage_limits,
+						usage_alerts: inputEntities[0].billing_controls.usage_alerts,
+						overage_allowed: inputEntities[0].billing_controls.overage_allowed,
+					}),
+				},
+			});
+
+			data = data.slice(1);
+			newEntities.push(updatedEntity);
+		}
+
+		const insertAndAttach = async ({
+			transactionDb,
+		}: {
+			transactionDb: DrizzleCli;
+		}) => {
+			const transactionCtx = { ...ctx, db: transactionDb };
+			const insertedEntities = await EntityService.insert({
+				db: transactionDb,
+				data,
+			});
+			newEntities.push(...insertedEntities);
+			await attachDefaultProductsToEntities({
+				ctx: transactionCtx,
+				fullCustomer: fullCus,
+				entities: newEntities,
+				customerData,
+			});
+		};
+
+		if (inputEntities.some((entity) => !entity.id) || noIdEntity) {
+			await insertAndAttach({ transactionDb: db });
+		} else {
+			canReplay = true;
+			await db.transaction(
+				async (transactionDb) =>
+					await insertAndAttach({
+						transactionDb: transactionDb as unknown as DrizzleCli,
+					}),
+			);
+		}
+
+		// Get api entity for each entity...
+		const apiEntities = [];
+		for (const entity of newEntities) {
+			const clonedFullCus = structuredClone(fullCus);
+			clonedFullCus.entity = entity;
+
+			const apiEntity = await getApiEntity({
+				ctx,
+				customerId,
+				entityId: entity.id ?? entity.internal_id,
+				fullCus: clonedFullCus,
+				withAutumnId,
+			});
+			apiEntities.push(apiEntity);
+		}
+
+		return apiEntities;
 	};
 
-	if (inputEntities.some((entity) => !entity.id) || noIdEntity) {
-		await insertAndAttach({ transactionDb: db });
-	} else {
-		await shed503OnTransientError({
-			ctx,
-			source: "entities.create",
-			run: async () =>
-				await db.transaction(
-					async (transactionDb) =>
-						await insertAndAttach({
-							transactionDb: transactionDb as unknown as DrizzleCli,
-						}),
-				),
-			onTransientError: async () => {
-				await queueFailedEntityCreation({
-					ctx,
-					params: {
-						customer_id: customerId,
-						create_entity_data: inputEntities,
-						customer_data: customerData,
-					},
-				});
-			},
-		});
-	}
-
-	// Get api entity for each entity...
-	const apiEntities = [];
-	for (const entity of newEntities) {
-		const clonedFullCus = structuredClone(fullCus);
-		clonedFullCus.entity = entity;
-
-		const apiEntity = await getApiEntity({
-			ctx,
-			customerId,
-			entityId: entity.id ?? entity.internal_id,
-			fullCus: clonedFullCus,
-			withAutumnId,
-		});
-		apiEntities.push(apiEntity);
-	}
-
-	return apiEntities;
+	return shed503OnTransientError({
+		ctx,
+		source: "entities.create",
+		run,
+		onTransientError: async () => {
+			if (!canReplay) return;
+			await queueFailedEntityCreation({
+				ctx,
+				params: {
+					customer_id: customerId,
+					create_entity_data: inputEntities,
+					customer_data: customerData,
+				},
+			});
+		},
+	});
 };
 
 export const batchCreateEntities = async (

--- a/server/src/internal/entities/recovery/entityCreationRecoveryTypes.ts
+++ b/server/src/internal/entities/recovery/entityCreationRecoveryTypes.ts
@@ -1,0 +1,27 @@
+import type {
+	ApiVersion,
+	AppEnv,
+	CreateEntityParams,
+	CustomerData,
+} from "@autumn/shared";
+
+export interface EntityCreationRecoveryPayload {
+	kind: "entity";
+	orgId: string;
+	env: AppEnv;
+	customerId: string;
+	requestId: string;
+	apiVersion: ApiVersion;
+	params: {
+		customer_id: string;
+		create_entity_data: CreateEntityParams[];
+		customer_data?: CustomerData;
+	};
+}
+
+export const isEntityCreationRecoveryPayload = (
+	payload: unknown,
+): payload is EntityCreationRecoveryPayload =>
+	typeof payload === "object" &&
+	payload !== null &&
+	(payload as { kind?: unknown }).kind === "entity";

--- a/server/src/internal/entities/recovery/queueFailedEntityCreation.ts
+++ b/server/src/internal/entities/recovery/queueFailedEntityCreation.ts
@@ -1,0 +1,33 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID } from "@/internal/customers/recovery/queueFailedCustomerCreation.js";
+import { JobName } from "@/queue/JobName.js";
+import { addTaskToQueue } from "@/queue/queueUtils.js";
+import type { EntityCreationRecoveryPayload } from "./entityCreationRecoveryTypes.js";
+
+export const queueFailedEntityCreation = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: EntityCreationRecoveryPayload["params"];
+}) => {
+	const queueUrl = process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL;
+	if (!queueUrl) return false;
+	await addTaskToQueue({
+		jobName: JobName.CustomerCreationRecovery,
+		queueUrl,
+		messageGroupId: CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID,
+		messageDeduplicationId: `entity-creation-${Bun.hash(JSON.stringify(params)).toString(16)}`,
+		generateDeduplicationId: false,
+		payload: {
+			kind: "entity",
+			orgId: ctx.org.id,
+			env: ctx.env,
+			customerId: params.customer_id,
+			requestId: ctx.id,
+			apiVersion: ctx.apiVersion.value,
+			params,
+		},
+	});
+	return true;
+};

--- a/server/src/internal/entities/recovery/queueFailedEntityCreation.ts
+++ b/server/src/internal/entities/recovery/queueFailedEntityCreation.ts
@@ -18,28 +18,37 @@ export const queueFailedEntityCreation = async ({
 		);
 		return false;
 	}
-	await addTaskToQueue({
-		jobName: JobName.CustomerCreationRecovery,
-		queueUrl,
-		messageGroupId: CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID,
-		messageDeduplicationId: `entity-creation-${Bun.hash(
-			JSON.stringify({
+	try {
+		await addTaskToQueue({
+			jobName: JobName.CustomerCreationRecovery,
+			queueUrl,
+			messageGroupId: CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID,
+			messageDeduplicationId: `entity-creation-${Bun.hash(
+				JSON.stringify({
+					orgId: ctx.org.id,
+					env: ctx.env,
+					apiVersion: ctx.apiVersion.value,
+					params,
+				}),
+			).toString(16)}`,
+			generateDeduplicationId: false,
+			payload: {
+				kind: "entity",
 				orgId: ctx.org.id,
 				env: ctx.env,
+				customerId: params.customer_id,
+				requestId: ctx.id,
 				apiVersion: ctx.apiVersion.value,
 				params,
-			}),
-		).toString(16)}`,
-		generateDeduplicationId: false,
-		payload: {
-			kind: "entity",
-			orgId: ctx.org.id,
-			env: ctx.env,
-			customerId: params.customer_id,
-			requestId: ctx.id,
-			apiVersion: ctx.apiVersion.value,
-			params,
-		},
-	});
-	return true;
+			},
+		});
+		ctx.extraLogs.entityCreationRecoveryQueued = { queueUrl };
+		return true;
+	} catch (error) {
+		ctx.logger.error(
+			"[entityCreationRecovery] Failed to enqueue entity creation recovery",
+			{ error },
+		);
+		return false;
+	}
 };

--- a/server/src/internal/entities/recovery/queueFailedEntityCreation.ts
+++ b/server/src/internal/entities/recovery/queueFailedEntityCreation.ts
@@ -12,12 +12,24 @@ export const queueFailedEntityCreation = async ({
 	params: EntityCreationRecoveryPayload["params"];
 }) => {
 	const queueUrl = process.env.CUSTOMER_CREATION_RECOVERY_SQS_QUEUE_URL;
-	if (!queueUrl) return false;
+	if (!queueUrl) {
+		ctx.logger.error(
+			"[entityCreationRecovery] Recovery queue URL is not configured",
+		);
+		return false;
+	}
 	await addTaskToQueue({
 		jobName: JobName.CustomerCreationRecovery,
 		queueUrl,
 		messageGroupId: CUSTOMER_CREATION_RECOVERY_MESSAGE_GROUP_ID,
-		messageDeduplicationId: `entity-creation-${Bun.hash(JSON.stringify(params)).toString(16)}`,
+		messageDeduplicationId: `entity-creation-${Bun.hash(
+			JSON.stringify({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				apiVersion: ctx.apiVersion.value,
+				params,
+			}),
+		).toString(16)}`,
 		generateDeduplicationId: false,
 		payload: {
 			kind: "entity",

--- a/server/src/internal/entities/recovery/replayFailedEntityCreation.ts
+++ b/server/src/internal/entities/recovery/replayFailedEntityCreation.ts
@@ -27,49 +27,55 @@ export const replayFailedEntityCreation = async ({
 		ctx,
 		idOrInternalId: payload.params.customer_id,
 	});
-	const missing: Array<{ inputEntity: CreateEntityParams; feature: Feature }> =
-		[];
-	for (const inputEntity of payload.params.create_entity_data) {
-		const feature = findFeatureById({
-			features: ctx.features,
-			featureId: inputEntity.feature_id,
-			errorOnNotFound: true,
-		});
-		const existing = await EntityService.get({
-			db: ctx.db,
-			id: inputEntity.id as string,
-			internalCustomerId: customer.internal_id,
-			internalFeatureId: feature.internal_id,
-		});
-		if (!existing) missing.push({ inputEntity, feature });
-	}
-	if (missing.length === 0) return;
-	await ctx.db.transaction(async (tx) => {
-		const transactionCtx = { ...ctx, db: tx as unknown as DrizzleCli };
-		const entities = missing.map(({ inputEntity, feature }) =>
-			constructEntity({
-				inputEntity,
-				feature,
+	while (true) {
+		const missing: Array<{
+			inputEntity: CreateEntityParams;
+			feature: Feature;
+		}> = [];
+		for (const inputEntity of payload.params.create_entity_data) {
+			const feature = findFeatureById({
+				features: ctx.features,
+				featureId: inputEntity.feature_id,
+				errorOnNotFound: true,
+			});
+			const existing = await EntityService.get({
+				db: ctx.db,
+				id: inputEntity.id as string,
 				internalCustomerId: customer.internal_id,
-				orgId: ctx.org.id,
-				env: ctx.env,
-			}),
-		);
-		try {
-			await EntityService.insert({ db: transactionCtx.db, data: entities });
-		} catch (error) {
-			if (
-				!(error instanceof RecaseError) ||
-				error.code !== EntityErrorCode.EntityAlreadyExists
-			)
-				throw error;
-			return;
+				internalFeatureId: feature.internal_id,
+			});
+			if (!existing) missing.push({ inputEntity, feature });
 		}
-		await attachDefaultProductsToEntities({
-			ctx: transactionCtx,
-			fullCustomer: customer,
-			entities,
-			customerData: payload.params.customer_data,
+		if (missing.length === 0) return;
+		const inserted = await ctx.db.transaction(async (tx) => {
+			const transactionCtx = { ...ctx, db: tx as unknown as DrizzleCli };
+			const entities = missing.map(({ inputEntity, feature }) =>
+				constructEntity({
+					inputEntity,
+					feature,
+					internalCustomerId: customer.internal_id,
+					orgId: ctx.org.id,
+					env: ctx.env,
+				}),
+			);
+			try {
+				await EntityService.insert({ db: transactionCtx.db, data: entities });
+			} catch (error) {
+				if (
+					!(error instanceof RecaseError) ||
+					error.code !== EntityErrorCode.EntityAlreadyExists
+				)
+					throw error;
+				return false;
+			}
+			await attachDefaultProductsToEntities({
+				ctx: transactionCtx,
+				fullCustomer: customer,
+				entities,
+				customerData: payload.params.customer_data,
+			});
+			return true;
 		});
-	});
+		if (inserted) return;
+	}
 };

--- a/server/src/internal/entities/recovery/replayFailedEntityCreation.ts
+++ b/server/src/internal/entities/recovery/replayFailedEntityCreation.ts
@@ -1,11 +1,4 @@
-import {
-	ApiVersionClass,
-	type CreateEntityParams,
-	EntityErrorCode,
-	type Feature,
-	findFeatureById,
-	RecaseError,
-} from "@autumn/shared";
+import { ApiVersionClass, findFeatureById } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { EntityService } from "@/internal/api/entities/EntityService.js";
@@ -27,55 +20,32 @@ export const replayFailedEntityCreation = async ({
 		ctx,
 		idOrInternalId: payload.params.customer_id,
 	});
-	while (true) {
-		const missing: Array<{
-			inputEntity: CreateEntityParams;
-			feature: Feature;
-		}> = [];
-		for (const inputEntity of payload.params.create_entity_data) {
-			const feature = findFeatureById({
-				features: ctx.features,
-				featureId: inputEntity.feature_id,
-				errorOnNotFound: true,
-			});
-			const existing = await EntityService.get({
-				db: ctx.db,
-				id: inputEntity.id as string,
-				internalCustomerId: customer.internal_id,
-				internalFeatureId: feature.internal_id,
-			});
-			if (!existing) missing.push({ inputEntity, feature });
-		}
-		if (missing.length === 0) return;
-		const inserted = await ctx.db.transaction(async (tx) => {
-			const transactionCtx = { ...ctx, db: tx as unknown as DrizzleCli };
-			const entities = missing.map(({ inputEntity, feature }) =>
-				constructEntity({
-					inputEntity,
-					feature,
-					internalCustomerId: customer.internal_id,
-					orgId: ctx.org.id,
-					env: ctx.env,
+	await ctx.db.transaction(async (tx) => {
+		const transactionCtx = { ...ctx, db: tx as unknown as DrizzleCli };
+		const entities = payload.params.create_entity_data.map((inputEntity) =>
+			constructEntity({
+				inputEntity,
+				feature: findFeatureById({
+					features: ctx.features,
+					featureId: inputEntity.feature_id,
+					errorOnNotFound: true,
 				}),
-			);
-			try {
-				await EntityService.insert({ db: transactionCtx.db, data: entities });
-			} catch (error) {
-				if (
-					!(error instanceof RecaseError) ||
-					error.code !== EntityErrorCode.EntityAlreadyExists
-				)
-					throw error;
-				return false;
-			}
-			await attachDefaultProductsToEntities({
-				ctx: transactionCtx,
-				fullCustomer: customer,
-				entities,
-				customerData: payload.params.customer_data,
-			});
-			return true;
+				internalCustomerId: customer.internal_id,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			}),
+		);
+		const insertedEntities = await EntityService.insert({
+			db: transactionCtx.db,
+			data: entities,
+			ignoreConflicts: true,
 		});
-		if (inserted) return;
-	}
+		if (insertedEntities.length === 0) return;
+		await attachDefaultProductsToEntities({
+			ctx: transactionCtx,
+			fullCustomer: customer,
+			entities: insertedEntities,
+			customerData: payload.params.customer_data,
+		});
+	});
 };

--- a/server/src/internal/entities/recovery/replayFailedEntityCreation.ts
+++ b/server/src/internal/entities/recovery/replayFailedEntityCreation.ts
@@ -1,0 +1,75 @@
+import {
+	ApiVersionClass,
+	type CreateEntityParams,
+	EntityErrorCode,
+	type Feature,
+	findFeatureById,
+	RecaseError,
+} from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { EntityService } from "@/internal/api/entities/EntityService.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { attachDefaultProductsToEntities } from "../actions/batchCreateEntities/attachDefaultProductsToEntities.js";
+import { constructEntity } from "../entityUtils/entityUtils.js";
+import type { EntityCreationRecoveryPayload } from "./entityCreationRecoveryTypes.js";
+
+export const replayFailedEntityCreation = async ({
+	ctx,
+	payload,
+}: {
+	ctx: AutumnContext;
+	payload: EntityCreationRecoveryPayload;
+}) => {
+	ctx.apiVersion = new ApiVersionClass(payload.apiVersion);
+	ctx.skipCache = true;
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: payload.params.customer_id,
+	});
+	const missing: Array<{ inputEntity: CreateEntityParams; feature: Feature }> =
+		[];
+	for (const inputEntity of payload.params.create_entity_data) {
+		const feature = findFeatureById({
+			features: ctx.features,
+			featureId: inputEntity.feature_id,
+			errorOnNotFound: true,
+		});
+		const existing = await EntityService.get({
+			db: ctx.db,
+			id: inputEntity.id as string,
+			internalCustomerId: customer.internal_id,
+			internalFeatureId: feature.internal_id,
+		});
+		if (!existing) missing.push({ inputEntity, feature });
+	}
+	if (missing.length === 0) return;
+	await ctx.db.transaction(async (tx) => {
+		const transactionCtx = { ...ctx, db: tx as unknown as DrizzleCli };
+		const entities = missing.map(({ inputEntity, feature }) =>
+			constructEntity({
+				inputEntity,
+				feature,
+				internalCustomerId: customer.internal_id,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			}),
+		);
+		try {
+			await EntityService.insert({ db: transactionCtx.db, data: entities });
+		} catch (error) {
+			if (
+				!(error instanceof RecaseError) ||
+				error.code !== EntityErrorCode.EntityAlreadyExists
+			)
+				throw error;
+			return;
+		}
+		await attachDefaultProductsToEntities({
+			ctx: transactionCtx,
+			fullCustomer: customer,
+			entities,
+			customerData: payload.params.customer_data,
+		});
+	});
+};

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -29,6 +29,8 @@ import { storeDeferredInvoiceLineItems } from "@/internal/billing/v2/workflows/s
 import { storeInvoiceLineItems } from "@/internal/billing/v2/workflows/storeInvoiceLineItems/storeInvoiceLineItems.js";
 import { batchResetCustomerEntitlements } from "@/internal/customers/actions/resetCustomerEntitlements/batchResetCustomerEntitlements.js";
 import { replayFailedCustomerCreation } from "@/internal/customers/recovery/replayFailedCustomerCreation.js";
+import { isEntityCreationRecoveryPayload } from "@/internal/entities/recovery/entityCreationRecoveryTypes.js";
+import { replayFailedEntityCreation } from "@/internal/entities/recovery/replayFailedEntityCreation.js";
 import { runClearCreditSystemCacheTask } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import { generateFeatureDisplay } from "@/internal/features/workflows/generateFeatureDisplay.js";
 import { runMigrationTask } from "@/internal/migrations/runMigrationTask.js";
@@ -209,10 +211,11 @@ export const processMessage = async ({
 			if (!ctx) {
 				throw new Error("No context found for customer creation recovery job");
 			}
-			await replayFailedCustomerCreation({
-				ctx,
-				payload: job.data,
-			});
+			if (isEntityCreationRecoveryPayload(job.data)) {
+				await replayFailedEntityCreation({ ctx, payload: job.data });
+			} else {
+				await replayFailedCustomerCreation({ ctx, payload: job.data });
+			}
 			return;
 		}
 

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -214,6 +214,20 @@ export const processMessage = async ({
 			if (isEntityCreationRecoveryPayload(job.data)) {
 				await replayFailedEntityCreation({ ctx, payload: job.data });
 			} else {
+				if (
+					typeof job.data === "object" &&
+					job.data !== null &&
+					"kind" in job.data &&
+					job.data.kind !== undefined
+				) {
+					workerLogger.warn(
+						"[customerCreationRecovery] Unknown recovery payload kind",
+						{
+							kind: job.data.kind,
+							sourceRequestId: job.data.requestId,
+						},
+					);
+				}
 				await replayFailedCustomerCreation({ ctx, payload: job.data });
 			}
 			return;

--- a/server/src/queue/queueUtils.ts
+++ b/server/src/queue/queueUtils.ts
@@ -12,6 +12,7 @@ import { generateId } from "@server/utils/genUtils";
 import type { StripeWebhookReplayPayload } from "@/external/stripe/webhookReplay/runStripeWebhookReplay.js";
 import type { BatchResetCustomerEntitlementsV2Payload } from "@/internal/balances/batchReset/types.js";
 import type { CustomerCreationRecoveryPayload } from "@/internal/customers/recovery/customerCreationRecoveryTypes.js";
+import type { EntityCreationRecoveryPayload } from "@/internal/entities/recovery/entityCreationRecoveryTypes.js";
 import type { ClearCreditSystemCachePayload } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import type { GenerateFeatureDisplayPayload } from "@/internal/features/workflows/generateFeatureDisplay.js";
 import { getSqsClient } from "./initSqs.js";
@@ -85,7 +86,9 @@ export interface Payloads {
 		redisInstance: string;
 		timestamp: number;
 	};
-	[JobName.CustomerCreationRecovery]: CustomerCreationRecoveryPayload;
+	[JobName.CustomerCreationRecovery]:
+		| CustomerCreationRecoveryPayload
+		| EntityCreationRecoveryPayload;
 	[JobName.StripeWebhookReplay]: StripeWebhookReplayPayload;
 	[JobName.ClearCreditSystemCustomerCache]: ClearCreditSystemCachePayload;
 	[JobName.GenerateFeatureDisplay]: GenerateFeatureDisplayPayload;

--- a/server/tests/unit/entities/recovery/batch-create-entities-recovery-boundary.test.ts
+++ b/server/tests/unit/entities/recovery/batch-create-entities-recovery-boundary.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Entity recovery must not change the normal create transaction boundary.
+ *
+ * Red (current): stable-ID creates wrap insert + defaults in a transaction, so
+ * a default-attachment failure rolls back the entity and queues a replay.
+ * Green (after): only a failed insert is captured; a successful normal insert
+ * stays committed and later failures do not enter entity recovery.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const transientError = Object.assign(new Error("connect timeout"), {
+	code: "CONNECT_TIMEOUT",
+});
+
+const state = {
+	attachCalls: 0,
+	entityCommitted: false,
+	failure: undefined as "seat" | "insert" | "attach" | undefined,
+	insertCalls: 0,
+	queueCalls: [] as Record<string, unknown>[],
+	seatChargeCalls: 0,
+	transactionCalls: 0,
+};
+
+const transactionDb = { name: "transaction" };
+let requestDb: object;
+
+const mockedPaths = [
+	"@/external/redis/utils/lockUtils/withLock.js",
+	"@/internal/api/entities/EntityService.js",
+	"@/internal/entities/recovery/queueFailedEntityCreation.js",
+	"@/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.js",
+	"@/internal/entities/handlers/handleCreateEntity/getInputEntities.js",
+	"@/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.js",
+] as const;
+const realModules = new Map<string, Record<string, unknown>>();
+for (const path of mockedPaths) {
+	realModules.set(path, { ...(await import(path)) });
+}
+
+afterAll(() => {
+	for (const [path, realModule] of realModules) {
+		mock.module(path, () => realModule);
+	}
+});
+
+mock.module("@/external/redis/utils/lockUtils/withLock.js", () => ({
+	withLock: async ({ fn }: { fn: () => Promise<unknown> }) => fn(),
+}));
+
+mock.module("@/internal/api/entities/EntityService.js", () => ({
+	EntityService: {
+		insert: async ({ db, data }: { db: object; data: unknown[] }) => {
+			state.insertCalls++;
+			if (state.failure === "insert") throw transientError;
+			if (db === requestDb) state.entityCommitted = true;
+			return data;
+		},
+		update: async () => {
+			throw new Error("unexpected placeholder update");
+		},
+	},
+}));
+
+mock.module(
+	"@/internal/entities/recovery/queueFailedEntityCreation.js",
+	() => ({
+		queueFailedEntityCreation: async (args: Record<string, unknown>) => {
+			state.queueCalls.push(args);
+			return true;
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.js",
+	() => ({
+		createEntityForCusProduct: async () => {
+			state.seatChargeCalls++;
+			if (state.failure === "seat") throw transientError;
+		},
+	}),
+);
+
+mock.module(
+	"@/internal/entities/handlers/handleCreateEntity/getInputEntities.js",
+	() => ({
+		validateAndGetInputEntities: async () => ({
+			customer: {
+				id: "customer_123",
+				internal_id: "customer_internal_123",
+			},
+			inputEntities: [
+				{ id: "entity_123", name: "Entity", feature_id: "seats" },
+			],
+			cusProducts: [{}],
+			existingEntities: [],
+		}),
+	}),
+);
+
+mock.module(
+	"@/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.js",
+	() => ({
+		attachDefaultProductsToEntities: async () => {
+			state.attachCalls++;
+			if (state.failure === "attach") throw transientError;
+		},
+	}),
+);
+
+const { batchCreateEntities } = await import(
+	// @ts-expect-error Bun test cache-busting import query isolates module mocks.
+	"@/internal/entities/actions/batchCreateEntities.js?entityRecoveryBoundary"
+);
+
+const buildContext = () => {
+	requestDb = {
+		transaction: async (fn: (db: object) => Promise<unknown>) => {
+			state.transactionCalls++;
+			return fn(transactionDb);
+		},
+	};
+
+	return {
+		id: "request_123",
+		org: { id: "org_123" },
+		env: AppEnv.Live,
+		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		features: [
+			{ id: "seats", internal_id: "feature_internal_123", name: "Seats" },
+		],
+		extraLogs: {},
+		db: requestDb,
+		logger: {
+			warn: mock(() => {}),
+			error: mock(() => {}),
+		},
+	} as unknown as AutumnContext;
+};
+
+const createEntity = ({ ctx }: { ctx: AutumnContext }) =>
+	batchCreateEntities({
+		ctx,
+		customerId: "customer_123",
+		createEntityData: {
+			id: "entity_123",
+			name: "Entity",
+			feature_id: "seats",
+		},
+	});
+
+describe("batchCreateEntities recovery boundary", () => {
+	beforeEach(() => {
+		state.attachCalls = 0;
+		state.entityCommitted = false;
+		state.failure = undefined;
+		state.insertCalls = 0;
+		state.queueCalls = [];
+		state.seatChargeCalls = 0;
+		state.transactionCalls = 0;
+	});
+
+	test("keeps a successful normal insert committed when default attachment fails", async () => {
+		state.failure = "attach";
+
+		await expect(createEntity({ ctx: buildContext() })).rejects.toBe(
+			transientError,
+		);
+
+		expect(state.entityCommitted).toBe(true);
+		expect(state.transactionCalls).toBe(0);
+		expect(state.queueCalls).toHaveLength(0);
+	});
+
+	test("captures only a transient stable-ID insert failure", async () => {
+		state.failure = "insert";
+		const ctx = buildContext();
+
+		await expect(createEntity({ ctx })).rejects.toMatchObject({
+			statusCode: 503,
+		});
+
+		expect(state.seatChargeCalls).toBe(1);
+		expect(state.attachCalls).toBe(0);
+		expect(state.entityCommitted).toBe(false);
+		expect(state.transactionCalls).toBe(0);
+		expect(state.queueCalls).toEqual([
+			expect.objectContaining({
+				ctx,
+				params: expect.objectContaining({
+					customer_id: "customer_123",
+					create_entity_data: [
+						{ id: "entity_123", name: "Entity", feature_id: "seats" },
+					],
+				}),
+			}),
+		]);
+	});
+
+	test("does not capture a seat-bookkeeping failure", async () => {
+		state.failure = "seat";
+
+		await expect(createEntity({ ctx: buildContext() })).rejects.toBe(
+			transientError,
+		);
+
+		expect(state.insertCalls).toBe(0);
+		expect(state.queueCalls).toHaveLength(0);
+	});
+});

--- a/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
+++ b/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
@@ -1,14 +1,24 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import {
-	ApiVersion,
-	ApiVersionClass,
-	AppEnv,
-	EntityErrorCode,
-	RecaseError,
-} from "@autumn/shared";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
-const state = { existing: false, inserts: 0, attaches: 0, conflictOnce: false };
+const state = { existing: false, inserts: 0, attaches: 0 };
+
+const mockedPaths = [
+	"@/internal/customers/CusService.js",
+	"@/internal/api/entities/EntityService.js",
+	"@/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.js",
+] as const;
+const realModules = new Map<string, Record<string, unknown>>();
+for (const path of mockedPaths) {
+	realModules.set(path, { ...(await import(path)) });
+}
+
+afterAll(() => {
+	for (const [path, realModule] of realModules) {
+		mock.module(path, () => realModule);
+	}
+});
 
 mock.module("@/internal/customers/CusService.js", () => ({
 	CusService: {
@@ -23,16 +33,15 @@ mock.module("@/internal/customers/CusService.js", () => ({
 mock.module("@/internal/api/entities/EntityService.js", () => ({
 	EntityService: {
 		get: async () => (state.existing ? { id: "entity" } : undefined),
-		insert: async ({ data }: { data: unknown[] }) => {
+		insert: async ({
+			data,
+			ignoreConflicts,
+		}: {
+			data: unknown[];
+			ignoreConflicts?: boolean;
+		}) => {
 			state.inserts++;
-			if (state.conflictOnce) {
-				state.conflictOnce = false;
-				throw new RecaseError({
-					message: "Entity already exists",
-					code: EntityErrorCode.EntityAlreadyExists,
-					statusCode: 409,
-				});
-			}
+			if (ignoreConflicts && state.existing) return [];
 			return data;
 		},
 	},
@@ -66,27 +75,6 @@ describe("replayFailedEntityCreation", () => {
 		state.existing = false;
 		state.inserts = 0;
 		state.attaches = 0;
-		state.conflictOnce = false;
-	});
-	test("rechecks and retries when an insert races", async () => {
-		state.conflictOnce = true;
-		await replayFailedEntityCreation({
-			ctx: context(),
-			payload: {
-				kind: "entity",
-				orgId: "org",
-				env: AppEnv.Live,
-				customerId: "customer",
-				requestId: "request",
-				apiVersion: ApiVersion.V2_1,
-				params: {
-					customer_id: "customer",
-					create_entity_data: [{ id: "entity", feature_id: "seats" }],
-				},
-			},
-		});
-		expect(state.inserts).toBe(2);
-		expect(state.attaches).toBe(1);
 	});
 	test("inserts only missing stable-ID entities with their defaults in one transaction", async () => {
 		await replayFailedEntityCreation({
@@ -124,7 +112,7 @@ describe("replayFailedEntityCreation", () => {
 				},
 			},
 		});
-		expect(state.inserts).toBe(0);
+		expect(state.inserts).toBe(1);
 		expect(state.attaches).toBe(0);
 	});
 });

--- a/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
+++ b/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const state = { existing: false, inserts: 0, attaches: 0 };
+
+mock.module("@/internal/customers/CusService.js", () => ({
+	CusService: {
+		getFull: async () => ({
+			id: "customer",
+			internal_id: "customer_internal",
+			customer_products: [],
+			entities: [],
+		}),
+	},
+}));
+mock.module("@/internal/api/entities/EntityService.js", () => ({
+	EntityService: {
+		get: async () => (state.existing ? { id: "entity" } : undefined),
+		insert: async ({ data }: { data: unknown[] }) => {
+			state.inserts++;
+			return data;
+		},
+	},
+}));
+mock.module(
+	"@/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.js",
+	() => ({
+		attachDefaultProductsToEntities: async () => {
+			state.attaches++;
+		},
+	}),
+);
+
+const { replayFailedEntityCreation } = await import(
+	// @ts-expect-error Bun test cache-busting import query isolates module mocks.
+	"@/internal/entities/recovery/replayFailedEntityCreation.js?stableEntityRecovery"
+);
+
+const context = () =>
+	({
+		org: { id: "org" },
+		env: AppEnv.Live,
+		apiVersion: new ApiVersionClass(ApiVersion.V0_2),
+		features: [{ id: "seats", internal_id: "feature_internal" }],
+		skipCache: false,
+		db: { transaction: async (fn: (tx: object) => Promise<void>) => fn({}) },
+	}) as unknown as AutumnContext;
+
+describe("replayFailedEntityCreation", () => {
+	beforeEach(() => {
+		state.existing = false;
+		state.inserts = 0;
+		state.attaches = 0;
+	});
+	test("inserts only missing stable-ID entities with their defaults in one transaction", async () => {
+		await replayFailedEntityCreation({
+			ctx: context(),
+			payload: {
+				kind: "entity",
+				orgId: "org",
+				env: AppEnv.Live,
+				customerId: "customer",
+				requestId: "request",
+				apiVersion: ApiVersion.V2_1,
+				params: {
+					customer_id: "customer",
+					create_entity_data: [{ id: "entity", feature_id: "seats" }],
+				},
+			},
+		});
+		expect(state.inserts).toBe(1);
+		expect(state.attaches).toBe(1);
+	});
+	test("does nothing when the entity already exists", async () => {
+		state.existing = true;
+		await replayFailedEntityCreation({
+			ctx: context(),
+			payload: {
+				kind: "entity",
+				orgId: "org",
+				env: AppEnv.Live,
+				customerId: "customer",
+				requestId: "request",
+				apiVersion: ApiVersion.V2_1,
+				params: {
+					customer_id: "customer",
+					create_entity_data: [{ id: "entity", feature_id: "seats" }],
+				},
+			},
+		});
+		expect(state.inserts).toBe(0);
+		expect(state.attaches).toBe(0);
+	});
+});

--- a/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
+++ b/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
+import {
+	ApiVersion,
+	ApiVersionClass,
+	AppEnv,
+	EntityErrorCode,
+	RecaseError,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
-const state = { existing: false, inserts: 0, attaches: 0 };
+const state = { existing: false, inserts: 0, attaches: 0, conflictOnce: false };
 
 mock.module("@/internal/customers/CusService.js", () => ({
 	CusService: {
@@ -19,6 +25,14 @@ mock.module("@/internal/api/entities/EntityService.js", () => ({
 		get: async () => (state.existing ? { id: "entity" } : undefined),
 		insert: async ({ data }: { data: unknown[] }) => {
 			state.inserts++;
+			if (state.conflictOnce) {
+				state.conflictOnce = false;
+				throw new RecaseError({
+					message: "Entity already exists",
+					code: EntityErrorCode.EntityAlreadyExists,
+					statusCode: 409,
+				});
+			}
 			return data;
 		},
 	},
@@ -52,6 +66,27 @@ describe("replayFailedEntityCreation", () => {
 		state.existing = false;
 		state.inserts = 0;
 		state.attaches = 0;
+		state.conflictOnce = false;
+	});
+	test("rechecks and retries when an insert races", async () => {
+		state.conflictOnce = true;
+		await replayFailedEntityCreation({
+			ctx: context(),
+			payload: {
+				kind: "entity",
+				orgId: "org",
+				env: AppEnv.Live,
+				customerId: "customer",
+				requestId: "request",
+				apiVersion: ApiVersion.V2_1,
+				params: {
+					customer_id: "customer",
+					create_entity_data: [{ id: "entity", feature_id: "seats" }],
+				},
+			},
+		});
+		expect(state.inserts).toBe(2);
+		expect(state.attaches).toBe(1);
 	});
 	test("inserts only missing stable-ID entities with their defaults in one transaction", async () => {
 		await replayFailedEntityCreation({

--- a/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
+++ b/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
@@ -95,7 +95,7 @@ describe("replayFailedEntityCreation", () => {
 		expect(state.inserts).toBe(1);
 		expect(state.attaches).toBe(1);
 	});
-	test("does nothing when the entity already exists", async () => {
+	test("does not attach defaults when the entity already exists", async () => {
 		state.existing = true;
 		await replayFailedEntityCreation({
 			ctx: context(),

--- a/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
+++ b/server/tests/unit/entities/recovery/replay-failed-entity-creation.test.ts
@@ -2,7 +2,16 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { ApiVersion, ApiVersionClass, AppEnv } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 
-const state = { existing: false, inserts: 0, attaches: 0 };
+const state = {
+	attachDb: undefined as unknown,
+	attaches: 0,
+	existing: false,
+	insertDb: undefined as unknown,
+	inserts: 0,
+	transactions: 0,
+};
+
+const transactionDb = { name: "transaction" };
 
 const mockedPaths = [
 	"@/internal/customers/CusService.js",
@@ -34,13 +43,16 @@ mock.module("@/internal/api/entities/EntityService.js", () => ({
 	EntityService: {
 		get: async () => (state.existing ? { id: "entity" } : undefined),
 		insert: async ({
+			db,
 			data,
 			ignoreConflicts,
 		}: {
+			db: unknown;
 			data: unknown[];
 			ignoreConflicts?: boolean;
 		}) => {
 			state.inserts++;
+			state.insertDb = db;
 			if (ignoreConflicts && state.existing) return [];
 			return data;
 		},
@@ -49,8 +61,13 @@ mock.module("@/internal/api/entities/EntityService.js", () => ({
 mock.module(
 	"@/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.js",
 	() => ({
-		attachDefaultProductsToEntities: async () => {
+		attachDefaultProductsToEntities: async ({
+			ctx,
+		}: {
+			ctx: AutumnContext;
+		}) => {
 			state.attaches++;
+			state.attachDb = ctx.db;
 		},
 	}),
 );
@@ -67,14 +84,22 @@ const context = () =>
 		apiVersion: new ApiVersionClass(ApiVersion.V0_2),
 		features: [{ id: "seats", internal_id: "feature_internal" }],
 		skipCache: false,
-		db: { transaction: async (fn: (tx: object) => Promise<void>) => fn({}) },
+		db: {
+			transaction: async (fn: (tx: object) => Promise<void>) => {
+				state.transactions++;
+				return fn(transactionDb);
+			},
+		},
 	}) as unknown as AutumnContext;
 
 describe("replayFailedEntityCreation", () => {
 	beforeEach(() => {
+		state.attachDb = undefined;
 		state.existing = false;
+		state.insertDb = undefined;
 		state.inserts = 0;
 		state.attaches = 0;
+		state.transactions = 0;
 	});
 	test("inserts only missing stable-ID entities with their defaults in one transaction", async () => {
 		await replayFailedEntityCreation({
@@ -94,6 +119,9 @@ describe("replayFailedEntityCreation", () => {
 		});
 		expect(state.inserts).toBe(1);
 		expect(state.attaches).toBe(1);
+		expect(state.transactions).toBe(1);
+		expect(state.insertDb).toBe(transactionDb);
+		expect(state.attachDb).toBe(transactionDb);
 	});
 	test("does not attach defaults when the entity already exists", async () => {
 		state.existing = true;


### PR DESCRIPTION
## What

Recovers stable-ID entity creates that shed with a transient infrastructure error.

- Captures only after the normal validation/customer lookup succeeds.
- Does not capture any batch containing an id-less entity.
- The worker checks entity rows by ID; it inserts only missing rows and attaches free defaults in the same database transaction.
- Existing rows are a no-op. Replay never performs seat billing, balance changes, or Stripe work.

## Verification

- Focused unit replay tests
- `bun ts`
- Biome check (only pre-existing warnings in shared queue files)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replays stable-ID entity creates only when the insert fails due to a transient infrastructure error, preserving 503 shed behavior. Previously, recovery could be triggered after a successful insert (e.g., during default attachment); now successful inserts stay committed and only insert failures are captured.

- Request path: For stable-ID batches, wraps insert in `shed503OnTransientError`; on transient insert error, enqueues `kind: "entity"` recovery and returns 503. Default-attachment or seat-bookkeeping failures do not enqueue and do not roll back already-inserted rows.
- Queue/worker: Reuses the CustomerCreationRecovery queue; `processMessage` routes `kind: "entity"` via a type guard, logging unknown kinds. Payload preserves org/env/API-version context using `@autumn/shared` types and dedups by org/env/apiVersion/params.
- Recovery: Constructs entities deterministically, inserts with `ignoreConflicts`, and attaches default products only for newly inserted rows in a single DB transaction. No seat billing, balance updates, or Stripe work.
- Guardrails: Queues only after validation and customer lookup succeed, and only if every input entity has an ID; existing rows are a no-op.

<sup>Written for commit 7345b29f58370e1d5a760895493a5f2f9e0b4b16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds recovery of stable-ID entity creations that fail because of transient infrastructure errors.

- **[Improvements, Bug fixes]** Queues failed stable-ID inserts with tenant-aware FIFO deduplication and preserves the originating API version.
- **[Improvements, Bug fixes]** Replays missing entities and attaches their free defaults within one database transaction.
- **[API changes]** Extends the customer-creation recovery queue payload to route entity recovery jobs.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a recovery job can acknowledge an existing entity without attaching the free defaults that the failed request never reached.

EntityService inserts entities before updating customer metadata; if that subsequent update fails transiently, recovery is queued after the entity already exists. The worker's conflict-ignoring insert then returns no row and exits without attaching defaults, so the previously reported incomplete-entity state remains reachable.

**Files Needing Attention:** server/src/internal/api/entities/EntityService.ts; server/src/internal/entities/recovery/replayFailedEntityCreation.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/api/entities/EntityService.ts | Adds optional conflict-ignoring bulk inserts that return only newly inserted entity rows. |
| server/src/internal/entities/actions/batchCreateEntities.ts | Captures transient stable-ID insertion failures and submits them to the recovery queue. |
| server/src/internal/entities/recovery/queueFailedEntityCreation.ts | Builds tenant- and environment-aware FIFO recovery messages for failed entity inserts. |
| server/src/internal/entities/recovery/replayFailedEntityCreation.ts | Reconstructs and transactionally inserts missing entities before attaching free defaults. |
| server/src/queue/processMessage.ts | Routes entity recovery payloads through the existing customer-recovery worker. |
| server/src/queue/queueUtils.ts | Extends the recovery queue's payload type to include entity creation jobs. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as Entity API
    participant DB as PostgreSQL
    participant Queue as Recovery Queue
    participant Worker as Recovery Worker
    API->>DB: Insert stable-ID entities
    alt transient failure
        API->>Queue: Enqueue tenant-scoped recovery
        API-->>API: Return 503
        Queue->>Worker: Deliver entity recovery job
        Worker->>DB: Insert missing rows, ignoring conflicts
        Worker->>DB: Attach free defaults in same transaction
    else insert succeeds
        DB-->>API: Return inserted entities
        API->>DB: Attach free defaults
    end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: scope entity recovery to insert fai..."](https://github.com/useautumn/autumn/commit/7345b29f58370e1d5a760895493a5f2f9e0b4b16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52313080)</sub>

<!-- /greptile_comment -->