### PR TITLE
fix: preserve constant ids in config rewrites

### DIFF
--- a/packages/atmn/src/lib/config/loadConfig.ts
+++ b/packages/atmn/src/lib/config/loadConfig.ts
@@ -17,7 +17,7 @@ export type LoadedConfig = {
 	referralPrograms: ReferralProgram[];
 };
 
-type ConfigModule = {
+export type ConfigModule = {
 	default?: Partial<Pick<LoadedConfig, "features" | "plans">> & {
 		products?: Plan[];
 	};
@@ -26,7 +26,7 @@ type ConfigModule = {
 export const DEFAULT_REWARD_EXPORT_ERROR =
 	"Rewards and referral programs must be named reward() and referralProgram() exports; move them out of the default export before pulling or pushing.";
 
-const importConfig = async ({
+export const loadConfigModule = async ({
 	cwd,
 }: {
 	cwd: string;
@@ -46,7 +46,7 @@ export const loadConfig = async ({
 }: {
 	cwd?: string;
 } = {}): Promise<LoadedConfig> => {
-	const mod = await importConfig({ cwd });
+	const mod = await loadConfigModule({ cwd });
 	const config: LoadedConfig = {
 		features: [],
 		plans: [],

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
@@ -38,14 +38,22 @@ export interface ParsedConfig {
 	source: string;
 }
 
-/**
- * Extract the 'id' value from source lines using regex
- */
-function extractId(lines: string[]): string | null {
+/** Resolve a literal ID, falling back to the generated variable name. */
+function extractId({
+	idsByVarName,
+	lines,
+	varName,
+}: {
+	idsByVarName?: Map<string, string>;
+	lines: string[];
+	varName: string | null;
+}): string | null {
 	const joined = lines.join("\n");
 	// Match id: 'value' or id: "value"
 	const match = joined.match(/id:\s*['"]([^'"]+)['"]/);
-	return match ? (match[1] ?? null) : null;
+	return (
+		match?.[1] ?? (varName ? idsByVarName?.get(varName) : undefined) ?? null
+	);
 }
 
 /**
@@ -93,7 +101,13 @@ function determineEntityType(lines: string[]): ParsedEntity["type"] | null {
 /**
  * Parse an existing autumn.config.ts file using line-based parsing
  */
-export function parseExistingConfig(configPath: string): ParsedConfig {
+export function parseExistingConfig({
+	configPath,
+	idsByVarName,
+}: {
+	configPath: string;
+	idsByVarName?: Map<string, string>;
+}): ParsedConfig {
 	const source = readFileSync(configPath, "utf-8");
 	const lines = source.split("\n");
 
@@ -191,7 +205,7 @@ export function parseExistingConfig(configPath: string): ParsedConfig {
 			const endLine = i;
 			const blockLines = lines.slice(startLine, endLine + 1);
 
-			const id = extractId(blockLines);
+			const id = extractId({ idsByVarName, lines: blockLines, varName });
 			const entityType = determineEntityType(blockLines);
 
 			if (id && entityType && varName) {

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
@@ -122,6 +122,10 @@ function determineEntityType(lines: string[]): ParsedEntity["type"] | null {
 	return null;
 }
 
+const isResourceExpression = (source: string) =>
+	/=\s*(?:feature|plan|referralProgram|reward)\s*\(/.test(source) ||
+	/=\s*\w+\.variant\s*\(/.test(source);
+
 /**
  * Parse an existing autumn.config.ts file using line-based parsing
  */
@@ -235,7 +239,7 @@ export function parseExistingConfig({
 			const entityType = determineEntityType(blockLines);
 			const blockSource = blockLines.join("\n");
 			const declaration =
-				entityType && varName
+				entityType && varName && isResourceExpression(blockSource)
 					? {
 							requiresRuntimeIdentity: !/id:\s*['"][^'"]+['"]/.test(
 								blockSource,

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
@@ -10,12 +10,18 @@ export interface ParsedEntity {
 	id: string;
 	type: "feature" | "plan" | "referral_program" | "reward" | "variant";
 	varName: string;
+	version?: number;
 	/** Starting line index (0-based) */
 	startLine: number;
 	/** Ending line index (0-based, inclusive) */
 	endLine: number;
 	/** The original source lines */
 	lines: string[];
+}
+
+export interface ParsedIdentity {
+	id: string;
+	version?: number;
 }
 
 export interface ParsedBlock {
@@ -39,21 +45,32 @@ export interface ParsedConfig {
 }
 
 /** Resolve a literal ID, falling back to the generated variable name. */
-function extractId({
-	idsByVarName,
+function extractIdentity({
+	identitiesByTypeAndVarName,
 	lines,
+	type,
 	varName,
 }: {
-	idsByVarName?: Map<string, string>;
+	identitiesByTypeAndVarName?: Map<
+		ParsedEntity["type"],
+		Map<string, ParsedIdentity>
+	>;
 	lines: string[];
+	type: ParsedEntity["type"] | null;
 	varName: string | null;
-}): string | null {
+}): ParsedIdentity | null {
 	const joined = lines.join("\n");
-	// Match id: 'value' or id: "value"
-	const match = joined.match(/id:\s*['"]([^'"]+)['"]/);
-	return (
-		match?.[1] ?? (varName ? idsByVarName?.get(varName) : undefined) ?? null
-	);
+	const mapped =
+		type && varName
+			? identitiesByTypeAndVarName?.get(type)?.get(varName)
+			: undefined;
+	const id = joined.match(/id:\s*['"]([^'"]+)['"]/)?.[1];
+	if (!id) return mapped ?? null;
+	if (mapped?.id === id) return mapped;
+	const version = joined.match(
+		/id:\s*['"][^'"]+['"]\s*,?\s*version:\s*(\d+)/,
+	)?.[1];
+	return { id, version: version === undefined ? undefined : Number(version) };
 }
 
 /**
@@ -103,10 +120,13 @@ function determineEntityType(lines: string[]): ParsedEntity["type"] | null {
  */
 export function parseExistingConfig({
 	configPath,
-	idsByVarName,
+	identitiesByTypeAndVarName,
 }: {
 	configPath: string;
-	idsByVarName?: Map<string, string>;
+	identitiesByTypeAndVarName?: Map<
+		ParsedEntity["type"],
+		Map<string, ParsedIdentity>
+	>;
 }): ParsedConfig {
 	const source = readFileSync(configPath, "utf-8");
 	const lines = source.split("\n");
@@ -205,12 +225,17 @@ export function parseExistingConfig({
 			const endLine = i;
 			const blockLines = lines.slice(startLine, endLine + 1);
 
-			const id = extractId({ idsByVarName, lines: blockLines, varName });
 			const entityType = determineEntityType(blockLines);
+			const identity = extractIdentity({
+				identitiesByTypeAndVarName,
+				lines: blockLines,
+				type: entityType,
+				varName,
+			});
 
-			if (id && entityType && varName) {
+			if (identity && entityType && varName) {
 				const entity: ParsedEntity = {
-					id,
+					...identity,
 					type: entityType,
 					varName,
 					startLine,

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
@@ -24,11 +24,18 @@ export interface ParsedIdentity {
 	version?: number;
 }
 
+export interface ParsedDeclaration {
+	requiresRuntimeIdentity: boolean;
+	type: ParsedEntity["type"];
+	varName: string;
+}
+
 export interface ParsedBlock {
 	type: "import" | "comment" | "export" | "other";
 	startLine: number;
 	endLine: number;
 	lines: string[];
+	declaration?: ParsedDeclaration;
 	/** For export blocks */
 	entity?: ParsedEntity;
 }
@@ -226,6 +233,17 @@ export function parseExistingConfig({
 			const blockLines = lines.slice(startLine, endLine + 1);
 
 			const entityType = determineEntityType(blockLines);
+			const blockSource = blockLines.join("\n");
+			const declaration =
+				entityType && varName
+					? {
+							requiresRuntimeIdentity: !/id:\s*['"][^'"]+['"]/.test(
+								blockSource,
+							),
+							type: entityType,
+							varName,
+						}
+					: undefined;
 			const identity = extractIdentity({
 				identitiesByTypeAndVarName,
 				lines: blockLines,
@@ -248,6 +266,7 @@ export function parseExistingConfig({
 					startLine,
 					endLine,
 					lines: blockLines,
+					declaration,
 					entity,
 				});
 
@@ -259,6 +278,7 @@ export function parseExistingConfig({
 					startLine,
 					endLine,
 					lines: blockLines,
+					declaration,
 				});
 			}
 

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
@@ -4,11 +4,14 @@
  * Uses line-based parsing for reliability
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import type { ReferralProgram, Reward } from "../../../compose/index.js";
 import type { Feature } from "../../../compose/models/index.js";
 import type { Plan } from "../../../compose/models/variantModels.js";
-import { DEFAULT_REWARD_EXPORT_ERROR } from "../../config/loadConfig.js";
+import {
+	DEFAULT_REWARD_EXPORT_ERROR,
+	loadConfigModule,
+} from "../../config/loadConfig.js";
 import { resolveConfigPath } from "../../env/index.js";
 import { buildFeatureCode } from "../sdkToCode/feature.js";
 import {
@@ -16,7 +19,6 @@ import {
 	featureIdToVarName,
 	idToVarName,
 	planIdToVarName,
-	resolveVarNames,
 	variantIdToVarName,
 	versionedCodegenId,
 } from "../sdkToCode/helpers.js";
@@ -114,39 +116,10 @@ const ensureAtmnImports = (importText: string, imports: string[]) =>
 		importText,
 	);
 
-const resolveExistingVarNames = ({
-	candidate,
-	declaredVarNames,
-	resolvedVarNames,
-	resources,
-	suffix,
-}: {
-	candidate: (resource: ParsedIdentity) => string;
-	declaredVarNames: string[];
-	resolvedVarNames: Map<string, string>;
-	resources: ParsedIdentity[];
-	suffix: string;
-}) => {
-	const identitiesByVarName = new Map<string, ParsedIdentity>();
-	for (const resource of resources) {
-		const varName = resolvedVarNames.get(versionedCodegenId(resource));
-		if (varName) identitiesByVarName.set(varName, resource);
-	}
-	for (const varName of declaredVarNames) {
-		if (identitiesByVarName.has(varName)) continue;
-		const matches = resources.filter((resource) => {
-			const baseName = candidate(resource);
-			const claimedSuffix = varName.slice(baseName.length + suffix.length);
-			return (
-				varName === baseName ||
-				(varName.startsWith(baseName + suffix) && /^\d*$/.test(claimedSuffix))
-			);
-		});
-		const [match] = matches;
-		if (matches.length === 1 && match) identitiesByVarName.set(varName, match);
-	}
-	return identitiesByVarName;
-};
+const versionedIds = (resources: ParsedIdentity[]) =>
+	new Set(
+		resources.flatMap(({ id, version }) => (version === undefined ? [] : [id])),
+	);
 
 /** Updates managed entities in place while preserving custom source. */
 export async function updateConfigInPlace({
@@ -168,83 +141,43 @@ export async function updateConfigInPlace({
 		throw new Error(`Config file not found: ${configPath}`);
 	}
 
-	const resolvedVarNames = resolveVarNames(
-		features.map(({ id }) => id),
-		plans.map(versionedCodegenId),
-		plans.flatMap((plan) => plan.variants?.map(versionedCodegenId) ?? []),
-		{
-			rewardIds: rewards?.map(({ id }) => id),
-			referralProgramIds: referralPrograms?.map(({ id }) => id),
-		},
+	let parsed = parseExistingConfig({ configPath });
+	const versionedIdsByType = new Map<ParsedEntity["type"], Set<string>>([
+		["plan", versionedIds(plans)],
+		["variant", versionedIds(plans.flatMap((plan) => plan.variants ?? []))],
+	]);
+	const runtimeDeclarations = parsed.blocks.flatMap(
+		({ declaration, entity }) =>
+			declaration &&
+			(declaration.requiresRuntimeIdentity ||
+				(entity && versionedIdsByType.get(entity.type)?.has(entity.id)))
+				? [declaration]
+				: [],
 	);
-	const declaredVarNames = [
-		...readFileSync(configPath, "utf8").matchAll(
-			/export\s+const\s+([\w$]+)\s*=/g,
-		),
-	].flatMap(([, varName]) => (varName ? [varName] : []));
-	const variants = plans.flatMap((plan) => plan.variants ?? []);
-	const resourceGroups: [
-		ParsedEntity["type"],
-		ParsedIdentity[],
-		Map<string, string>,
-		(resource: ParsedIdentity) => string,
-		string,
-	][] = [
-		[
-			"feature",
-			features,
-			resolvedVarNames.featureVarMap,
-			({ id }) => featureIdToVarName(id),
-			"Feature",
-		],
-		[
-			"plan",
-			plans,
-			resolvedVarNames.planVarMap,
-			(resource) => planIdToVarName(versionedCodegenId(resource)),
-			"Plan",
-		],
-		[
-			"variant",
-			variants,
-			resolvedVarNames.variantVarMap,
-			(resource) => variantIdToVarName(versionedCodegenId(resource)),
-			"Variant",
-		],
-		[
-			"reward",
-			rewards ?? [],
-			resolvedVarNames.rewardVarMap,
-			({ id }) => idToVarName(`reward-${id}`),
-			"Reward",
-		],
-		[
-			"referral_program",
-			referralPrograms ?? [],
-			resolvedVarNames.referralProgramVarMap,
-			({ id }) => idToVarName(`referral-program-${id}`),
-			"ReferralProgram",
-		],
-	];
-	const identitiesByTypeAndVarName = new Map<
-		ParsedEntity["type"],
-		Map<string, ParsedIdentity>
-	>(
-		resourceGroups.map(([type, resources, varNames, candidate, suffix]) => [
-			type,
-			resolveExistingVarNames({
-				candidate,
-				declaredVarNames,
-				resolvedVarNames: varNames,
-				resources,
-				suffix,
-			}),
-		]),
-	);
-	const parsed = parseExistingConfig({
-		configPath,
-		identitiesByTypeAndVarName,
-	});
+	if (runtimeDeclarations.length) {
+		const mod = await loadConfigModule({ cwd });
+		const identitiesByTypeAndVarName = new Map<
+			ParsedEntity["type"],
+			Map<string, ParsedIdentity>
+		>();
+		for (const declaration of runtimeDeclarations) {
+			const value = mod[declaration.varName] as
+				| { id?: unknown; version?: unknown }
+				| undefined;
+			if (typeof value?.id !== "string")
+				throw new Error(
+					`Could not resolve the ID of export '${declaration.varName}'.`,
+				);
+			const identities =
+				identitiesByTypeAndVarName.get(declaration.type) ?? new Map();
+			identities.set(declaration.varName, {
+				id: value.id,
+				version: typeof value.version === "number" ? value.version : undefined,
+			});
+			identitiesByTypeAndVarName.set(declaration.type, identities);
+		}
+		parsed = parseExistingConfig({ configPath, identitiesByTypeAndVarName });
+	}
 	const hasDefaultResources =
 		/\bexport\s+default\b/.test(parsed.source) &&
 		/\b(?:rewards|referralPrograms)\b/.test(parsed.source);

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
@@ -16,6 +16,7 @@ import {
 	featureIdToVarName,
 	idToVarName,
 	planIdToVarName,
+	resolveVarNames,
 	variantIdToVarName,
 } from "../sdkToCode/helpers.js";
 import { buildImports } from "../sdkToCode/imports.js";
@@ -128,7 +129,21 @@ export async function updateConfigInPlace({
 		throw new Error(`Config file not found: ${configPath}`);
 	}
 
-	const parsed = parseExistingConfig(configPath);
+	const resolvedVarNames = resolveVarNames(
+		features.map(({ id }) => id),
+		plans.map(({ id }) => id),
+		plans.flatMap((plan) => plan.variants?.map(({ id }) => id) ?? []),
+		{
+			rewardIds: rewards?.map(({ id }) => id),
+			referralProgramIds: referralPrograms?.map(({ id }) => id),
+		},
+	);
+	const idsByVarName = new Map(
+		Object.values(resolvedVarNames).flatMap((varNames) =>
+			[...varNames].map(([id, varName]) => [varName, id] as const),
+		),
+	);
+	const parsed = parseExistingConfig({ configPath, idsByVarName });
 	const hasDefaultResources =
 		/\bexport\s+default\b/.test(parsed.source) &&
 		/\b(?:rewards|referralPrograms)\b/.test(parsed.source);

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
@@ -142,6 +142,10 @@ export async function updateConfigInPlace({
 	}
 
 	let parsed = parseExistingConfig({ configPath });
+	const hasDefaultResources =
+		/\bexport\s+default\b/.test(parsed.source) &&
+		/\b(?:rewards|referralPrograms)\b/.test(parsed.source);
+	if (hasDefaultResources) throw new Error(DEFAULT_REWARD_EXPORT_ERROR);
 	const versionedIdsByType = new Map<ParsedEntity["type"], Set<string>>([
 		["plan", versionedIds(plans)],
 		["variant", versionedIds(plans.flatMap((plan) => plan.variants ?? []))],
@@ -178,10 +182,6 @@ export async function updateConfigInPlace({
 		}
 		parsed = parseExistingConfig({ configPath, identitiesByTypeAndVarName });
 	}
-	const hasDefaultResources =
-		/\bexport\s+default\b/.test(parsed.source) &&
-		/\b(?:rewards|referralPrograms)\b/.test(parsed.source);
-	if (hasDefaultResources) throw new Error(DEFAULT_REWARD_EXPORT_ERROR);
 	const requiredImports = [
 		...(plans.some((plan) => plan.billingControls) ? ["billingControls"] : []),
 		...(rewards?.length ? ["reward"] : []),

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts
@@ -4,7 +4,7 @@
  * Uses line-based parsing for reliability
  */
 
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { ReferralProgram, Reward } from "../../../compose/index.js";
 import type { Feature } from "../../../compose/models/index.js";
 import type { Plan } from "../../../compose/models/variantModels.js";
@@ -18,6 +18,7 @@ import {
 	planIdToVarName,
 	resolveVarNames,
 	variantIdToVarName,
+	versionedCodegenId,
 } from "../sdkToCode/helpers.js";
 import { buildImports } from "../sdkToCode/imports.js";
 import { buildPlanCode } from "../sdkToCode/plan.js";
@@ -26,7 +27,11 @@ import {
 	buildRewardCode,
 } from "../sdkToCode/reward.js";
 import { buildVariantCode } from "../sdkToCode/variant.js";
-import { parseExistingConfig } from "./parseConfig.js";
+import {
+	type ParsedEntity,
+	type ParsedIdentity,
+	parseExistingConfig,
+} from "./parseConfig.js";
 
 export interface UpdateResult {
 	/** Number of features updated in place */
@@ -93,7 +98,7 @@ function generatePlanWithVariantsCode({
 			variant,
 			features,
 			featureVarMap,
-			varNameOverride: variantVarMap.get(variant.id),
+			varNameOverride: variantVarMap.get(versionedCodegenId(variant)),
 		}),
 	);
 
@@ -108,6 +113,40 @@ const ensureAtmnImports = (importText: string, imports: string[]) =>
 				: text.replace(/\{/, `{ ${name},`),
 		importText,
 	);
+
+const resolveExistingVarNames = ({
+	candidate,
+	declaredVarNames,
+	resolvedVarNames,
+	resources,
+	suffix,
+}: {
+	candidate: (resource: ParsedIdentity) => string;
+	declaredVarNames: string[];
+	resolvedVarNames: Map<string, string>;
+	resources: ParsedIdentity[];
+	suffix: string;
+}) => {
+	const identitiesByVarName = new Map<string, ParsedIdentity>();
+	for (const resource of resources) {
+		const varName = resolvedVarNames.get(versionedCodegenId(resource));
+		if (varName) identitiesByVarName.set(varName, resource);
+	}
+	for (const varName of declaredVarNames) {
+		if (identitiesByVarName.has(varName)) continue;
+		const matches = resources.filter((resource) => {
+			const baseName = candidate(resource);
+			const claimedSuffix = varName.slice(baseName.length + suffix.length);
+			return (
+				varName === baseName ||
+				(varName.startsWith(baseName + suffix) && /^\d*$/.test(claimedSuffix))
+			);
+		});
+		const [match] = matches;
+		if (matches.length === 1 && match) identitiesByVarName.set(varName, match);
+	}
+	return identitiesByVarName;
+};
 
 /** Updates managed entities in place while preserving custom source. */
 export async function updateConfigInPlace({
@@ -131,19 +170,81 @@ export async function updateConfigInPlace({
 
 	const resolvedVarNames = resolveVarNames(
 		features.map(({ id }) => id),
-		plans.map(({ id }) => id),
-		plans.flatMap((plan) => plan.variants?.map(({ id }) => id) ?? []),
+		plans.map(versionedCodegenId),
+		plans.flatMap((plan) => plan.variants?.map(versionedCodegenId) ?? []),
 		{
 			rewardIds: rewards?.map(({ id }) => id),
 			referralProgramIds: referralPrograms?.map(({ id }) => id),
 		},
 	);
-	const idsByVarName = new Map(
-		Object.values(resolvedVarNames).flatMap((varNames) =>
-			[...varNames].map(([id, varName]) => [varName, id] as const),
+	const declaredVarNames = [
+		...readFileSync(configPath, "utf8").matchAll(
+			/export\s+const\s+([\w$]+)\s*=/g,
 		),
+	].flatMap(([, varName]) => (varName ? [varName] : []));
+	const variants = plans.flatMap((plan) => plan.variants ?? []);
+	const resourceGroups: [
+		ParsedEntity["type"],
+		ParsedIdentity[],
+		Map<string, string>,
+		(resource: ParsedIdentity) => string,
+		string,
+	][] = [
+		[
+			"feature",
+			features,
+			resolvedVarNames.featureVarMap,
+			({ id }) => featureIdToVarName(id),
+			"Feature",
+		],
+		[
+			"plan",
+			plans,
+			resolvedVarNames.planVarMap,
+			(resource) => planIdToVarName(versionedCodegenId(resource)),
+			"Plan",
+		],
+		[
+			"variant",
+			variants,
+			resolvedVarNames.variantVarMap,
+			(resource) => variantIdToVarName(versionedCodegenId(resource)),
+			"Variant",
+		],
+		[
+			"reward",
+			rewards ?? [],
+			resolvedVarNames.rewardVarMap,
+			({ id }) => idToVarName(`reward-${id}`),
+			"Reward",
+		],
+		[
+			"referral_program",
+			referralPrograms ?? [],
+			resolvedVarNames.referralProgramVarMap,
+			({ id }) => idToVarName(`referral-program-${id}`),
+			"ReferralProgram",
+		],
+	];
+	const identitiesByTypeAndVarName = new Map<
+		ParsedEntity["type"],
+		Map<string, ParsedIdentity>
+	>(
+		resourceGroups.map(([type, resources, varNames, candidate, suffix]) => [
+			type,
+			resolveExistingVarNames({
+				candidate,
+				declaredVarNames,
+				resolvedVarNames: varNames,
+				resources,
+				suffix,
+			}),
+		]),
 	);
-	const parsed = parseExistingConfig({ configPath, idsByVarName });
+	const parsed = parseExistingConfig({
+		configPath,
+		identitiesByTypeAndVarName,
+	});
 	const hasDefaultResources =
 		/\bexport\s+default\b/.test(parsed.source) &&
 		/\b(?:rewards|referralPrograms)\b/.test(parsed.source);
@@ -164,7 +265,7 @@ export async function updateConfigInPlace({
 
 	// Build lookup maps
 	const apiFeatureMap = new Map(features.map((f) => [f.id, f]));
-	const apiPlanMap = new Map(plans.map((p) => [p.id, p]));
+	const apiPlanMap = new Map(plans.map((p) => [versionedCodegenId(p), p]));
 	const apiRewardMap = new Map(
 		(rewards ?? []).map((reward) => [reward.id, reward]),
 	);
@@ -173,7 +274,9 @@ export async function updateConfigInPlace({
 	);
 	const apiVariantMap = new Map(
 		plans.flatMap((plan) =>
-			(plan.variants ?? []).map((variant) => [variant.id, variant] as const),
+			(plan.variants ?? []).map(
+				(variant) => [versionedCodegenId(variant), variant] as const,
+			),
 		),
 	);
 
@@ -185,7 +288,7 @@ export async function updateConfigInPlace({
 		if (entity.type === "feature") {
 			featureVarMap.set(entity.id, entity.varName);
 		} else if (entity.type === "variant") {
-			existingVariantVarMap.set(entity.id, entity.varName);
+			existingVariantVarMap.set(versionedCodegenId(entity), entity.varName);
 		}
 	}
 
@@ -218,11 +321,11 @@ export async function updateConfigInPlace({
 	// Resolve new plan var names, avoiding all names already in use.
 	// "New" means the plan ID is not present in any parsed entity.
 	const existingPlanIds = new Set(
-		parsed.entities.filter((e) => e.type === "plan").map((e) => e.id),
+		parsed.entities.filter((e) => e.type === "plan").map(versionedCodegenId),
 	);
 	const newPlanIds = plans
-		.filter((p) => !existingPlanIds.has(p.id))
-		.map((p) => p.id);
+		.filter((p) => !existingPlanIds.has(versionedCodegenId(p)))
+		.map(versionedCodegenId);
 
 	const newPlanVarMap = new Map<string, string>();
 	for (const id of newPlanIds) {
@@ -235,18 +338,18 @@ export async function updateConfigInPlace({
 	}
 
 	const variantVarMap = new Map<string, string>();
-	for (const id of apiVariantMap.keys()) {
-		if (existingVariantVarMap.has(id)) {
-			variantVarMap.set(id, existingVariantVarMap.get(id)!);
+	for (const key of apiVariantMap.keys()) {
+		if (existingVariantVarMap.has(key)) {
+			variantVarMap.set(key, existingVariantVarMap.get(key)!);
 			continue;
 		}
 
 		const varName = claimVarName({
-			candidate: variantIdToVarName(id),
+			candidate: variantIdToVarName(key),
 			suffix: "Variant",
 			usedNames: existingVarNames,
 		});
-		variantVarMap.set(id, varName);
+		variantVarMap.set(key, varName);
 	}
 
 	const newRewardVarMap = new Map<string, string>();
@@ -358,7 +461,8 @@ export async function updateConfigInPlace({
 					result.featuresDeleted++;
 				}
 			} else if (entity.type === "plan") {
-				const apiPlan = apiPlanMap.get(entity.id);
+				const planKey = versionedCodegenId(entity);
+				const apiPlan = apiPlanMap.get(planKey);
 				if (apiPlan) {
 					// Update existing plan
 					const newCode = generatePlanWithVariantsCode({
@@ -369,7 +473,7 @@ export async function updateConfigInPlace({
 						variantVarMap,
 					});
 					outputBlocks.push(newCode);
-					matchedPlanIds.add(entity.id);
+					matchedPlanIds.add(planKey);
 					lastPlanBlockIndex = outputBlocks.length - 1;
 					result.plansUpdated++;
 				} else {
@@ -377,7 +481,7 @@ export async function updateConfigInPlace({
 					result.plansDeleted++;
 				}
 			} else if (entity.type === "variant") {
-				if (!apiVariantMap.has(entity.id)) {
+				if (!apiVariantMap.has(versionedCodegenId(entity))) {
 					result.plansDeleted++;
 				}
 			} else if (entity.type === "reward") {
@@ -486,7 +590,9 @@ export async function updateConfigInPlace({
 	}
 
 	// Add new plans (in API but not in local config)
-	const newPlans = plans.filter((p) => !matchedPlanIds.has(p.id));
+	const newPlans = plans.filter(
+		(p) => !matchedPlanIds.has(versionedCodegenId(p)),
+	);
 	if (newPlans.length > 0) {
 		const newPlanCode = newPlans
 			.map((p) =>
@@ -494,7 +600,7 @@ export async function updateConfigInPlace({
 					featureVarMap,
 					features,
 					plan: p,
-					planVarName: newPlanVarMap.get(p.id),
+					planVarName: newPlanVarMap.get(versionedCodegenId(p)),
 					variantVarMap,
 				}),
 			)

--- a/packages/atmn/src/lib/transforms/sdkToCode/configFile.ts
+++ b/packages/atmn/src/lib/transforms/sdkToCode/configFile.ts
@@ -2,19 +2,11 @@ import type { ReferralProgram, Reward } from "../../../compose/index.js";
 import type { Feature } from "../../../compose/models/index.js";
 import type { Plan } from "../../../compose/models/variantModels.js";
 import { buildFeatureCode } from "./feature.js";
-import { resolveVarNames } from "./helpers.js";
+import { resolveVarNames, versionedCodegenId } from "./helpers.js";
 import { buildImports } from "./imports.js";
 import { buildPlanCode } from "./plan.js";
 import { buildReferralProgramCode, buildRewardCode } from "./reward.js";
 import { buildVariantCode } from "./variant.js";
-
-const versionedCodegenId = ({
-	id,
-	version,
-}: {
-	id: string;
-	version?: number;
-}) => (version === undefined ? id : `${id}-v-${version}`);
 
 /**
  * Generate complete autumn.config.ts file content

--- a/packages/atmn/src/lib/transforms/sdkToCode/helpers.ts
+++ b/packages/atmn/src/lib/transforms/sdkToCode/helpers.ts
@@ -60,6 +60,14 @@ export function variantIdToVarName(id: string): string {
 	return idToVarName(id, 'plan');
 }
 
+export const versionedCodegenId = ({
+	id,
+	version,
+}: {
+	id: string;
+	version?: number;
+}) => (version === undefined ? id : `${id}-v-${version}`);
+
 export function claimVarName({
 	candidate,
 	suffix,

--- a/packages/atmn/test/codegen/in-place-licenses.test.ts
+++ b/packages/atmn/test/codegen/in-place-licenses.test.ts
@@ -37,6 +37,12 @@ test.concurrent(
 			expect(config.indexOf("export const pro")).toBeLessThan(
 				config.indexOf("export const seats"),
 			);
+			await writeConfig({ features: [], plans, cwd });
+			expect(
+				[
+					...readFileSync(configPath, "utf8").matchAll(/export const (\w+)/g),
+				].map(([, varName]) => varName),
+			).toEqual(["pro", "seats"]);
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });
 		}

--- a/packages/atmn/test/integration/catalog/separate-reset-price-intervals.test.ts
+++ b/packages/atmn/test/integration/catalog/separate-reset-price-intervals.test.ts
@@ -1,9 +1,9 @@
-/** Verifies the built package preserves separate prepaid reset and billing intervals. */
+/** Verifies built-CLI constant IDs and separate reset/billing intervals. */
 import { expect, test } from "bun:test";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { ApiVersion, type ApiPlanV1 } from "@autumn/shared";
+import { type ApiPlanV1, ApiVersion } from "@autumn/shared";
 import chalk from "chalk";
 import { AutumnRpcCli } from "../../../../../server/src/external/autumn/autumnRpcCli.js";
 import {
@@ -15,7 +15,7 @@ import {
 const atmnPackageDir = fileURLToPath(new URL("../../../", import.meta.url));
 const builtCliPath = join(atmnPackageDir, "dist/cli.js");
 
-test(`${chalk.yellowBright("atmn built CLI: push → pull → push preserves separate intervals")}`, async () => {
+test(`${chalk.yellowBright("atmn built CLI: constant-ID push → pull → push preserves separate intervals")}`, async () => {
 	const planId = "atmn_split_cycle_scale_annual";
 	const ctx = await createCleanAtmnIntegrationContext();
 	const build = Bun.spawn(["bun", "run", "build"], {
@@ -28,10 +28,15 @@ test(`${chalk.yellowBright("atmn built CLI: push → pull → push preserves sep
 		atmnPackageDir,
 		secretKey: ctx.orgSecretKey,
 	});
+	await writeFile(
+		join(workspace.workspaceDir, "ids.ts"),
+		`export const PLAN_IDS = { SPLIT_CYCLE: '${planId}' } as const;\n`,
+	);
 
 	await writeFile(
 		workspace.configPath,
 		`import { feature, item, plan } from 'atmn';
+import { PLAN_IDS } from './ids';
 
 export const splitCycleCredits = feature({
 \tid: 'atmn_split_cycle_credits',
@@ -41,7 +46,7 @@ export const splitCycleCredits = feature({
 });
 
 export const splitCycleScaleAnnual = plan({
-\tid: '${planId}',
+\tid: PLAN_IDS.SPLIT_CYCLE,
 \tname: 'Split Cycle Scale Annual',
 \titems: [
 \t\titem({
@@ -79,13 +84,16 @@ export const splitCycleScaleAnnual = plan({
 	});
 
 	await runAtmnWorkspaceCli({
-		args: ["--force", "--no-declaration-file"],
+		args: ["--no-declaration-file"],
 		cliPath: builtCliPath,
 		command: "pull",
 		headless: true,
 		workspace,
 	});
 	const pulledConfig = await readFile(workspace.configPath, "utf8");
+	expect(
+		pulledConfig.match(/export const splitCycleScaleAnnual/g),
+	).toHaveLength(1);
 	expect(pulledConfig).toContain("reset: {");
 	expect(pulledConfig).toContain("interval: 'month'");
 	expect(pulledConfig).toContain("interval: 'year'");

--- a/packages/atmn/test/pull/config-pipeline.test.ts
+++ b/packages/atmn/test/pull/config-pipeline.test.ts
@@ -12,6 +12,11 @@ const withConfigWorkspace = async (
 ) => {
 	const cwd = mkdtempSync(join(tmpdir(), "atmn-config-pipeline-"));
 	try {
+		writeFileSync(
+			join(cwd, "builders.ts"),
+			`export const feature = value => ({ ...value, __atmnType: "feature" });
+export const plan = value => ({ ...value, __atmnType: "plan", variant: variant => ({ ...variant, __atmnType: "variant" }) });`,
+		);
 		if (config !== null) writeFileSync(join(cwd, "autumn.config.ts"), config);
 		await run(cwd);
 	} finally {
@@ -113,13 +118,18 @@ export const keepMe = "custom";
  * Existing exports must remain unique across repeated in-place rewrites. */
 test("in-place updates match exports with constant IDs", async () => {
 	await withConfigWorkspace(
-		`import { feature, plan } from "atmn";
+		`import { feature, plan } from "./builders";
 import { FEATURE_IDS, PLAN_IDS } from "./ids";
 export const employees = feature({ id: FEATURE_IDS.EMPLOYEES, name: "Employees", type: "metered", consumable: false });
 export const basePlan = plan({ id: PLAN_IDS.BASE, name: "Base Plan", items: [] });
 export const basePlanYearly = basePlan.variant({ id: PLAN_IDS.BASE_YEARLY, name: "Base Plan Yearly" });
 `,
 		async (cwd) => {
+			writeFileSync(
+				join(cwd, "ids.ts"),
+				`export const FEATURE_IDS = { EMPLOYEES: "employees" };
+export const PLAN_IDS = { BASE: "base-plan", BASE_YEARLY: "base-plan-yearly" };`,
+			);
 			const config = {
 				features: [
 					{
@@ -157,14 +167,19 @@ export const basePlanYearly = basePlan.variant({ id: PLAN_IDS.BASE_YEARLY, name:
  * The surviving plan keeps its existing suffixed variable name. */
 test("constant-ID exports survive disappearing name collisions", async () => {
 	await withConfigWorkspace(
-		`import { plan } from "atmn";
+		`import { plan } from "./builders";
 import { PLAN_IDS } from "./ids";
-export const freePlan = plan({ id: PLAN_IDS.FREE, name: "Free", items: [] });
+export const fooBar = plan({ id: PLAN_IDS.FOO_DASH, name: "Dash", items: [] });
+export const fooBarPlan = plan({ id: PLAN_IDS.FOO_UNDERSCORE, name: "Underscore", items: [] });
 `,
 		async (cwd) => {
+			writeFileSync(
+				join(cwd, "ids.ts"),
+				`export const PLAN_IDS = { FOO_DASH: "foo-bar", FOO_UNDERSCORE: "foo_bar" };`,
+			);
 			await writeConfig({
 				features: [],
-				plans: [{ id: "free", name: "Free", items: [] }],
+				plans: [{ id: "foo_bar", name: "Underscore", items: [] }],
 				cwd,
 			});
 			const source = readFileSync(join(cwd, "autumn.config.ts"), "utf8");
@@ -172,7 +187,41 @@ export const freePlan = plan({ id: PLAN_IDS.FREE, name: "Free", items: [] });
 				([, varName]) => varName,
 			);
 
-			expect(exports).toEqual(["freePlan"]);
+			expect(exports).toEqual(["fooBarPlan"]);
+			expect(source).toContain("name: 'Underscore'");
+		},
+	);
+});
+
+/** Adding a colliding resource must not rebind an existing constant-ID export.
+ * The existing resource keeps its variable name regardless of API order. */
+test("constant-ID exports survive new name collisions", async () => {
+	await withConfigWorkspace(
+		`import { plan } from "./builders";
+import { PLAN_IDS } from "./ids";
+export const fooBar = plan({ id: PLAN_IDS.FOO_DASH, name: "Dash", items: [] });
+`,
+		async (cwd) => {
+			writeFileSync(
+				join(cwd, "ids.ts"),
+				`export const PLAN_IDS = { FOO_DASH: "foo-bar" };`,
+			);
+			await writeConfig({
+				features: [],
+				plans: [
+					{ id: "foo_bar", name: "Underscore", items: [] },
+					{ id: "foo-bar", name: "Dash", items: [] },
+				],
+				cwd,
+			});
+			const source = readFileSync(join(cwd, "autumn.config.ts"), "utf8");
+
+			expect(source).toMatch(
+				/export const fooBar = plan\(\{[\s\S]*?id: 'foo-bar',[\s\S]*?name: 'Dash'/,
+			);
+			expect(source).toMatch(
+				/export const fooBarPlan = plan\(\{[\s\S]*?id: 'foo_bar',[\s\S]*?name: 'Underscore'/,
+			);
 		},
 	);
 });
@@ -181,7 +230,7 @@ export const freePlan = plan({ id: PLAN_IDS.FREE, name: "Free", items: [] });
  * In-place rewrites preserve each version exactly once. */
 test("in-place updates match versioned plans with constant IDs", async () => {
 	await withConfigWorkspace(
-		`import { plan } from "atmn";
+		`import { plan } from "./builders";
 import { PLAN_IDS } from "./ids";
 export const proV1 = plan({ id: PLAN_IDS.PRO, version: 1, name: "Pro v1", items: [] });
 export const proV2 = plan({ id: PLAN_IDS.PRO, version: 2, name: "Pro v2", items: [] });
@@ -189,6 +238,10 @@ export const proAnnualV1 = proV2.variant({ id: PLAN_IDS.PRO_ANNUAL, version: 1, 
 export const proAnnualV2 = proV2.variant({ id: PLAN_IDS.PRO_ANNUAL, version: 2, name: "Pro annual v2" });
 `,
 		async (cwd) => {
+			writeFileSync(
+				join(cwd, "ids.ts"),
+				`export const PLAN_IDS = { PRO: "pro", PRO_ANNUAL: "pro-annual" };`,
+			);
 			await writeConfig({
 				features: [],
 				plans: [
@@ -214,6 +267,33 @@ export const proAnnualV2 = proV2.variant({ id: PLAN_IDS.PRO_ANNUAL, version: 2, 
 			expect(exports).toEqual(["proV1", "proV2", "proAnnualV1", "proAnnualV2"]);
 			expect(source.match(/version: 1/g)).toHaveLength(2);
 			expect(source.match(/version: 2/g)).toHaveLength(2);
+		},
+	);
+});
+
+/** Literal version identity must not depend on property order or adjacency.
+ * Reordered versioned exports remain stable across in-place rewrites. */
+test("in-place updates parse reordered top-level versions", async () => {
+	await withConfigWorkspace(
+		`import { plan } from "./builders";
+export const legacyPro = plan({
+	version: 1,
+	name: "Pro v1",
+	id: "pro",
+	items: [],
+});
+`,
+		async (cwd) => {
+			await writeConfig({
+				features: [],
+				plans: [{ id: "pro", version: 1, name: "Pro v1", items: [] }],
+				cwd,
+			});
+			const source = readFileSync(join(cwd, "autumn.config.ts"), "utf8");
+
+			expect([...source.matchAll(/export const (\w+)/g)]).toHaveLength(1);
+			expect(source).toContain("export const legacyPro = plan({");
+			expect(source).toContain("version: 1");
 		},
 	);
 });

--- a/packages/atmn/test/pull/config-pipeline.test.ts
+++ b/packages/atmn/test/pull/config-pipeline.test.ts
@@ -153,6 +153,71 @@ export const basePlanYearly = basePlan.variant({ id: PLAN_IDS.BASE_YEARLY, name:
 	);
 });
 
+/** A removed collision must not change the identity of a constant-ID export.
+ * The surviving plan keeps its existing suffixed variable name. */
+test("constant-ID exports survive disappearing name collisions", async () => {
+	await withConfigWorkspace(
+		`import { plan } from "atmn";
+import { PLAN_IDS } from "./ids";
+export const freePlan = plan({ id: PLAN_IDS.FREE, name: "Free", items: [] });
+`,
+		async (cwd) => {
+			await writeConfig({
+				features: [],
+				plans: [{ id: "free", name: "Free", items: [] }],
+				cwd,
+			});
+			const source = readFileSync(join(cwd, "autumn.config.ts"), "utf8");
+			const exports = [...source.matchAll(/export const (\w+)/g)].map(
+				([, varName]) => varName,
+			);
+
+			expect(exports).toEqual(["freePlan"]);
+		},
+	);
+});
+
+/** Versioned constant-ID plans must use the same identity keys as full codegen.
+ * In-place rewrites preserve each version exactly once. */
+test("in-place updates match versioned plans with constant IDs", async () => {
+	await withConfigWorkspace(
+		`import { plan } from "atmn";
+import { PLAN_IDS } from "./ids";
+export const proV1 = plan({ id: PLAN_IDS.PRO, version: 1, name: "Pro v1", items: [] });
+export const proV2 = plan({ id: PLAN_IDS.PRO, version: 2, name: "Pro v2", items: [] });
+export const proAnnualV1 = proV2.variant({ id: PLAN_IDS.PRO_ANNUAL, version: 1, name: "Pro annual v1" });
+export const proAnnualV2 = proV2.variant({ id: PLAN_IDS.PRO_ANNUAL, version: 2, name: "Pro annual v2" });
+`,
+		async (cwd) => {
+			await writeConfig({
+				features: [],
+				plans: [
+					{ id: "pro", version: 1, name: "Pro v1", items: [] },
+					{
+						id: "pro",
+						version: 2,
+						name: "Pro v2",
+						items: [],
+						variants: [
+							{ id: "pro-annual", version: 1, name: "Pro annual v1" },
+							{ id: "pro-annual", version: 2, name: "Pro annual v2" },
+						],
+					},
+				],
+				cwd,
+			});
+			const source = readFileSync(join(cwd, "autumn.config.ts"), "utf8");
+			const exports = [...source.matchAll(/export const (\w+)/g)].map(
+				([, varName]) => varName,
+			);
+
+			expect(exports).toEqual(["proV1", "proV2", "proAnnualV1", "proAnnualV2"]);
+			expect(source.match(/version: 1/g)).toHaveLength(2);
+			expect(source.match(/version: 2/g)).toHaveLength(2);
+		},
+	);
+});
+
 test("merges default and named exports without duplicating aliases", async () => {
 	await withConfigWorkspace(
 		`const credits = { id: "credits", name: "Credits", type: "metered", consumable: true };

--- a/packages/atmn/test/pull/config-pipeline.test.ts
+++ b/packages/atmn/test/pull/config-pipeline.test.ts
@@ -109,6 +109,50 @@ export const keepMe = "custom";
 	});
 });
 
+/** Previously, constant IDs were unmatched and rewrites appended suffixed declarations.
+ * Existing exports must remain unique across repeated in-place rewrites. */
+test("in-place updates match exports with constant IDs", async () => {
+	await withConfigWorkspace(
+		`import { feature, plan } from "atmn";
+import { FEATURE_IDS, PLAN_IDS } from "./ids";
+export const employees = feature({ id: FEATURE_IDS.EMPLOYEES, name: "Employees", type: "metered", consumable: false });
+export const basePlan = plan({ id: PLAN_IDS.BASE, name: "Base Plan", items: [] });
+export const basePlanYearly = basePlan.variant({ id: PLAN_IDS.BASE_YEARLY, name: "Base Plan Yearly" });
+`,
+		async (cwd) => {
+			const config = {
+				features: [
+					{
+						id: "employees",
+						name: "Employees",
+						type: "metered" as const,
+						consumable: false,
+					},
+				],
+				plans: [
+					{
+						id: "base-plan",
+						name: "Base Plan",
+						items: [],
+						variants: [{ id: "base-plan-yearly", name: "Base Plan Yearly" }],
+					},
+				],
+			};
+
+			await writeConfig({ ...config, cwd });
+			const firstPull = readFileSync(join(cwd, "autumn.config.ts"), "utf8");
+			await writeConfig({ ...config, cwd });
+			const secondPull = readFileSync(join(cwd, "autumn.config.ts"), "utf8");
+			const exports = [...secondPull.matchAll(/export const (\w+)/g)].map(
+				([, varName]) => varName,
+			);
+
+			expect(exports).toEqual(["employees", "basePlan", "basePlanYearly"]);
+			expect(secondPull).toBe(firstPull);
+		},
+	);
+});
+
 test("merges default and named exports without duplicating aliases", async () => {
 	await withConfigWorkspace(
 		`const credits = { id: "credits", name: "Credits", type: "metered", consumable: true };

--- a/packages/atmn/test/pull/config-pipeline.test.ts
+++ b/packages/atmn/test/pull/config-pipeline.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { writeConfig } from "../../src/commands/pull/writeConfig.js";
 import { referralProgram, reward } from "../../src/compose/index.js";
 import { loadConfig } from "../../src/lib/config/loadConfig.js";
@@ -14,8 +15,9 @@ const withConfigWorkspace = async (
 	try {
 		writeFileSync(
 			join(cwd, "builders.ts"),
-			`export const feature = value => ({ ...value, __atmnType: "feature" });
-export const plan = value => ({ ...value, __atmnType: "plan", variant: variant => ({ ...variant, __atmnType: "variant" }) });`,
+			`export { feature, plan } from ${JSON.stringify(
+				pathToFileURL(join(import.meta.dir, "../../src/compose/index.ts")).href,
+			)};`,
 		);
 		if (config !== null) writeFileSync(join(cwd, "autumn.config.ts"), config);
 		await run(cwd);
@@ -69,6 +71,28 @@ test("in-place pull rejects default-export resources without changing source", a
 			}),
 		).rejects.toThrow("must be named reward() and referralProgram() exports");
 		expect(readFileSync(join(cwd, "autumn.config.ts"), "utf8")).toBe(source);
+	});
+});
+
+test("default-export resources are rejected before constant IDs execute", async () => {
+	const source = `throw new Error("must not execute");
+export const basePlan = plan({ id: PLAN_IDS.BASE, name: "Base", items: [] });
+export default { rewards: [] };`;
+	await withConfigWorkspace(source, async (cwd) => {
+		await expect(
+			writeConfig({ features: [], plans: [], cwd, rewards: [] }),
+		).rejects.toThrow("must be named reward() and referralProgram() exports");
+		expect(readFileSync(join(cwd, "autumn.config.ts"), "utf8")).toBe(source);
+	});
+});
+
+test("entity-shaped helper exports do not trigger config execution", async () => {
+	const source = `export const buildPlanShape = () => ({ id: PLAN_IDS.BASE, items: [] });`;
+	await withConfigWorkspace(source, async (cwd) => {
+		await writeConfig({ features: [], plans: [], cwd });
+		expect(readFileSync(join(cwd, "autumn.config.ts"), "utf8")).toContain(
+			source,
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary
- resolve constant-based config IDs through their generated variable names
- prevent in-place pull/push rewrites from appending suffixed duplicate declarations
- add an idempotent repeated-rewrite regression test for a base plan and variant

## Testing
- `bun test test/codegen test/pull/config-pipeline.test.ts test/pull/reward-transform.test.ts test/pull/mergeEnvironments.test.ts`
- `bun run ts` in `packages/atmn`
- `bunx tsgo --build --noEmit` in `server`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes in-place config rewrites to preserve constant-based and versioned IDs without duplicating exports. Resolves IDs from exports only when needed and rejects default-export resources before any execution.

- **Bug Fixes**
  - Use `loadConfigModule` only when blocks require runtime identity; map named exports to `{ id, version }` and re-parse to match resources in place.
  - Reject default-export `reward`/`referralProgram` before executing and skip execution for helper exports or features-only default exports.
  - Use version-aware keys via `versionedCodegenId` for plans and variants, including when matching existing variant exports.
  - Preserve existing suffixed names when collisions change; prevent duplicates; maintain license ordering; add regression tests for constant IDs, versioned plans/variants, reordered `version` fields, non-execution guards, and built-CLI constant-ID push → pull → push.

<sup>Written for commit 6f8fc1c5ca87067ceb07a5494dceb32f530437e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes in-place config rewrites so constant-based and versioned resource IDs retain their existing export names across repeated pulls.

- **[Bug fixes]** Resolves constant IDs from runtime exports before matching existing plans, variants, and other resources.
- **[Bug fixes, Improvements]** Uses version-aware identity keys and preserves historical collision suffixes when colliding resources appear or disappear.
- **[Improvements]** Adds regression coverage for repeated rewrites, collision changes, versioned resources, reordered fields, and built-CLI round trips.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported collision-suffix identity issue is addressed by resolving existing declarations through their runtime export names, and regression tests establish that historical names remain stable when collisions disappear or appear.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts | Adds runtime-backed identity parsing while retaining literal-ID and version extraction for managed exports. |
| packages/atmn/src/lib/transforms/inPlaceUpdate/updateConfig.ts | Re-parses constant-ID declarations using loaded exports and consistently matches plans and variants by versioned identity. |
| packages/atmn/src/lib/config/loadConfig.ts | Exposes the config-module loader for identity resolution without changing the normal loaded-config contract. |
| packages/atmn/src/lib/transforms/sdkToCode/helpers.ts | Centralizes the version-aware code-generation identity helper for full and in-place generation. |
| packages/atmn/test/pull/config-pipeline.test.ts | Covers constant IDs, changing name collisions, versioned plans and variants, reordered properties, and idempotent rewrites. |

<sub>Reviews (4): Last reviewed commit: ["fix: 🐛 guard config identity loading"](https://github.com/useautumn/autumn/commit/6f8fc1c5ca87067ceb07a5494dceb32f530437e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52519991)</sub>

**Context used:**

- Knowledge Base — [`atmn` Catalog Configuration CLI](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/atmn-cli.md)

<!-- /greptile_comment -->