### PR TITLE
Show customer identity in delete title

### DIFF
--- a/vite/src/views/customers/customer/components/DeleteCustomerDialog.tsx
+++ b/vite/src/views/customers/customer/components/DeleteCustomerDialog.tsx
@@ -78,16 +78,11 @@ export const DeleteCustomerDialog = ({
 			>
 				<DialogHeader>
 					<DialogTitle>
-						Delete customer {customer.name || customer.email || customer.id}
+						Delete customer {customer.name ?? customer.email ?? customer.id}
 					</DialogTitle>
 				</DialogHeader>
 
 				<div className="mb-2 text-sm">
-					<div className="mb-3 rounded-md border border-border bg-muted/50 p-3 font-semibold">
-						<div>Name: {customer.name || "Not provided"}</div>
-						<div>Email: {customer.email || "Not provided"}</div>
-						<div>ID: {customer.id || customer.internal_id}</div>
-					</div>
 					<p className="text-muted-foreground">
 						Are you sure you want to delete this customer in Autumn? This action
 						cannot be undone. Select whether to delete this customer in Stripe

--- a/vite/src/views/customers/customer/components/DeleteCustomerDialog.tsx
+++ b/vite/src/views/customers/customer/components/DeleteCustomerDialog.tsx
@@ -81,6 +81,11 @@ export const DeleteCustomerDialog = ({
 				</DialogHeader>
 
 				<div className="mb-2 text-sm">
+					<div className="mb-3 rounded-md border border-border bg-muted/50 p-3 font-semibold">
+						<div>Name: {customer.name || "Not provided"}</div>
+						<div>Email: {customer.email || "Not provided"}</div>
+						<div>ID: {customer.id || customer.internal_id}</div>
+					</div>
 					<p className="text-muted-foreground">
 						Are you sure you want to delete this customer in Autumn? This action
 						cannot be undone. Select whether to delete this customer in Stripe

--- a/vite/src/views/customers/customer/components/DeleteCustomerDialog.tsx
+++ b/vite/src/views/customers/customer/components/DeleteCustomerDialog.tsx
@@ -77,7 +77,9 @@ export const DeleteCustomerDialog = ({
 				onClick={(e) => e.stopPropagation()}
 			>
 				<DialogHeader>
-					<DialogTitle>Delete Customer</DialogTitle>
+					<DialogTitle>
+						Delete customer {customer.name || customer.email || customer.id}
+					</DialogTitle>
 				</DialogHeader>
 
 				<div className="mb-2 text-sm">


### PR DESCRIPTION
Simplifies the delete-customer confirmation title to show the selected customer directly:

`Delete customer ${name ?? email ?? id}`

Removes the extra identity panel and keeps the existing confirmation copy and actions unchanged.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The delete confirmation dialog now identifies the selected customer directly in its title.
- **Improvements:** Displays the customer's name, email, or ID in the delete-dialog title.
- **Improvements:** Removes the generic “Delete Customer” title while leaving the confirmation copy and actions unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/components/DeleteCustomerDialog.tsx | Updates the delete-dialog title to include the selected customer's identity; no eligible follow-up issue was identified. |

<sub>Reviews (2): Last reviewed commit: ["Simplify delete customer title"](https://github.com/useautumn/autumn/commit/fb4887add72c8600654e6699d1674a5495663237) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52538489)</sub>

<!-- /greptile_comment -->