### PR TITLE
fix: record add_to_balance grants in adjustment so track refunds can restore them

### DIFF
--- a/server/src/internal/balances/updateBalance/v2/handleUpdateBalanceDeductionErrorV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/handleUpdateBalanceDeductionErrorV2.ts
@@ -11,12 +11,14 @@ export const handleUpdateBalanceDeductionErrorV2 = async ({
 	fullSubject,
 	featureDeductions,
 	customerEntitlementFilters,
+	alterGrantedBalance = false,
 }: {
 	ctx: AutumnContext;
 	error: Error;
 	fullSubject: FullSubject;
 	featureDeductions: FeatureDeduction[];
 	customerEntitlementFilters?: CustomerEntitlementFilters;
+	alterGrantedBalance?: boolean;
 }) => {
 	if (!(error instanceof RedisDeductionError) || !error.shouldFallback())
 		throw error;
@@ -32,7 +34,7 @@ export const handleUpdateBalanceDeductionErrorV2 = async ({
 		options: {
 			overageBehaviour: "allow",
 			customerEntitlementFilters,
-			alterGrantedBalance: false,
+			alterGrantedBalance,
 		},
 	});
 };

--- a/server/src/internal/balances/updateBalance/v2/updateRemainingV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateRemainingV2.ts
@@ -43,6 +43,12 @@ export const updateRemainingV2 = async ({
 
 	const entityId = fullSubject.entityId;
 
+	// add_to_balance is a manual grant: record it in the granted level
+	// (adjustment) so the refund ceiling in track covers it. Setting
+	// remaining/current_balance stays a usage edit and leaves the granted
+	// level untouched.
+	const alterGrantedBalance = notNullish(addToBalance);
+
 	const { data: result, error } = await tryCatch(
 		executeRedisDeductionV2({
 			ctx,
@@ -52,7 +58,7 @@ export const updateRemainingV2 = async ({
 			deductionOptions: {
 				overageBehaviour: "allow",
 				customerEntitlementFilters,
-				alterGrantedBalance: false,
+				alterGrantedBalance,
 			},
 		}),
 	);
@@ -64,6 +70,7 @@ export const updateRemainingV2 = async ({
 			fullSubject,
 			featureDeductions,
 			customerEntitlementFilters,
+			alterGrantedBalance,
 		});
 	}
 

--- a/server/tests/integration/balances/track/basic/track-negative-after-add-to-balance.test.ts
+++ b/server/tests/integration/balances/track/basic/track-negative-after-add-to-balance.test.ts
@@ -1,0 +1,170 @@
+/**
+ * TDD test for granted-balance-only entitlements being unrefundable via track.
+ *
+ * A cusEnt whose balance came purely from a manual grant (add_to_balance)
+ * has entitlement.allowance = 0, and the grant used to bump `balance` only,
+ * so the refund ceiling (startingBalance + adjustment) stayed at 0 and any
+ * negative track above it was silently swallowed with a 200.
+ *
+ * Red-failure mode (current behavior):
+ *  - add_to_balance 5, track +2 (balance 3), track -2 → balance stays 3,
+ *    no error, HTTP 200.
+ *
+ * Green-success criteria (after fix):
+ *  - add_to_balance records the grant in `adjustment`, so the negative track
+ *    restores the balance to 5, and refunds still clamp at the granted level
+ *    (allowance + adjustment) — never above it.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomer, TrackResponseV2 } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+// ═══════════════════════════════════════════════════════════════════
+// TRACK-NEGATIVE-GRANT1: refund after add_to_balance grant restores balance
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("track-negative-grant1: negative track restores balance granted via add_to_balance")}`,
+	async () => {
+		const messagesItem = items.monthlyMessages({ includedUsage: 0 });
+		const freeProd = products.base({ id: "free", items: [messagesItem] });
+
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "track-negative-grant1",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd], createInStripe: false }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		// Grant 5 via add_to_balance (allowance is 0)
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			add_to_balance: 5,
+		});
+
+		// The grant is recorded in the granted level, not as negative usage
+		const customerAfterGrant =
+			await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(customerAfterGrant.balances[TestFeature.Messages]).toMatchObject({
+			granted_balance: 5,
+			current_balance: 5,
+			usage: 0,
+		});
+
+		// Track usage — works, balance goes down
+		const trackRes1: TrackResponseV2 = await autumnV2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 2,
+		});
+		expect(trackRes1.balance).toMatchObject({
+			granted_balance: 5,
+			current_balance: 3,
+			usage: 2,
+		});
+
+		// Refund the usage — must restore the balance to the granted level
+		const trackRes2: TrackResponseV2 = await autumnV2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: -2,
+		});
+		expect(trackRes2.balance).toMatchObject({
+			granted_balance: 5,
+			current_balance: 5,
+			usage: 0,
+		});
+
+		// Refunds must still clamp at the granted level, never inflate above it
+		const trackRes3: TrackResponseV2 = await autumnV2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: -100,
+		});
+		expect(trackRes3.balance).toMatchObject({
+			granted_balance: 5,
+			current_balance: 5,
+			usage: 0,
+		});
+
+		await timeout(2000);
+		const customerDb = await autumnV2.customers.get<ApiCustomer>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customerDb.balances[TestFeature.Messages]).toMatchObject({
+			granted_balance: 5,
+			current_balance: 5,
+			usage: 0,
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// TRACK-NEGATIVE-GRANT2: allowance-backed refund clamps at allowance + grant
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("track-negative-grant2: refund clamps at allowance plus add_to_balance grant")}`,
+	async () => {
+		const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+		const freeProd = products.base({ id: "free", items: [messagesItem] });
+
+		const { customerId, autumnV2 } = await initScenario({
+			customerId: "track-negative-grant2",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [freeProd], createInStripe: false }),
+			],
+			actions: [s.attach({ productId: freeProd.id })],
+		});
+
+		// Grant 5 on top of the allowance
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			add_to_balance: 5,
+		});
+
+		const trackRes1: TrackResponseV2 = await autumnV2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: 10,
+		});
+		expect(trackRes1.balance).toMatchObject({
+			granted_balance: 105,
+			current_balance: 95,
+			usage: 10,
+		});
+
+		// Over-refund: must clamp at the granted level (100 + 5), not inflate
+		const trackRes2: TrackResponseV2 = await autumnV2.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			value: -20,
+		});
+		expect(trackRes2.balance).toMatchObject({
+			granted_balance: 105,
+			current_balance: 105,
+			usage: 0,
+		});
+
+		await timeout(2000);
+		const customerDb = await autumnV2.customers.get<ApiCustomer>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customerDb.balances[TestFeature.Messages]).toMatchObject({
+			granted_balance: 105,
+			current_balance: 105,
+			usage: 0,
+		});
+	},
+);

--- a/shared/api/balances/update/updateBalanceParams.ts
+++ b/shared/api/balances/update/updateBalanceParams.ts
@@ -12,7 +12,7 @@ export const ExtUpdateBalanceParamsV0Schema = BalanceParamsBaseSchema.extend({
 	}),
 	add_to_balance: z.number().optional().meta({
 		description:
-			"Add this amount to the current balance. Use negative values to subtract. Cannot be combined with current_balance.",
+			"Add this amount to the current balance. The granted balance is adjusted by the same amount, so refunds via track can restore the added balance. Use negative values to subtract. Cannot be combined with current_balance.",
 	}),
 
 	usage: z.number().optional().meta({

--- a/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx
@@ -683,12 +683,13 @@ function SubmitButton({
 					const defaultGPB =
 						form.options.defaultValues?.grantedAndPurchasedBalance ?? 0;
 					const newGPB = defaultGPB + addAmount;
-					const grantedBalanceInput = values.updateGrantedBalance
-						? computeGrantedBalanceInput({
-								newGPB,
-								prepaidAllowance: form.prepaidAllowance,
-							})
-						: undefined;
+					// add_to_balance now records the grant server-side (so refunds via
+					// track can restore it). When the toggle is off, pin the granted
+					// balance at its current value to keep it unchanged.
+					const grantedBalanceInput = computeGrantedBalanceInput({
+						newGPB: values.updateGrantedBalance ? newGPB : defaultGPB,
+						prepaidAllowance: form.prepaidAllowance,
+					});
 
 					promises.push(
 						axiosInstance.post("/v1/balances/update", {


### PR DESCRIPTION
## Problem

Granted-balance-only entitlements (allowance 0, balance from a manual `add_to_balance` grant) are unrefundable via track: negative tracks are silently swallowed with a 200 (see repro in the test).

Root cause is upstream of the deduction engine: `updateRemainingV2` executed `add_to_balance` with `alterGrantedBalance: false`, so the grant bumped `balance` only. The refund ceiling in both deduction paths (`deductFromMainBalanceV2.lua` and the TS mirror `calculateDeduction.ts`) is `startingBalance + adjustment`, which stayed at 0 — every refund above it computed `to_change = 0`. The grant was effectively encoded as negative usage, indistinguishable from refund-inflation, so no ceiling formula could fix this at the engine layer: the proposed `max(startingBalance + adjustment, currentBalance)` is algebraically identical to the current clamp (`max(0, ceiling − balance)` ≡ `max(0, max(ceiling, balance) − balance)`).

## Fix

- `updateRemainingV2` now passes `alterGrantedBalance: true` for `add_to_balance` (and threads the flag through the Postgres fallback in `handleUpdateBalanceDeductionErrorV2`). The grant lands in `adjustment` — same mechanism as `included_grant` and the legacy `handleUpdateBalancesV2` — so the existing Lua/TS refund ceilings cover it with no engine change, on both the Redis and Postgres paths.
- `remaining` / `current_balance` updates are untouched: they stay usage edits with the granted level unchanged (pinned by `update-balance-basic` tests).
- Dashboard `BalanceEditSheet` "Add" mode with **Also Update Granted Balance** off now pins `included_grant` at its current value, preserving the explicit opt-out (the toggle-on flow is unchanged: the absolute `included_grant` set overwrites the adjustment bump to the same final state).
- Updated the `add_to_balance` param description; the Speakeasy SDK copy regenerates from it.

Side effect worth noting: `add_to_balance` now reports sanely in the API — granted 5 / usage 0 instead of granted 0 / usage −5.

## Verification

Verified live against a sandbox server (Redis path):

- allowance 0 + `add_to_balance` 5 → track +2 (remaining 3) → track −2 now restores remaining 5 (previously stuck at 3 with a 200); track −100 clamps at 5.
- allowance 100: track 30 → refund −50 still clamps at 100; with a +5 grant the clamp moves to 105.
- `current_balance` set to 80 leaves granted unchanged and usage adjusts — pinned semantics intact.

Regression test: `server/tests/integration/balances/track/basic/track-negative-after-add-to-balance.test.ts` (red before the fix — balance stuck at 3; green after). Balances unit suite (141 tests) and server typecheck pass. Note: this sandbox has no Stripe test key, so the integration harness (`initCustomerV3` creates a Stripe customer per test) couldn't run here — please run that file once in a normal dev environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes refunds for manual balance grants. `add_to_balance` now increases granted balance, so negative `track` restores the added balance and clamps correctly.

- **Bug Fixes**
  - Record `add_to_balance` in the granted level by passing `alterGrantedBalance: true` (applies to Redis and Postgres fallback paths).
  - Keep `remaining`/`current_balance` updates as usage-only edits; granted level stays unchanged.
  - Update BalanceEditSheet: with "Also Update Granted Balance" off, pin the granted balance; toggle-on flow unchanged.
  - Clarify `add_to_balance` docs; API now reports grants as granted balance (not negative usage). Added a regression test for refunds after a grant.

<sup>Written for commit be60116147d24784585eac7134ad0fda2a03e96a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR records manual balance additions as granted-balance adjustments so later negative tracking can refund usage up to the correct ceiling.
- **Bug fixes, API changes:** Treats `add_to_balance` as a grant in both Redis and PostgreSQL deduction paths and documents the resulting API semantics.
- **Bug fixes:** Adds integration coverage for refunding manually granted balances and clamping over-refunds.
- **Improvements, Bug fixes:** Updates the dashboard’s Add flow to preserve granted balance when its toggle is disabled, but the absolute snapshot can overwrite a concurrent grant change.
</details>

<h3>Confidence Score: 4/5</h3>

The server-side refund fix is sound, but the dashboard’s toggle-off Add flow should be corrected before merging because it can silently erase a concurrent granted-balance update.

The dashboard now submits a stale absolute granted balance when the administrator explicitly opts not to update it, allowing another grant made while the sheet is open to be overwritten.

**Files Needing Attention:** vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/updateBalance/v2/updateRemainingV2.ts | Enables granted-balance adjustment for `add_to_balance` while retaining usage-edit semantics for absolute remaining-balance updates. |
| server/src/internal/balances/updateBalance/v2/handleUpdateBalanceDeductionErrorV2.ts | Preserves the new granted-balance behavior when Redis deductions fall back to PostgreSQL. |
| vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx | Pins the grant during toggle-off Add operations using an absolute form-opening snapshot, which can overwrite a newer grant. |
| shared/api/balances/update/updateBalanceParams.ts | Documents that `add_to_balance` now adjusts both current and granted balance. |
| server/tests/integration/balances/track/basic/track-negative-after-add-to-balance.test.ts | Covers refund restoration and upper-bound clamping for manually granted balances. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Balance Edit Sheet
    participant API as Balance Update API
    participant Engine as Deduction Engine
    participant Store as Entitlement State
    UI->>API: add_to_balance + included_grant snapshot
    API->>Engine: "alterGrantedBalance=true"
    Engine->>Store: Increase balance and adjustment
    Engine->>Store: Set included_grant to submitted snapshot
    Note over UI,Store: A grant added after the sheet opened can be overwritten by the stale snapshot
    API-->>UI: Updated balance
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/customers2/components/sheets/BalanceEditSheet.tsx:689-692
**Stale granted balance overwrite**

If another request changes the granted balance after this sheet opens, the toggle-off branch submits the old `defaultGPB` as an absolute `included_grant`, overwriting the newer grant. For example, a grant raised from 5 to 10 while the sheet is open is reset to 5 when the administrator submits an Add operation with “Also Update Granted Balance” disabled.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: record add\_to\_balance grants in gra..."](https://github.com/useautumn/autumn/commit/be60116147d24784585eac7134ad0fda2a03e96a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52320811)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->