### PR TITLE
fix(attach): default removed plan IDs in request builder

### DIFF
--- a/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts
@@ -92,7 +92,7 @@ export function buildAttachRequestBody({
 	customLineItems,
 	disableProration,
 	currency,
-	removePlanIds,
+	removePlanIds = [],
 }: BuildAttachRequestBodyParams): AttachParamsV0 | null {
 	if (!customerId || !product) {
 		return null;

--- a/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
+++ b/vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts
@@ -383,3 +383,28 @@ describe("buildAttachRequestBody — long-lived checkout", () => {
 		expect(result?.long_lived_checkout).toBeUndefined();
 	});
 });
+
+describe("buildAttachRequestBody — removed plans", () => {
+	const product = makeProduct({ items: [] });
+
+	test("sends selected plan IDs", () => {
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+			removePlanIds: ["prod_legacy"],
+		});
+
+		expect(result?.remove_plan_ids).toEqual(["prod_legacy"]);
+	});
+
+	test("omits removed plans when none are selected", () => {
+		const result = buildAttachRequestBody({
+			...baseParams,
+			product,
+			prepaidOptions: {},
+		});
+
+		expect(result?.remove_plan_ids).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Prevents the pure attach request-body builder from crashing when older or partial callers omit `removePlanIds`.

Adds focused coverage for serializing selected plan IDs and omitting the field when no plans are selected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `removePlanIds` to an empty array in the attach request-body builder to prevent crashes when callers omit it. Added tests to ensure `remove_plan_ids` is sent when IDs are selected and omitted when none are selected.

<sup>Written for commit f19d07de4709d236d677450519c572d7ea84152c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR safely handles callers that omit removed-plan IDs and adds focused request-serialization coverage.

- **Bug fixes:** Defaults an omitted `removePlanIds` value to an empty array, preventing request construction from reading `.length` from `undefined`.
- **Improvements:** Tests that selected plan IDs are serialized and that the field remains absent when no plans are selected.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new default matching both client serialization and server request semantics.

Omitted removed-plan IDs are normalized before the existing array-length check, while selected IDs continue to serialize and empty selections remain omitted as expected.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/forms/attach-v2/hooks/useAttachRequestBody.ts | Defaults omitted removed-plan IDs while preserving the existing behavior of excluding empty selections from the request. |
| vite/tests/components/forms/attach-v2/hooks/build-attach-request-body.test.ts | Adds focused tests for populated and omitted removed-plan serialization. |

<sub>Reviews (1): Last reviewed commit: ["fix(attach): default removed plan IDs in..."](https://github.com/useautumn/autumn/commit/f19d07de4709d236d677450519c572d7ea84152c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52546861)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->