### PR TITLE
Fix invoicing backdated multi-attach

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/errors/handleStartDateErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleStartDateErrors.ts
@@ -5,6 +5,7 @@ import {
 	isFutureStartDate,
 	isPastStartDate,
 	isProductPaidAndRecurring,
+	PAST_START_REQUIRES_INVOICE,
 	RecaseError,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
@@ -50,8 +51,7 @@ export const handleStartDateErrors = ({
 		// backdating) or Stripe Checkout (doesn't), so only block checkout on execute.
 		if (!preview && billingContext.checkoutMode === "stripe_checkout") {
 			throw new RecaseError({
-				message:
-					"Past starts_at cannot be used when Stripe Checkout is required.",
+				message: PAST_START_REQUIRES_INVOICE,
 				code: ErrCode.InvalidRequest,
 				statusCode: StatusCodes.BAD_REQUEST,
 			});

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachStartDateErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachStartDateErrors.ts
@@ -3,6 +3,7 @@ import {
 	isFutureStartDate,
 	isOneOffProduct,
 	isProductPaidAndRecurring,
+	PAST_START_REQUIRES_INVOICE,
 	type MultiAttachBillingContext,
 	type MultiAttachParamsV0,
 	RecaseError,
@@ -41,15 +42,6 @@ export const handleMultiAttachStartDateErrors = ({
 
 	assertNoBackdateWithExistingSubscription({ billingContext });
 
-	if (billingContext.checkoutMode === "stripe_checkout") {
-		throw new RecaseError({
-			message:
-				"Past starts_at cannot be used when Stripe Checkout is required.",
-			code: ErrCode.InvalidRequest,
-			statusCode: 400,
-		});
-	}
-
 	if (billingContext.trialContext?.trialEndsAt) {
 		throw new RecaseError({
 			message: "Past starts_at cannot be used together with a free trial.",
@@ -62,5 +54,25 @@ export const handleMultiAttachStartDateErrors = ({
 		products: billingContext.fullProducts,
 		startsAt: params.starts_at,
 		currentEpochMs: billingContext.currentEpochMs,
+	});
+};
+
+export const handleMultiAttachBackdateCheckoutError = ({
+	billingContext,
+	params,
+}: {
+	billingContext: MultiAttachBillingContext;
+	params: MultiAttachParamsV0;
+}) => {
+	if (
+		params.starts_at === undefined ||
+		billingContext.checkoutMode !== "stripe_checkout"
+	)
+		return;
+
+	throw new RecaseError({
+		message: PAST_START_REQUIRES_INVOICE,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
 	});
 };

--- a/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts
@@ -20,6 +20,7 @@ import {
 	handleMultiAttachBillingPlanErrors,
 	handleMultiAttachErrors,
 } from "./errors/handleMultiAttachErrors";
+import { handleMultiAttachBackdateCheckoutError } from "./errors/handleMultiAttachStartDateErrors";
 import { logMultiAttachContext } from "./logs/logMultiAttachContext";
 import { setupMultiAttachBillingContext } from "./setup/setupMultiAttachBillingContext";
 
@@ -86,6 +87,7 @@ export async function multiAttach({
 	};
 
 	handleMultiAttachBillingPlanErrors({ ctx, billingContext, billingPlan });
+	handleMultiAttachBackdateCheckoutError({ billingContext, params });
 
 	if (preview) {
 		const previewBillingPlan = await computeAttachPreviewBillingPlan({

--- a/server/tests/integration/billing/multi-attach/multi-attach-backdate.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-backdate.test.ts
@@ -21,7 +21,7 @@ import { getCustomerProduct } from "../attach/params/start-date/utils";
 test.concurrent(
 	`${chalk.yellowBright("multi-attach backdate: shared starts_at backdates every plan")}`,
 	async () => {
-		const customerId = "multi-attach-backdate";
+		const customerId = "multi-attach-backdate-invoice";
 		const plan = products.pro({
 			id: "plan",
 			items: [items.monthlyMessages({ includedUsage: 100 })],
@@ -81,7 +81,7 @@ test.concurrent(
 test.concurrent(
 	`${chalk.yellowBright("multi-attach backdate: preview and execution reject Stripe Checkout")}`,
 	async () => {
-		const customerId = "multi-attach-backdate-checkout";
+		const customerId = "multi-attach-backdate-validation-order";
 		const plan = products.pro({
 			id: "plan",
 			items: [items.monthlyMessages({ includedUsage: 100 })],
@@ -105,7 +105,6 @@ test.concurrent(
 			errMessage:
 				"Past starts_at cannot be used when Stripe Checkout is required",
 		};
-
 		await expectAutumnError({
 			...expectedError,
 			func: () => autumnV2_2.billing.previewMultiAttach(params),

--- a/server/tests/unit/billing/attach/handle-start-date-errors.spec.ts
+++ b/server/tests/unit/billing/attach/handle-start-date-errors.spec.ts
@@ -4,10 +4,16 @@ import {
 	type AttachParamsV1,
 	addInterval,
 	BillingInterval,
+	type MultiAttachBillingContext,
+	type MultiAttachParamsV0,
 } from "@autumn/shared";
 import { prices } from "@tests/utils/fixtures/db/prices";
 import { products } from "@tests/utils/fixtures/db/products";
 import { handleStartDateErrors } from "@/internal/billing/v2/actions/attach/errors/handleStartDateErrors";
+import {
+	handleMultiAttachBackdateCheckoutError,
+	handleMultiAttachStartDateErrors,
+} from "@/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachStartDateErrors";
 import { STRIPE_BACKDATE_INVOICE_LINE_ITEM_LIMIT } from "@/internal/billing/v2/utils/backdate/countBackdatedPeriods";
 
 const startsAt = Date.UTC(2026, 0, 1);
@@ -109,4 +115,23 @@ describe("handleStartDateErrors", () => {
 			}),
 		).not.toThrow();
 	});
+});
+
+test("multi-attach surfaces non-recoverable backdate errors before checkout", () => {
+	const billingContext = {
+		currentEpochMs: dateAfterMonthlyCycles(
+			STRIPE_BACKDATE_INVOICE_LINE_ITEM_LIMIT + 1,
+		),
+		fullProducts: [
+			products.createFull({ prices: [prices.createFixed({ id: "price" })] }),
+		],
+		checkoutMode: "stripe_checkout",
+		trialContext: null,
+	} as unknown as MultiAttachBillingContext;
+	const params = { starts_at: startsAt } as MultiAttachParamsV0;
+
+	expect(() => {
+		handleMultiAttachStartDateErrors({ billingContext, params });
+		handleMultiAttachBackdateCheckoutError({ billingContext, params });
+	}).toThrow("at most 250 line items");
 });

--- a/shared/enums/AttachErrCode.ts
+++ b/shared/enums/AttachErrCode.ts
@@ -2,3 +2,6 @@ export enum AttachErrCode {
 	// InvalidOptions = "invalid_options",
 	ProductAlreadyAttached = "product_already_attached",
 }
+
+export const PAST_START_REQUIRES_INVOICE =
+	"Past starts_at cannot be used when Stripe Checkout is required.";

--- a/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx
@@ -1,8 +1,12 @@
 import { Button } from "@autumn/ui";
 import { DisabledTooltipButton } from "@/components/forms/shared";
 import { BillingFooter } from "@/components/forms/shared/BillingFooter";
-import { getInvoiceButtonState } from "@/components/forms/shared/utils/invoiceButtonState";
+import {
+	getInvoiceButtonState,
+	shouldDisableInvoiceButton,
+} from "@/components/forms/shared/utils/invoiceButtonState";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { getBackendErr } from "@/utils/genUtils";
 import { useAttachFormContext } from "../context/AttachFormProvider";
 import { isFutureStartDate } from "../utils/buildAttachPreviewTotals";
 import { getAttachConfirmLabel } from "../utils/getAttachConfirmLabel";
@@ -23,7 +27,10 @@ export function AttachFooterV3() {
 	const { isEndOfCycleSelected, createsRecurringSubscription } = billingOptions;
 
 	const previewData = previewQuery.data;
-	const previewFailed = !!previewQuery.error;
+	const previewError = previewQuery.error
+		? getBackendErr(previewQuery.error, "Failed to load preview")
+		: undefined;
+	const previewFailed = !!previewError;
 	const isMultiPlan = additionalPlans.isMultiPlan;
 	const startDate = isMultiPlan ? null : formValues.startDate;
 	const hasFutureStartDate = isFutureStartDate(startDate);
@@ -32,6 +39,7 @@ export function AttachFooterV3() {
 	const { isInvoiceOnlyStart, label, zeroAmountReason } = getInvoiceButtonState(
 		{
 			preview: previewData,
+			previewFailed,
 			createsRecurringSubscription,
 			trialEnabled: formValues.trialEnabled === true,
 		},
@@ -64,7 +72,7 @@ export function AttachFooterV3() {
 			<DisabledTooltipButton
 				variant="secondary"
 				className="w-full"
-				disabled={previewFailed || isPending}
+				disabled={shouldDisableInvoiceButton({ isPending, previewError })}
 				disabledReason={invoiceDisabledReason}
 				tooltipClassName="max-w-(--anchor-width)"
 				isLoading={isInvoiceOnlyStart && isPending}

--- a/vite/src/components/forms/shared/utils/invoiceButtonState.ts
+++ b/vite/src/components/forms/shared/utils/invoiceButtonState.ts
@@ -1,5 +1,16 @@
+import { PAST_START_REQUIRES_INVOICE } from "@autumn/shared";
+
 const ZERO_AMOUNT_REASON =
 	"Cannot send an invoice for $0 amounts. Please confirm the change instead.";
+
+export const shouldDisableInvoiceButton = ({
+	isPending,
+	previewError,
+}: {
+	isPending: boolean;
+	previewError?: string;
+}) =>
+	isPending || (!!previewError && previewError !== PAST_START_REQUIRES_INVOICE);
 
 type InvoicePreview = {
 	total: number;
@@ -12,13 +23,17 @@ type InvoicePreview = {
  */
 export function getInvoiceButtonState({
 	preview,
+	previewFailed = false,
 	createsRecurringSubscription,
 	trialEnabled = false,
 }: {
 	preview: InvoicePreview | undefined;
+	previewFailed?: boolean;
 	createsRecurringSubscription: boolean;
 	trialEnabled?: boolean;
 }) {
+	if (previewFailed) preview = undefined;
+
 	const hasNothingToInvoice =
 		!!preview && preview.total <= 0 && !createsRecurringSubscription;
 

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -50,6 +50,7 @@ const baseParams: Omit<
 	carryOverUsages: false,
 	carryOverUsageFeatureIds: [],
 	customLineItems: [],
+	removePlanIds: [],
 	disableProration: false,
 	enablePlanImmediately: false,
 	currency: null,

--- a/vite/tests/components/forms/shared/utils/invoice-button-state.test.ts
+++ b/vite/tests/components/forms/shared/utils/invoice-button-state.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { PAST_START_REQUIRES_INVOICE } from "@autumn/shared";
+import {
+	getInvoiceButtonState,
+	shouldDisableInvoiceButton,
+} from "@/components/forms/shared/utils/invoiceButtonState";
+
+test("allows invoice mode when it resolves the failed preview", () => {
+	expect(
+		shouldDisableInvoiceButton({
+			isPending: false,
+			previewError: PAST_START_REQUIRES_INVOICE,
+		}),
+	).toBe(false);
+});
+
+test("disables other preview failures and pending requests", () => {
+	expect(
+		shouldDisableInvoiceButton({
+			isPending: false,
+			previewError: "Past starts_at is too far in the past.",
+		}),
+	).toBe(true);
+	expect(shouldDisableInvoiceButton({ isPending: true })).toBe(true);
+});
+
+test("ignores a retained zero-dollar preview after the current preview fails", () => {
+	expect(
+		getInvoiceButtonState({
+			preview: { total: 0 },
+			previewFailed: true,
+			createsRecurringSubscription: true,
+		}).isInvoiceOnlyStart,
+	).toBe(false);
+});


### PR DESCRIPTION
## Summary

- keep Send an Invoice enabled when invoice mode resolves the Stripe Checkout backdate error
- ignore retained preview totals when the current preview failed
- emit the recoverable checkout error only after other multi-attach validations pass
- share the checkout error message between backend and frontend

## Validation

- focused UI regressions red/green: 3 pass, 0 fail
- full Vite suite: 423 pass, 0 fail
- multi-attach backdate integration: 2 pass, 0 fail
- start-date validation unit suite: 6 pass, 0 fail
- Vite and server typechecks pass

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes backdated multi-plan invoicing by distinguishing the recoverable Stripe Checkout error from other preview failures and preventing retained preview data from selecting the wrong action.

- **Bug fixes:** Moves the multi-attach Stripe Checkout rejection after other backdate validation so more specific validation errors remain visible.
- **Bug fixes:** Keeps “Send an Invoice” available when invoice mode resolves the current preview failure.
- **Bug fixes:** Ignores retained preview totals after a failed request, preventing an old zero-dollar preview from immediately executing the current attachment.
- **Improvements:** Adds focused backend and frontend regression coverage for validation ordering, button state, and retained preview data.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported stale-preview action selection is prevented by excluding retained preview totals whenever the current preview fails.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachStartDateErrors.ts | Separates the Stripe Checkout incompatibility from general start-date validation so specific backdate errors take precedence. |
| server/src/internal/billing/v2/actions/multiAttach/multiAttach.ts | Applies the recoverable checkout-mode error after billing-plan validation and before preview computation. |
| shared/enums/AttachErrCode.ts | Defines a shared error message used consistently by the backend and frontend. |
| vite/src/components/forms/attach-v2/components/AttachFooterV3.tsx | Uses the current preview failure when selecting and disabling invoice actions. |
| vite/src/components/forms/shared/utils/invoiceButtonState.ts | Allows the invoice-required error while rejecting other failures and excludes stale preview totals after failed requests. |
| vite/tests/components/forms/shared/utils/invoice-button-state.test.ts | Covers the recoverable error, ordinary failures, pending requests, and retained zero-dollar preview regression. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Request backdated multi-plan preview] --> B{Backdate validation succeeds?}
  B -- No --> C[Return specific validation error]
  B -- Yes --> D{Stripe Checkout required?}
  D -- No --> E[Return invoice preview]
  D -- Yes --> F[Return invoice-required error]
  F --> G[Discard retained preview totals]
  G --> H[Enable Send an Invoice]
  H --> I[Open invoice review sheet]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: allow invoicing backdated multi-att..."](https://github.com/useautumn/autumn/commit/e2f744f4e335db68ec5ed2f0b833c028e5f8402e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52538130)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->