### PR TITLE
Allow no-billing changes without Stripe

### DIFF
--- a/server/src/cron/resetCron/getStripeSubscriptionAnchor.ts
+++ b/server/src/cron/resetCron/getStripeSubscriptionAnchor.ts
@@ -49,11 +49,6 @@ export const getStripeSubscriptionAnchor = async ({
 		id: cusEnt.customer_product_id ?? "",
 	});
 
-	// Get org and env
-	const env = cusProduct.product.env as AppEnv;
-	const org = cusProduct.product.org as Organization;
-
-	const stripeCli = createStripeCli({ org, env });
 	if (
 		!cusProduct.subscription_ids ||
 		cusProduct.subscription_ids.length === 0
@@ -61,6 +56,9 @@ export const getStripeSubscriptionAnchor = async ({
 		return nextResetAt;
 	}
 
+	const env = cusProduct.product.env as AppEnv;
+	const org = cusProduct.product.org as Organization;
+	const stripeCli = createStripeCli({ org, env });
 	const subId = cusProduct.subscription_ids[0];
 	const sub = await stripeCli.subscriptions.retrieve(subId);
 

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts
@@ -11,7 +11,7 @@ import { carryOverUsagesToExistingUsagesConfig } from "@/internal/billing/v2/uti
 import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
 
 type NewCustomerProductParams = Partial<
-	Pick<AttachParamsV1, "carry_over_usages" | "ends_at">
+	Pick<AttachParamsV1, "carry_over_usages" | "ends_at" | "no_billing_changes">
 >;
 
 const getScheduledBillingCycleAnchorResetAt = ({
@@ -118,6 +118,9 @@ export const computeAttachNewCustomerProduct = ({
 
 	const isRevertTrial =
 		trialContext?.onEnd === "revert" && planTiming === "immediate";
+	const preservedBillingLinkage = params.no_billing_changes
+		? currentCustomerProduct
+		: undefined;
 
 	const newFullCustomerProduct = initFullCustomerProduct({
 		ctx,
@@ -138,8 +141,11 @@ export const computeAttachNewCustomerProduct = ({
 		},
 		initOptions: {
 			isCustom,
-			subscriptionId: stripeSubscription?.id,
-			subscriptionScheduleId: stripeSubscriptionSchedule?.id,
+			subscriptionId:
+				stripeSubscription?.id ?? preservedBillingLinkage?.subscription_ids?.[0],
+			subscriptionScheduleId:
+				stripeSubscriptionSchedule?.id ??
+				preservedBillingLinkage?.scheduled_ids?.[0],
 			startsAt,
 			endedAt: params.ends_at,
 			accessStartsAt,

--- a/server/src/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors.ts
+++ b/server/src/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors.ts
@@ -14,6 +14,7 @@ export const handleCurrentCustomerProductErrors = ({
 		currentCustomerProduct,
 		attachProduct,
 		stripeSubscription,
+		skipBillingChanges,
 		skipExternalPSPGuard,
 		canceledStripeSubscriptionId,
 	} = billingContext;
@@ -34,6 +35,7 @@ export const handleCurrentCustomerProductErrors = ({
 	// on `cusProductToProcessorType`. A subscription that is linked but canceled
 	// is explained linkage, not broken linkage, so it passes too.
 	if (
+		!skipBillingChanges &&
 		!skipExternalPSPGuard &&
 		!canceledStripeSubscriptionId &&
 		isCustomerProductPaid(currentCustomerProduct) &&

--- a/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
+++ b/server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts
@@ -13,6 +13,7 @@ import { all } from "better-all";
 import type Stripe from "stripe";
 import { stripeSubscriptionToScheduleId } from "@/external/stripe/subscriptions/utils/convertStripeSubscription";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { isStripeConnected } from "@/internal/orgs/orgUtils";
 import { fetchStripeCustomerForBilling } from "./fetchStripeCustomerForBilling";
 import { fetchStripeDiscountsForBilling } from "./fetchStripeDiscountsForBilling";
 import {
@@ -60,7 +61,13 @@ export const setupStripeBillingContext = async ({
 
 	if (stripeBillingContext) return stripeBillingContext;
 
-	if (skipBillingFetching) {
+	if (
+		skipBillingFetching ||
+		(params &&
+			"no_billing_changes" in params &&
+			params.no_billing_changes === true &&
+			!isStripeConnected({ org: ctx.org, env: ctx.env }))
+	) {
 		return {
 			stripeSubscription: undefined,
 			stripeSubscriptionSchedule: undefined,

--- a/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
+++ b/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, expect, mock, test } from "bun:test";
 import {
 	AppEnv,
 	EntInterval,
@@ -19,21 +19,26 @@ const JULY_31_2026 = Date.UTC(2026, 6, 31, 15, 13, 9);
 
 const realDateNow = Date.now;
 let stripeBillingCycleAnchor = MAY_31_2026;
+let stripeCliCalls = 0;
+let stripeSubscriptionIds = ["sub_month_end"];
 
 mock.module("@/external/connect/createStripeCli.js", () => ({
-	createStripeCli: () => ({
-		subscriptions: {
-			retrieve: async () => ({
-				billing_cycle_anchor: Math.floor(stripeBillingCycleAnchor / 1000),
-			}),
-		},
-	}),
+	createStripeCli: () => {
+		stripeCliCalls++;
+		return {
+			subscriptions: {
+				retrieve: async () => ({
+					billing_cycle_anchor: Math.floor(stripeBillingCycleAnchor / 1000),
+				}),
+			},
+		};
+	},
 }));
 
 mock.module("@/internal/customers/cusProducts/CusProductService", () => ({
 	CusProductService: {
 		getByIdForReset: async () => ({
-			subscription_ids: ["sub_month_end"],
+			subscription_ids: stripeSubscriptionIds,
 			product: {
 				env: AppEnv.Sandbox,
 				org: { id: "org_month_end" },
@@ -59,6 +64,11 @@ const monthEndCusEnt = {
 
 afterAll(() => {
 	Date.now = realDateNow;
+});
+
+afterEach(() => {
+	stripeCliCalls = 0;
+	stripeSubscriptionIds = ["sub_month_end"];
 });
 
 test(
@@ -169,5 +179,22 @@ test(
 		});
 
 		expect(nextResetAt).toBe(JUNE_30_2026);
+	},
+);
+
+test(
+	`${chalk.yellowBright("month-end reset cron: free plan does not require Stripe")}`,
+	async () => {
+		stripeSubscriptionIds = [];
+
+		const nextResetAt = await getStripeSubscriptionAnchor({
+			db: null as never,
+			cusEnt: monthEndCusEnt,
+			curResetAt: MAY_31_2026,
+			nextResetAt: JUNE_30_2026,
+		});
+
+		expect(nextResetAt).toBe(JUNE_30_2026);
+		expect(stripeCliCalls).toBe(0);
 	},
 );

--- a/server/tests/integration/billing/attach/params/no-billing-changes.test.ts
+++ b/server/tests/integration/billing/attach/params/no-billing-changes.test.ts
@@ -1,18 +1,111 @@
 import { expect, test } from "bun:test";
-import type {
-	ApiCustomerV3,
-	AttachParamsV0Input,
-	AttachParamsV1Input,
-} from "@autumn/shared";
+import type { ApiCustomerV3, AttachParamsV0Input } from "@autumn/shared";
 import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
 import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
 import { expectNoStripeSubscription } from "@tests/integration/billing/utils/expectNoStripeSubscription";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
 import { products } from "@tests/utils/fixtures/products";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
+import { billingActions } from "@/internal/billing/v2/actions";
 import { CusService } from "@/internal/customers/CusService";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+
+const withoutStripe = (ctx: TestContext): TestContext => ({
+	...ctx,
+	org: {
+		...ctx.org,
+		stripe_connected: false,
+		stripe_config: null,
+		test_stripe_connect: {},
+	},
+});
+
+/**
+ * Regression: a free plan attach with no_billing_changes should not require
+ * the organization to have a Stripe account connected.
+ */
+test.concurrent(
+	`${chalk.yellowBright("no_billing_changes: attaches a free plan without a Stripe connection")}`,
+	async () => {
+		const customerId = "no-billing-changes-free-plan-unlinked-org";
+		const pro = products.base({
+			id: "pro-free-unlinked-org",
+			items: [items.monthlyCredits({ includedUsage: 100 })],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [pro] })],
+			actions: [],
+		});
+
+		await billingActions.attach({
+			ctx: withoutStripe(ctx),
+			params: {
+				customer_id: customerId,
+				plan_id: pro.id,
+				no_billing_changes: true,
+				redirect_mode: "never",
+				enable_plan_immediately: true,
+			},
+		});
+		await deleteCachedFullCustomer({ ctx, customerId });
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({ customer, active: [pro.id] });
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Credits,
+			balance: 100,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("no_billing_changes: transitions priced plans without a Stripe connection")}`,
+	async () => {
+		const customerId = "no-billing-changes-priced-transition";
+		const pro = products.pro({ id: "pro-unlinked-priced", items: [] });
+		const premium = products.premium({
+			id: "premium-unlinked-priced",
+			items: [],
+		});
+
+		const { autumnV1, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+		const noStripeCtx = withoutStripe(ctx);
+
+		for (const plan of [pro, premium]) {
+			await billingActions.attach({
+				ctx: noStripeCtx,
+				params: {
+					customer_id: customerId,
+					plan_id: plan.id,
+					no_billing_changes: true,
+					redirect_mode: "never",
+				},
+			});
+			await deleteCachedFullCustomer({ ctx, customerId });
+		}
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectCustomerProducts({
+			customer,
+			active: [premium.id],
+			notPresent: [pro.id],
+		});
+	},
+);
 
 test.concurrent(`${chalk.yellowBright("no_billing_changes: attach with no_billing_changes does not create stripe customer")}`, async () => {
 	const customerId = "no-billing-changes-no-stripe";
@@ -79,15 +172,10 @@ test.concurrent(`${chalk.yellowBright("no_billing_changes: attach with no_billin
 });
 
 /**
- * Regression: attaching with no_billing_changes:true on a customer whose
- * current paid product is linked to a Stripe subscription used to fail with
- * "paid but no stripe subscription is linked to it", because skipBillingFetching
- * short-circuited setupStripeBillingContext and the guard read the (undefined)
- * runtime-fetched stripeSubscription. Fix decouples no_billing_changes from
- * skipBillingFetching: writes are still suppressed, but the sub is read so its
- * id carries over to the new cusProduct.
+ * Regression: a no-write transition after disconnecting Stripe must retain the
+ * existing subscription and schedule linkage stored in Autumn.
  */
-test.concurrent(`${chalk.yellowBright("no_billing_changes: carries subscription_ids forward when current paid product is linked")}`, async () => {
+test.concurrent(`${chalk.yellowBright("no_billing_changes: carries billing linkage forward after Stripe disconnect")}`, async () => {
 	const customerId = "no-billing-changes-paid-current";
 
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
@@ -100,7 +188,7 @@ test.concurrent(`${chalk.yellowBright("no_billing_changes: carries subscription_
 		items: [items.monthlyMessages({ includedUsage: 500 })],
 	});
 
-	const { autumnV1, autumnV2_2, ctx } = await initScenario({
+	const { autumnV1, ctx } = await initScenario({
 		customerId,
 		setup: [
 			s.customer({ testClock: true, paymentMethod: "success" }),
@@ -118,12 +206,24 @@ test.concurrent(`${chalk.yellowBright("no_billing_changes: carries subscription_
 	);
 	const expectedSubscriptionIds = beforeProCusProduct?.subscription_ids ?? [];
 	expect(expectedSubscriptionIds.length).toBeGreaterThan(0);
-
-	await autumnV2_2.billing.attach<AttachParamsV1Input>({
-		customer_id: customerId,
-		plan_id: premium.id,
-		no_billing_changes: true,
+	const expectedScheduleIds = ["sub_sched_disconnected"];
+	await CusProductService.update({
+		ctx,
+		cusProductId: beforeProCusProduct!.id,
+		updates: { scheduled_ids: expectedScheduleIds },
 	});
+	await deleteCachedFullCustomer({ ctx, customerId });
+
+	await billingActions.attach({
+		ctx: withoutStripe(ctx),
+		params: {
+			customer_id: customerId,
+			plan_id: premium.id,
+			no_billing_changes: true,
+			redirect_mode: "never",
+		},
+	});
+	await deleteCachedFullCustomer({ ctx, customerId });
 
 	const afterCustomer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
 	await expectCustomerProducts({
@@ -143,4 +243,5 @@ test.concurrent(`${chalk.yellowBright("no_billing_changes: carries subscription_
 	expect(afterPremiumCusProduct?.subscription_ids).toEqual(
 		expectedSubscriptionIds,
 	);
+	expect(afterPremiumCusProduct?.scheduled_ids).toEqual(expectedScheduleIds);
 });

--- a/server/tests/integration/billing/update-subscription/params/update-processor-no-billing-changes.test.ts
+++ b/server/tests/integration/billing/update-subscription/params/update-processor-no-billing-changes.test.ts
@@ -9,14 +9,75 @@ import { expectCustomerProductStatuses } from "@tests/integration/billing/utils/
 import { items } from "@tests/utils/fixtures/items";
 import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
 import { products } from "@tests/utils/fixtures/products";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
+import { billingActions } from "@/internal/billing/v2/actions";
 import { CusService } from "@/internal/customers/CusService";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
+import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
+
+const withoutStripe = (ctx: TestContext): TestContext => ({
+	...ctx,
+	org: {
+		...ctx.org,
+		stripe_connected: false,
+		stripe_config: null,
+		test_stripe_connect: {},
+	},
+});
 
 test(`${chalk.yellowBright("processor_subscription_id: attach with existing stripe subscription anchors reset cycle")}`, async () => {});
 
 test(`${chalk.yellowBright("processor_subscription_id: upgrade with no_billing_changes preserves anchor and subscription")}`, async () => {});
+
+test.concurrent(
+	`${chalk.yellowBright("update no_billing_changes: updates a priced plan without a Stripe connection")}`,
+	async () => {
+		const customerId = "update-no-billing-unlinked-org";
+		const pro = products.base({
+			id: "pro-unlinked-org",
+			items: [
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.monthlyPrice({ price: 20 }),
+			],
+		});
+
+		const { autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [pro] })],
+			actions: [],
+		});
+		const noStripeCtx = withoutStripe(ctx);
+
+		await billingActions.attach({
+			ctx: noStripeCtx,
+			params: {
+				customer_id: customerId,
+				plan_id: pro.id,
+				no_billing_changes: true,
+				redirect_mode: "never",
+			},
+		});
+		await deleteCachedFullCustomer({ ctx, customerId });
+
+		await billingActions.updateSubscription({
+			ctx: noStripeCtx,
+			params: {
+				customer_id: customerId,
+				plan_id: pro.id,
+				no_billing_changes: true,
+				customize: { price: itemsV2.monthlyPrice({ amount: 50 }) },
+			},
+		});
+		await deleteCachedFullCustomer({ ctx, customerId });
+
+		await expectCustomerProducts({
+			customer: await autumnV2_2.customers.get(customerId),
+			active: [pro.id],
+		});
+	},
+);
 
 test(`${chalk.yellowBright("update no_billing_changes: customize preserves subscription_ids on new cusProduct")}`, async () => {
 	const customerId = "update-no-billing-preserves-sub";


### PR DESCRIPTION
## Summary

- skip Stripe context fetching when `no_billing_changes` is explicit and the organization has no Stripe connection
- allow database-only paid-plan transitions without requiring Stripe subscription linkage
- avoid constructing a Stripe client during resets when the customer product has no subscription IDs
- cover free attach, priced transition, subscription update, linked subscription preservation, and month-end reset behavior

## Testing

- `cd server && bun ts`
- `./run.sh "$PWD/server/tests/integration/billing/attach/params/no-billing-changes.test.ts"` — 4 passed
- `./run.sh "$PWD/server/tests/integration/billing/update-subscription/params/update-processor-no-billing-changes.test.ts"` — 5 passed
- `./run.sh "$PWD/server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts"` — 7 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `no_billing_changes` operations to run without Stripe. Free attaches, priced plan transitions, updates, and month‑end resets work for orgs without a Stripe connection, and we preserve stored subscription and schedule IDs after Stripe is disconnected.

- **Bug Fixes**
  - Skip Stripe context when `no_billing_changes` is true and the org isn’t Stripe-connected.
  - Preserve `subscription_ids` and `scheduled_ids` from the current product when `no_billing_changes` is set.
  - Gate linkage errors behind `skipBillingChanges` so DB-only paid transitions aren’t blocked.
  - Create the Stripe client only when `subscription_ids` exist during month‑end reset.
  - Added integration tests for free/paid attaches, updates with `no_billing_changes`, reset behavior, and linkage carryover.

<sup>Written for commit 8cfa59c33e3f19d1721e5368c24276858a68fb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR allows explicitly database-only billing operations to proceed without a Stripe connection while preserving existing local billing linkage where applicable.
- **Bug fixes:** Skip Stripe context setup for `no_billing_changes` requests from organizations without Stripe.
- **Bug fixes:** Permit database-only paid-plan transitions and preserve existing subscription and schedule identifiers.
- **Improvements:** Avoid constructing a Stripe client during entitlement resets when no subscription is linked.
- **Improvements:** Add integration coverage for attach, update-subscription, linkage preservation, and month-end reset behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext.ts | Skips Stripe reads only for explicit no-billing-change operations when the organization has no active Stripe connection. |
| server/src/internal/billing/v2/actions/attach/compute/computeAttachNewCustomerProduct.ts | Carries the current product’s local subscription and schedule linkage into database-only transitions. |
| server/src/internal/billing/v2/actions/attach/errors/handleCurrentCustomerProductErrors.ts | Avoids rejecting intentionally database-only transitions for lacking a fetched Stripe subscription. |
| server/src/cron/resetCron/getStripeSubscriptionAnchor.ts | Defers Stripe client construction until a linked subscription actually needs to be retrieved. |
| server/tests/integration/billing/attach/params/no-billing-changes.test.ts | Covers free and priced transitions without Stripe and verifies preservation of local billing linkage. |
| server/tests/integration/billing/update-subscription/params/update-processor-no-billing-changes.test.ts | Covers database-only updates to priced plans for organizations without Stripe. |
| server/tests/integration/balances/reset/month-end-stripe-anchor-reset.test.ts | Verifies resets without subscription IDs do not construct a Stripe client. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Billing attach or update request] --> B{no_billing_changes is true?}
  B -- No --> C[Load Stripe billing context]
  B -- Yes --> D{Organization connected to Stripe?}
  D -- Yes --> C
  D -- No --> E[Skip Stripe context]
  E --> F[Compute database-only transition]
  F --> G[Preserve existing local billing linkage]
  C --> H[Compute transition with Stripe context]
  G --> I[Persist billing plan]
  H --> I
  J[Entitlement reset] --> K{Subscription IDs present?}
  K -- No --> L[Use calculated reset time without Stripe client]
  K -- Yes --> M[Fetch Stripe billing anchor]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(billing): allow no-billing changes w..."](https://github.com/useautumn/autumn/commit/8cfa59c33e3f19d1721e5368c24276858a68fb8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52543113)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)

<!-- /greptile_comment -->