### PR TITLE
test(catalog-v2): plan upsert integration coverage

### DIFF
--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -1,0 +1,471 @@
+# catalogV2 plan cases — test matrix
+
+Every create / update / batch / error case for `catalogV2.update` +
+`preview_update` with `params.plans`, mapped to the test file that owns it.
+
+Status legend:
+
+- `✓` — test written and expected green against current implementation
+- `red` — test written (or to write) as spec; server behavior not implemented
+  yet (see-red-see-green TDD)
+- blank — not written yet
+
+Implementation order = file order below. One file at a time: write, typecheck,
+run, fix, then move on.
+
+Existing V1 suites to mirror coverage from (do NOT duplicate their transport,
+only their scenarios): `server/tests/integration/crud/plans/**` (create shapes,
+update lanes, in-place claims), `server/tests/integration/billing/misc/reuse-stripe-prices-*.test.ts`,
+`server/tests/integration/crud/plans/update/update-plan-paid-item-stripe-carryforward.test.ts`.
+
+Folder layout:
+
+```
+plans/
+  CASES.md
+  utils/expectCatalogPlans.ts
+  create/
+    create-plans.test.ts
+    create-plan-items.test.ts
+  update/
+    idempotent-plans.test.ts
+    update-plan-details.test.ts
+    update-plan-items.test.ts
+    update-plan-rows.test.ts
+    update-plan-free-trial.test.ts
+    stripe-reuse.test.ts
+  versions/
+    plan-versions.test.ts
+  validation/
+    default-flag.test.ts
+    free-trial-validation.test.ts
+    plan-errors.test.ts
+  batch/
+    batch-ops.test.ts
+    features-plans-resolution.test.ts
+    features-plans-type-and-removal.test.ts
+  preview/
+    utils/expectPlanPreview.ts
+    preview-actions.test.ts
+    preview-state-versioning.test.ts
+    changes/
+      changes-details.test.ts
+      changes-base-price.test.ts
+      changes-items.test.ts
+      changes-free-trial.test.ts
+      changes-mixed.test.ts
+```
+
+## 1. Create basics — `create/create-plans.test.ts` (exists)
+
+| Case | Status |
+|---|---|
+| Preview reports `create` and writes nothing | ✓ |
+| Minimal `plan_id` + `name` → v1, empty items, defaults (`add_on`/`is_default` false) | ✓ |
+| Boolean item + metered included + `$20/mo` base price | ✓ |
+| Trial + `add_on` + `auto_enable` (+ `is_default`) + metadata + config + billing_controls | ✓ |
+
+## 2. Create item shapes — `create/create-plan-items.test.ts`
+
+One case per `CreatePlanItemParamsV1` field/knob; assert round-trip through
+`catalogV2.get` (extend `ExpectedPlan` with a full `items` matcher).
+
+| Case | Status |
+|---|---|
+| Boolean feature (bare `feature_id`) | ✓ |
+| Metered `included` + `reset.interval` month / year / `interval_count: 3` | ✓ |
+| Non-resetting consumable (omit `reset`) | ✓ |
+| `unlimited: true` | ✓ |
+| `pooled: true` (unpriced boolean + unlimited metered — the accepted shapes) | ✓ |
+| Reset AND priced (usage_based, `reset.interval === price.interval`) | ✓ |
+| Prepaid flat `amount` + `billing_units: 100` + `max_purchase` | ✓ |
+| Prepaid with `price.interval` differing from `reset.interval` (allowed for prepaid only) | ✓ |
+| Usage-based graduated tiers (multi-tier, `to` boundaries above `included`) | ✓ |
+| Volume tiers + `flat_amount` (prepaid; `tier_behavior: volume_based`) | ✓ |
+| `additional_currencies` on flat amount + on tiers (org must have multi-currency enabled — check scenario setup; skip if not supported by harness) | ✓ |
+| `proration` `on_increase`/`on_decrease` on prepaid | ✓ |
+| `rollover` max / `max_percentage` / expiry duration | ✓ |
+| `entity_feature_id` (allocated / per-entity item) | ✓ |
+| Base `price` with `interval_count: 3` and `additional_currencies` | ✓ |
+
+## 3. Idempotent — `update/idempotent-plans.test.ts`
+
+| Case | Status |
+|---|---|
+| Re-send identical simple plan → action `none`, no write | ✓ |
+| Re-send identical shaped plan (items + base price + metadata/config) → `none`; ent/price row ids unchanged (DB) | ✓ |
+| Preview of identical re-send reports `none` | ✓ |
+
+## 4. Detail facets — `update/update-plan-details.test.ts`
+
+| Case | Status |
+|---|---|
+| name / description / group diffs reported in `previous_attributes`; persisted | ✓ (persisted; preview `changes.previous_attributes` not wired yet) |
+| Details-only update leaves items/prices untouched (row ids stable, DB) | ✓ |
+| metadata update (shared across versions) / config `ignore_past_due` toggle | ✓ |
+| billing_controls patch persists / identical → `none` | ✓ |
+| billing_controls single-key patch merges; other columns untouched | ✓ |
+| billing_controls clear a lane via `[]`; re-send cleared lane → `none` | ✓ |
+| billing_controls two plans in one call → no cross-contamination | ✓ |
+| free_trial facets → moved to section 14 (`update/update-plan-free-trial.test.ts`) with exact-shape asserts | moved |
+| archive / unarchive; omitted `archived` preserves | ✓ |
+| `new_plan_id` clean rename (no customers): id changes, versions & rows intact | ✓ |
+| auto_enable true on free plan → `is_default` persisted; auto_enable false clears | ✓ |
+
+## 5. Item/price update lanes — `update/update-plan-items.test.ts`
+
+Omit-semantics + per-facet shape changes, no customers. Assert via
+`catalogV2.get` shape.
+
+| Case | Status |
+|---|---|
+| Both `price`/`items` omitted → both unchanged | ✓ |
+| `items` only → base price carried | ✓ |
+| `price` only → items carried | ✓ |
+| `price: null` → base removed, items carried | ✓ |
+| Both set → both replaced | ✓ |
+| Add feature item | ✓ |
+| Remove feature item (`items` without it) | ✓ |
+| Change `included` (allowance bump) | ✓ |
+| Free → paid on same feature (add `price` to item) | ✓ |
+| Paid → free (drop item price) | ✓ |
+| Change price amount / tiers / tier_behavior / billing_units | ✓ |
+| Change reset interval (month → year) | ✓ |
+| Toggle unlimited / pooled / rollover / proration on existing item | ✓ |
+
+## 6. Claim / row carry-over — `update/update-plan-rows.test.ts`
+
+DB-level asserts on entitlement/price rows (`ProductService.getFull`),
+mirroring `crud/plans/update/in-place/*`. Claim rule: definition-exact match →
+`same` (row id stable); any change mints `new` row; old row `deleted` (no
+customers) or `retired` + `is_custom: true` (customers exist, never hard-deleted).
+
+Customer refs are DB-seeded (Stripe Connect harness currently broken for
+`s.customer` / attach).
+
+| Case | Status |
+|---|---|
+| Base price only change: feature ent/price row ids stable; old base price row gone (no customers) | ✓ |
+| Remove one item: remaining rows stable; removed rows deleted (no customers) | ✓ |
+| Included bump: new ent row id; old ent deleted (no customers) | ✓ |
+| With attached customer — included bump: old ent retained + `is_custom: true`; customer's cus_ent still references old ent id | red (execute ignores `retired` — no `is_custom` stamp) |
+| With attached customer — remove item: old rows retained/retired; customer keeps grant | red (execute ignores `retired`) |
+| With attached customer — base price change: old base price retired; customer billing rows untouched | red (execute ignores `retired`) |
+| Expired-only customers → treated as no-customers (rows deleted, not retired) | red (`hasAnyCustomerProducts` includes expired) |
+
+## 7. Stripe ID re-use — `update/stripe-reuse.test.ts`
+
+Seed stripe ids on rows (or attach once to create them), then update via
+catalogV2 and assert `processor` ids on DB rows. Mirror
+`update-plan-paid-item-stripe-carryforward` + `reuse-stripe-prices-versioning`
+scenarios for the in-place path.
+
+| Case | Status |
+|---|---|
+| Unchanged paid item across update → `stripe_price_id` + `stripe_product_id` carried | ✓ |
+| Details-only update → all stripe ids carried | ✓ |
+| Price amount change on item → `stripe_product_id` (+ meter) carried, `stripe_price_id` NOT reused | ✓ |
+| Prepaid amount change → `stripe_price_id` not reused | ✓ |
+| Graduated → volume switch → `stripe_price_id` not reused | ✓ |
+| Base price change → new base row carries stripe product; old price id dropped | ✓ (reclassified: fixed amount change gets no stripe carry — usage-only product carry; new row has null ids) |
+| Add new paid item → no stripe ids (minted lazily later) | ✓ |
+
+## 8. Versions — `versions/plan-versions.test.ts`
+
+| Case | Status |
+|---|---|
+| Pinned `version: 1` edit; latest (v2) untouched | ✓ |
+| Omit version targets latest | ✓ |
+| Multi-entry same plan_id (v1 + v2 different payloads) in one call | ✓ |
+| Mint ladder: existing v1; entries v1 (update) + v2 (create) → v2 row created | ✓ |
+| `all_versions` (omit version): change propagates to every existing version | ✓ |
+| `all_versions` on brand-new plan → plain create, no error | ✓ |
+| `all_versions` propagates `free_trial` to every version (section 14 cross-ref) | ✓ (passed via per-row free-trial facet; no versioning work needed) |
+| Pinned `version: 1` trial edit; latest untouched (section 14 cross-ref) | ✓ (passed via per-row free-trial facet; no versioning work needed) |
+
+## 9. Default flag — `validation/default-flag.test.ts`
+
+Spec: only free plans and default-trial plans (`card_required: false`) can be
+`auto_enable`. Evaluated against projected upsert state (no silent flips).
+
+| Case | Status |
+|---|---|
+| Free plan `auto_enable: true` → OK | ✓ |
+| Paid plan + cardless trial (`card_required: false`) `auto_enable: true` → OK | ✓ |
+| Paid recurring plan, no trial, `auto_enable: true` → error | ✓ |
+| One-off priced plan `auto_enable: true` → error | ✓ |
+| `auto_enable: true` on pinned historical version → error (`HistoricalPlanVersionCannotBeDefault`) | ✓ |
+| Defaults in different groups coexist → OK | ✓ |
+
+Open question (do not test yet): multiple free defaults in the SAME group —
+v1 `validateDefaultFlag` rejects; user leaning toward allowing. Decide before
+wiring validation into catalogV2.
+
+## 10. Errors — `validation/plan-errors.test.ts`
+
+| Case | Status |
+|---|---|
+| `versioning: "new_version"` → 400 `invalid_request` | ✓ |
+| `versioning: "all_versions"` + explicit `version` → 400 | ✓ |
+| Duplicate `(plan_id, version)` entries → error | ✓ |
+| Two unpinned entries for same plan_id → error | ✓ |
+| Version gap (declare v3 when max is v1) → error | ✓ |
+| Create without `name` → error | ✓ |
+| `new_plan_id` rename blocked when plan has customers | ✓ |
+| `new_plan_id` rename blocked when reward program references plan | ✓ |
+| Invalid item shape passes through Zod errors (amount+tiers both set; volume flat_amount on graduated; `tiers[0].to <= included`; proration on usage_based; reset/price interval mismatch on non-prepaid) | ✓ |
+
+## 11. Plan × plan batch — `batch/batch-ops.test.ts`
+
+| Case | Status |
+|---|---|
+| Create + update + archive (3 plans) in one call; preview reports all three, writes nothing | ✓ |
+| Create two plans with the same `plan_id` → error | ✓ |
+| Rename A→B while plan B already exists → error | red (throws `internal_error` today — want `invalid_request`) |
+| Rename A→B while B is also being created in the same call → error | red |
+| Create + update of the same plan_id in one call (create entry + pinned v1 entry) → deterministic single outcome or error | red (needs spec decision — encode error) |
+| Rename A→B and separately update A in same call → error (stale reference) | ✓ (caught as duplicate unpinned plan_id) |
+
+## 12. Feature × plan interplay — `batch/features-plans-resolution.test.ts` + `batch/features-plans-type-and-removal.test.ts`
+
+Plan compute resolves items against the projected feature set (post
+update/insert/remove), so same-call creates and renames are visible and stale
+ids are a 404 `feature_not_found`.
+
+### Resolution (creates/renames) — `batch/features-plans-resolution.test.ts`
+
+| Case | Status |
+|---|---|
+| Create feature + create plan with item referencing it → entitlement linked to the batch-created feature row | ✓ |
+| Create metered feature + credit system + plan granting the CS, one call | ✓ |
+| Rename feature F→G + plan item referencing G (new id) → resolves | ✓ |
+| Rename feature F→G + plan item referencing F (old id) → 404 `feature_not_found` | ✓ |
+| Plan referencing pre-existing feature alongside unrelated feature ops → green path | ✓ |
+
+### Type changes + removals — `batch/features-plans-type-and-removal.test.ts`
+
+| Case | Status |
+|---|---|
+| Change feature type (boolean→metered) + plan item using metered config, one call | ✓ |
+| Change feature type (metered→boolean) + plan item with metered config (`100 X/mo`) → coerced to bare boolean item (no included/reset) | red (item persists included/reset as-is; no coercion and no validateProductItems rule) |
+| Remove feature + create/update plan that references it → 404 `feature_not_found` | ✓ |
+| Remove + recreate same feature id + plan referencing it → `invalid_feature` same-call conflict | red (plan compute throws `feature_not_found` first, so the guard error depends on whether a plan references the feature) |
+| Remove feature + update plan dropping its item in same call → OK | ✓ |
+
+## 13. Preview completeness — `preview/`
+
+`buildUpsertProductsPreview` currently stubs `versioning: null`, `changes:
+null`, `will_archive: false` — so all `changes`/`versioning` cases are red
+spec. Every test here also parses the response with
+`PreviewUpdateCatalogResponseSchema` and asserts preview writes nothing.
+
+Diff semantics under test (from `diffPlanV1` — the contract for `customize`):
+
+- Item identity (match key) = `feature_id | billing_method | interval |
+  interval_count`. In-place modification = `remove_items` filter + `add_items`
+  entry ("out with the old, in with the new").
+- Defaults normalize away: `included: 0`, `interval_count: 1`, `billing_units:
+  1`, `pooled: false`, `tier_behavior: graduated` (with tiers), trial
+  `card_required: true` / `on_end: "bill"` / `duration_type: month` — explicit
+  default ≡ omitted, so they must NOT produce a diff.
+- Additional currencies: adding/removing a currency is NOT a diff; only a
+  changed amount for a currency present on both sides is.
+- `customize` lanes: `price`, `add_items`, `remove_items`, `free_trial`.
+
+Known schema gap (flag, don't test): preview rows have no top-level `version`;
+multi-version entries are only distinguishable via `versioning.current_version`.
+
+### A. Actions — `preview/preview-actions.test.ts`
+
+| Case | Status |
+|---|---|
+| New plan_id → `create` | ✓ |
+| Existing plan, detail-only diff → `update` | ✓ |
+| Existing plan, items-only diff → `update` | ✓ |
+| Existing plan, base-price-only diff → `update` | ✓ |
+| Identical re-send → `none` | ✓ |
+| Re-send with explicit defaults (`included: 0` on boolean, `interval_count: 1`, `pooled: false`) → `none` (normalization, no false positives) | ✓ |
+| Omitting `items`/`price` lanes entirely, same details → `none` | ✓ |
+| `archived` toggle → `update` | ✓ |
+| Multi-plan call → per-entry actions independent (create + update + none in one preview) | ✓ |
+| Pinned `version: 1` entry → action computed against v1 row, not latest | ✓ |
+| `update` response `results.plans` actions match the preview's actions for identical params (parity) | ✓ |
+
+### B1. Detail changes — `preview/changes/changes-details.test.ts`
+
+All red until `changes` is wired. Each case: `previous_attributes` holds the
+old value for exactly the changed keys; `customize` null; `item_changes`
+empty; no `price_change`.
+
+| Case | Status |
+|---|---|
+| `name` change → `previous_attributes.name` = old name, nothing else | red (changes stubbed null) |
+| `description` / `group` / `add_on` each individually | red (changes stubbed null) |
+| `auto_enable` flip → previous `is_default` (or `auto_enable`) exposed | red (changes stubbed null) |
+| `archived` flip → previous value exposed | red (changes stubbed null; also not in diffPlanV1PreviousAttributes keys today) |
+| `metadata` change → previous metadata object | red (changes stubbed null; also not in diffPlanV1PreviousAttributes keys today) |
+| `billing_controls` change → previous nested `billing_controls` | red (changes stubbed null) |
+| `config.ignore_past_due` flip → previous config | red (changes stubbed null) |
+| Multi-detail change → all changed keys present, unchanged keys absent | red (changes stubbed null) |
+| Field explicitly set to its current value → NOT in `previous_attributes` | red (changes stubbed null) |
+
+### B2. Base price changes — `preview/changes/changes-base-price.test.ts`
+
+Each case asserts BOTH `price_change { previous, current }` and the
+`customize.price` lane.
+
+| Case | Status |
+|---|---|
+| Add base price (none → `$20/mo`) → `previous: null`, `current` populated; `customize.price` = full params | red (changes stubbed null) |
+| Amount change (`20 → 30`) | red (changes stubbed null) |
+| Interval change (month → year) | red (changes stubbed null) |
+| `interval_count` change (1 → 3); explicit `interval_count: 1` → no diff | red (changes stubbed null; explicit-1 half expects action `none`) |
+| Remove (`price: null`) → `current: null`; `customize.price: null` | red (changes stubbed null) |
+| Additional currency amount change (currency on both sides) → diff | red (changes stubbed null) |
+| Additional currency added/removed only → NO price diff (compatible rule) | red (changes stubbed null; compute currently reports action `update` — ambiguity vs diffPlanV1) |
+| Items-only update → no `price_change`, `customize.price` absent | red (changes stubbed null) |
+
+### B3. Item changes — `preview/changes/changes-items.test.ts`
+
+Each case asserts BOTH `item_changes` (created/deleted snapshots) and the
+`customize.add_items`/`remove_items` lanes, including the remove-filter shape
+(`feature_id` + `billing_method`/`interval`/`interval_count` when priced).
+
+| Case | Status |
+|---|---|
+| Add free item → `created` entry; `add_items` full params; no `remove_items` | red (changes stubbed null) |
+| Add priced item → `created`; `add_items` includes price block | red (changes stubbed null) |
+| Remove item → `deleted`; `remove_items` filter only | red (changes stubbed null) |
+| Included bump (same match key) → `deleted`+`created` pair; `remove_items` filter + `add_items` new shape | red (changes stubbed null) |
+| Price amount change on priced item (same key) → remove+add pair | red (changes stubbed null) |
+| Reset/billing interval change (match key CHANGES) → `remove_items` filter carries the OLD interval, `add_items` the new | red (changes stubbed null) |
+| `billing_method` change prepaid → usage_based (key change) → remove(old method)+add(new) | red (changes stubbed null) |
+| Free → paid on same feature → remove(free key)+add(paid key) | red (changes stubbed null) |
+| Paid → free | red (changes stubbed null) |
+| `unlimited` toggle → remove+add (same key) | red (changes stubbed null) |
+| `pooled` toggle → remove+add | red (changes stubbed null) |
+| Rollover add / change / remove → remove+add | red (changes stubbed null) |
+| Proration change on prepaid → remove+add | red (changes stubbed null) |
+| `billing_units` / `max_purchase` change → remove+add | red (changes stubbed null) |
+| Tier edit (amount, `to` boundary, `flat_amount`) → remove+add | red (changes stubbed null) |
+| `tier_behavior` graduated → volume → remove+add; explicit `graduated` with tiers → no diff | red (volume half stubbed; graduated-explicit expects `none`) |
+| Item additional-currency amount change → diff; currency add/remove only → no diff | red (amount half stubbed; remove-only expects `none` — compute may still update) |
+| Two items same feature, different intervals → only the edited keyed pair diffs, sibling untouched | red (changes stubbed null) |
+| Re-send with explicit defaults on items → `item_changes` empty, no customize lanes | ✓ |
+
+### B4. Free trial lane — `preview/changes/changes-free-trial.test.ts`
+
+Red twice over: trial persistence AND changes are unimplemented.
+
+| Case | Status |
+|---|---|
+| Add trial → `customize.free_trial` = params | red (changes stubbed; trial also not in upsert op → action may stay `none`) |
+| `duration_length` / `duration_type` change → diff | red (changes stubbed; trial persistence missing) |
+| `card_required` flip → diff; explicit `card_required: true` ≡ omitted → no diff | red (changes stubbed; trial persistence missing) |
+| `on_end` change → diff; explicit `"bill"` ≡ omitted → no diff | red (changes stubbed; trial persistence missing) |
+| Remove trial (`free_trial: null`) → `customize.free_trial: null` | red (changes stubbed; trial persistence missing) |
+
+### B5. Mixed changes — `preview/changes/changes-mixed.test.ts`
+
+| Case | Status |
+|---|---|
+| Details + base price + items + trial in one entry → `previous_attributes`, `price_change`, `item_changes`, and all `customize` lanes populated coherently | red (changes stubbed null) |
+| Create with full shape → `changes` non-null: `customize` carries entire desired shape (price + add_items), `previous_attributes` null | red (changes stubbed null) |
+| Items + price change, details untouched → `previous_attributes` null/empty | red (changes stubbed null) |
+| Multi-plan call → each row's `changes` scoped to its own plan | red (changes stubbed null) |
+
+### C. State + versioning — `preview/preview-state-versioning.test.ts`
+
+| Case | Status |
+|---|---|
+| Plan with attached customer → `has_customers: true`; without → `false` | ✓ |
+| Expired-only customers → `has_customers: false` | ✓ |
+| Update targeting latest of a 2-version plan → `versioning { current_version: 2, new_version: null, resolved: "existing" }` | red (versioning stubbed null) |
+| `versioning.options` lists all three strategies; `new_version` has `available: false` + `reason` while unimplemented | red (versioning stubbed null) |
+| `all_versions` on a multi-version plan → one preview row per affected version, each identifiable via `versioning.current_version`, `resolved: "all_versions"` | red (versioning stubbed null; today only one preview row) |
+
+## 14. Free trials — `update/update-plan-free-trial.test.ts` + `validation/free-trial-validation.test.ts`
+
+Spec for the free-trial slice now being implemented server-side (claim-style
+`computeFreeTrialPlan` taking `FreeTrialParamsV1`, with a `freeTrialsAreSame`
+comparator). Intended semantics, which differ from v1 `handleNewFreeTrial`:
+
+- Unchanged trial → RE-USE the existing free_trial row (same row id).
+- Changed or removed trial → ALWAYS retire the old row (`is_custom: true`,
+  never hard-delete, no customer-reference detection) and mint a new row on
+  change. v1 mutated the row in place — that behavior is gone.
+- Comparator must include `on_end` (v1's `freeTrialsAreSame` misses it) and
+  normalize param defaults: `duration_type: month`, `card_required: true`,
+  `on_end: bill` ≡ omitted. `unique_fingerprint` is row-side only (not in
+  params) — never a diff source.
+- Validation runs against PROJECTED state and rejects; no silent `is_default`
+  flips (v1 unset default when `card_required` went false→true).
+
+**Helper change (done):** `ExpectedPlan.hasFreeTrial` replaced with
+`freeTrial?: { duration_length, duration_type, card_required, on_end } | null`
+in `utils/expectCatalogPlans.ts` (exact object; `on_end` normalized `?? null`;
+`null` = absent). Swept create-plans / default-flag; trial facets removed from
+update-plan-details (section 4 → moved).
+
+### Shape round-trip + update lanes — `update/update-plan-free-trial.test.ts`
+
+| Case | Status |
+|---|---|
+| Create with full trial (`day`/7/`card_required: false`/`on_end: revert`) → exact shape via catalogV2.get | ✓ |
+| Create with minimal trial (`duration_length` only) → defaults resolved: `duration_type: month`, `card_required: true` | ✓ |
+| `duration_type` day / month / year round-trip; `on_end` bill / revert round-trip | ✓ |
+| Add trial to existing plan without one | ✓ |
+| Change each field individually (length, type, card_required, on_end) → exact new shape | ✓ |
+| Remove (`free_trial: null`) → absent in response | ✓ |
+| Omit `free_trial` key → preserved exactly (carry) | ✓ |
+| Cross-facet patch: items+price change (trial omitted) → trial preserved; trial-only change → items/base price carried | ✓ |
+| Identical re-send (incl. explicit defaults `card_required: true` / `on_end: bill` / `duration_type: month`) → action `none` | ✓ |
+| Trial-only change → action `update` (today op stays `none`) | ✓ |
+
+### Row semantics (DB asserts on free_trial rows)
+
+| Case | Status |
+|---|---|
+| Unchanged trial across update → same free_trial row id | ✓ |
+| Changed trial → NEW row id; old row retained with `is_custom: true` (no customers needed) | ✓ |
+| Removed trial → old row retained, `is_custom: true`, never deleted | ✓ |
+| `on_end`-only change → counts as change (new row) — comparator includes on_end | ✓ |
+| Plan with attached customer on trial → same retire behavior; customer's cus_product keeps old trial row reference | ✓ |
+
+### Validation (projected state) — `validation/free-trial-validation.test.ts`
+
+| Case | Status |
+|---|---|
+| Trial on one-off plan (create, one entry) → 400 | ✓ |
+| Add trial to existing one-off plan → 400 | ✓ |
+| Same-call projection: update making plan one-off while keeping/adding trial → 400 | ✓ |
+| Default plan (auto_enable) + trial with `card_required: true` → 400 (not silent flip) | ✓ |
+| Update trial `card_required` false→true on a default plan → 400 | ✓ |
+| Remove trial from default paid plan (no longer default-trial eligible) → 400 | ✓ |
+| Free default plan without trial → OK (control) | ✓ |
+
+### Related coverage elsewhere (cross-refs, keep in their files)
+
+| Case | Where |
+|---|---|
+| `customize.free_trial` diff lane (add/change/remove/defaults) | `preview/changes/changes-free-trial.test.ts` (B4) |
+| Cardless-trial default plan allowed | `validation/default-flag.test.ts` |
+| `all_versions` trial propagation; version-pinned trial edit | `versions/plan-versions.test.ts` — both ✓ via per-row trial facet |
+
+### Comparator unit matrix (impl agent owns, listed for completeness)
+
+`freeTrialsAreSame` unit cases: null×null → same; null×set → differ; each
+field differing (length, type, card_required, on_end); defaults normalization
+(month / card true / on_end bill ≡ omitted); `unique_fingerprint` ignored for
+params-side comparison.
+
+## Deferred (later slice)
+
+| Case |
+|---|
+| `new_version` strategy (currently rejected) |
+| `all_versions` + direct per-version override ordering |
+| Variants / licenses in catalog params |
+| Stripe price re-use on version mint (needs new_version) |
+| `create_in_stripe` behavior (currently unused) |
+| In-place `updated` EP bucket (never populated today) |

--- a/server/tests/integration/catalog-v2/plans/batch/batch-ops.test.ts
+++ b/server/tests/integration/catalog-v2/plans/batch/batch-ops.test.ts
@@ -1,0 +1,250 @@
+/**
+ * catalogV2.update — multi-plan batch interactions in one call.
+ *
+ * Green path: create + update + archive across three distinct plan_ids with
+ * preview reporting all three and writing nothing.
+ * Red: duplicate plan_id creates, rename collisions / stale refs.
+ */
+
+import { test } from "bun:test";
+import { ErrCode, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	expectCatalogPreviewCorrect,
+	expectCatalogResultsCorrect,
+} from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+	expectDbPlansAbsent,
+} from "../utils/expectCatalogPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 batch-ops: create + update + archive in one call; preview writes nothing")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const createId = uniqueTestId("cv2_batch_c");
+		const updateId = uniqueTestId("cv2_batch_u");
+		const archiveId = uniqueTestId("cv2_batch_a");
+		await deleteDbPlans({
+			ctx,
+			planIds: [createId, updateId, archiveId],
+		});
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: updateId,
+						name: "Update Target",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+					{ plan_id: archiveId, name: "Archive Target" },
+				],
+			});
+
+			const params = {
+				plans: [
+					{ plan_id: createId, name: "Batch Create" },
+					{
+						plan_id: updateId,
+						name: "Updated Name",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 50,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+					{ plan_id: archiveId, archived: true },
+				],
+			};
+
+			const preview = await autumnV2_3.catalogV2.previewUpdate(params);
+			expectCatalogPreviewCorrect({
+				preview,
+				plans: [
+					{ planId: createId, action: "create", hasCustomers: false },
+					{ planId: updateId, action: "update", hasCustomers: false },
+					{ planId: archiveId, action: "update", hasCustomers: false },
+				],
+			});
+			await expectDbPlansAbsent({ ctx, planIds: [createId] });
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{ id: updateId, name: "Update Target" },
+					{ id: archiveId, archived: false },
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [
+					{ id: createId, action: "create" },
+					{ id: updateId, action: "update" },
+					{ id: archiveId, action: "update" },
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{ id: createId, name: "Batch Create" },
+					{
+						id: updateId,
+						name: "Updated Name",
+						allowances: { [TestFeature.Messages]: 50 },
+					},
+					{ id: archiveId, archived: true },
+				],
+			});
+		} finally {
+			await deleteDbPlans({
+				ctx,
+				planIds: [createId, updateId, archiveId],
+			});
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 batch-ops: create two plans with same plan_id → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_batch_dup");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planId, name: "First" },
+							{ plan_id: planId, name: "Second" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED: rename into existing plan_id not rejected
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 batch-ops: rename A→B while B already exists → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_batch_ra");
+		const planB = uniqueTestId("cv2_batch_rb");
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planA, name: "A" },
+					{ plan_id: planB, name: "B" },
+				],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: planA, new_plan_id: planB }],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);
+
+// RED: rename into same-call create not rejected
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 batch-ops: rename A→B while B created in same call → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_batch_rca");
+		const planB = uniqueTestId("cv2_batch_rcb");
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planA, name: "A" }],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planA, new_plan_id: planB },
+							{ plan_id: planB, name: "New B" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);
+
+// RED: create + pinned update same plan_id — encode as error until spec decides
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 batch-ops: create + pinned v1 update same plan_id → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_batch_cup");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planId, name: "Create" },
+							{ plan_id: planId, version: 1, name: "Pinned" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 batch-ops: rename A→B and update A in same call → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_batch_stale");
+		const planB = uniqueTestId("cv2_batch_stale_b");
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planA, name: "A" }],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planA, new_plan_id: planB },
+							{ plan_id: planA, name: "Stale Update" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/batch/features-plans-resolution.test.ts
+++ b/server/tests/integration/catalog-v2/plans/batch/features-plans-resolution.test.ts
@@ -1,0 +1,342 @@
+/**
+ * catalogV2.update — same-call feature creates/renames resolving into plan items.
+ *
+ * Plan compute resolves items against the projected feature set (post
+ * update/insert), so same-call creates and renames are visible and stale ids
+ * are a 404 `feature_not_found`.
+ */
+
+import { expect, test } from "bun:test";
+import { FeatureType, FeatureUsageType, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import {
+	deleteDbFeatures,
+	expectDbFeaturesCorrect,
+} from "../../utils/expectCatalogFeatures.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: create feature + plan item referencing it")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const featureId = uniqueTestId("cv2_int_feat");
+		const planId = uniqueTestId("cv2_int_plan");
+		await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "Batch Feature",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: "Uses New Feature",
+						items: [
+							{
+								feature_id: featureId,
+								included: 25,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectDbFeaturesCorrect({
+				ctx,
+				expected: [
+					{
+						id: featureId,
+						type: FeatureType.Metered,
+						usageType: FeatureUsageType.Single,
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [featureId],
+						allowances: { [featureId]: 25 },
+					},
+				],
+			});
+
+			const full = await getFull({ ctx, planId });
+			const ent = full.entitlements.find((e) => e.feature.id === featureId);
+			expect(
+				ent,
+				"entitlement should link batch-created feature",
+			).toBeDefined();
+			expect(ent?.feature.id).toBe(featureId);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: metered + credit system + plan granting CS")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const meteredId = uniqueTestId("cv2_int_met");
+		const creditSystemId = uniqueTestId("cv2_int_cs");
+		const planId = uniqueTestId("cv2_int_cs_plan");
+		await deleteDbFeatures({
+			ctx,
+			featureIds: [meteredId, creditSystemId],
+		});
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: meteredId,
+						name: "Metered",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+					{
+						feature_id: creditSystemId,
+						name: "Credits",
+						type: FeatureType.CreditSystem,
+						credit_schema: [{ metered_feature_id: meteredId, credit_cost: 1 }],
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: "CS Plan",
+						items: [
+							{
+								feature_id: creditSystemId,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [creditSystemId],
+						allowances: { [creditSystemId]: 100 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({
+				ctx,
+				featureIds: [meteredId, creditSystemId],
+			});
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: rename F→G + plan item referencing G → resolves")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const fromId = uniqueTestId("cv2_int_ren_from");
+		const toId = uniqueTestId("cv2_int_ren_to");
+		const planId = uniqueTestId("cv2_int_ren_plan");
+		await deleteDbFeatures({ ctx, featureIds: [fromId, toId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: fromId,
+						name: "Old Id",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: fromId,
+						name: "Old Id",
+						new_feature_id: toId,
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: "Uses Renamed",
+						items: [
+							{
+								feature_id: toId,
+								included: 5,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [toId],
+						allowances: { [toId]: 5 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [fromId, toId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: rename F→G + plan item referencing F → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const fromId = uniqueTestId("cv2_int_old_from");
+		const toId = uniqueTestId("cv2_int_old_to");
+		const planId = uniqueTestId("cv2_int_old_plan");
+		await deleteDbFeatures({ ctx, featureIds: [fromId, toId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: fromId,
+						name: "Old Id",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+			});
+
+			await expectAutumnError({
+				errCode: "feature_not_found",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						features: [
+							{
+								feature_id: fromId,
+								name: "Old Id",
+								new_feature_id: toId,
+								type: FeatureType.Metered,
+								consumable: true,
+							},
+						],
+						plans: [
+							{
+								plan_id: planId,
+								name: "Uses Old Id",
+								items: [
+									{
+										feature_id: fromId,
+										included: 5,
+										reset: { interval: ResetInterval.Month },
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [fromId, toId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: plan uses pre-existing feature alongside unrelated feature ops")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const unrelatedFeatureId = uniqueTestId("cv2_int_unrel");
+		const planId = uniqueTestId("cv2_int_unrel_plan");
+		await deleteDbFeatures({ ctx, featureIds: [unrelatedFeatureId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: unrelatedFeatureId,
+						name: "Unrelated",
+						type: FeatureType.Boolean,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: "Uses Existing",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 15,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectDbFeaturesCorrect({
+				ctx,
+				expected: [{ id: unrelatedFeatureId, type: FeatureType.Boolean }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [TestFeature.Messages],
+						allowances: { [TestFeature.Messages]: 15 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [unrelatedFeatureId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/batch/features-plans-type-and-removal.test.ts
+++ b/server/tests/integration/catalog-v2/plans/batch/features-plans-type-and-removal.test.ts
@@ -1,0 +1,331 @@
+/**
+ * catalogV2.update — feature type changes and removals × plan upsert in one call.
+ *
+ * Plan compute resolves items against the projected feature set (post
+ * update/remove), so type changes are visible to same-call items and removed
+ * ids are a 404 `feature_not_found`.
+ */
+
+import { expect, test } from "bun:test";
+import { FeatureType, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import {
+	deleteDbFeatures,
+	expectDbFeaturesCorrect,
+} from "../../utils/expectCatalogFeatures.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+// Works today: feature already exists in ctx.features; type update + plan item land.
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: boolean→metered + plan item with metered config")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const featureId = uniqueTestId("cv2_int_type");
+		const planId = uniqueTestId("cv2_int_type_plan");
+		await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "Was Boolean",
+						type: FeatureType.Boolean,
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "Now Metered",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: "Metered Item",
+						items: [
+							{
+								feature_id: featureId,
+								included: 40,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [featureId],
+						allowances: { [featureId]: 40 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		}
+	},
+);
+
+// No validateProductItems rule rejects metered config on a boolean feature
+// (only pooled booleans); today included/reset persist as-is instead of coercing.
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 interplay: metered→boolean + plan item with metered config → boolean item")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const featureId = uniqueTestId("cv2_int_mtb");
+		const planId = uniqueTestId("cv2_int_mtb_plan");
+		await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "Was Metered",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "Now Boolean",
+						type: FeatureType.Boolean,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: "Boolean Item",
+						items: [
+							{
+								feature_id: featureId,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectDbFeaturesCorrect({
+				ctx,
+				expected: [{ id: featureId, type: FeatureType.Boolean }],
+			});
+
+			const catalog = await autumnV2_3.catalogV2.get({
+				include_archived: true,
+			});
+			const plan = catalog.plans.find((p) => p.id === planId);
+			expect(plan, `missing plan ${planId}`).toBeDefined();
+			const item = plan?.items.find((i) => i.feature_id === featureId);
+			expect(item, "item should exist for boolean feature").toBeDefined();
+			expect(item?.included ?? null).toBeNull();
+			expect(item?.reset ?? null).toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: remove feature + plan still referencing it → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const featureId = uniqueTestId("cv2_int_rm_ref");
+		const planId = uniqueTestId("cv2_int_rm_ref_plan");
+		await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "To Remove",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Has Feature",
+						items: [
+							{
+								feature_id: featureId,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectAutumnError({
+				errCode: "feature_not_found",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						remove_features: [{ feature_id: featureId }],
+						plans: [
+							{
+								plan_id: planId,
+								name: "Still Has Feature",
+								items: [
+									{
+										feature_id: featureId,
+										included: 10,
+										reset: { interval: ResetInterval.Month },
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		}
+	},
+);
+
+// Spec: the remove+upsert same-call guard (invalid_feature) should win. Today plan
+// item resolution 404s first (feature_not_found), so the error depends on plan refs.
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 interplay: remove + recreate feature + plan referencing it → same-call conflict error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const featureId = uniqueTestId("cv2_int_rm_rc");
+		const planId = uniqueTestId("cv2_int_rm_rc_plan");
+		await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "Original",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+			});
+
+			await expectAutumnError({
+				errCode: "invalid_feature",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						remove_features: [{ feature_id: featureId }],
+						features: [
+							{
+								feature_id: featureId,
+								name: "Recreated",
+								type: FeatureType.Metered,
+								consumable: true,
+							},
+						],
+						plans: [
+							{
+								plan_id: planId,
+								name: "Uses Recreated",
+								items: [
+									{
+										feature_id: featureId,
+										included: 10,
+										reset: { interval: ResetInterval.Month },
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 interplay: remove feature + plan drops its item → OK")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const featureId = uniqueTestId("cv2_int_rm_drop");
+		const planId = uniqueTestId("cv2_int_rm_drop_plan");
+		await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: featureId,
+						name: "Drop Me",
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Has Both",
+						items: [
+							{ feature_id: TestFeature.Dashboard },
+							{
+								feature_id: featureId,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				remove_features: [{ feature_id: featureId }],
+				plans: [
+					{
+						plan_id: planId,
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+				],
+			});
+
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [TestFeature.Dashboard],
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/create/create-plan-items-free.test.ts
+++ b/server/tests/integration/catalog-v2/plans/create/create-plan-items-free.test.ts
@@ -1,0 +1,270 @@
+/**
+ * catalogV2.update — create FREE plan item shapes (no price on the item):
+ * boolean, metered included/reset, unlimited, pooled, rollover, entity scope.
+ *
+ * Contract: each item field round-trips through catalogV2.get after create.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ResetInterval,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { expectCatalogResultsCorrect } from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+import { createAndAssert } from "./utils/createAndAssert.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: boolean feature (bare feature_id)")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_bool");
+		await createAndAssert({
+			planId,
+			name: "Boolean Item",
+			items: [{ feature_id: TestFeature.Dashboard }],
+			expectedItems: [{ feature_id: TestFeature.Dashboard }],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: metered included + reset month / year / interval_count 3")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_reset");
+		await createAndAssert({
+			planId,
+			name: "Reset Intervals",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					reset: { interval: ResetInterval.Month },
+				},
+				{
+					feature_id: TestFeature.Words,
+					included: 500,
+					reset: { interval: ResetInterval.Year },
+				},
+				{
+					feature_id: TestFeature.Action1,
+					included: 50,
+					reset: { interval: ResetInterval.Month, interval_count: 3 },
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					reset: { interval: ResetInterval.Month },
+				},
+				{
+					feature_id: TestFeature.Words,
+					included: 500,
+					reset: { interval: ResetInterval.Year },
+				},
+				{
+					feature_id: TestFeature.Action1,
+					included: 50,
+					reset: { interval: ResetInterval.Month, interval_count: 3 },
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: non-resetting consumable (omit reset)")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_noreset");
+		// interval:null in → ResetInterval.OneOff out on the API response
+		await createAndAssert({
+			planId,
+			name: "Non-Resetting",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 250,
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 250,
+					reset: { interval: ResetInterval.OneOff },
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: unlimited true")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_unlim");
+		await createAndAssert({
+			planId,
+			name: "Unlimited",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					unlimited: true,
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					unlimited: true,
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: pooled boolean + pooled unlimited metered")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pooled");
+		const params = {
+			plans: [
+				{
+					plan_id: planId,
+					name: "Pooled",
+					items: [
+						{ feature_id: TestFeature.Dashboard, pooled: true },
+						{
+							feature_id: TestFeature.Messages,
+							unlimited: true,
+							pooled: true,
+						},
+					],
+				},
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "create" }],
+			});
+			// Unlimited metered pooled round-trips via catalogV2.get; boolean pooled
+			// is persisted but omitted by toFeatureItem's boolean branch — assert DB.
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								unlimited: true,
+								pooled: true,
+							},
+						],
+					},
+				],
+			});
+			const full = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			const dashboardEnt = full.entitlements.find(
+				(ent) => ent.feature.id === TestFeature.Dashboard,
+			);
+			expect(dashboardEnt?.pooled).toBe(true);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: rollover max / max_percentage / expiry")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_roll");
+		await createAndAssert({
+			planId,
+			name: "Rollover",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 1000,
+					reset: { interval: ResetInterval.Month },
+					rollover: {
+						max: 2000,
+						expiry_duration_type: RolloverExpiryDurationType.Month,
+						expiry_duration_length: 1,
+					},
+				},
+				{
+					feature_id: TestFeature.Words,
+					included: 500,
+					reset: { interval: ResetInterval.Month },
+					rollover: {
+						max_percentage: 50,
+						expiry_duration_type: RolloverExpiryDurationType.Month,
+						expiry_duration_length: 2,
+					},
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 1000,
+					rollover: {
+						max: 2000,
+						expiry_duration_type: RolloverExpiryDurationType.Month,
+						expiry_duration_length: 1,
+					},
+				},
+				{
+					feature_id: TestFeature.Words,
+					included: 500,
+					rollover: {
+						max_percentage: 50,
+						expiry_duration_type: RolloverExpiryDurationType.Month,
+						expiry_duration_length: 2,
+					},
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: entity_feature_id (allocated / per-entity)")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_ent");
+		await createAndAssert({
+			planId,
+			name: "Entity Scoped",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					reset: { interval: ResetInterval.Month },
+					entity_feature_id: TestFeature.Users,
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					entity_feature_id: TestFeature.Users,
+				},
+			],
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/create/create-plan-items-priced.test.ts
+++ b/server/tests/integration/catalog-v2/plans/create/create-plan-items-priced.test.ts
@@ -1,0 +1,538 @@
+/**
+ * catalogV2.update — create PRICED plan item shapes across the billing-model
+ * matrix: consumable prepaid, allocated prepaid, consumable usage-based, and
+ * allocated usage-based (arrear / "v2"; prorated "v1" is not creatable via
+ * these params — proration + usage_based is rejected in plan-errors).
+ *
+ * Contract: each price field round-trips through catalogV2.get after create.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	AllocatedBillingBehavior,
+	BillingInterval,
+	BillingMethod,
+	isFixedPrice,
+	OnDecrease,
+	OnIncrease,
+	ResetInterval,
+	TierBehavior,
+	TierInfinite,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { expectCatalogResultsCorrect } from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+import { createAndAssert } from "./utils/createAndAssert.js";
+
+// ─── Consumable usage-based ──────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: consumable usage-based — reset + priced (matched intervals)")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_rppu");
+		await createAndAssert({
+			planId,
+			name: "Reset + Usage",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					reset: { interval: ResetInterval.Month },
+					price: {
+						amount: 0.5,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.UsageBased,
+						billing_units: 1,
+					},
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					reset: { interval: ResetInterval.Month },
+					price: {
+						amount: 0.5,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.UsageBased,
+						billing_units: 1,
+					},
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: consumable usage-based — graduated tiers")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_grad");
+		await createAndAssert({
+			planId,
+			name: "Graduated Tiers",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					price: {
+						tiers: [
+							{ to: 500, amount: 0.1 },
+							{ to: 2000, amount: 0.05 },
+							{ to: TierInfinite, amount: 0.02 },
+						],
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.UsageBased,
+						billing_units: 1,
+					},
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					price: {
+						tiers: [
+							{ to: 500, amount: 0.1 },
+							{ to: 2000, amount: 0.05 },
+							{ to: TierInfinite, amount: 0.02 },
+						],
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.UsageBased,
+						billing_units: 1,
+					},
+				},
+			],
+		});
+	},
+);
+
+// ─── Consumable prepaid ──────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: consumable prepaid — flat + billing_units + max_purchase")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_pp");
+		await createAndAssert({
+			planId,
+			name: "Prepaid Flat",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 0,
+					price: {
+						amount: 10,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.Prepaid,
+						billing_units: 100,
+						max_purchase: 500,
+					},
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 0,
+					price: {
+						amount: 10,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.Prepaid,
+						billing_units: 100,
+						max_purchase: 500,
+					},
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: prepaid price.interval differs from reset.interval")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_ppdiff");
+		await createAndAssert({
+			planId,
+			name: "Prepaid Diff Intervals",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					reset: { interval: ResetInterval.Month },
+					price: {
+						amount: 15,
+						interval: BillingInterval.Year,
+						billing_method: BillingMethod.Prepaid,
+						billing_units: 100,
+					},
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					reset: { interval: ResetInterval.Month },
+					price: {
+						amount: 15,
+						interval: BillingInterval.Year,
+						billing_method: BillingMethod.Prepaid,
+						billing_units: 100,
+					},
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: volume tiers + flat_amount (prepaid)")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_vol");
+		await createAndAssert({
+			planId,
+			name: "Volume Flat",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					price: {
+						tiers: [
+							{ to: 600, amount: 10, flat_amount: 5 },
+							{ to: TierInfinite, amount: 5, flat_amount: 0 },
+						],
+						tier_behavior: TierBehavior.VolumeBased,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.Prepaid,
+						billing_units: 100,
+					},
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 100,
+					price: {
+						tiers: [
+							{ to: 600, amount: 10, flat_amount: 5 },
+							{ to: TierInfinite, amount: 5, flat_amount: 0 },
+						],
+						tier_behavior: TierBehavior.VolumeBased,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.Prepaid,
+						billing_units: 100,
+					},
+				},
+			],
+		});
+	},
+);
+
+// ─── Allocated prepaid (continuous-use feature + prepaid) ────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: allocated prepaid — proration on_increase / on_decrease")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pror");
+		const params = {
+			plans: [
+				{
+					plan_id: planId,
+					name: "Prepaid Proration",
+					items: [
+						{
+							feature_id: TestFeature.Users,
+							included: 0,
+							price: {
+								amount: 10,
+								interval: BillingInterval.Month,
+								billing_method: BillingMethod.Prepaid,
+								billing_units: 1,
+							},
+							proration: {
+								on_increase: OnIncrease.ProrateImmediately,
+								on_decrease: OnDecrease.NoProrations,
+							},
+						},
+					],
+				},
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "create" }],
+			});
+			// catalogV2.get strips proration (productV2ToApiPlanV1); assert DB row.
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Users,
+								price: {
+									amount: 10,
+									billing_method: BillingMethod.Prepaid,
+								},
+							},
+						],
+					},
+				],
+			});
+			const full = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			const usagePrice = full.prices.find((price) => !isFixedPrice(price));
+			expect(usagePrice?.proration_config).toMatchObject({
+				on_increase: OnIncrease.ProrateImmediately,
+				on_decrease: OnDecrease.NoProrations,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// ─── Allocated usage-based (arrear / "v2") ───────────────────────────────────
+
+// Continuous-use feature + usage_based with no proration knobs resolves to
+// allocated arrear billing: never resets, bills holdings at cycle end.
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: allocated usage-based (arrear) — behavior + should_prorate false")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_alloc_v2");
+		const params = {
+			plans: [
+				{
+					plan_id: planId,
+					name: "Allocated Arrear",
+					items: [
+						{
+							feature_id: TestFeature.Users,
+							included: 2,
+							price: {
+								amount: 10,
+								interval: BillingInterval.Month,
+								billing_method: BillingMethod.UsageBased,
+								billing_units: 1,
+							},
+						},
+					],
+				},
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "create" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Users,
+								included: 2,
+								price: {
+									amount: 10,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.UsageBased,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			const full = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			const usagePrice = full.prices.find((price) => !isFixedPrice(price));
+			const config = usagePrice?.config as {
+				allocated_billing_behavior?: string;
+				should_prorate?: boolean;
+			};
+			expect(config?.allocated_billing_behavior).toBe(
+				AllocatedBillingBehavior.Arrear,
+			);
+			expect(config?.should_prorate).toBe(false);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// ─── stripe_price_id threading (internal param) ──────────────────────────────
+
+// stripe_price_id is internal-only but raw API calls must thread it through to
+// the price config so sync flows can preserve existing Stripe prices.
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: price.stripe_price_id threaded to price config")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_spid");
+		const stripePriceId = `price_stub_${planId}`;
+		const params = {
+			plans: [
+				{
+					plan_id: planId,
+					name: "Stripe Price Threaded",
+					items: [
+						{
+							feature_id: TestFeature.Messages,
+							included: 100,
+							reset: { interval: ResetInterval.Month },
+							price: {
+								stripe_price_id: stripePriceId,
+								amount: 0.5,
+								interval: BillingInterval.Month,
+								billing_method: BillingMethod.UsageBased,
+								billing_units: 1,
+							},
+						},
+					],
+				},
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "create" }],
+			});
+			const full = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			const usagePrice = full.prices.find((price) => !isFixedPrice(price));
+			const config = usagePrice?.config as { stripe_price_id?: string | null };
+			expect(config?.stripe_price_id).toBe(stripePriceId);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// ─── Multi-currency + base price extras ──────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: additional_currencies on flat amount + tiers")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_mc");
+		await createAndAssert({
+			planId,
+			name: "Multi Currency Items",
+			items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 0,
+					price: {
+						amount: 10,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.Prepaid,
+						billing_units: 100,
+						additional_currencies: [{ currency: "eur", amount: 9 }],
+					},
+				},
+				{
+					feature_id: TestFeature.Words,
+					included: 100,
+					price: {
+						tiers: [
+							{
+								to: 1000,
+								amount: 0.5,
+								additional_currencies: [{ currency: "eur", amount: 0.4 }],
+							},
+							{
+								to: TierInfinite,
+								amount: 0.3,
+								additional_currencies: [{ currency: "eur", amount: 0.25 }],
+							},
+						],
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.UsageBased,
+						billing_units: 1,
+					},
+				},
+			],
+			expectedItems: [
+				{
+					feature_id: TestFeature.Messages,
+					price: {
+						amount: 10,
+						additional_currencies: [{ currency: "eur", amount: 9 }],
+					},
+				},
+				{
+					feature_id: TestFeature.Words,
+					price: {
+						tiers: [
+							{
+								to: 1000,
+								amount: 0.5,
+								additional_currencies: [{ currency: "eur", amount: 0.4 }],
+							},
+							{
+								to: TierInfinite,
+								amount: 0.3,
+								additional_currencies: [{ currency: "eur", amount: 0.25 }],
+							},
+						],
+					},
+				},
+			],
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 create items: base price interval_count 3 + additional_currencies")}`,
+	async () => {
+		const planId = uniqueTestId("cv2_base");
+		await createAndAssert({
+			planId,
+			name: "Base Price Extras",
+			price: {
+				amount: 30,
+				interval: BillingInterval.Month,
+				interval_count: 3,
+				additional_currencies: [{ currency: "eur", amount: 27 }],
+			},
+			items: [{ feature_id: TestFeature.Dashboard }],
+			expectedItems: [{ feature_id: TestFeature.Dashboard }],
+			expectedBasePrice: {
+				amount: 30,
+				interval: BillingInterval.Month,
+				interval_count: 3,
+				additional_currencies: [{ currency: "eur", amount: 27 }],
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/create/create-plans.test.ts
+++ b/server/tests/integration/catalog-v2/plans/create/create-plans.test.ts
@@ -23,13 +23,13 @@ import chalk from "chalk";
 import {
 	expectCatalogPreviewCorrect,
 	expectCatalogResultsCorrect,
-} from "../utils/expectCatalogUpdate.js";
-import { uniqueTestId } from "../utils/uniqueTestId.js";
+} from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
 import {
 	deleteDbPlans,
 	expectCatalogPlansCorrect,
 	expectDbPlansAbsent,
-} from "./utils/expectCatalogPlans.js";
+} from "../utils/expectCatalogPlans.js";
 
 test.concurrent(
 	`${chalk.yellowBright("catalogV2 create plans: preview create, update inserts minimal")}`,
@@ -67,7 +67,7 @@ test.concurrent(
 						isDefault: false,
 						featureIds: [],
 						basePrice: null,
-						hasFreeTrial: false,
+						freeTrial: null,
 					},
 				],
 			});
@@ -195,7 +195,12 @@ test.concurrent(
 						isAddOn: true,
 						// auto_enable maps to is_default on the product row
 						isDefault: true,
-						hasFreeTrial: true,
+						freeTrial: {
+							duration_type: FreeTrialDuration.Day,
+							duration_length: 14,
+							card_required: false,
+							on_end: null,
+						},
 						metadata: { source: "catalog-v2-create", tier: 1 },
 						config: { ignore_past_due: true },
 						billingControls,

--- a/server/tests/integration/catalog-v2/plans/create/utils/createAndAssert.ts
+++ b/server/tests/integration/catalog-v2/plans/create/utils/createAndAssert.ts
@@ -1,0 +1,80 @@
+import type { BillingInterval, CreatePlanItemParamsV1Input } from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import {
+	expectCatalogPreviewCorrect,
+	expectCatalogResultsCorrect,
+} from "../../../utils/expectCatalogUpdate.js";
+import {
+	deleteDbPlans,
+	type ExpectedPlanItem,
+	expectCatalogPlansCorrect,
+	expectDbPlansAbsent,
+} from "../../utils/expectCatalogPlans.js";
+
+type BasePriceParams = {
+	amount: number;
+	interval: BillingInterval;
+	interval_count?: number;
+	additional_currencies?: Array<{ currency: string; amount: number }>;
+};
+
+/** Preview → create → assert exact round-trip via catalogV2.get, then clean up. */
+export const createAndAssert = async ({
+	planId,
+	name,
+	items,
+	price,
+	expectedItems,
+	expectedBasePrice,
+}: {
+	planId: string;
+	name: string;
+	items: CreatePlanItemParamsV1Input[];
+	price?: BasePriceParams;
+	expectedItems: ExpectedPlanItem[];
+	expectedBasePrice?: BasePriceParams | null;
+}) => {
+	const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+	const params = {
+		plans: [
+			{
+				plan_id: planId,
+				name,
+				...(price ? { price } : {}),
+				items,
+			},
+		],
+	};
+
+	await deleteDbPlans({ ctx, planIds: [planId] });
+	try {
+		const preview = await autumnV2_3.catalogV2.previewUpdate(params);
+		expectCatalogPreviewCorrect({
+			preview,
+			plans: [{ planId, action: "create" }],
+		});
+		await expectDbPlansAbsent({ ctx, planIds: [planId] });
+
+		const response = await autumnV2_3.catalogV2.update(params);
+		expectCatalogResultsCorrect({
+			response,
+			plans: [{ id: planId, action: "create" }],
+		});
+		await expectCatalogPlansCorrect({
+			autumn: autumnV2_3,
+			expected: [
+				{
+					id: planId,
+					version: 1,
+					name,
+					items: expectedItems,
+					...(expectedBasePrice !== undefined
+						? { basePrice: expectedBasePrice }
+						: {}),
+				},
+			],
+		});
+	} finally {
+		await deleteDbPlans({ ctx, planIds: [planId] });
+	}
+};

--- a/server/tests/integration/catalog-v2/plans/preview/changes/changes-base-price.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/changes/changes-base-price.test.ts
@@ -1,0 +1,405 @@
+/**
+ * catalogV2.preview_update — price_change + customize.price.
+ *
+ * RED: changes stubbed null. Spec asserts BOTH price_change { previous,
+ * current } and customize.price (toBasePriceParams shape). Additional
+ * currencies: amount change for shared currency diffs; add/remove alone does
+ * not.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	PreviewUpdateCatalogResponseSchema,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../utils/expectPlanPreview.js";
+
+const month20 = {
+	amount: 20,
+	interval: BillingInterval.Month,
+} as const;
+
+const month30 = {
+	amount: 30,
+	interval: BillingInterval.Month,
+} as const;
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: add base price none → $20/mo")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_add");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Free Then Paid" }],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, price: { ...month20 } }],
+				}),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					priceChange: {
+						previous: null,
+						current: { ...month20 },
+					},
+					customize: { price: { ...month20 } },
+				},
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, basePrice: null }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: amount 20 → 30")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_amt");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Amt", price: { ...month20 } }],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, price: { ...month30 } }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					priceChange: {
+						previous: { ...month20 },
+						current: { ...month30 },
+					},
+					customize: { price: { ...month30 } },
+				},
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, basePrice: { ...month20 } }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: interval month → year")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_ivl");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Ivl", price: { ...month20 } }],
+			});
+			const year20 = {
+				amount: 20,
+				interval: BillingInterval.Year,
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, price: year20 }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					priceChange: {
+						previous: { ...month20 },
+						current: year20,
+					},
+					customize: { price: year20 },
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — interval_count 1→3 diffs; explicit 1 ≡ omitted → no price diff
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: interval_count 1→3; explicit 1 → no diff")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_ic");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "IC", price: { ...month20 } }],
+			});
+
+			const noDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							price: { ...month20, interval_count: 1 },
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: noDiff,
+				expected: {
+					planId,
+					action: "none",
+					changes: null,
+				},
+			});
+
+			const withDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							price: { ...month20, interval_count: 3 },
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: withDiff,
+				expected: {
+					planId,
+					action: "update",
+					customize: {
+						price: { ...month20, interval_count: 3 },
+					},
+					priceChange: {
+						previous: { ...month20 },
+						current: { ...month20, interval_count: 3 },
+					},
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: remove price → null")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_rm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Rm", price: { ...month20 } }],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, price: null }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					priceChange: {
+						previous: { ...month20 },
+						current: null,
+					},
+					customize: { price: null },
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — shared currency amount change diffs
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: additional currency amount change → diff")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_fx");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "FX",
+						price: {
+							...month20,
+							additional_currencies: [{ currency: "eur", amount: 18 }],
+						},
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							price: {
+								...month20,
+								additional_currencies: [{ currency: "eur", amount: 22 }],
+							},
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					customize: {
+						price: {
+							...month20,
+							additional_currencies: [{ currency: "eur", amount: 22 }],
+						},
+					},
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — currency add/remove alone is NOT a price diff (compatible rule)
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: currency add/remove only → no price diff")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_fxn");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "FX None",
+						price: {
+							...month20,
+							additional_currencies: [{ currency: "eur", amount: 18 }],
+						},
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							price: { ...month20 },
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "none",
+					changes: null,
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — items-only update must not populate price_change / customize.price
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-base-price: items-only → no price_change")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cbp_items");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Items",
+						price: { ...month20 },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 50,
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+						},
+					],
+				}),
+			);
+			// Full contract: changes present with item diffs, but no price lane.
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					priceChange: null,
+				},
+			});
+			const row = preview.plans.find((p) => p.plan_id === planId);
+			expect(
+				row?.changes,
+				"changes must be wired for items-only",
+			).not.toBeNull();
+			expect(row?.changes?.customize?.price).toBeUndefined();
+			expect((row?.changes?.item_changes ?? []).length).toBeGreaterThan(0);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/changes/changes-details.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/changes/changes-details.test.ts
@@ -1,0 +1,360 @@
+/**
+ * catalogV2.preview_update — previous_attributes for plan detail fields.
+ *
+ * RED: buildUpsertProductsPreview stubs changes: null. Spec asserts
+ * previous_attributes holds old values for exactly the changed keys;
+ * customize null; item_changes empty; no price_change.
+ *
+ * Ambiguity: diffPlanV1PreviousAttributes keys today are id/name/description/
+ * group/add_on/auto_enable/free_trial/config/billing_controls — not archived
+ * or metadata. CASES wants those too; tests assert the CASES contract.
+ */
+
+import { test } from "bun:test";
+import { PreviewUpdateCatalogResponseSchema } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../utils/expectPlanPreview.js";
+
+const assertDetailChange = async ({
+	planId,
+	seed,
+	params,
+	previousAttributes,
+	autumn,
+	ctx,
+}: {
+	planId: string;
+	seed: Record<string, unknown>;
+	params: Record<string, unknown>;
+	previousAttributes: Record<string, unknown>;
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, ...seed }],
+	});
+	const preview = parsePlanPreview(
+		await autumn.catalogV2.previewUpdate({
+			plans: [{ plan_id: planId, ...params }],
+		}),
+	);
+	PreviewUpdateCatalogResponseSchema.parse(preview);
+	expectPlanPreviewRowCorrect({
+		preview,
+		expected: {
+			planId,
+			action: "update",
+			previousAttributes,
+			customize: null,
+			itemChanges: [],
+			priceChange: null,
+		},
+	});
+	// Preview must not persist the change — seed values still win.
+	await expectCatalogPlansCorrect({
+		autumn,
+		expected: [
+			{
+				id: planId,
+				...(typeof seed.name === "string" ? { name: seed.name } : {}),
+			},
+		],
+	});
+	void ctx;
+};
+
+// RED: changes stubbed null
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: name → previous_attributes.name")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_name");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await assertDetailChange({
+				planId,
+				seed: { name: "Old Name" },
+				params: { name: "New Name" },
+				previousAttributes: { name: "Old Name" },
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: description / group / add_on individually")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planDesc = uniqueTestId("cv2_cd_desc");
+		const planGroup = uniqueTestId("cv2_cd_grp");
+		const planAddon = uniqueTestId("cv2_cd_addon");
+		await deleteDbPlans({
+			ctx,
+			planIds: [planDesc, planGroup, planAddon],
+		});
+		try {
+			await assertDetailChange({
+				planId: planDesc,
+				seed: { name: "D", description: "old desc" },
+				params: { description: "new desc" },
+				previousAttributes: { description: "old desc" },
+				autumn: autumnV2_3,
+				ctx,
+			});
+			await assertDetailChange({
+				planId: planGroup,
+				seed: { name: "G", group: "g_old" },
+				params: { group: "g_new" },
+				previousAttributes: { group: "g_old" },
+				autumn: autumnV2_3,
+				ctx,
+			});
+			await assertDetailChange({
+				planId: planAddon,
+				seed: { name: "A", add_on: false },
+				params: { add_on: true },
+				previousAttributes: { add_on: false },
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({
+				ctx,
+				planIds: [planDesc, planGroup, planAddon],
+			});
+		}
+	},
+);
+
+// RED — CASES allows is_default or auto_enable key; assert auto_enable (ApiPlanV1 field)
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: auto_enable flip → previous auto_enable")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_ae");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await assertDetailChange({
+				planId,
+				seed: {
+					name: "Defaultable",
+					auto_enable: false,
+					items: [{ feature_id: TestFeature.Dashboard }],
+				},
+				params: { auto_enable: true },
+				previousAttributes: { auto_enable: false },
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — archived not in diffPlanV1PreviousAttributes today; CASES wants it
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: archived flip → previous value")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_arch");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await assertDetailChange({
+				planId,
+				seed: { name: "Arch", archived: false },
+				params: { archived: true },
+				previousAttributes: { archived: false },
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — metadata not in diffPlanV1PreviousAttributes today; CASES wants it
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: metadata → previous metadata object")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_meta");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await assertDetailChange({
+				planId,
+				seed: { name: "Meta", metadata: { a: "1" } },
+				params: { metadata: { a: "2" } },
+				previousAttributes: { metadata: { a: "1" } },
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — billing_controls previous value exposed nested (API shape), not per column
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: billing_controls change → previous billing_controls")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_bc");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await assertDetailChange({
+				planId,
+				seed: {
+					name: "BC",
+					billing_controls: {
+						overage_allowed: [
+							{ feature_id: TestFeature.Messages, enabled: true },
+						],
+					},
+				},
+				params: {
+					billing_controls: {
+						overage_allowed: [
+							{ feature_id: TestFeature.Messages, enabled: false },
+						],
+					},
+				},
+				previousAttributes: {
+					billing_controls: {
+						overage_allowed: [
+							{ feature_id: TestFeature.Messages, enabled: true },
+						],
+					},
+				},
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: config.ignore_past_due flip")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_cfg");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await assertDetailChange({
+				planId,
+				seed: { name: "Cfg", config: { ignore_past_due: false } },
+				params: { config: { ignore_past_due: true } },
+				previousAttributes: { config: { ignore_past_due: false } },
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: multi-detail → only changed keys")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_multi");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await assertDetailChange({
+				planId,
+				seed: {
+					name: "Multi",
+					description: "d1",
+					group: "g1",
+					add_on: false,
+				},
+				params: {
+					name: "Multi2",
+					description: "d2",
+					group: "g1",
+					add_on: false,
+				},
+				previousAttributes: {
+					name: "Multi",
+					description: "d1",
+				},
+				autumn: autumnV2_3,
+				ctx,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — setting field to current value must not appear in previous_attributes
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-details: explicit same value → absent from previous_attributes")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cd_same");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Same",
+						description: "keep",
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Changed",
+							description: "keep",
+						},
+					],
+				}),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					previousAttributes: { name: "Same" },
+					customize: null,
+					itemChanges: [],
+					priceChange: null,
+				},
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, name: "Same", description: "keep" }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/changes/changes-free-trial.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/changes/changes-free-trial.test.ts
@@ -1,0 +1,295 @@
+/**
+ * catalogV2.preview_update — customize.free_trial lane.
+ *
+ * RED twice: trial persistence AND changes are unimplemented. Spec asserts
+ * freeTrialsEqual normalization (card_required true / on_end "bill" /
+ * duration_type month ≡ omitted).
+ */
+
+import { test } from "bun:test";
+import {
+	BillingInterval,
+	FreeTrialDuration,
+	PreviewUpdateCatalogResponseSchema,
+} from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	findPlanPreviewRow,
+	parsePlanPreview,
+} from "../utils/expectPlanPreview.js";
+
+const paidSeed = (planId: string) => ({
+	plan_id: planId,
+	name: "Trial Plan",
+	price: { amount: 20, interval: BillingInterval.Month },
+});
+
+const trial14 = {
+	duration_length: 14,
+	duration_type: FreeTrialDuration.Day,
+	card_required: false,
+};
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-free-trial: add trial → customize.free_trial")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cft_add");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [paidSeed(planId)],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, free_trial: trial14 }],
+				}),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+			// Trial not in upsert op today → action may stay `none`; still require customize.
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					customize: { free_trial: trial14 },
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — duration_length / duration_type change
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-free-trial: duration_length / duration_type change")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cft_dur");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			// Seed via params even if persistence is broken — preview compare
+			// still needs a desired→desired diff once wiring lands; until then RED.
+			await autumnV2_3.catalogV2.update({
+				plans: [{ ...paidSeed(planId), free_trial: trial14 }],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							free_trial: {
+								duration_length: 30,
+								duration_type: FreeTrialDuration.Day,
+								card_required: false,
+							},
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					customize: {
+						free_trial: {
+							duration_length: 30,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — card_required flip diffs; explicit true ≡ omitted → no trial diff
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-free-trial: card_required flip vs explicit true ≡ omit")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cft_card");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						...paidSeed(planId),
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+						},
+					},
+				],
+			});
+
+			const noDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							free_trial: {
+								duration_length: 14,
+								duration_type: FreeTrialDuration.Day,
+								card_required: true,
+							},
+						},
+					],
+				}),
+			);
+			// Once trial persists + changes wired: action none / no free_trial lane.
+			// Today trial doesn't persist so this may look like an add — still RED.
+			const row = findPlanPreviewRow({ preview: noDiff, planId });
+			if (row.changes?.customize?.free_trial !== undefined) {
+				throw new Error(
+					"explicit card_required:true must not produce free_trial diff",
+				);
+			}
+
+			const withDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							free_trial: {
+								duration_length: 14,
+								duration_type: FreeTrialDuration.Day,
+								card_required: false,
+							},
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: withDiff,
+				expected: {
+					planId,
+					customize: {
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — on_end change; explicit "bill" ≡ omitted
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-free-trial: on_end change vs explicit bill ≡ omit")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cft_end");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						...paidSeed(planId),
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+
+			const noDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							free_trial: {
+								duration_length: 14,
+								duration_type: FreeTrialDuration.Day,
+								card_required: false,
+								on_end: "bill",
+							},
+						},
+					],
+				}),
+			);
+			const noDiffRow = findPlanPreviewRow({ preview: noDiff, planId });
+			if (noDiffRow.changes?.customize?.free_trial !== undefined) {
+				throw new Error(
+					"explicit on_end:bill must not produce free_trial diff",
+				);
+			}
+
+			const withDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							free_trial: {
+								duration_length: 14,
+								duration_type: FreeTrialDuration.Day,
+								card_required: false,
+								on_end: "revert",
+							},
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: withDiff,
+				expected: {
+					planId,
+					customize: {
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: "revert",
+						},
+					},
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-free-trial: remove trial → customize.free_trial null")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cft_rm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ ...paidSeed(planId), free_trial: trial14 }],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, free_trial: null }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					customize: { free_trial: null },
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/changes/changes-items.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/changes/changes-items.test.ts
@@ -1,0 +1,958 @@
+/**
+ * catalogV2.preview_update — item_changes + customize.add_items/remove_items.
+ *
+ * RED: changes stubbed null. Match key = feature_id|billing_method|interval|
+ * interval_count. In-place mods = remove filter (OLD key) + add entry.
+ * toCreatePlanItemParams omits default-valued fields.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	OnDecrease,
+	OnIncrease,
+	PreviewUpdateCatalogResponseSchema,
+	ResetInterval,
+	RolloverExpiryDurationType,
+	TierBehavior,
+	TierInfinite,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	findPlanPreviewRow,
+	parsePlanPreview,
+} from "../utils/expectPlanPreview.js";
+
+const messagesFree = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const messagesPrepaid = ({
+	amount,
+	interval = BillingInterval.Month,
+}: {
+	amount: number;
+	interval?: BillingInterval;
+}) => ({
+	feature_id: TestFeature.Messages,
+	included: 0,
+	price: {
+		amount,
+		interval,
+		billing_method: BillingMethod.Prepaid,
+		billing_units: 1,
+	},
+	reset: { interval: ResetInterval.Month },
+});
+
+const messagesUsage = ({
+	amount,
+	interval = BillingInterval.Month,
+}: {
+	amount: number;
+	interval?: BillingInterval;
+}) => ({
+	feature_id: TestFeature.Messages,
+	included: 0,
+	price: {
+		amount,
+		interval,
+		billing_method: BillingMethod.UsageBased,
+		billing_units: 1,
+	},
+	reset: { interval },
+});
+
+/** Assert changes wired with expected customize item lanes. */
+const expectItemCustomize = ({
+	preview,
+	planId,
+	addItems,
+	removeItems,
+}: {
+	preview: ReturnType<typeof parsePlanPreview>;
+	planId: string;
+	addItems?: unknown;
+	removeItems?: unknown;
+}) => {
+	const row = findPlanPreviewRow({ preview, planId });
+	expect(row.changes, "changes must be non-null").not.toBeNull();
+	if (addItems !== undefined) {
+		expect(row.changes?.customize?.add_items).toEqual(addItems as never);
+	}
+	if (removeItems !== undefined) {
+		expect(row.changes?.customize?.remove_items).toEqual(removeItems as never);
+	}
+};
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: add free item")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_addf");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Add Free" }],
+			});
+			const item = messagesFree(10);
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, items: [item] }],
+				}),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "update" },
+			});
+			expectItemCustomize({
+				preview,
+				planId,
+				addItems: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 10,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+				removeItems: undefined,
+			});
+			const row = findPlanPreviewRow({ preview, planId });
+			expect(row.changes?.customize?.remove_items).toBeUndefined();
+			expect(row.changes?.item_changes).toEqual([
+				expect.objectContaining({
+					action: "created",
+					feature_id: TestFeature.Messages,
+				}),
+			]);
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, featureIds: [] }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: add priced item")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_addp");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Add Priced" }],
+			});
+			const item = messagesPrepaid({ amount: 5 });
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, items: [item] }],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				addItems: [
+					expect.objectContaining({
+						feature_id: TestFeature.Messages,
+						price: expect.objectContaining({
+							amount: 5,
+							billing_method: BillingMethod.Prepaid,
+						}),
+					}),
+				],
+			});
+			const row = findPlanPreviewRow({ preview, planId });
+			expect(row.changes?.item_changes?.[0]?.action).toBe("created");
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: remove item → deleted + remove_items filter")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_rm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Remove",
+						items: [messagesFree(10)],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, items: [] }],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				addItems: undefined,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						interval: ResetInterval.Month,
+						interval_count: 1,
+					},
+				],
+			});
+			const row = findPlanPreviewRow({ preview, planId });
+			expect(row.changes?.customize?.add_items).toBeUndefined();
+			expect(row.changes?.item_changes).toEqual([
+				expect.objectContaining({
+					action: "deleted",
+					feature_id: TestFeature.Messages,
+				}),
+			]);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — same match key → deleted+created pair
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: included bump → remove+add same key")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_inc");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Inc",
+						items: [messagesFree(10)],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, items: [messagesFree(50)] }],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						interval: ResetInterval.Month,
+						interval_count: 1,
+					},
+				],
+				addItems: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 50,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+			});
+			const row = findPlanPreviewRow({ preview, planId });
+			const actions = (row.changes?.item_changes ?? []).map((c) => c.action);
+			expect(actions.sort()).toEqual(["created", "deleted"]);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: priced amount change → remove+add")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_pamt");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "PAmt",
+						items: [messagesPrepaid({ amount: 5 })],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, items: [messagesPrepaid({ amount: 9 })] }],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.Prepaid,
+						interval: BillingInterval.Month,
+						interval_count: 1,
+					},
+				],
+			});
+			const row = findPlanPreviewRow({ preview, planId });
+			expect(row.changes?.customize?.add_items?.[0]?.price?.amount).toBe(9);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — match key CHANGES: remove filter carries OLD interval
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: reset/billing interval change → old key on remove")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_ivl");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Ivl",
+						items: [
+							messagesUsage({ amount: 1, interval: BillingInterval.Month }),
+						],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								messagesUsage({ amount: 1, interval: BillingInterval.Year }),
+							],
+						},
+					],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.UsageBased,
+						interval: BillingInterval.Month,
+						interval_count: 1,
+					},
+				],
+				addItems: [
+					expect.objectContaining({
+						feature_id: TestFeature.Messages,
+						price: expect.objectContaining({
+							interval: BillingInterval.Year,
+						}),
+					}),
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: billing_method prepaid → usage_based")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_bm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "BM",
+						items: [messagesPrepaid({ amount: 5 })],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [messagesUsage({ amount: 5 })],
+						},
+					],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.Prepaid,
+						interval: BillingInterval.Month,
+						interval_count: 1,
+					},
+				],
+				addItems: [
+					expect.objectContaining({
+						price: expect.objectContaining({
+							billing_method: BillingMethod.UsageBased,
+						}),
+					}),
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: free → paid / paid → free")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const freeToPaid = uniqueTestId("cv2_ci_f2p");
+		const paidToFree = uniqueTestId("cv2_ci_p2f");
+		await deleteDbPlans({ ctx, planIds: [freeToPaid, paidToFree] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: freeToPaid,
+						name: "F2P",
+						items: [messagesFree(10)],
+					},
+					{
+						plan_id: paidToFree,
+						name: "P2F",
+						items: [messagesPrepaid({ amount: 5 })],
+					},
+				],
+			});
+
+			const f2p = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: freeToPaid,
+							items: [messagesPrepaid({ amount: 5 })],
+						},
+					],
+				}),
+			);
+			expectItemCustomize({
+				preview: f2p,
+				planId: freeToPaid,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						interval: ResetInterval.Month,
+						interval_count: 1,
+					},
+				],
+			});
+
+			const p2f = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: paidToFree,
+							items: [messagesFree(10)],
+						},
+					],
+				}),
+			);
+			expectItemCustomize({
+				preview: p2f,
+				planId: paidToFree,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.Prepaid,
+						interval: BillingInterval.Month,
+						interval_count: 1,
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [freeToPaid, paidToFree] });
+		}
+	},
+);
+
+// RED — unlimited / pooled toggles
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: unlimited + pooled toggles → remove+add")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_flags");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Flags",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									unlimited: true,
+									pooled: true,
+								},
+							],
+						},
+					],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						interval: ResetInterval.Month,
+						interval_count: 1,
+					},
+				],
+				addItems: [
+					{
+						feature_id: TestFeature.Messages,
+						unlimited: true,
+						pooled: true,
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — rollover / proration / billing_units / max_purchase / tiers / tier_behavior
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: rollover / proration / units / tiers / tier_behavior")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_shape");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Shape",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 0,
+								price: {
+									amount: 1,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 1,
+									max_purchase: 10,
+								},
+								reset: { interval: ResetInterval.Month },
+								proration: {
+									on_increase: OnIncrease.ProrateImmediately,
+									on_decrease: OnDecrease.ProrateImmediately,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 0,
+									price: {
+										tiers: [
+											{ to: 100, amount: 2 },
+											{ to: TierInfinite, amount: 1 },
+										],
+										tier_behavior: TierBehavior.VolumeBased,
+										interval: BillingInterval.Month,
+										billing_method: BillingMethod.Prepaid,
+										billing_units: 10,
+										max_purchase: 20,
+									},
+									reset: { interval: ResetInterval.Month },
+									rollover: {
+										max: 50,
+										expiry_duration_type: RolloverExpiryDurationType.Month,
+										expiry_duration_length: 1,
+									},
+									proration: {
+										on_increase: OnIncrease.ProrateNextCycle,
+										on_decrease: OnDecrease.ProrateImmediately,
+									},
+								},
+							],
+						},
+					],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.Prepaid,
+						interval: BillingInterval.Month,
+						interval_count: 1,
+					},
+				],
+			});
+			const row = findPlanPreviewRow({ preview, planId });
+			expect(row.changes?.customize?.add_items?.[0]?.rollover).toBeDefined();
+			expect(row.changes?.customize?.add_items?.[0]?.price?.tier_behavior).toBe(
+				TierBehavior.VolumeBased,
+			);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — graduated explicit ≡ default → no diff; volume flip diffs
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: tier_behavior graduated explicit → no diff; → volume diffs")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_tb");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const tiers = [
+				{ to: 100, amount: 2 },
+				{ to: TierInfinite, amount: 1 },
+			];
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "TB",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 0,
+								price: {
+									tiers,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 1,
+								},
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const noDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 0,
+									price: {
+										tiers,
+										tier_behavior: TierBehavior.Graduated,
+										interval: BillingInterval.Month,
+										billing_method: BillingMethod.Prepaid,
+										billing_units: 1,
+									},
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: noDiff,
+				expected: { planId, action: "none", changes: null },
+			});
+
+			const withDiff = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 0,
+									price: {
+										tiers,
+										tier_behavior: TierBehavior.VolumeBased,
+										interval: BillingInterval.Month,
+										billing_method: BillingMethod.Prepaid,
+										billing_units: 1,
+									},
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+						},
+					],
+				}),
+			);
+			expect(
+				findPlanPreviewRow({ preview: withDiff, planId }).changes,
+			).not.toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — item FX amount change diffs; currency add/remove no item diff
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: item currency amount change vs add/remove")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_fx");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "ItemFX",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 0,
+								price: {
+									amount: 5,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 1,
+									additional_currencies: [{ currency: "eur", amount: 4 }],
+								},
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const amountChange = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 0,
+									price: {
+										amount: 5,
+										interval: BillingInterval.Month,
+										billing_method: BillingMethod.Prepaid,
+										billing_units: 1,
+										additional_currencies: [{ currency: "eur", amount: 6 }],
+									},
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+						},
+					],
+				}),
+			);
+			expect(
+				findPlanPreviewRow({ preview: amountChange, planId }).changes,
+			).not.toBeNull();
+
+			const currencyRemoved = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 0,
+									price: {
+										amount: 5,
+										interval: BillingInterval.Month,
+										billing_method: BillingMethod.Prepaid,
+										billing_units: 1,
+									},
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: currencyRemoved,
+				expected: { planId, action: "none", changes: null },
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — two items same feature different intervals; only edited key diffs
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: sibling intervals — only edited key diffs")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_sib");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const monthItem = messagesUsage({
+				amount: 1,
+				interval: BillingInterval.Month,
+			});
+			const yearItem = messagesUsage({
+				amount: 1,
+				interval: BillingInterval.Year,
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Siblings",
+						items: [monthItem, yearItem],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								messagesUsage({ amount: 3, interval: BillingInterval.Month }),
+								yearItem,
+							],
+						},
+					],
+				}),
+			);
+			expectItemCustomize({
+				preview,
+				planId,
+				removeItems: [
+					{
+						feature_id: TestFeature.Messages,
+						billing_method: BillingMethod.UsageBased,
+						interval: BillingInterval.Month,
+						interval_count: 1,
+					},
+				],
+			});
+			const row = findPlanPreviewRow({ preview, planId });
+			const removeIntervals = (row.changes?.customize?.remove_items ?? []).map(
+				(f) => f.interval,
+			);
+			expect(removeIntervals).not.toContain(BillingInterval.Year);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — explicit defaults → empty item_changes / no customize lanes
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-items: explicit item defaults → empty changes")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ci_defs");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Defs",
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							items: [
+								{
+									feature_id: TestFeature.Dashboard,
+									included: 0,
+									pooled: false,
+								},
+							],
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "none",
+					changes: null,
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/changes/changes-mixed.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/changes/changes-mixed.test.ts
@@ -1,0 +1,233 @@
+/**
+ * catalogV2.preview_update — mixed changes blocks in one entry / multi-plan.
+ *
+ * RED: changes stubbed null. Create with full shape should still emit
+ * changes.customize carrying the desired shape (price + add_items) with
+ * previous_attributes null.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	FreeTrialDuration,
+	PreviewUpdateCatalogResponseSchema,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectDbPlansAbsent,
+} from "../../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	findPlanPreviewRow,
+	parsePlanPreview,
+} from "../utils/expectPlanPreview.js";
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-mixed: details + price + items + trial coherent")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cm_all");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Old",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							name: "New",
+							price: { amount: 20, interval: BillingInterval.Month },
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 50,
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+							free_trial: {
+								duration_length: 7,
+								duration_type: FreeTrialDuration.Day,
+								card_required: false,
+							},
+						},
+					],
+				}),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+			const row = findPlanPreviewRow({ preview, planId });
+			expect(row.changes).not.toBeNull();
+			expect(row.changes?.previous_attributes).toMatchObject({ name: "Old" });
+			expect(row.changes?.price_change).toBeDefined();
+			expect((row.changes?.item_changes ?? []).length).toBeGreaterThan(0);
+			expect(row.changes?.customize?.price).toBeDefined();
+			expect(row.changes?.customize?.add_items).toBeDefined();
+			expect(row.changes?.customize?.remove_items).toBeDefined();
+			expect(row.changes?.customize?.free_trial).toBeDefined();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — create full shape: previous_attributes null, customize carries desired
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-mixed: create full shape → customize desired, previous null")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cm_create");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Created",
+							price: { amount: 20, interval: BillingInterval.Month },
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 10,
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "create",
+					previousAttributes: null,
+					customize: {
+						price: { amount: 20, interval: BillingInterval.Month },
+						add_items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				},
+			});
+			await expectDbPlansAbsent({ ctx, planIds: [planId] });
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — items + price, details untouched → previous_attributes null/empty
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-mixed: items+price, details untouched → no previous_attributes")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_cm_nodet");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stable Name",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							name: "Stable Name",
+							price: { amount: 20, interval: BillingInterval.Month },
+							items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 50,
+									reset: { interval: ResetInterval.Month },
+								},
+							],
+						},
+					],
+				}),
+			);
+			const row = findPlanPreviewRow({ preview, planId });
+			expect(row.changes).not.toBeNull();
+			expect(row.changes?.previous_attributes ?? null).toBeNull();
+			expect(row.changes?.price_change).toBeDefined();
+			expect((row.changes?.item_changes ?? []).length).toBeGreaterThan(0);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — multi-plan: each row's changes scoped to its own plan
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 changes-mixed: multi-plan changes scoped per row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_cm_a");
+		const planB = uniqueTestId("cv2_cm_b");
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planA, name: "A1" },
+					{ plan_id: planB, name: "B1" },
+				],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{ plan_id: planA, name: "A2" },
+						{
+							plan_id: planB,
+							price: { amount: 10, interval: BillingInterval.Month },
+						},
+					],
+				}),
+			);
+			const rowA = findPlanPreviewRow({ preview, planId: planA });
+			const rowB = findPlanPreviewRow({ preview, planId: planB });
+			expect(rowA.changes).not.toBeNull();
+			expect(rowB.changes).not.toBeNull();
+			expect(rowA.changes?.previous_attributes).toMatchObject({ name: "A1" });
+			expect(rowA.changes?.price_change).toBeUndefined();
+			expect(rowB.changes?.price_change).toBeDefined();
+			expect(rowB.changes?.previous_attributes ?? null).toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/preview-actions.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/preview-actions.test.ts
@@ -1,0 +1,478 @@
+/**
+ * catalogV2.preview_update — action correctness for plans.
+ *
+ * Asserts create / update / none / archive / multi-plan / pinned-version /
+ * preview↔update parity. Always schema-parses the response and checks
+ * preview writes nothing.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	PreviewUpdateCatalogResponseSchema,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+	expectDbPlansAbsent,
+	expectDbPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	expectPlanPreviewRowsCorrect,
+	parsePlanPreview,
+} from "./utils/expectPlanPreview.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: new plan_id → create")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_create");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const params = {
+				plans: [{ plan_id: planId, name: "Preview Create" }],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "create", name: "Preview Create" },
+			});
+			await expectDbPlansAbsent({ ctx, planIds: [planId] });
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: detail-only diff → update")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_det");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Before" }],
+			});
+			const params = {
+				plans: [{ plan_id: planId, name: "After" }],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "update" },
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, name: "Before" }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: items-only diff → update")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_items");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Items",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const params = {
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 50,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "update" },
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, allowances: { [TestFeature.Messages]: 10 } }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: base-price-only diff → update")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_price");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Priced",
+						price: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+			const params = {
+				plans: [
+					{
+						plan_id: planId,
+						price: { amount: 30, interval: BillingInterval.Month },
+					},
+				],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "update" },
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						basePrice: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: identical re-send → none")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_none");
+		const params = {
+			plans: [
+				{
+					plan_id: planId,
+					name: "Same",
+					items: [{ feature_id: TestFeature.Dashboard }],
+					price: { amount: 10, interval: BillingInterval.Month },
+				},
+			],
+		};
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update(params);
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "none" },
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: explicit defaults → none (no false positive)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_defs");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Defaults",
+						items: [{ feature_id: TestFeature.Dashboard }],
+						price: { amount: 10, interval: BillingInterval.Month },
+					},
+				],
+			});
+			const params = {
+				plans: [
+					{
+						plan_id: planId,
+						name: "Defaults",
+						items: [
+							{
+								feature_id: TestFeature.Dashboard,
+								included: 0,
+								pooled: false,
+							},
+						],
+						price: {
+							amount: 10,
+							interval: BillingInterval.Month,
+							interval_count: 1,
+						},
+					},
+				],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "none" },
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: omit items/price lanes → none")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_omit");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Keep Lanes",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+						price: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+			const params = {
+				plans: [{ plan_id: planId, name: "Keep Lanes" }],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "none" },
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						allowances: { [TestFeature.Messages]: 10 },
+						basePrice: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: archived toggle → update")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_arch");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Archive Me" }],
+			});
+			const params = {
+				plans: [{ plan_id: planId, archived: true }],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: { planId, action: "update" },
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, archived: false }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: multi-plan create + update + none")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const createId = uniqueTestId("cv2_pa_mc");
+		const updateId = uniqueTestId("cv2_pa_mu");
+		const noneId = uniqueTestId("cv2_pa_mn");
+		await deleteDbPlans({ ctx, planIds: [createId, updateId, noneId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: updateId, name: "Will Update" },
+					{ plan_id: noneId, name: "Stay Same" },
+				],
+			});
+			const params = {
+				plans: [
+					{ plan_id: createId, name: "New" },
+					{ plan_id: updateId, name: "Updated" },
+					{ plan_id: noneId, name: "Stay Same" },
+				],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			expectPlanPreviewRowsCorrect({
+				preview,
+				expected: [
+					{ planId: createId, action: "create" },
+					{ planId: updateId, action: "update" },
+					{ planId: noneId, action: "none" },
+				],
+			});
+			await expectDbPlansAbsent({ ctx, planIds: [createId] });
+		} finally {
+			await deleteDbPlans({
+				ctx,
+				planIds: [createId, updateId, noneId],
+			});
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: pinned version:1 action against v1 not latest")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pa_pin");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "V1 Name" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version: 2, name: "V2 Name" }],
+			});
+
+			// Re-send v1's current name → none against v1; latest stays V2.
+			const nonePreview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, version: 1, name: "V1 Name" }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: nonePreview,
+				expected: { planId, action: "none" },
+			});
+
+			const updatePreview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, version: 1, name: "V1 Renamed" }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: updatePreview,
+				expected: { planId, action: "update" },
+			});
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{ id: planId, version: 1, name: "V1 Name" },
+					{ id: planId, version: 2, name: "V2 Name" },
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-actions: update results.plans actions match preview")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const createId = uniqueTestId("cv2_pa_par_c");
+		const updateId = uniqueTestId("cv2_pa_par_u");
+		const noneId = uniqueTestId("cv2_pa_par_n");
+		await deleteDbPlans({ ctx, planIds: [createId, updateId, noneId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: updateId, name: "Before" },
+					{ plan_id: noneId, name: "Stable" },
+				],
+			});
+			const params = {
+				plans: [
+					{ plan_id: createId, name: "Created" },
+					{ plan_id: updateId, name: "After" },
+					{ plan_id: noneId, name: "Stable" },
+				],
+			};
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate(params),
+			);
+			const response = await autumnV2_3.catalogV2.update(params);
+
+			for (const planId of [createId, updateId, noneId]) {
+				const previewAction = preview.plans.find(
+					(row) => row.plan_id === planId,
+				)?.action;
+				const resultAction = response.results.plans.find(
+					(row) => row.id === planId,
+				)?.action;
+				expect(resultAction).toBe(previewAction);
+			}
+		} finally {
+			await deleteDbPlans({
+				ctx,
+				planIds: [createId, updateId, noneId],
+			});
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/preview-state-versioning.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/preview-state-versioning.test.ts
@@ -1,0 +1,344 @@
+/**
+ * catalogV2.preview_update — state.has_customers + versioning block.
+ *
+ * has_customers is already populated from upsert.state (green-expected).
+ * versioning is stubbed null → RED for versioning cases.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	customerProducts,
+	customers,
+	PreviewUpdateCatalogResponseSchema,
+} from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	findPlanPreviewRow,
+	parsePlanPreview,
+} from "./utils/expectPlanPreview.js";
+
+const getFull = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version?: number;
+}) =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+
+const seedCustomerProductRef = async ({
+	ctx,
+	planId,
+	status = CusProductStatus.Active,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	status?: CusProductStatus;
+	version?: number;
+}) => {
+	const full = await getFull({ ctx, planId, version });
+	const customerId = uniqueTestId("cv2_pv_cus");
+	const internalCustomerId = generateId("cus");
+	const cusProductId = generateId("cus_prod");
+
+	await ctx.db.insert(customers).values({
+		internal_id: internalCustomerId,
+		id: customerId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		name: customerId,
+		email: `${customerId}@test.com`,
+	});
+
+	await ctx.db.insert(customerProducts).values({
+		id: cusProductId,
+		internal_customer_id: internalCustomerId,
+		product_id: planId,
+		internal_product_id: full.internal_id,
+		status,
+		created_at: Date.now(),
+		starts_at: Date.now(),
+		quantity: 1,
+		options: [],
+		is_custom: false,
+	});
+
+	return { customerId, internalCustomerId, cusProductId };
+};
+
+const cleanupCustomerRefs = async ({
+	ctx,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+}) => {
+	for (const planId of planIds) {
+		const cusProds = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(eq(customerProducts.product_id, planId));
+		for (const row of cusProds) {
+			await ctx.db
+				.delete(customerProducts)
+				.where(eq(customerProducts.id, row.id));
+			await ctx.db
+				.delete(customers)
+				.where(eq(customers.internal_id, row.internal_customer_id));
+		}
+	}
+};
+
+const unimplementedNewVersionReason =
+	'versioning "new_version" is not implemented yet';
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-state: has_customers true with attached customer; false without")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const withCus = uniqueTestId("cv2_pv_hc");
+		const withoutCus = uniqueTestId("cv2_pv_nc");
+		await deleteDbPlans({ ctx, planIds: [withCus, withoutCus] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: withCus, name: "With Cus" },
+					{ plan_id: withoutCus, name: "No Cus" },
+				],
+			});
+			await seedCustomerProductRef({ ctx, planId: withCus });
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{ plan_id: withCus, name: "With Cus Renamed" },
+						{ plan_id: withoutCus, name: "No Cus Renamed" },
+					],
+				}),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: withCus,
+					action: "update",
+					hasCustomers: true,
+				},
+			});
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: withoutCus,
+					action: "update",
+					hasCustomers: false,
+				},
+			});
+		} finally {
+			await cleanupCustomerRefs({ ctx, planIds: [withCus, withoutCus] });
+			await deleteDbPlans({ ctx, planIds: [withCus, withoutCus] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 preview-state: expired-only customers → has_customers false")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pv_exp");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Expired Only" }],
+			});
+			await seedCustomerProductRef({
+				ctx,
+				planId,
+				status: CusProductStatus.Expired,
+			});
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, name: "Expired Renamed" }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					hasCustomers: false,
+				},
+			});
+		} finally {
+			await cleanupCustomerRefs({ ctx, planIds: [planId] });
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED: versioning stubbed null
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 preview-versioning: latest of 2-version → existing resolved")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pv_ver");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "V1" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version: 2, name: "V2" }],
+			});
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, name: "V2 Renamed" }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					versioning: {
+						current_version: 2,
+						new_version: null,
+						resolved: "existing",
+						options: [
+							{ strategy: "existing", available: true },
+							{
+								strategy: "new_version",
+								available: false,
+								reason: unimplementedNewVersionReason,
+							},
+							{ strategy: "all_versions", available: true },
+						],
+					},
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — options list; new_version unavailable
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 preview-versioning: options list; new_version unavailable")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pv_opts");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Opts" }],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, name: "Opts2" }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					versioning: {
+						current_version: 1,
+						new_version: null,
+						resolved: "existing",
+						options: [
+							{ strategy: "existing", available: true },
+							{
+								strategy: "new_version",
+								available: false,
+								reason: unimplementedNewVersionReason,
+							},
+							{ strategy: "all_versions", available: true },
+						],
+					},
+				},
+			});
+			const strategies = (
+				findPlanPreviewRow({ preview, planId }).versioning?.options ?? []
+			).map((o) => o.strategy);
+			expect(strategies.sort()).toEqual([
+				"all_versions",
+				"existing",
+				"new_version",
+			]);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — all_versions → one preview row per affected version
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 preview-versioning: all_versions → one row per version")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_pv_all");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "V1" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version: 2, name: "V2" }],
+			});
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							versioning: "all_versions",
+							name: "Propagated",
+						},
+					],
+				}),
+			);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+
+			const rows = preview.plans.filter((p) => p.plan_id === planId);
+			expect(rows.length).toBeGreaterThanOrEqual(2);
+			const versions = rows.map((r) => r.versioning?.current_version).sort();
+			expect(versions).toEqual([1, 2]);
+			for (const row of rows) {
+				expect(row.versioning?.resolved).toBe("all_versions");
+				expect(row.versioning?.new_version).toBeNull();
+				expect(row.versioning?.options).toEqual([
+					{ strategy: "existing", available: true },
+					{
+						strategy: "new_version",
+						available: false,
+						reason: unimplementedNewVersionReason,
+					},
+					{ strategy: "all_versions", available: true },
+				]);
+			}
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
@@ -1,0 +1,117 @@
+import { expect } from "bun:test";
+import type { PreviewUpdateCatalogResponse } from "@autumn/shared";
+import { PreviewUpdateCatalogResponseSchema } from "@autumn/shared";
+
+type PlanPreviewRow = PreviewUpdateCatalogResponse["plans"][number];
+type PlanPreviewChanges = NonNullable<PlanPreviewRow["changes"]>;
+type PlanPreviewVersioning = NonNullable<PlanPreviewRow["versioning"]>;
+
+type ExpectedPlanPreviewRow = {
+	planId: string;
+	action?: PlanPreviewRow["action"];
+	name?: string;
+	hasCustomers?: boolean;
+	willArchive?: boolean;
+	/** Exact match; pass `null` to assert stubbed/absent versioning. */
+	versioning?: PlanPreviewVersioning | null;
+	/** Exact match; pass `null` to assert stubbed/absent changes. */
+	changes?: PlanPreviewChanges | null;
+	/** Containment over changes.previous_attributes keys/values. */
+	previousAttributes?: Record<string, unknown> | null;
+	/** Containment over customize lanes. */
+	customize?: PlanPreviewChanges["customize"];
+	priceChange?: PlanPreviewChanges["price_change"] | null;
+	itemChanges?: PlanPreviewChanges["item_changes"];
+};
+
+/** Parse + schema-validate the preview response; throws on shape drift. */
+export const parsePlanPreview = (raw: unknown): PreviewUpdateCatalogResponse =>
+	PreviewUpdateCatalogResponseSchema.parse(raw);
+
+export const findPlanPreviewRow = ({
+	preview,
+	planId,
+}: {
+	preview: PreviewUpdateCatalogResponse;
+	planId: string;
+}): PlanPreviewRow => {
+	const row = preview.plans.find((candidate) => candidate.plan_id === planId);
+	expect(row, `missing preview row for plan ${planId}`).toBeDefined();
+	if (!row) throw new Error(`missing preview row for plan ${planId}`);
+	return row;
+};
+
+/** Containment asserts for one plan preview row — only fields passed are checked. */
+export const expectPlanPreviewRowCorrect = ({
+	preview,
+	expected,
+}: {
+	preview: PreviewUpdateCatalogResponse;
+	expected: ExpectedPlanPreviewRow;
+}) => {
+	const row = findPlanPreviewRow({ preview, planId: expected.planId });
+
+	if (expected.action !== undefined) {
+		expect(row.action).toBe(expected.action);
+	}
+	if (expected.name !== undefined) {
+		expect(row.name).toBe(expected.name);
+	}
+	if (expected.hasCustomers !== undefined) {
+		expect(row.state.has_customers).toBe(expected.hasCustomers);
+	}
+	if (expected.willArchive !== undefined) {
+		expect(row.state.will_archive).toBe(expected.willArchive);
+	}
+	if (expected.versioning !== undefined) {
+		expect(row.versioning).toEqual(expected.versioning);
+	}
+	if (expected.changes !== undefined) {
+		expect(row.changes).toEqual(expected.changes);
+	}
+	if (expected.previousAttributes !== undefined) {
+		if (expected.previousAttributes === null) {
+			expect(row.changes?.previous_attributes ?? null).toBeNull();
+		} else {
+			expect(row.changes).not.toBeNull();
+			expect(row.changes?.previous_attributes).toMatchObject(
+				expected.previousAttributes,
+			);
+			for (const key of Object.keys(row.changes?.previous_attributes ?? {})) {
+				expect(
+					Object.keys(expected.previousAttributes),
+					`unexpected previous_attributes key ${key}`,
+				).toContain(key);
+			}
+		}
+	}
+	if (expected.customize !== undefined) {
+		if (expected.customize === null) {
+			expect(row.changes?.customize ?? null).toBeNull();
+		} else {
+			expect(row.changes?.customize).toMatchObject(expected.customize);
+		}
+	}
+	if (expected.priceChange !== undefined) {
+		if (expected.priceChange === null) {
+			expect(row.changes?.price_change).toBeUndefined();
+		} else {
+			expect(row.changes?.price_change).toEqual(expected.priceChange);
+		}
+	}
+	if (expected.itemChanges !== undefined) {
+		expect(row.changes?.item_changes ?? []).toEqual(expected.itemChanges);
+	}
+};
+
+export const expectPlanPreviewRowsCorrect = ({
+	preview,
+	expected,
+}: {
+	preview: PreviewUpdateCatalogResponse;
+	expected: ExpectedPlanPreviewRow[];
+}) => {
+	for (const row of expected) {
+		expectPlanPreviewRowCorrect({ preview, expected: row });
+	}
+};

--- a/server/tests/integration/catalog-v2/plans/update/idempotent-plans.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/idempotent-plans.test.ts
@@ -1,0 +1,172 @@
+/**
+ * catalogV2.update — idempotent re-send of identical plan params.
+ *
+ * Contract:
+ *   - identical re-send → action "none", no entitlement/price writes
+ *   - preview of identical re-send also reports "none"
+ *   - row ids (entitlements + prices) stay stable across the no-op update
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+import {
+	expectCatalogPreviewCorrect,
+	expectCatalogResultsCorrect,
+} from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 idempotent: re-send identical simple plan → none")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_idemp_min");
+		const params = {
+			plans: [{ plan_id: planId, name: "Idempotent Minimal" }],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update(params);
+
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "none" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "Idempotent Minimal",
+						featureIds: [],
+						basePrice: null,
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 idempotent: re-send shaped plan → none; row ids stable")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_idemp_shape");
+		const params = {
+			plans: [
+				{
+					plan_id: planId,
+					name: "Idempotent Shaped",
+					metadata: { source: "idemp" },
+					config: { ignore_past_due: true },
+					price: { amount: 20, interval: BillingInterval.Month },
+					items: [
+						{ feature_id: TestFeature.Dashboard },
+						{
+							feature_id: TestFeature.Messages,
+							included: 100,
+							reset: { interval: ResetInterval.Month },
+						},
+					],
+				},
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update(params);
+
+			const before = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			const beforeEntIds = before.entitlements.map((ent) => ent.id).sort();
+			const beforePriceIds = before.prices.map((price) => price.id).sort();
+
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "none" }],
+			});
+
+			const after = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			expect(after.entitlements.map((ent) => ent.id).sort()).toEqual(
+				beforeEntIds,
+			);
+			expect(after.prices.map((price) => price.id).sort()).toEqual(
+				beforePriceIds,
+			);
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						name: "Idempotent Shaped",
+						featureIds: [TestFeature.Dashboard, TestFeature.Messages],
+						allowances: { [TestFeature.Messages]: 100 },
+						basePrice: { amount: 20, interval: BillingInterval.Month },
+						metadata: { source: "idemp" },
+						config: { ignore_past_due: true },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 idempotent: preview of identical re-send reports none")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_idemp_prev");
+		const params = {
+			plans: [
+				{
+					plan_id: planId,
+					name: "Idempotent Preview",
+					items: [
+						{
+							feature_id: TestFeature.Messages,
+							included: 50,
+							reset: { interval: ResetInterval.Month },
+						},
+					],
+				},
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update(params);
+
+			const preview = await autumnV2_3.catalogV2.previewUpdate(params);
+			expectCatalogPreviewCorrect({
+				preview,
+				plans: [{ planId, action: "none" }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/stripe-reuse.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/stripe-reuse.test.ts
@@ -1,0 +1,540 @@
+/**
+ * catalogV2.update — Stripe id carry-forward on entitlement/price rows.
+ *
+ * Full carry (stripe_price_id + stripe_product_id + meter) when price AND
+ * entitlement definitions match; product-only carry when same usage feature +
+ * entity scope; otherwise nothing.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	type FullProduct,
+	findPriceByFeatureId,
+	isFixedPrice,
+	type Price,
+	ResetInterval,
+	TierBehavior,
+	TierInfinite,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { PriceService } from "@/internal/products/prices/PriceService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+
+type StripeConfig = {
+	stripe_product_id?: string | null;
+	stripe_price_id?: string | null;
+	stripe_meter_id?: string | null;
+};
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<FullProduct> =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const seedPriceStripe = async ({
+	ctx,
+	price,
+	stripeProductId,
+	stripePriceId,
+	stripeMeterId,
+}: {
+	ctx: AutumnContext;
+	price: Price;
+	stripeProductId?: string;
+	stripePriceId?: string;
+	stripeMeterId?: string;
+}) => {
+	await PriceService.update({
+		db: ctx.db,
+		id: price.id,
+		update: {
+			config: {
+				...price.config,
+				...(stripeProductId !== undefined
+					? { stripe_product_id: stripeProductId }
+					: {}),
+				...(stripePriceId !== undefined
+					? { stripe_price_id: stripePriceId }
+					: {}),
+				...(stripeMeterId !== undefined
+					? { stripe_meter_id: stripeMeterId }
+					: {}),
+			} as Price["config"],
+		},
+	});
+};
+
+const priceConfig = ({
+	product,
+	featureId,
+}: {
+	product: FullProduct;
+	featureId: string;
+}): StripeConfig => {
+	const price = findPriceByFeatureId({
+		prices: product.prices,
+		featureId,
+	});
+	if (!price) throw new Error(`missing price for ${featureId}`);
+	return price.config as StripeConfig;
+};
+
+const prepaidMessagesItem = ({ amount }: { amount: number }) => ({
+	feature_id: TestFeature.Messages,
+	included: 0,
+	price: {
+		amount,
+		interval: BillingInterval.Month,
+		billing_method: BillingMethod.Prepaid,
+		billing_units: 100,
+	},
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 stripe: unchanged paid item carries full stripe ids")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_str_same");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe Same",
+						items: [
+							prepaidMessagesItem({ amount: 10 }),
+							{ feature_id: TestFeature.Dashboard },
+						],
+					},
+				],
+			});
+
+			const before = await getFull({ ctx, planId });
+			const paid = findPriceByFeatureId({
+				prices: before.prices,
+				featureId: TestFeature.Messages,
+			})!;
+			const stripeProductId = `prod_${planId}`;
+			const stripePriceId = `price_${planId}`;
+			await seedPriceStripe({
+				ctx,
+				price: paid,
+				stripeProductId,
+				stripePriceId,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe Same Renamed",
+						items: [
+							prepaidMessagesItem({ amount: 10 }),
+							{ feature_id: TestFeature.Dashboard },
+						],
+					},
+				],
+			});
+
+			const after = await getFull({ ctx, planId });
+			const config = priceConfig({
+				product: after,
+				featureId: TestFeature.Messages,
+			});
+			expect(config.stripe_product_id).toBe(stripeProductId);
+			expect(config.stripe_price_id).toBe(stripePriceId);
+			const afterPaid = findPriceByFeatureId({
+				prices: after.prices,
+				featureId: TestFeature.Messages,
+			});
+			expect(afterPaid?.id).toBe(paid.id);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 stripe: details-only update carries all stripe ids")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_str_det");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe Details",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [prepaidMessagesItem({ amount: 5 })],
+					},
+				],
+			});
+
+			const before = await getFull({ ctx, planId });
+			const paid = findPriceByFeatureId({
+				prices: before.prices,
+				featureId: TestFeature.Messages,
+			})!;
+			const base = before.prices.find(isFixedPrice)!;
+			await seedPriceStripe({
+				ctx,
+				price: paid,
+				stripeProductId: `prod_paid_${planId}`,
+				stripePriceId: `price_paid_${planId}`,
+			});
+			await seedPriceStripe({
+				ctx,
+				price: base,
+				stripeProductId: `prod_base_${planId}`,
+				stripePriceId: `price_base_${planId}`,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Stripe Details Renamed" }],
+			});
+
+			const after = await getFull({ ctx, planId });
+			const paidConfig = priceConfig({
+				product: after,
+				featureId: TestFeature.Messages,
+			});
+			const afterBase = after.prices.find(isFixedPrice)!;
+			expect(paidConfig.stripe_product_id).toBe(`prod_paid_${planId}`);
+			expect(paidConfig.stripe_price_id).toBe(`price_paid_${planId}`);
+			expect((afterBase.config as StripeConfig).stripe_product_id).toBe(
+				`prod_base_${planId}`,
+			);
+			expect((afterBase.config as StripeConfig).stripe_price_id).toBe(
+				`price_base_${planId}`,
+			);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 stripe: amount change carries product, not price id")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_str_amt");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe Amt",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+								price: {
+									amount: 0.5,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.UsageBased,
+									billing_units: 1,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			const before = await getFull({ ctx, planId });
+			const paid = findPriceByFeatureId({
+				prices: before.prices,
+				featureId: TestFeature.Messages,
+			})!;
+			const stripeProductId = `prod_${planId}`;
+			const stripePriceId = `price_${planId}`;
+			const stripeMeterId = `meter_${planId}`;
+			await seedPriceStripe({
+				ctx,
+				price: paid,
+				stripeProductId,
+				stripePriceId,
+				stripeMeterId,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+								price: {
+									amount: 0.9,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.UsageBased,
+									billing_units: 1,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			const after = await getFull({ ctx, planId });
+			const config = priceConfig({
+				product: after,
+				featureId: TestFeature.Messages,
+			});
+			expect(config.stripe_product_id).toBe(stripeProductId);
+			expect(config.stripe_meter_id).toBe(stripeMeterId);
+			expect(config.stripe_price_id).not.toBe(stripePriceId);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 stripe: prepaid amount change does not reuse stripe_price_id")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_str_pp");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe Prepaid",
+						items: [prepaidMessagesItem({ amount: 10 })],
+					},
+				],
+			});
+
+			const before = await getFull({ ctx, planId });
+			const paid = findPriceByFeatureId({
+				prices: before.prices,
+				featureId: TestFeature.Messages,
+			})!;
+			const stripePriceId = `price_${planId}`;
+			await seedPriceStripe({
+				ctx,
+				price: paid,
+				stripeProductId: `prod_${planId}`,
+				stripePriceId,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [prepaidMessagesItem({ amount: 20 })],
+					},
+				],
+			});
+
+			const after = await getFull({ ctx, planId });
+			const config = priceConfig({
+				product: after,
+				featureId: TestFeature.Messages,
+			});
+			expect(config.stripe_product_id).toBe(`prod_${planId}`);
+			expect(config.stripe_price_id).not.toBe(stripePriceId);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 stripe: graduated → volume does not reuse stripe_price_id")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_str_tier");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe Tiers",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								price: {
+									tiers: [
+										{ to: 600, amount: 10 },
+										{ to: TierInfinite, amount: 5 },
+									],
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 100,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			const before = await getFull({ ctx, planId });
+			const paid = findPriceByFeatureId({
+				prices: before.prices,
+				featureId: TestFeature.Messages,
+			})!;
+			const stripePriceId = `price_${planId}`;
+			await seedPriceStripe({
+				ctx,
+				price: paid,
+				stripeProductId: `prod_${planId}`,
+				stripePriceId,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								price: {
+									tiers: [
+										{ to: 600, amount: 10 },
+										{ to: TierInfinite, amount: 5 },
+									],
+									tier_behavior: TierBehavior.VolumeBased,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 100,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			const after = await getFull({ ctx, planId });
+			const config = priceConfig({
+				product: after,
+				featureId: TestFeature.Messages,
+			});
+			expect(config.stripe_price_id).not.toBe(stripePriceId);
+			expect(config.stripe_product_id).toBe(`prod_${planId}`);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 stripe: base price change mints new row; no stripe carry (fixed ≠ usage)")}`,
+	async () => {
+		// Product-only carry is usage-feature scoped (getPriceStripeReuseLevel);
+		// fixed base amount changes get reuse level "none".
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_str_base");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe Base",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+				],
+			});
+
+			const before = await getFull({ ctx, planId });
+			const base = before.prices.find(isFixedPrice)!;
+			const stripeProductId = `prod_base_${planId}`;
+			const stripePriceId = `price_base_${planId}`;
+			await seedPriceStripe({
+				ctx,
+				price: base,
+				stripeProductId,
+				stripePriceId,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						price: { amount: 40, interval: BillingInterval.Month },
+					},
+				],
+			});
+
+			const after = await getFull({ ctx, planId });
+			const newBase = after.prices.find(isFixedPrice)!;
+			expect(newBase.id).not.toBe(base.id);
+			const config = newBase.config as StripeConfig;
+			expect(config.stripe_product_id ?? null).toBeNull();
+			expect(config.stripe_price_id ?? null).toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 stripe: add new paid item → no stripe ids")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_str_new");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stripe New",
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{ feature_id: TestFeature.Dashboard },
+							prepaidMessagesItem({ amount: 10 }),
+						],
+					},
+				],
+			});
+
+			const after = await getFull({ ctx, planId });
+			const config = priceConfig({
+				product: after,
+				featureId: TestFeature.Messages,
+			});
+			expect(config.stripe_product_id ?? null).toBeNull();
+			expect(config.stripe_price_id ?? null).toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/update-plan-details.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/update-plan-details.test.ts
@@ -1,0 +1,511 @@
+/**
+ * catalogV2.update — plan detail facets (name/description/group/metadata/
+ * config/billing_controls/archive/rename/auto_enable). free_trial lives in
+ * update-plan-free-trial.test.ts (section 14).
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+import {
+	expectCatalogPreviewCorrect,
+	expectCatalogResultsCorrect,
+} from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+	expectDbPlansAbsent,
+} from "../utils/expectCatalogPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: name / description / group persist")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_name");
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Original",
+						description: "before",
+						group: "g1",
+					},
+				],
+			});
+
+			const params = {
+				plans: [
+					{
+						plan_id: planId,
+						name: "Renamed",
+						description: "after",
+						group: "g2",
+					},
+				],
+			};
+			// preview.changes is always null today — previous_attributes not wired yet.
+			const preview = await autumnV2_3.catalogV2.previewUpdate(params);
+			expectCatalogPreviewCorrect({
+				preview,
+				plans: [{ planId, action: "update" }],
+			});
+
+			const response = await autumnV2_3.catalogV2.update(params);
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						name: "Renamed",
+						description: "after",
+						group: "g2",
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: details-only leaves item/price row ids stable")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_stable");
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stable Rows",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const before = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			const beforeEntIds = before.entitlements.map((ent) => ent.id).sort();
+			const beforePriceIds = before.prices.map((price) => price.id).sort();
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Stable Rows v2", description: "d" }],
+			});
+
+			const after = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			expect(after.entitlements.map((ent) => ent.id).sort()).toEqual(
+				beforeEntIds,
+			);
+			expect(after.prices.map((price) => price.id).sort()).toEqual(
+				beforePriceIds,
+			);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: metadata + config ignore_past_due")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_meta");
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Meta Plan",
+						metadata: { a: 1 },
+						config: { ignore_past_due: false },
+					},
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						metadata: { a: 2, b: "x" },
+						config: { ignore_past_due: true },
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						metadata: { a: 2, b: "x" },
+						config: { ignore_past_due: true },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: billing_controls patch persists / identical → none")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_bc");
+		const billingControls = {
+			overage_allowed: [{ feature_id: TestFeature.Messages, enabled: true }],
+		};
+		const spendLimits = {
+			spend_limits: [
+				{
+					feature_id: TestFeature.Messages,
+					overage_limit: 50,
+					enabled: true,
+				},
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "BC Plan" }],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, billing_controls: billingControls }],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, billingControls }],
+			});
+
+			const noneResponse = await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, billing_controls: billingControls }],
+			});
+			expectCatalogResultsCorrect({
+				response: noneResponse,
+				plans: [{ id: planId, action: "none" }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, billing_controls: spendLimits }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						billingControls: {
+							...billingControls,
+							...spendLimits,
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: billing_controls clear via empty array; other columns untouched")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_bc_clear");
+		const overageAllowed = [
+			{ feature_id: TestFeature.Messages, enabled: true },
+		];
+		const spendLimits = [
+			{ feature_id: TestFeature.Messages, overage_limit: 50, enabled: true },
+		];
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "BC Clear",
+						billing_controls: {
+							overage_allowed: overageAllowed,
+							spend_limits: spendLimits,
+						},
+					},
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, billing_controls: { spend_limits: [] } }],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						billingControlsExact: {
+							overage_allowed: overageAllowed,
+							spend_limits: [],
+						},
+					},
+				],
+			});
+
+			// Re-sending the cleared lane is a no-op.
+			const noneResponse = await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, billing_controls: { spend_limits: [] } }],
+			});
+			expectCatalogResultsCorrect({
+				response: noneResponse,
+				plans: [{ id: planId, action: "none" }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: billing_controls batch — two plans in one call, no cross-contamination")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_det_bc_a");
+		const planB = uniqueTestId("cv2_det_bc_b");
+		const controlsA = {
+			overage_allowed: [{ feature_id: TestFeature.Messages, enabled: true }],
+		};
+		const controlsB = {
+			spend_limits: [
+				{ feature_id: TestFeature.Messages, overage_limit: 25, enabled: true },
+			],
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planA, name: "BC Batch A" },
+					{ plan_id: planB, name: "BC Batch B" },
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planA, billing_controls: controlsA },
+					{ plan_id: planB, billing_controls: controlsB },
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [
+					{ id: planA, action: "update" },
+					{ id: planB, action: "update" },
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{ id: planA, billingControlsExact: controlsA },
+					{ id: planB, billingControlsExact: controlsB },
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: archive / unarchive; omit preserves")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_arch");
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Archive Me" }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, archived: true }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, archived: true }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Still Archived" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, name: "Still Archived", archived: true }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, archived: false }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, archived: false }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: new_plan_id clean rename (no customers)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_ren_a");
+		const newPlanId = uniqueTestId("cv2_det_ren_b");
+
+		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Rename Me",
+						price: { amount: 10, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 50,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const before = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: planId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			const beforeEntIds = before.entitlements.map((ent) => ent.id).sort();
+			const beforePriceIds = before.prices.map((price) => price.id).sort();
+			const beforeInternalId = before.internal_id;
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+			});
+
+			await expectDbPlansAbsent({ ctx, planIds: [planId] });
+			const after = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: newPlanId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			expect(after.internal_id).toBe(beforeInternalId);
+			expect(after.version).toBe(1);
+			expect(after.entitlements.map((ent) => ent.id).sort()).toEqual(
+				beforeEntIds,
+			);
+			expect(after.prices.map((price) => price.id).sort()).toEqual(
+				beforePriceIds,
+			);
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: newPlanId, name: "Rename Me", version: 1 }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update details: auto_enable toggles is_default")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_det_def");
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Defaultable",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, auto_enable: true }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, isDefault: true }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, auto_enable: false }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, isDefault: false }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/update-plan-free-trial.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/update-plan-free-trial.test.ts
@@ -1,0 +1,938 @@
+/**
+ * catalogV2.update — free_trial shape round-trip, update lanes, and claim-
+ * style row semantics (reuse unchanged; retire+mint on change/remove).
+ *
+ * Spec (section 14): computeFreeTrialPlan takes FreeTrialParamsV1; comparator
+ * includes on_end and normalizes defaults (duration_type month, card_required
+ * true, on_end bill ≡ omitted). Retired rows stay with is_custom: true.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	CusProductStatus,
+	customerProducts,
+	customers,
+	FreeTrialDuration,
+	freeTrials,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { expectCatalogResultsCorrect } from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+const paidSeed = ({
+	planId,
+	name = "Trial Plan",
+	freeTrial,
+}: {
+	planId: string;
+	name?: string;
+	freeTrial?: {
+		duration_length: number;
+		duration_type?: FreeTrialDuration;
+		card_required?: boolean;
+		on_end?: "bill" | "revert";
+	};
+}) => ({
+	plan_id: planId,
+	name,
+	price: { amount: 20, interval: BillingInterval.Month },
+	...(freeTrial ? { free_trial: freeTrial } : {}),
+});
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+/** All free_trial rows for a product — including retired (is_custom) ones. */
+const listFreeTrialRows = async ({
+	ctx,
+	internalProductId,
+}: {
+	ctx: AutumnContext;
+	internalProductId: string;
+}) =>
+	ctx.db
+		.select()
+		.from(freeTrials)
+		.where(eq(freeTrials.internal_product_id, internalProductId));
+
+const seedCustomerWithTrialRef = async ({
+	ctx,
+	planId,
+	freeTrialId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	freeTrialId: string;
+}) => {
+	const full = await getFull({ ctx, planId });
+	const customerId = uniqueTestId("cv2_ft_cus");
+	const internalCustomerId = generateId("cus");
+	const cusProductId = generateId("cus_prod");
+
+	await ctx.db.insert(customers).values({
+		internal_id: internalCustomerId,
+		id: customerId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		name: customerId,
+		email: `${customerId}@test.com`,
+	});
+
+	await ctx.db.insert(customerProducts).values({
+		id: cusProductId,
+		internal_customer_id: internalCustomerId,
+		product_id: planId,
+		internal_product_id: full.internal_id,
+		status: CusProductStatus.Active,
+		created_at: Date.now(),
+		starts_at: Date.now(),
+		quantity: 1,
+		options: [],
+		is_custom: false,
+		free_trial_id: freeTrialId,
+	});
+
+	return { customerId, internalCustomerId, cusProductId };
+};
+
+const cleanupCustomerRefs = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const cusProds = await ctx.db
+		.select()
+		.from(customerProducts)
+		.where(eq(customerProducts.product_id, planId));
+	for (const row of cusProds) {
+		await ctx.db
+			.delete(customerProducts)
+			.where(eq(customerProducts.id, row.id));
+		await ctx.db
+			.delete(customers)
+			.where(eq(customers.internal_id, row.internal_customer_id));
+	}
+};
+
+// ─── Shape round-trip + update lanes ─────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: create full trial → exact shape")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_full");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: "revert",
+						},
+					}),
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: "revert",
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: minimal duration_length → defaults resolved")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_min");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: { duration_length: 14 },
+					}),
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: null,
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: duration_type + on_end round-trip")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const dayId = uniqueTestId("cv2_ft_day");
+		const monthId = uniqueTestId("cv2_ft_mo");
+		const yearId = uniqueTestId("cv2_ft_yr");
+		await deleteDbPlans({ ctx, planIds: [dayId, monthId, yearId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId: dayId,
+						name: "Day",
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: true,
+							on_end: "bill",
+						},
+					}),
+					paidSeed({
+						planId: monthId,
+						name: "Month",
+						freeTrial: {
+							duration_length: 1,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: "revert",
+						},
+					}),
+					paidSeed({
+						planId: yearId,
+						name: "Year",
+						freeTrial: {
+							duration_length: 1,
+							duration_type: FreeTrialDuration.Year,
+							card_required: false,
+						},
+					}),
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: dayId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: true,
+							on_end: "bill",
+						},
+					},
+					{
+						id: monthId,
+						freeTrial: {
+							duration_length: 1,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: "revert",
+						},
+					},
+					{
+						id: yearId,
+						freeTrial: {
+							duration_length: 1,
+							duration_type: FreeTrialDuration.Year,
+							card_required: false,
+							on_end: null,
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [dayId, monthId, yearId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: add / change each field / remove / omit-preserves")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_lanes");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [paidSeed({ planId })],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, freeTrial: null }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: null,
+						},
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: null,
+						},
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: false,
+						},
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: false,
+							on_end: null,
+						},
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+						},
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: null,
+						},
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: "revert",
+						},
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: "revert",
+						},
+					},
+				],
+			});
+
+			// Omit free_trial → preserve
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Renamed Trial Plan" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						name: "Renamed Trial Plan",
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: "revert",
+						},
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, free_trial: null }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, freeTrial: null }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// Items updates rebuild price/ent rows — a different path than details-only
+// renames — so trial carry-over across that rebuild needs its own assertion.
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: cross-facet patch — items change keeps trial; trial change keeps items/price")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_xpatch");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		const trial = {
+			duration_length: 7,
+			duration_type: FreeTrialDuration.Day,
+			card_required: true,
+			on_end: null,
+		};
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Cross Patch Plan",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+						free_trial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+						},
+					},
+				],
+			});
+
+			// Items + price update, free_trial omitted → trial preserved
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						price: { amount: 30, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 250,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						basePrice: { amount: 30, interval: BillingInterval.Month },
+						allowances: { [TestFeature.Messages]: 250 },
+						freeTrial: trial,
+					},
+				],
+			});
+
+			// Trial-only update → items + base price carried
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+						},
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						basePrice: { amount: 30, interval: BillingInterval.Month },
+						featureIds: [TestFeature.Messages],
+						allowances: { [TestFeature.Messages]: 250 },
+						freeTrial: { ...trial, duration_length: 14 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: identical re-send with explicit defaults → none")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_idemp");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: { duration_length: 14 },
+					}),
+				],
+			});
+			// Require persistence first — otherwise action `none` is a false green.
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: null,
+						},
+					},
+				],
+			});
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Trial Plan",
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Month,
+							card_required: true,
+							on_end: "bill",
+						},
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "none" }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: trial-only change → action update")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_op");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+						},
+					}),
+				],
+			});
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+						},
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// ─── Row semantics ───────────────────────────────────────────────────────────
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: unchanged → same free_trial row id")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_same");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					}),
+				],
+			});
+			const before = await getFull({ ctx, planId });
+			const beforeId = before.free_trial?.id;
+			expect(beforeId).toBeTruthy();
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Renamed",
+						free_trial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+			const after = await getFull({ ctx, planId });
+			expect(after.free_trial?.id).toBe(beforeId);
+
+			const rows = await listFreeTrialRows({
+				ctx,
+				internalProductId: before.internal_id,
+			});
+			expect(rows).toHaveLength(1);
+			expect(rows[0]?.is_custom).toBe(false);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: changed → new row id; old is_custom true")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_chg");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+						},
+					}),
+				],
+			});
+			const before = await getFull({ ctx, planId });
+			const oldId = before.free_trial?.id;
+			expect(oldId).toBeTruthy();
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+						},
+					},
+				],
+			});
+			const after = await getFull({ ctx, planId });
+			expect(after.free_trial?.id).toBeTruthy();
+			expect(after.free_trial?.id).not.toBe(oldId);
+
+			const rows = await listFreeTrialRows({
+				ctx,
+				internalProductId: before.internal_id,
+			});
+			expect(rows.length).toBeGreaterThanOrEqual(2);
+			const retired = rows.find((row) => row.id === oldId);
+			expect(retired, "old free_trial row must be retained").toBeDefined();
+			expect(retired?.is_custom).toBe(true);
+			const active = rows.find((row) => row.id === after.free_trial?.id);
+			expect(active?.is_custom).toBe(false);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: removed → old row retained is_custom true")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_rm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+						},
+					}),
+				],
+			});
+			const before = await getFull({ ctx, planId });
+			const oldId = before.free_trial?.id;
+			expect(oldId).toBeTruthy();
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, free_trial: null }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, freeTrial: null }],
+			});
+
+			const rows = await listFreeTrialRows({
+				ctx,
+				internalProductId: before.internal_id,
+			});
+			expect(rows.length).toBeGreaterThanOrEqual(1);
+			const retired = rows.find((row) => row.id === oldId);
+			expect(retired).toBeDefined();
+			expect(retired?.is_custom).toBe(true);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: on_end-only change → new row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_onend");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: true,
+							on_end: "bill",
+						},
+					}),
+				],
+			});
+			const before = await getFull({ ctx, planId });
+			const oldId = before.free_trial?.id;
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: true,
+							on_end: "revert",
+						},
+					},
+				],
+			});
+			const after = await getFull({ ctx, planId });
+			expect(after.free_trial?.id).not.toBe(oldId);
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: true,
+							on_end: "revert",
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial: customer keeps old trial row ref after retire")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ft_cus");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					paidSeed({
+						planId,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+						},
+					}),
+				],
+			});
+			const before = await getFull({ ctx, planId });
+			const oldId = before.free_trial?.id;
+			expect(oldId, "seed free_trial row required").toBeTruthy();
+			if (!oldId) throw new Error("missing free_trial id");
+			const { cusProductId } = await seedCustomerWithTrialRef({
+				ctx,
+				planId,
+				freeTrialId: oldId,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+						},
+					},
+				],
+			});
+
+			const [cusProd] = await ctx.db
+				.select()
+				.from(customerProducts)
+				.where(eq(customerProducts.id, cusProductId))
+				.limit(1);
+			expect(cusProd?.free_trial_id).toBe(oldId);
+
+			const rows = await listFreeTrialRows({
+				ctx,
+				internalProductId: before.internal_id,
+			});
+			const retired = rows.find((row) => row.id === oldId);
+			expect(retired?.is_custom).toBe(true);
+		} finally {
+			await cleanupCustomerRefs({ ctx, planId });
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/update-plan-items.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/update-plan-items.test.ts
@@ -1,0 +1,660 @@
+/**
+ * catalogV2.update — item/price omit-semantics and per-facet shape changes
+ * (no customers). Assert via catalogV2.get.
+ */
+
+import { test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	OnDecrease,
+	OnIncrease,
+	ResetInterval,
+	RolloverExpiryDurationType,
+	TierBehavior,
+	TierInfinite,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { expectCatalogResultsCorrect } from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+const seedBasePlan = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "Item Lane Plan",
+				price: { amount: 20, interval: BillingInterval.Month },
+				items: [
+					{ feature_id: TestFeature.Dashboard },
+					{
+						feature_id: TestFeature.Messages,
+						included: 100,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: both price/items omitted → unchanged")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_omit");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Renamed Only" }],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						name: "Renamed Only",
+						featureIds: [TestFeature.Dashboard, TestFeature.Messages],
+						allowances: { [TestFeature.Messages]: 100 },
+						basePrice: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: items only → base price carried")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_items");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 500,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [TestFeature.Messages],
+						allowances: { [TestFeature.Messages]: 500 },
+						basePrice: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: price only → items carried")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_price");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						price: { amount: 49, interval: BillingInterval.Month },
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [TestFeature.Dashboard, TestFeature.Messages],
+						allowances: { [TestFeature.Messages]: 100 },
+						basePrice: { amount: 49, interval: BillingInterval.Month },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: price null → base removed, items carried")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_pnull");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, price: null }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [TestFeature.Dashboard, TestFeature.Messages],
+						basePrice: null,
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: both set → both replaced")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_both");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						price: { amount: 99, interval: BillingInterval.Year },
+						items: [
+							{
+								feature_id: TestFeature.Words,
+								included: 10,
+								reset: { interval: ResetInterval.Year },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [TestFeature.Words],
+						allowances: { [TestFeature.Words]: 10 },
+						basePrice: { amount: 99, interval: BillingInterval.Year },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: add / remove feature item")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_addrm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{ feature_id: TestFeature.Dashboard },
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+							{
+								feature_id: TestFeature.Words,
+								included: 25,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [
+							TestFeature.Dashboard,
+							TestFeature.Messages,
+							TestFeature.Words,
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						featureIds: [TestFeature.Messages],
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: change included allowance")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_incl");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{ feature_id: TestFeature.Dashboard },
+							{
+								feature_id: TestFeature.Messages,
+								included: 250,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						allowances: { [TestFeature.Messages]: 250 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: free → paid and paid → free on same feature")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_f2p");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Free to Paid",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+								price: {
+									amount: 0.5,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.UsageBased,
+									billing_units: 1,
+								},
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								price: {
+									amount: 0.5,
+									billing_method: BillingMethod.UsageBased,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								price: null,
+							},
+						],
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: change amount / tiers / tier_behavior / billing_units")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_price2");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Price Shape",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								price: {
+									amount: 10,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 100,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								price: {
+									tiers: [
+										{ to: 600, amount: 8 },
+										{ to: TierInfinite, amount: 4 },
+									],
+									tier_behavior: TierBehavior.VolumeBased,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 50,
+								},
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								price: {
+									tiers: [
+										{ to: 600, amount: 8 },
+										{ to: TierInfinite, amount: 4 },
+									],
+									tier_behavior: TierBehavior.VolumeBased,
+									billing_units: 50,
+									billing_method: BillingMethod.Prepaid,
+								},
+							},
+						],
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: change reset interval month → year")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_reset");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedBasePlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{ feature_id: TestFeature.Dashboard },
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Year },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Year },
+							},
+						],
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 update items: toggle unlimited / pooled / rollover / proration")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_it_tog");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Toggles",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+							{
+								feature_id: TestFeature.Users,
+								included: 0,
+								price: {
+									amount: 10,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 1,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								unlimited: true,
+								pooled: true,
+							},
+							{
+								feature_id: TestFeature.Words,
+								included: 200,
+								reset: { interval: ResetInterval.Month },
+								rollover: {
+									max: 400,
+									expiry_duration_type: RolloverExpiryDurationType.Month,
+									expiry_duration_length: 1,
+								},
+							},
+							{
+								feature_id: TestFeature.Users,
+								included: 0,
+								price: {
+									amount: 10,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 1,
+								},
+								proration: {
+									on_increase: OnIncrease.ProrateImmediately,
+									on_decrease: OnDecrease.NoProrations,
+								},
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								unlimited: true,
+								pooled: true,
+							},
+							{
+								feature_id: TestFeature.Words,
+								included: 200,
+								rollover: {
+									max: 400,
+									expiry_duration_type: RolloverExpiryDurationType.Month,
+									expiry_duration_length: 1,
+								},
+							},
+							{
+								feature_id: TestFeature.Users,
+								price: {
+									amount: 10,
+									billing_method: BillingMethod.Prepaid,
+								},
+							},
+						],
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/update-plan-rows.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/update-plan-rows.test.ts
@@ -1,0 +1,696 @@
+/**
+ * catalogV2.update — claim / row carry-over (definition-exact → same row ids;
+ * any change mints new rows; old deleted without customers, or retired +
+ * is_custom with customers).
+ *
+ * Customer refs are DB-seeded: the local Stripe Connect account is currently
+ * unreachable from s.customer / attach, which would otherwise fail before the
+ * catalog assert runs.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	CusProductStatus,
+	customerEntitlements,
+	customerPrices,
+	customerProducts,
+	customers,
+	entitlements,
+	isFixedPrice,
+	prices,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { expectCatalogResultsCorrect } from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const entByFeature = async ({
+	ctx,
+	planId,
+	featureId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	featureId: string;
+}) => {
+	const full = await getFull({ ctx, planId });
+	return full.entitlements.find((ent) => ent.feature.id === featureId);
+};
+
+const basePriceRow = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const full = await getFull({ ctx, planId });
+	return full.prices.find(isFixedPrice);
+};
+
+const fetchEntRow = async ({
+	ctx,
+	entId,
+}: {
+	ctx: AutumnContext;
+	entId: string;
+}) => {
+	const [row] = await ctx.db
+		.select()
+		.from(entitlements)
+		.where(eq(entitlements.id, entId))
+		.limit(1);
+	return row ?? null;
+};
+
+const fetchPriceRow = async ({
+	ctx,
+	priceId,
+}: {
+	ctx: AutumnContext;
+	priceId: string;
+}) => {
+	const [row] = await ctx.db
+		.select()
+		.from(prices)
+		.where(eq(prices.id, priceId))
+		.limit(1);
+	return row ?? null;
+};
+
+/** Minimal customer + cus_product (+ optional cus_ent / cus_price) for protect refs. */
+const seedCustomerProductRef = async ({
+	ctx,
+	planId,
+	status = CusProductStatus.Active,
+	entitlementId,
+	internalFeatureId,
+	priceId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	status?: CusProductStatus;
+	entitlementId?: string;
+	internalFeatureId?: string;
+	priceId?: string;
+}) => {
+	const full = await getFull({ ctx, planId });
+	const customerId = uniqueTestId("cv2_cus");
+	const internalCustomerId = generateId("cus");
+	const cusProductId = generateId("cus_prod");
+
+	await ctx.db.insert(customers).values({
+		internal_id: internalCustomerId,
+		id: customerId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		name: customerId,
+		email: `${customerId}@test.com`,
+	});
+
+	await ctx.db.insert(customerProducts).values({
+		id: cusProductId,
+		internal_customer_id: internalCustomerId,
+		product_id: planId,
+		internal_product_id: full.internal_id,
+		status,
+		created_at: Date.now(),
+		starts_at: Date.now(),
+		quantity: 1,
+		options: [],
+		is_custom: false,
+	});
+
+	if (entitlementId && internalFeatureId) {
+		await ctx.db.insert(customerEntitlements).values({
+			id: generateId("cus_ent"),
+			customer_product_id: cusProductId,
+			entitlement_id: entitlementId,
+			internal_customer_id: internalCustomerId,
+			internal_feature_id: internalFeatureId,
+			balance: 100,
+			created_at: Date.now(),
+		});
+	}
+
+	if (priceId) {
+		await ctx.db.insert(customerPrices).values({
+			id: generateId("cus_price"),
+			created_at: Date.now(),
+			price_id: priceId,
+			internal_customer_id: internalCustomerId,
+			customer_product_id: cusProductId,
+		});
+	}
+
+	return { customerId, internalCustomerId, cusProductId };
+};
+
+const cleanupPlanRefs = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const full = await getFull({ ctx, planId }).catch(() => null);
+	if (!full) {
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		return;
+	}
+	await ctx.db
+		.delete(customerProducts)
+		.where(eq(customerProducts.internal_product_id, full.internal_id));
+	await deleteDbPlans({ ctx, planIds: [planId] });
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rows: base price change keeps feature rows; old base deleted (no customers)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_row_base");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Rows Base",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+							{ feature_id: TestFeature.Dashboard },
+						],
+					},
+				],
+			});
+
+			const before = await getFull({ ctx, planId });
+			const beforeEntIds = before.entitlements.map((ent) => ent.id).sort();
+			const beforeFeaturePriceIds = before.prices
+				.filter((price) => !isFixedPrice(price))
+				.map((price) => price.id)
+				.sort();
+			const oldBaseId = before.prices.find(isFixedPrice)?.id;
+			expect(oldBaseId).toBeDefined();
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						price: { amount: 40, interval: BillingInterval.Month },
+					},
+				],
+			});
+
+			const after = await getFull({ ctx, planId });
+			expect(after.entitlements.map((ent) => ent.id).sort()).toEqual(
+				beforeEntIds,
+			);
+			expect(
+				after.prices
+					.filter((price) => !isFixedPrice(price))
+					.map((price) => price.id)
+					.sort(),
+			).toEqual(beforeFeaturePriceIds);
+			const newBase = after.prices.find(isFixedPrice);
+			expect(newBase?.id).not.toBe(oldBaseId);
+			expect((newBase?.config as { amount?: number })?.amount).toBe(40);
+			expect(await fetchPriceRow({ ctx, priceId: oldBaseId! })).toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rows: remove item deletes removed rows; remaining stable (no customers)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_row_rm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Rows Remove",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+							{ feature_id: TestFeature.Dashboard },
+						],
+					},
+				],
+			});
+
+			const beforeDash = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Dashboard,
+			});
+			const beforeMsg = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+			expect(beforeDash).toBeDefined();
+			expect(beforeMsg).toBeDefined();
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const afterMsg = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+			expect(afterMsg?.id).toBe(beforeMsg?.id);
+			expect(
+				await entByFeature({
+					ctx,
+					planId,
+					featureId: TestFeature.Dashboard,
+				}),
+			).toBeUndefined();
+			expect(await fetchEntRow({ ctx, entId: beforeDash!.id })).toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rows: included bump mints new ent; old deleted (no customers)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_row_incl");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Rows Incl",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const oldEnt = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 250,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const newEnt = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+			expect(newEnt?.id).not.toBe(oldEnt?.id);
+			expect(newEnt?.allowance).toBe(250);
+			expect(await fetchEntRow({ ctx, entId: oldEnt!.id })).toBeNull();
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED: executeUpsertProducts ignores entitlementPricesPlan.retired (no is_custom stamp)
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 rows: with customer — included bump retires old ent (is_custom)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_row_cus_incl");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Cus Incl",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const oldEnt = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+			expect(oldEnt).toBeDefined();
+
+			await seedCustomerProductRef({
+				ctx,
+				planId,
+				entitlementId: oldEnt!.id,
+				internalFeatureId: oldEnt!.internal_feature_id,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 200,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const newEnt = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+			expect(newEnt?.id).not.toBe(oldEnt?.id);
+			expect(newEnt?.allowance).toBe(200);
+			expect(newEnt?.is_custom).toBe(false);
+
+			const retired = await fetchEntRow({ ctx, entId: oldEnt!.id });
+			expect(retired).toBeTruthy();
+			expect(retired?.is_custom).toBe(true);
+
+			const [cusEnt] = await ctx.db
+				.select()
+				.from(customerEntitlements)
+				.where(eq(customerEntitlements.entitlement_id, oldEnt!.id))
+				.limit(1);
+			expect(cusEnt).toBeDefined();
+		} finally {
+			await cleanupPlanRefs({ ctx, planId });
+		}
+	},
+);
+
+// RED: executeUpsertProducts ignores entitlementPricesPlan.retired (no is_custom stamp)
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 rows: with customer — remove item retires rows; customer keeps grant")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_row_cus_rm");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Cus Remove",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+							{ feature_id: TestFeature.Dashboard },
+						],
+					},
+				],
+			});
+
+			const oldDash = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Dashboard,
+			});
+			expect(oldDash).toBeDefined();
+
+			await seedCustomerProductRef({
+				ctx,
+				planId,
+				entitlementId: oldDash!.id,
+				internalFeatureId: oldDash!.internal_feature_id,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			expect(
+				await entByFeature({
+					ctx,
+					planId,
+					featureId: TestFeature.Dashboard,
+				}),
+			).toBeUndefined();
+
+			const retired = await fetchEntRow({ ctx, entId: oldDash!.id });
+			expect(retired).toBeTruthy();
+			expect(retired?.is_custom).toBe(true);
+
+			const [cusEnt] = await ctx.db
+				.select()
+				.from(customerEntitlements)
+				.where(eq(customerEntitlements.entitlement_id, oldDash!.id))
+				.limit(1);
+			expect(cusEnt).toBeDefined();
+		} finally {
+			await cleanupPlanRefs({ ctx, planId });
+		}
+	},
+);
+
+// RED: executeUpsertProducts ignores entitlementPricesPlan.retired (no is_custom stamp)
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 rows: with customer — base price change retires old base")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_row_cus_base");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Cus Base",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const oldBase = await basePriceRow({ ctx, planId });
+			expect((oldBase?.config as { amount?: number })?.amount).toBe(20);
+
+			await seedCustomerProductRef({
+				ctx,
+				planId,
+				priceId: oldBase!.id,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						price: { amount: 35, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const newBase = await basePriceRow({ ctx, planId });
+			expect(newBase?.id).not.toBe(oldBase?.id);
+			expect((newBase?.config as { amount?: number })?.amount).toBe(35);
+			expect(newBase?.is_custom).toBe(false);
+
+			const retired = await fetchPriceRow({ ctx, priceId: oldBase!.id });
+			expect(retired).toBeTruthy();
+			expect(retired?.is_custom).toBe(true);
+
+			const [cusPrice] = await ctx.db
+				.select()
+				.from(customerPrices)
+				.where(eq(customerPrices.price_id, oldBase!.id))
+				.limit(1);
+			expect(cusPrice).toBeDefined();
+		} finally {
+			await cleanupPlanRefs({ ctx, planId });
+		}
+	},
+);
+
+// RED: protectReferencedRows uses hasAnyCustomerProducts (includes expired);
+// SPEC wants expired-only treated as no-customers (hard-delete).
+test.concurrent(
+	`${chalk.yellowBright("RED: catalogV2 rows: expired-only customers → rows deleted (not retired)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_row_exp");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Expired Only",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const oldEnt = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+
+			await seedCustomerProductRef({
+				ctx,
+				planId,
+				status: CusProductStatus.Expired,
+				entitlementId: oldEnt!.id,
+				internalFeatureId: oldEnt!.internal_feature_id,
+			});
+
+			const preview = await autumnV2_3.catalogV2.previewUpdate({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 200,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const entry = preview.plans.find((p) => p.plan_id === planId);
+			expect(entry?.state.has_customers).toBe(false);
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 200,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+
+			const newEnt = await entByFeature({
+				ctx,
+				planId,
+				featureId: TestFeature.Messages,
+			});
+			expect(newEnt?.id).not.toBe(oldEnt?.id);
+			expect(newEnt?.allowance).toBe(200);
+			expect(await fetchEntRow({ ctx, entId: oldEnt!.id })).toBeNull();
+		} finally {
+			await cleanupPlanRefs({ ctx, planId });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/utils/expectCatalogPlans.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/expectCatalogPlans.ts
@@ -1,21 +1,70 @@
 import { expect } from "bun:test";
 import {
+	type ApiPlanItemV1,
 	type BillingInterval,
+	type BillingMethod,
 	billingControlsFromColumns,
 	type CustomerBillingControls,
+	type FreeTrialDuration,
 	type FullProduct,
 	type GetCatalogResponse,
 	isFixedPrice,
+	type OnDecrease,
+	type OnIncrease,
+	type ResetInterval,
+	type RolloverExpiryDurationType,
+	type TierBehavior,
 } from "@autumn/shared";
 import type { AutumnInt } from "@/external/autumn/autumnCli.js";
 import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 
+/** Containment matcher for a catalog plan item — assert only fields passed. */
+export type ExpectedPlanItem = {
+	feature_id: string;
+	included?: number;
+	unlimited?: boolean;
+	pooled?: boolean;
+	reset?: {
+		interval?: ResetInterval;
+		interval_count?: number;
+	} | null;
+	price?: {
+		amount?: number;
+		tiers?: Array<{
+			to: number | "inf";
+			amount?: number;
+			flat_amount?: number;
+			additional_currencies?: Array<{ currency: string; amount: number }>;
+		}>;
+		tier_behavior?: TierBehavior;
+		interval?: BillingInterval;
+		interval_count?: number;
+		billing_units?: number;
+		billing_method?: BillingMethod;
+		max_purchase?: number | null;
+		additional_currencies?: Array<{ currency: string; amount: number }>;
+	} | null;
+	proration?: {
+		on_increase?: OnIncrease;
+		on_decrease?: OnDecrease;
+	};
+	rollover?: {
+		max?: number | null;
+		max_percentage?: number | null;
+		expiry_duration_type?: RolloverExpiryDurationType;
+		expiry_duration_length?: number;
+	};
+	entity_feature_id?: string;
+};
+
 type ExpectedPlan = {
 	id: string;
 	version?: number;
 	name?: string;
+	description?: string | null;
+	group?: string;
 	isAddOn?: boolean;
 	isDefault?: boolean;
 	archived?: boolean;
@@ -23,12 +72,90 @@ type ExpectedPlan = {
 	featureIds?: string[];
 	/** Included allowance per feature_id. */
 	allowances?: Record<string, number>;
+	/** Granular item shape matchers (containment, keyed by feature_id). */
+	items?: ExpectedPlanItem[];
 	/** Base (fixed) price amount + interval. */
-	basePrice?: { amount: number; interval: BillingInterval } | null;
-	hasFreeTrial?: boolean;
+	basePrice?: {
+		amount: number;
+		interval: BillingInterval;
+		interval_count?: number;
+		additional_currencies?: Array<{ currency: string; amount: number }>;
+	} | null;
+	/**
+	 * Exact free-trial shape. Non-null: assert duration_length / duration_type /
+	 * card_required / on_end (both sides `?? null`). Null: assert absent.
+	 */
+	freeTrial?: {
+		duration_length: number;
+		duration_type: FreeTrialDuration;
+		card_required: boolean;
+		on_end?: "bill" | "revert" | null;
+	} | null;
 	metadata?: Record<string, unknown>;
 	config?: { ignore_past_due?: boolean };
 	billingControls?: CustomerBillingControls;
+	/** Deep equality — asserts absent columns too (cross-contamination checks). */
+	billingControlsExact?: CustomerBillingControls;
+};
+
+const expectApiFreeTrialMatches = ({
+	actual,
+	expected,
+}: {
+	actual:
+		| {
+				duration_length?: number;
+				duration_type?: FreeTrialDuration;
+				card_required?: boolean;
+				on_end?: "bill" | "revert" | null;
+		  }
+		| null
+		| undefined;
+	expected: NonNullable<ExpectedPlan["freeTrial"]>;
+}) => {
+	expect(actual, "expected free_trial to be present").toBeTruthy();
+	if (!actual) return;
+	expect({
+		duration_length: actual.duration_length,
+		duration_type: actual.duration_type,
+		card_required: actual.card_required,
+		on_end: actual.on_end ?? null,
+	}).toEqual({
+		duration_length: expected.duration_length,
+		duration_type: expected.duration_type,
+		card_required: expected.card_required,
+		on_end: expected.on_end ?? null,
+	});
+};
+
+const expectDbFreeTrialMatches = ({
+	actual,
+	expected,
+}: {
+	actual:
+		| {
+				length?: number | null;
+				duration?: string | null;
+				card_required?: boolean | null;
+				on_end?: string | null;
+		  }
+		| null
+		| undefined;
+	expected: NonNullable<ExpectedPlan["freeTrial"]>;
+}) => {
+	expect(actual, "expected free_trial row to be present").toBeTruthy();
+	if (!actual) return;
+	expect({
+		duration_length: actual.length,
+		duration_type: actual.duration,
+		card_required: actual.card_required,
+		on_end: actual.on_end ?? null,
+	}).toEqual({
+		duration_length: expected.duration_length,
+		duration_type: expected.duration_type,
+		card_required: expected.card_required,
+		on_end: expected.on_end ?? null,
+	});
 };
 
 const getPlan = async ({
@@ -54,6 +181,79 @@ const getPlan = async ({
 	}
 };
 
+const expectPlanItemMatches = ({
+	item,
+	expected,
+}: {
+	item: ApiPlanItemV1;
+	expected: ExpectedPlanItem;
+}) => {
+	if (expected.included !== undefined) {
+		expect(item.included).toBe(expected.included);
+	}
+	if (expected.unlimited !== undefined) {
+		expect(item.unlimited).toBe(expected.unlimited);
+	}
+	if (expected.pooled !== undefined) {
+		expect(item.pooled).toBe(expected.pooled);
+	}
+	if (expected.reset === null) {
+		expect(item.reset).toBeNull();
+	} else if (expected.reset !== undefined) {
+		expect(item.reset).toBeTruthy();
+		if (expected.reset.interval !== undefined) {
+			expect(item.reset?.interval).toBe(expected.reset.interval);
+		}
+		if (expected.reset.interval_count !== undefined) {
+			expect(item.reset?.interval_count).toBe(expected.reset.interval_count);
+		}
+	}
+	if (expected.price === null) {
+		expect(item.price).toBeNull();
+	} else if (expected.price !== undefined) {
+		expect(item.price).toBeTruthy();
+		const price = expected.price;
+		if (price.amount !== undefined) {
+			expect(item.price?.amount).toBe(price.amount);
+		}
+		if (price.tiers !== undefined) {
+			expect(item.price?.tiers).toMatchObject(price.tiers);
+		}
+		if (price.tier_behavior !== undefined) {
+			expect(item.price?.tier_behavior).toBe(price.tier_behavior);
+		}
+		if (price.interval !== undefined) {
+			expect(item.price?.interval).toBe(price.interval);
+		}
+		if (price.interval_count !== undefined) {
+			expect(item.price?.interval_count).toBe(price.interval_count);
+		}
+		if (price.billing_units !== undefined) {
+			expect(item.price?.billing_units).toBe(price.billing_units);
+		}
+		if (price.billing_method !== undefined) {
+			expect(item.price?.billing_method).toBe(price.billing_method);
+		}
+		if (price.max_purchase !== undefined) {
+			expect(item.price?.max_purchase).toBe(price.max_purchase);
+		}
+		if (price.additional_currencies !== undefined) {
+			expect(item.price?.additional_currencies).toEqual(
+				price.additional_currencies,
+			);
+		}
+	}
+	if (expected.proration !== undefined) {
+		expect(item.proration).toMatchObject(expected.proration);
+	}
+	if (expected.rollover !== undefined) {
+		expect(item.rollover).toMatchObject(expected.rollover);
+	}
+	if (expected.entity_feature_id !== undefined) {
+		expect(item.entity_feature_id).toBe(expected.entity_feature_id);
+	}
+};
+
 const expectCatalogPlanMatches = ({
 	plan,
 	expectedPlan,
@@ -66,6 +266,12 @@ const expectCatalogPlanMatches = ({
 	}
 	if (expectedPlan.name !== undefined) {
 		expect(plan.name).toBe(expectedPlan.name);
+	}
+	if (expectedPlan.description !== undefined) {
+		expect(plan.description).toBe(expectedPlan.description);
+	}
+	if (expectedPlan.group !== undefined) {
+		expect(plan.group).toBe(expectedPlan.group);
 	}
 	if (expectedPlan.isAddOn !== undefined) {
 		expect(plan.add_on).toBe(expectedPlan.isAddOn);
@@ -91,16 +297,43 @@ const expectCatalogPlanMatches = ({
 			expect(item?.included).toBe(allowance);
 		}
 	}
+	if (expectedPlan.items !== undefined) {
+		for (const expectedItem of expectedPlan.items) {
+			const item = plan.items.find(
+				(candidate) => candidate.feature_id === expectedItem.feature_id,
+			);
+			expect(item, `missing item for ${expectedItem.feature_id}`).toBeDefined();
+			if (!item) continue;
+			expectPlanItemMatches({ item, expected: expectedItem });
+		}
+	}
 	if (expectedPlan.basePrice !== undefined) {
 		if (expectedPlan.basePrice === null) {
 			expect(plan.price).toBeNull();
 		} else {
 			expect(plan.price?.amount).toBe(expectedPlan.basePrice.amount);
 			expect(plan.price?.interval).toBe(expectedPlan.basePrice.interval);
+			if (expectedPlan.basePrice.interval_count !== undefined) {
+				expect(plan.price?.interval_count).toBe(
+					expectedPlan.basePrice.interval_count,
+				);
+			}
+			if (expectedPlan.basePrice.additional_currencies !== undefined) {
+				expect(plan.price?.additional_currencies).toEqual(
+					expectedPlan.basePrice.additional_currencies,
+				);
+			}
 		}
 	}
-	if (expectedPlan.hasFreeTrial !== undefined) {
-		expect(Boolean(plan.free_trial)).toBe(expectedPlan.hasFreeTrial);
+	if (expectedPlan.freeTrial !== undefined) {
+		if (expectedPlan.freeTrial === null) {
+			expect(plan.free_trial ?? undefined).toBeUndefined();
+		} else {
+			expectApiFreeTrialMatches({
+				actual: plan.free_trial,
+				expected: expectedPlan.freeTrial,
+			});
+		}
 	}
 	if (expectedPlan.metadata !== undefined) {
 		expect(plan.metadata).toMatchObject(expectedPlan.metadata);
@@ -110,6 +343,9 @@ const expectCatalogPlanMatches = ({
 	}
 	if (expectedPlan.billingControls !== undefined) {
 		expect(plan.billing_controls).toMatchObject(expectedPlan.billingControls);
+	}
+	if (expectedPlan.billingControlsExact !== undefined) {
+		expect(plan.billing_controls).toEqual(expectedPlan.billingControlsExact);
 	}
 };
 
@@ -198,8 +434,15 @@ export const expectDbPlansCorrect = async ({
 				expect(fixed?.config.interval).toBe(expectedPlan.basePrice.interval);
 			}
 		}
-		if (expectedPlan.hasFreeTrial !== undefined) {
-			expect(Boolean(plan.free_trial)).toBe(expectedPlan.hasFreeTrial);
+		if (expectedPlan.freeTrial !== undefined) {
+			if (expectedPlan.freeTrial === null) {
+				expect(plan.free_trial ?? undefined).toBeUndefined();
+			} else {
+				expectDbFreeTrialMatches({
+					actual: plan.free_trial,
+					expected: expectedPlan.freeTrial,
+				});
+			}
 		}
 		if (expectedPlan.metadata !== undefined) {
 			expect(plan.metadata).toMatchObject(expectedPlan.metadata);

--- a/server/tests/integration/catalog-v2/plans/validation/default-flag.test.ts
+++ b/server/tests/integration/catalog-v2/plans/validation/default-flag.test.ts
@@ -1,0 +1,252 @@
+/**
+ * catalogV2.update — auto_enable / default-flag rules.
+ *
+ * Spec (validateDefaultFlag): only free plans and default-trial plans
+ * (card_required: false) can be auto_enable. catalogV2 does not call
+ * validateDefaultFlag yet → most REJECT cases are RED.
+ */
+
+import { test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	ErrCode,
+	FreeTrialDuration,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { expectCatalogResultsCorrect } from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 default-flag: free plan auto_enable true → OK")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_def_free");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Free Default",
+						auto_enable: true,
+						group: `g_${planId}`,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "create" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, isDefault: true }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 default-flag: paid + cardless trial auto_enable → OK")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_def_trial");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Paid Trial Default",
+						auto_enable: true,
+						group: `g_${planId}`,
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: {
+							duration_type: FreeTrialDuration.Day,
+							duration_length: 14,
+							card_required: false,
+						},
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						isDefault: true,
+						freeTrial: {
+							duration_type: FreeTrialDuration.Day,
+							duration_length: 14,
+							card_required: false,
+							on_end: null,
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 default-flag: paid recurring no trial auto_enable → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_def_paid");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Paid Default",
+								auto_enable: true,
+								price: { amount: 20, interval: BillingInterval.Month },
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 default-flag: one-off priced auto_enable → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_def_oneoff");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "One Off Default",
+								auto_enable: true,
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 0,
+										price: {
+											amount: 10,
+											interval: BillingInterval.OneOff,
+											billing_method: BillingMethod.Prepaid,
+											billing_units: 1,
+										},
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 default-flag: auto_enable on pinned historical version → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_def_hist");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "V1" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version: 2, name: "V2" }],
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.HistoricalPlanVersionCannotBeDefault,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								version: 1,
+								auto_enable: true,
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 default-flag: defaults in different groups coexist")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_def_ga");
+		const planB = uniqueTestId("cv2_def_gb");
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planA,
+						name: "Default A",
+						auto_enable: true,
+						group: `group_a_${planA}`,
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+					{
+						plan_id: planB,
+						name: "Default B",
+						auto_enable: true,
+						group: `group_b_${planB}`,
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{ id: planA, isDefault: true, group: `group_a_${planA}` },
+					{ id: planB, isDefault: true, group: `group_b_${planB}` },
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/validation/free-trial-validation.test.ts
+++ b/server/tests/integration/catalog-v2/plans/validation/free-trial-validation.test.ts
@@ -1,0 +1,333 @@
+/**
+ * catalogV2.update — free_trial projected-state validation.
+ *
+ * Spec: reject with 400; no silent is_default flips. Validation must see
+ * projected plan state (same-call one-off + trial, default + carded trial).
+ */
+
+import { test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	ErrCode,
+	FreeTrialDuration,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+const trialDay = ({
+	length = 7,
+	cardRequired = false,
+}: {
+	length?: number;
+	cardRequired?: boolean;
+} = {}) => ({
+	duration_length: length,
+	duration_type: FreeTrialDuration.Day,
+	card_required: cardRequired,
+});
+
+// RED until validation is wired against projected state
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial validation: trial on one-off create → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ftv_oo");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "One Off Trial",
+								free_trial: trialDay(),
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 0,
+										price: {
+											amount: 10,
+											interval: BillingInterval.OneOff,
+											billing_method: BillingMethod.Prepaid,
+											billing_units: 1,
+										},
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial validation: add trial to existing one-off → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ftv_oo_add");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "One Off",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 0,
+								price: {
+									amount: 10,
+									interval: BillingInterval.OneOff,
+									billing_method: BillingMethod.Prepaid,
+									billing_units: 1,
+								},
+							},
+						],
+					},
+				],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								free_trial: trialDay(),
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — same-call projection: becoming one-off while keeping/adding trial
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial validation: same-call one-off + trial → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ftv_proj");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Was Recurring",
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: trialDay({ cardRequired: false }),
+					},
+				],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								price: null,
+								free_trial: trialDay({ cardRequired: false }),
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 0,
+										price: {
+											amount: 10,
+											interval: BillingInterval.OneOff,
+											billing_method: BillingMethod.Prepaid,
+											billing_units: 1,
+										},
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — default + carded trial must 400 (not silent is_default flip)
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial validation: default + card_required true → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ftv_def_card");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Default Carded Trial",
+								auto_enable: true,
+								group: `g_${planId}`,
+								price: { amount: 20, interval: BillingInterval.Month },
+								free_trial: trialDay({ cardRequired: true }),
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 10,
+										reset: { interval: ResetInterval.Month },
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — flip card_required false→true on default plan → 400
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial validation: default trial card_required false→true → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ftv_flip");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Default Cardless",
+						auto_enable: true,
+						group: `g_${planId}`,
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: trialDay({ cardRequired: false }),
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								free_trial: trialDay({ cardRequired: true }),
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// RED — remove trial from default paid plan (no longer default-trial eligible)
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial validation: remove trial from default paid → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ftv_rm_def");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Default Paid Trial",
+						auto_enable: true,
+						group: `g_${planId}`,
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: trialDay({ cardRequired: false }),
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: planId, free_trial: null }],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// Control: free default without trial → OK (may already be green)
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 free-trial validation: free default without trial → OK")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ftv_free");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Free Default",
+						auto_enable: true,
+						group: `g_${planId}`,
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 10,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						isDefault: true,
+						freeTrial: null,
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/validation/plan-errors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/validation/plan-errors.test.ts
@@ -1,0 +1,593 @@
+/**
+ * catalogV2.update — plan upsert error / validation surface.
+ *
+ * Green today: versioning guards (`new_version`, `all_versions`+explicit version)
+ * and Zod item-shape rejections.
+ * Red: duplicate entries, version gap, name-required, rename gates.
+ */
+
+import { test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	CouponDurationType,
+	CusProductStatus,
+	customerProducts,
+	customers,
+	ErrCode,
+	OnDecrease,
+	OnIncrease,
+	ResetInterval,
+	RewardTriggerEvent,
+	RewardType,
+	rewardPrograms,
+	rewards,
+	TierBehavior,
+	TierInfinite,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const seedCustomerProductRef = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const full = await getFull({ ctx, planId });
+	const customerId = uniqueTestId("cv2_cus");
+	const internalCustomerId = generateId("cus");
+	const cusProductId = generateId("cus_prod");
+
+	await ctx.db.insert(customers).values({
+		internal_id: internalCustomerId,
+		id: customerId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		name: customerId,
+		email: `${customerId}@test.com`,
+	});
+
+	await ctx.db.insert(customerProducts).values({
+		id: cusProductId,
+		internal_customer_id: internalCustomerId,
+		product_id: planId,
+		internal_product_id: full.internal_id,
+		status: CusProductStatus.Active,
+		created_at: Date.now(),
+		starts_at: Date.now(),
+		quantity: 1,
+		options: [],
+		is_custom: false,
+	});
+
+	return { customerId, internalCustomerId, cusProductId };
+};
+
+const seedRewardProgramRef = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const rewardId = uniqueTestId("cv2_rew");
+	const internalRewardId = generateId("rew");
+	const programId = uniqueTestId("cv2_rp");
+	const internalProgramId = generateId("rp");
+
+	await ctx.db.insert(rewards).values({
+		internal_id: internalRewardId,
+		id: rewardId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		name: rewardId,
+		type: RewardType.PercentageDiscount,
+		discount_config: {
+			discount_value: 10,
+			duration_type: CouponDurationType.OneOff,
+			duration_value: 1,
+			apply_to_all: false,
+			product_ids: [planId],
+		},
+	});
+
+	await ctx.db.insert(rewardPrograms).values({
+		internal_id: internalProgramId,
+		id: programId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		internal_reward_id: internalRewardId,
+		product_ids: [planId],
+		when: RewardTriggerEvent.Checkout,
+		max_redemptions: 1,
+		unlimited_redemptions: false,
+		exclude_trial: false,
+	});
+
+	return { rewardId, programId, internalRewardId, internalProgramId };
+};
+
+const cleanupRefs = async ({
+	ctx,
+	planIds,
+	rewardId,
+	programId,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+	rewardId?: string;
+	programId?: string;
+}) => {
+	if (programId) {
+		await ctx.db.delete(rewardPrograms).where(eq(rewardPrograms.id, programId));
+	}
+	if (rewardId) {
+		await ctx.db.delete(rewards).where(eq(rewards.id, rewardId));
+	}
+
+	for (const planId of planIds) {
+		const cusProds = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(eq(customerProducts.product_id, planId));
+
+		for (const row of cusProds) {
+			await ctx.db
+				.delete(customerProducts)
+				.where(eq(customerProducts.id, row.id));
+			await ctx.db
+				.delete(customers)
+				.where(eq(customers.internal_id, row.internal_customer_id));
+		}
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: versioning new_version → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_nv");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Base" }],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: 'versioning "new_version" is not implemented yet',
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Next",
+								versioning: "new_version",
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: all_versions + explicit version → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_av");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Base" }],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage:
+					'versioning "all_versions" cannot be combined with an explicit version',
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								version: 1,
+								versioning: "all_versions",
+								name: "Propagate",
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: duplicate (plan_id, version) entries → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_dup");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planId, name: "A", version: 1 },
+							{ plan_id: planId, name: "B", version: 1 },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: two unpinned entries same plan_id → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_unpin");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planId, name: "A" },
+							{ plan_id: planId, name: "B" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: version gap (declare v3 when max is v1) → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_gap");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "V1" }],
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: planId, version: 3, name: "V3" }],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: create without name → error")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_noname");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: planId }],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: new_plan_id blocked when plan has customers")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_ren_cus");
+		const newPlanId = uniqueTestId("cv2_err_ren_cus_new");
+		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Rename Me" }],
+			});
+			await seedCustomerProductRef({ ctx, planId });
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+					}),
+			});
+		} finally {
+			await cleanupRefs({ ctx, planIds: [planId, newPlanId] });
+			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: new_plan_id blocked when reward program references plan")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_ren_rp");
+		const newPlanId = uniqueTestId("cv2_err_ren_rp_new");
+		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		let rewardId: string | undefined;
+		let programId: string | undefined;
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Reward Linked",
+						price: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+			({ rewardId, programId } = await seedRewardProgramRef({ ctx, planId }));
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+					}),
+			});
+		} finally {
+			await cleanupRefs({
+				ctx,
+				planIds: [planId, newPlanId],
+				rewardId,
+				programId,
+			});
+			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: Zod — amount + tiers both set")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_zod_both");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errMessage: "'amount' and 'tiers' cannot both be defined",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Bad Item",
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 0,
+										price: {
+											amount: 10,
+											tiers: [
+												{ to: 100, amount: 5 },
+												{ to: TierInfinite, amount: 2 },
+											],
+											interval: BillingInterval.Month,
+											billing_method: BillingMethod.Prepaid,
+											billing_units: 1,
+										},
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: Zod — volume flat_amount on graduated")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_zod_flat");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errMessage:
+					"flat_amount on tiers is only supported for volume-based pricing",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Bad Flat",
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 0,
+										price: {
+											tiers: [
+												{ to: 100, amount: 5, flat_amount: 10 },
+												{ to: TierInfinite, amount: 2 },
+											],
+											tier_behavior: TierBehavior.Graduated,
+											interval: BillingInterval.Month,
+											billing_method: BillingMethod.Prepaid,
+											billing_units: 1,
+										},
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: Zod — tiers[0].to <= included")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_zod_to");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errMessage: "tiers[0].to must be greater than included",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Bad Boundary",
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 100,
+										price: {
+											tiers: [
+												{ to: 50, amount: 1 },
+												{ to: TierInfinite, amount: 0.5 },
+											],
+											interval: BillingInterval.Month,
+											billing_method: BillingMethod.UsageBased,
+											billing_units: 1,
+										},
+										reset: { interval: ResetInterval.Month },
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: Zod — proration on usage_based")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_zod_pror");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errMessage: "proration is only supported for prepaid features",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Bad Proration",
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 0,
+										price: {
+											amount: 1,
+											interval: BillingInterval.Month,
+											billing_method: BillingMethod.UsageBased,
+											billing_units: 1,
+										},
+										reset: { interval: ResetInterval.Month },
+										proration: {
+											on_increase: OnIncrease.ProrateImmediately,
+											on_decrease: OnDecrease.ProrateImmediately,
+										},
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-errors: Zod — reset/price interval mismatch on non-prepaid")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_err_zod_ivl");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await expectAutumnError({
+				errMessage:
+					"reset.interval and price.interval can only differ for prepaid prices",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								name: "Bad Intervals",
+								items: [
+									{
+										feature_id: TestFeature.Messages,
+										included: 0,
+										price: {
+											amount: 1,
+											interval: BillingInterval.Month,
+											billing_method: BillingMethod.UsageBased,
+											billing_units: 1,
+										},
+										reset: { interval: ResetInterval.Year },
+									},
+								],
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/plan-versions.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/plan-versions.test.ts
@@ -1,0 +1,570 @@
+/**
+ * catalogV2.update — pinned versions, omit→latest, multi-entry, mint ladder,
+ * all_versions propagation.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	FreeTrialDuration,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import {
+	expectCatalogPreviewCorrect,
+	expectCatalogResultsCorrect,
+} from "../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+	expectDbPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+const getFull = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version?: number;
+}) =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+
+const seedV1AndV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "V1",
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 100,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				version: 2,
+				name: "V2",
+				items: [
+					{
+						feature_id: TestFeature.Messages,
+						included: 200,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: pinned v1 edit; latest v2 untouched")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_pin");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version: 1,
+						name: "V1 Edited",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 150,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1 Edited",
+						allowances: { [TestFeature.Messages]: 150 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2",
+						allowances: { [TestFeature.Messages]: 200 },
+					},
+				],
+			});
+			// catalogV2.get is latest-only
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{
+						id: planId,
+						version: 2,
+						name: "V2",
+						allowances: { [TestFeature.Messages]: 200 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: omit version targets latest")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_latest");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Latest Edited",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 300,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1",
+						allowances: { [TestFeature.Messages]: 100 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "Latest Edited",
+						allowances: { [TestFeature.Messages]: 300 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: multi-entry same plan_id (v1 + v2) in one call")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_multi");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version: 1,
+						name: "V1 Multi",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 110,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+					{
+						plan_id: planId,
+						version: 2,
+						name: "V2 Multi",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 220,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "update" }],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1 Multi",
+						allowances: { [TestFeature.Messages]: 110 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2 Multi",
+						allowances: { [TestFeature.Messages]: 220 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: mint ladder v1 update + v2 create")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_mint");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Only V1",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 50,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version: 1,
+						name: "V1 Updated",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 60,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+					{
+						plan_id: planId,
+						version: 2,
+						name: "Minted V2",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 90,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			expect(response.results.plans.some((p) => p.action === "create")).toBe(
+				true,
+			);
+
+			const v2 = await getFull({ ctx, planId, version: 2 });
+			expect(v2).toBeTruthy();
+			expect(v2.name).toBe("Minted V2");
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1 Updated",
+						allowances: { [TestFeature.Messages]: 60 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "Minted V2",
+						allowances: { [TestFeature.Messages]: 90 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: all_versions propagates to every existing version")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_all");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "all_versions",
+						name: "Propagated",
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{ id: planId, version: 1, name: "Propagated" },
+					{ id: planId, version: 2, name: "Propagated" },
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: all_versions on brand-new plan → plain create")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_newall");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			const preview = await autumnV2_3.catalogV2.previewUpdate({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "all_versions",
+						name: "Brand New All",
+					},
+				],
+			});
+			expectCatalogPreviewCorrect({
+				preview,
+				plans: [{ planId, action: "create" }],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "all_versions",
+						name: "Brand New All",
+					},
+				],
+			});
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: planId, action: "create" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: planId, version: 1, name: "Brand New All" }],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+// Cross-ref section 14 — free trial × versioning
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: all_versions propagates free_trial to every version")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_ft_all");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "V1",
+						price: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version: 2,
+						name: "V2",
+						price: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "all_versions",
+						free_trial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: null,
+						},
+					},
+					{
+						id: planId,
+						version: 2,
+						freeTrial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: null,
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 versions: pinned version:1 trial edit leaves latest untouched")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ver_ft_pin");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "V1",
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: {
+							duration_length: 7,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version: 2,
+						name: "V2",
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version: 1,
+						free_trial: {
+							duration_length: 21,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+						},
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						freeTrial: {
+							duration_length: 21,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: null,
+						},
+					},
+					{
+						id: planId,
+						version: 2,
+						freeTrial: {
+							duration_length: 14,
+							duration_type: FreeTrialDuration.Day,
+							card_required: false,
+							on_end: null,
+						},
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/utils/expectCatalogUpdate.ts
+++ b/server/tests/integration/catalog-v2/utils/expectCatalogUpdate.ts
@@ -89,62 +89,107 @@ export const expectFeatureUsageCorrect = ({
 	}
 };
 
+type ExpectedPlanPreview = {
+	planId: string;
+	action: CatalogAction;
+	hasCustomers?: boolean;
+	willArchive?: boolean;
+};
+
 /** Optional fields are asserted only when passed. */
 export const expectCatalogPreviewCorrect = ({
 	preview,
 	features,
+	plans,
 }: {
 	preview: PreviewUpdateCatalogResponse;
-	features: ExpectedFeaturePreview[];
+	features?: ExpectedFeaturePreview[];
+	plans?: ExpectedPlanPreview[];
 }) => {
-	expect(preview.features).toHaveLength(features.length);
-	for (const expected of features) {
-		const entry = preview.features.find(
-			(candidate) => candidate.feature_id === expected.featureId,
-		);
-		expect(entry).toBeDefined();
-		expect(entry?.action).toBe(expected.action);
-		if (expected.hasCustomerEntitlements !== undefined) {
-			expect(entry?.state.has_customers).toBe(
-				expected.hasCustomerEntitlements,
+	if (features !== undefined) {
+		expect(preview.features).toHaveLength(features.length);
+		for (const expected of features) {
+			const entry = preview.features.find(
+				(candidate) => candidate.feature_id === expected.featureId,
 			);
+			expect(entry).toBeDefined();
+			expect(entry?.action).toBe(expected.action);
+			if (expected.hasCustomerEntitlements !== undefined) {
+				expect(entry?.state.has_customers).toBe(
+					expected.hasCustomerEntitlements,
+				);
+			}
+			if (expected.willArchive !== undefined) {
+				expect(entry?.state.will_archive).toBe(expected.willArchive);
+			}
+			if (expected.previousAttributes === null) {
+				expect(entry?.previous_attributes).toBeNull();
+			} else if (expected.previousAttributes !== undefined) {
+				expect(entry?.previous_attributes).toEqual(expected.previousAttributes);
+			}
+			if (expected.usage !== undefined && entry) {
+				expectFeatureUsageCorrect({
+					usage: entry.state.usage,
+					...expected.usage,
+				});
+			}
+			const reasonMessages =
+				entry?.state.reasons.map((reason) => reason.message) ?? [];
+			if (expected.reasonMessages !== undefined) {
+				expect(reasonMessages).toEqual(expected.reasonMessages);
+			}
+			if (expected.reasonsInclude !== undefined) {
+				for (const message of expected.reasonsInclude) {
+					expect(reasonMessages).toContain(message);
+				}
+			}
 		}
-		if (expected.willArchive !== undefined) {
-			expect(entry?.state.will_archive).toBe(expected.willArchive);
-		}
-		if (expected.previousAttributes === null) {
-			expect(entry?.previous_attributes).toBeNull();
-		} else if (expected.previousAttributes !== undefined) {
-			expect(entry?.previous_attributes).toEqual(expected.previousAttributes);
-		}
-		if (expected.usage !== undefined && entry) {
-			expectFeatureUsageCorrect({
-				usage: entry.state.usage,
-				...expected.usage,
-			});
-		}
-		const reasonMessages =
-			entry?.state.reasons.map((reason) => reason.message) ?? [];
-		if (expected.reasonMessages !== undefined) {
-			expect(reasonMessages).toEqual(expected.reasonMessages);
-		}
-		if (expected.reasonsInclude !== undefined) {
-			for (const message of expected.reasonsInclude) {
-				expect(reasonMessages).toContain(message);
+	}
+
+	// Plans: containment only — extra entries and new fields must NOT break
+	// existing tests. Assert exactly the fields passed, nothing else.
+	if (plans !== undefined) {
+		for (const expected of plans) {
+			const entry = preview.plans.find(
+				(candidate) => candidate.plan_id === expected.planId,
+			);
+			expect(entry, `missing preview entry for ${expected.planId}`).toBeDefined();
+			expect(entry?.action).toBe(expected.action);
+			if (expected.hasCustomers !== undefined) {
+				expect(entry?.state.has_customers).toBe(expected.hasCustomers);
+			}
+			if (expected.willArchive !== undefined) {
+				expect(entry?.state.will_archive).toBe(expected.willArchive);
 			}
 		}
 	}
 };
 
-/** Exact match on what the update reports it did, in order. */
+/**
+ * Features: exact match, in order. Plans: containment — each expected
+ * {id, action} must be reported, extra entries tolerated (future expansions).
+ */
 export const expectCatalogResultsCorrect = ({
 	response,
 	features,
+	plans,
 }: {
 	response: UpdateCatalogResponse;
-	features: { id: string; action: CatalogAction }[];
+	features?: { id: string; action: CatalogAction }[];
+	plans?: { id: string; action: CatalogAction }[];
 }) => {
-	expect(response.results.features).toEqual(features);
+	if (features !== undefined) {
+		expect(response.results.features).toEqual(features);
+	}
+	if (plans !== undefined) {
+		for (const expected of plans) {
+			const entry = response.results.plans.find(
+				(candidate) => candidate.id === expected.id,
+			);
+			expect(entry, `missing result for plan ${expected.id}`).toBeDefined();
+			expect(entry?.action).toBe(expected.action);
+		}
+	}
 };
 
 /** The plan's items reference exactly these feature ids, in item order. */

--- a/server/tests/unit/catalogV2/computeFreeTrialPlan/computeFreeTrialPlan.test.ts
+++ b/server/tests/unit/catalogV2/computeFreeTrialPlan/computeFreeTrialPlan.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type FreeTrial,
+	FreeTrialDuration,
+	type FreeTrialParamsV1,
+} from "@autumn/shared";
+import { computeFreeTrialPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeFreeTrialPlan/computeFreeTrialPlan";
+
+const currentRow = (overrides: Partial<FreeTrial> = {}): FreeTrial => ({
+	id: "ft_current",
+	duration: FreeTrialDuration.Day,
+	length: 14,
+	unique_fingerprint: false,
+	created_at: 1,
+	internal_product_id: "prod_1",
+	is_custom: false,
+	card_required: true,
+	on_end: null,
+	...overrides,
+});
+
+const params = (
+	overrides: Partial<FreeTrialParamsV1> = {},
+): FreeTrialParamsV1 => ({
+	duration_length: 14,
+	duration_type: FreeTrialDuration.Day,
+	card_required: true,
+	...overrides,
+});
+
+describe("computeFreeTrialPlan", () => {
+	test("omitted params → preserve current", () => {
+		const current = currentRow();
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: undefined,
+			currentFreeTrial: current,
+			internalProductId: "prod_1",
+		});
+		expect(plan).toEqual({
+			changed: false,
+			new: null,
+			same: current,
+			retired: null,
+			projected: current,
+		});
+	});
+
+	test("omitted with no current → all null / same null", () => {
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: undefined,
+			currentFreeTrial: null,
+			internalProductId: "prod_1",
+		});
+		expect(plan.changed).toBe(false);
+		expect(plan.projected).toBeNull();
+		expect(plan.same).toBeNull();
+		expect(plan.new).toBeNull();
+		expect(plan.retired).toBeNull();
+	});
+
+	test("null params → retire current, projected null", () => {
+		const current = currentRow();
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: null,
+			currentFreeTrial: current,
+			internalProductId: "prod_1",
+		});
+		expect(plan).toEqual({
+			changed: true,
+			new: null,
+			same: null,
+			retired: current,
+			projected: null,
+		});
+	});
+
+	test("null params with no current → unchanged", () => {
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: null,
+			currentFreeTrial: null,
+			internalProductId: "prod_1",
+		});
+		expect(plan.changed).toBe(false);
+		expect(plan.projected).toBeNull();
+	});
+
+	test("object matching current → claim same row id", () => {
+		const current = currentRow();
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: params(),
+			currentFreeTrial: current,
+			internalProductId: "prod_1",
+		});
+		expect(plan.changed).toBe(false);
+		expect(plan.new).toBeNull();
+		expect(plan.retired).toBeNull();
+		expect(plan.same).toBe(current);
+		expect(plan.projected).toBe(current);
+		expect(plan.projected?.id).toBe("ft_current");
+	});
+
+	test("object differing → retire + mint; projected is new", () => {
+		const current = currentRow();
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: params({ duration_length: 30 }),
+			currentFreeTrial: current,
+			internalProductId: "prod_1",
+		});
+		expect(plan.changed).toBe(true);
+		expect(plan.retired).toBe(current);
+		expect(plan.same).toBeNull();
+		expect(plan.new).not.toBeNull();
+		expect(plan.new?.id).not.toBe("ft_current");
+		expect(plan.new?.length).toBe(30);
+		expect(plan.projected).toBe(plan.new);
+		expect(plan.new?.internal_product_id).toBe("prod_1");
+	});
+
+	test("no current + object → new only", () => {
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: params({ card_required: false }),
+			currentFreeTrial: null,
+			internalProductId: "prod_new",
+		});
+		expect(plan.changed).toBe(true);
+		expect(plan.retired).toBeNull();
+		expect(plan.same).toBeNull();
+		expect(plan.new).not.toBeNull();
+		expect(plan.projected).toBe(plan.new);
+		expect(plan.new?.card_required).toBe(false);
+		expect(plan.new?.internal_product_id).toBe("prod_new");
+	});
+
+	test("on_end bill ≡ omitted → claim same", () => {
+		const current = currentRow({ on_end: null });
+		const plan = computeFreeTrialPlan({
+			freeTrialParams: params({ on_end: "bill" }),
+			currentFreeTrial: current,
+			internalProductId: "prod_1",
+		});
+		expect(plan.changed).toBe(false);
+		expect(plan.same).toBe(current);
+		expect(plan.new).toBeNull();
+	});
+});

--- a/server/tests/unit/catalogV2/computeFreeTrialPlan/freeTrialsAreSame.test.ts
+++ b/server/tests/unit/catalogV2/computeFreeTrialPlan/freeTrialsAreSame.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { FreeTrialDuration, freeTrialsAreSame } from "@autumn/shared";
+
+const base = {
+	length: 14,
+	unique_fingerprint: false,
+	duration: FreeTrialDuration.Day,
+	card_required: true,
+	on_end: "bill" as const,
+};
+
+describe("freeTrialsAreSame", () => {
+	test("both null/undefined → same", () => {
+		expect(freeTrialsAreSame({ ft1: null, ft2: null })).toBe(true);
+		expect(freeTrialsAreSame({ ft1: undefined, ft2: undefined })).toBe(true);
+		expect(freeTrialsAreSame({ ft1: null, ft2: undefined })).toBe(true);
+	});
+
+	test("one null → different", () => {
+		expect(freeTrialsAreSame({ ft1: base, ft2: null })).toBe(false);
+		expect(freeTrialsAreSame({ ft1: null, ft2: base })).toBe(false);
+	});
+
+	test("length difference → different", () => {
+		expect(
+			freeTrialsAreSame({
+				ft1: base,
+				ft2: { ...base, length: 7 },
+			}),
+		).toBe(false);
+	});
+
+	test("duration difference → different", () => {
+		expect(
+			freeTrialsAreSame({
+				ft1: base,
+				ft2: { ...base, duration: FreeTrialDuration.Month },
+			}),
+		).toBe(false);
+	});
+
+	test("card_required difference → different", () => {
+		expect(
+			freeTrialsAreSame({
+				ft1: base,
+				ft2: { ...base, card_required: false },
+			}),
+		).toBe(false);
+	});
+
+	test("on_end: undefined ≡ null ≡ bill → same", () => {
+		expect(
+			freeTrialsAreSame({
+				ft1: { ...base, on_end: undefined },
+				ft2: { ...base, on_end: null },
+			}),
+		).toBe(true);
+		expect(
+			freeTrialsAreSame({
+				ft1: { ...base, on_end: undefined },
+				ft2: { ...base, on_end: "bill" },
+			}),
+		).toBe(true);
+		expect(
+			freeTrialsAreSame({
+				ft1: { ...base, on_end: null },
+				ft2: { ...base, on_end: "bill" },
+			}),
+		).toBe(true);
+	});
+
+	test("on_end: revert vs bill/omitted → different", () => {
+		expect(
+			freeTrialsAreSame({
+				ft1: { ...base, on_end: "revert" },
+				ft2: { ...base, on_end: "bill" },
+			}),
+		).toBe(false);
+		expect(
+			freeTrialsAreSame({
+				ft1: { ...base, on_end: "revert" },
+				ft2: { ...base, on_end: undefined },
+			}),
+		).toBe(false);
+	});
+
+	test("unique_fingerprint difference → different", () => {
+		expect(
+			freeTrialsAreSame({
+				ft1: base,
+				ft2: { ...base, unique_fingerprint: true },
+			}),
+		).toBe(false);
+	});
+
+	test("identical fields → same", () => {
+		expect(freeTrialsAreSame({ ft1: base, ft2: { ...base } })).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- Integration + unit coverage for free trial, billing controls, default/trial guards, create/update/batch interplay
- Adds `CASES.md` matrix and preview/versioning RED specs for remaining work

## Test plan
- [ ] `bun test` catalog-v2/plans validation + update free-trial suites
- [ ] `bun test` catalog-v2/plans create + batch (non-RED)
- [ ] Confirm RED-prefixed preview/rows suites remain expected failures

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands integration and unit tests for `catalogV2` plan upsert to codify expected behavior across create/update/batch, item and price shapes, free-trial semantics, preview actions/versioning, idempotency, and Stripe reuse. This locks the contract and flags remaining gaps with RED tests.

- Covers create (free and priced items across billing models), update (details, items, rows lifecycle, free-trial rows), idempotent re-sends, and batch ops (multi-plan, archive, and feature↔plan resolution, including type changes and removals).
- Adds preview suites for action correctness, `state.has_customers`, and pinned versions; RED specs for `changes` blocks (base price, details, items, free-trial, mixed) and `versioning`.
- Adds validation/error suites: default-flag rules, projected-state free-trial guards, versioning guards, and Zod item-shape rejections; marks unimplemented cases RED.
- Verifies Stripe identifier reuse (`stripe_price_id`, `stripe_product_id`, meter) on definition matches, with fallbacks when partially matching.
- Introduces `server/tests/integration/catalog-v2/plans/CASES.md` matrix and shared helpers (`expectCatalogPlans`, `expectCatalogUpdate`, preview parsers). No production behavior changes; RED tests are intentional and document unimplemented preview/validation paths.

<sup>Written for commit 37df31101e65545093f28cab040f6dbade18e021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR substantially expands catalog-v2 plan-upsert test coverage and documents the remaining expected-failure specifications.
- **[Improvements]** Adds create, update, validation, batching, versioning, row-lifecycle, Stripe-reuse, and free-trial coverage for plan upserts.
- **[Improvements]** Adds preview action and change-shape specifications, including explicitly RED coverage for behavior not implemented yet.
- **[Improvements]** Extends shared catalog assertion helpers to validate plan items, prices, free trials, billing controls, and plan result actions.
- **[Improvements]** Adds a comprehensive `CASES.md` matrix that records covered, RED, and deferred scenarios.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the scope of the supplied follow-up threads.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/integration/catalog-v2/plans/CASES.md | Documents the catalog-v2 plan test matrix, implemented coverage, expected failures, and deferred work. |
| server/tests/integration/catalog-v2/plans/update/update-plan-free-trial.test.ts | Adds extensive free-trial persistence, update, row-retirement, and cross-facet integration coverage. |
| server/tests/integration/catalog-v2/plans/preview/changes/changes-items.test.ts | Adds specifications for preview item diffs across pricing, reset, rollover, proration, and normalization cases. |
| server/tests/integration/catalog-v2/plans/utils/expectCatalogPlans.ts | Expands catalog and database assertions for complete plan, item, price, free-trial, and billing-control shapes. |
| server/tests/integration/catalog-v2/utils/expectCatalogUpdate.ts | Extends preview and update-result assertions to support plan actions alongside feature actions. |
| server/tests/unit/catalogV2/computeFreeTrialPlan/computeFreeTrialPlan.test.ts | Adds unit coverage for free-trial reuse, replacement, removal, and retirement semantics. |

<sub>Reviews (3): Last reviewed commit: ["test(catalog-v2): add plan upsert integr..."](https://github.com/useautumn/autumn/commit/37df31101e65545093f28cab040f6dbade18e021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52501472)</sub>

<!-- /greptile_comment -->