### PR TITLE
Fix/leaf dead session done fallback

### DIFF
--- a/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
+++ b/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
@@ -4,12 +4,14 @@ import { ensureLeafResources } from "../../../harness/claudeManaged/ensureLeafRe
 import { ensureMemoryStore } from "../../../harness/claudeManaged/memory/ensureMemoryStore.js";
 import { cmaRepo } from "../../../harness/claudeManaged/repos/claudeManagedRepo.js";
 import {
+	type ClaudeManagedSessionRef,
 	createClaudeManagedSession,
 	getClaudeManagedSession,
 } from "../../../harness/claudeManaged/session/ensureSession.js";
 import { runClaudeManagedTurn } from "../../../harness/claudeManaged/session/runManagedTurn.js";
 import { buildUserMessageContent } from "../../../harness/claudeManaged/session/userMessage.js";
 import { ensureAutumnVault } from "../../../harness/claudeManaged/vaults/ensureAutumnVault.js";
+import { isMissingSessionApiError } from "../../../harness/common/deadSession.js";
 import { buildHarnessMessageText } from "../../../harness/common/messageText.js";
 import { runEngineLoop } from "../../../harness/common/runEngineLoop.js";
 import { cancelPendingSessionApprovals } from "../../../internal/approvals/actions/cancelPendingSessionApprovals.js";
@@ -18,22 +20,25 @@ import { claudeManagedMemoryEnabled } from "../../../lib/chatAgentConfig.js";
 import { db } from "../../../lib/db.js";
 import { createPhaseTimer } from "../../../lib/perf.js";
 import { createBraintrustLogger } from "../../../providers/braintrust/index.js";
+import type { AgentOutput } from "../../../types.js";
 import type { AgentEngine } from "../types.js";
 
 const client = new Anthropic();
 
-const AUTH_FAILURE_PATTERN =
-	/invalid or expired access token|request failed \(401\)/i;
-const isAutumnAuthFailure = (output: unknown) => {
-	try {
-		return AUTH_FAILURE_PATTERN.test(JSON.stringify(output) ?? "");
-	} catch {
-		return false;
-	}
-};
 // initLogger sets Braintrust's ambient logger so traced()/spans are recorded.
 const braintrustLogger = createBraintrustLogger();
 const braintrustEnabled = Boolean(braintrustLogger);
+
+const deadSessionFailure = (error: unknown) =>
+	error instanceof Error
+		? error
+		: new Error("The agent session for this thread could not be resumed.");
+
+type SessionAttempt = {
+	deadSessionError?: unknown;
+	output?: AgentOutput;
+	sessionDead: boolean;
+};
 
 export const claudeManagedEngine: AgentEngine = {
 	name: "claude-managed",
@@ -55,21 +60,9 @@ export const claudeManagedEngine: AgentEngine = {
 		} = ctx;
 
 		const perf = createPhaseTimer(logger);
-		const existingSession =
-			claudeManagedSession ??
-			(await perf.time("lookup_session", () =>
-				getClaudeManagedSession({
-					db,
-					env,
-					orgId: org.id,
-					thread,
-					userId: autumnUserId,
-				}),
-			));
-
-		let sessionRef = existingSession;
 		let orgContext: Awaited<ReturnType<typeof autumnOrgContextService.load>>;
-		if (!sessionRef) {
+
+		const startFreshSession = async () => {
 			const {
 				memoryStoreId,
 				orgContext: loadedOrgContext,
@@ -111,7 +104,7 @@ export const claudeManagedEngine: AgentEngine = {
 				},
 			});
 			orgContext = loadedOrgContext;
-			sessionRef = await perf.time("session_create", () =>
+			return perf.time("session_create", () =>
 				createClaudeManagedSession({
 					agentId,
 					client,
@@ -125,104 +118,178 @@ export const claudeManagedEngine: AgentEngine = {
 					vaultId,
 				}),
 			);
-		}
+		};
 
-		const {
-			braintrustParent,
-			newSession,
-			sessionId: activeSessionId,
-			threadKey,
-		} = sessionRef;
-		ctx.run?.resolveSessionId(activeSessionId);
+		const dropSessionRow = async ({ sessionId }: { sessionId: string }) => {
+			try {
+				await cmaRepo.deleteSessionById({
+					db,
+					env,
+					orgId: org.id,
+					sessionId,
+				});
+			} catch (error) {
+				logger.warn("Could not drop the dead session row", {
+					event: "leaf.cma_session_drop_failed",
+					context: { env, org_id: org.id },
+					data: { session_id: sessionId },
+					error,
+				});
+			}
+		};
 
-		if (!newSession) {
-			// Re-sync the vault: it's seeded only at session creation, but leaf
-			// rotates the shared OAuth refresh token each turn, so a stale vault 401s.
-			await ensureAutumnVault({
-				client,
-				env,
-				orgId: org.id,
-				provider: thread.provider,
-				workspaceId: thread.workspaceId,
-				userId: autumnUserId,
+		const runOnSession = async ({
+			sessionRef,
+		}: {
+			sessionRef: ClaudeManagedSessionRef;
+		}): Promise<SessionAttempt> => {
+			const {
+				braintrustParent,
+				newSession,
+				sessionId: activeSessionId,
+				threadKey,
+			} = sessionRef;
+			ctx.run?.resolveSessionId(activeSessionId);
+
+			if (!newSession) {
+				// Re-sync the vault: it's seeded only at session creation, but leaf
+				// rotates the shared OAuth refresh token each turn, so a stale vault 401s.
+				await ensureAutumnVault({
+					client,
+					env,
+					orgId: org.id,
+					provider: thread.provider,
+					workspaceId: thread.workspaceId,
+					userId: autumnUserId,
+				});
+
+				const { cancelledApprovals, cancelledCount } =
+					await cancelPendingSessionApprovals({
+						client,
+						db,
+						logger,
+						providerUserId,
+						query: {
+							channelId: thread.channelId,
+							env,
+							orgId: org.id,
+							provider: thread.provider,
+							runId: activeSessionId,
+							workspaceId: thread.workspaceId,
+						},
+						sessionId: activeSessionId,
+					});
+				if (cancelledCount > 0) {
+					await onApprovalsSuperseded?.(cancelledApprovals);
+				}
+			}
+
+			// Startup (resource/session provisioning) is done — release the
+			// "Starting Autumn" bootstrap card before the first turn runs.
+			await onAgentReady?.();
+
+			const content = buildUserMessageContent({
+				attachments: params.attachments,
+				text: buildHarnessMessageText({
+					env,
+					newSession,
+					orgContext,
+					params,
+				}),
 			});
 
-			const { cancelledApprovals, cancelledCount } =
-				await cancelPendingSessionApprovals({
-					client,
-					db,
-					logger,
-					providerUserId,
-					query: {
-						channelId: thread.channelId,
-						env,
-						orgId: org.id,
-						provider: thread.provider,
-						runId: activeSessionId,
-						workspaceId: thread.workspaceId,
+			let sessionDead = false;
+			try {
+				const output = await runEngineLoop({
+					braintrust: braintrustEnabled
+						? {
+								braintrustParent,
+								persistBraintrustParent: (parent) =>
+									cmaRepo.setBraintrustParent({
+										db,
+										env,
+										orgId: org.id,
+										parent,
+										threadKey,
+									}),
+								spanName: "leaf-claude-managed-message",
+							}
+						: undefined,
+					ctx,
+					interrupt: () =>
+						client.beta.sessions.events
+							.send(activeSessionId, { events: [{ type: "user.interrupt" }] })
+							.then(() => undefined),
+					newSession,
+					params,
+					runTurn: async ({ onTurnEnd, span }) => {
+						const outcome = await runClaudeManagedTurn({
+							client,
+							content,
+							env,
+							logger,
+							onAction,
+							onActionKeyed,
+							onThinking,
+							onTurnEnd,
+							orgId: org.id,
+							sessionId: activeSessionId,
+							span,
+						});
+						sessionDead ||= Boolean(outcome.sessionDead);
+						return outcome;
 					},
 					sessionId: activeSessionId,
 				});
-			if (cancelledCount > 0) {
-				await onApprovalsSuperseded?.(cancelledApprovals);
+				return { output, sessionDead };
+			} catch (error) {
+				if (!(sessionDead || isMissingSessionApiError(error))) throw error;
+				logger.warn("Claude Managed session is no longer usable", {
+					event: "leaf.cma_session_dead",
+					context: { env, org_id: org.id },
+					data: { session_id: activeSessionId },
+					error,
+				});
+				return { deadSessionError: error, sessionDead: true };
 			}
-		}
+		};
 
-		// Startup (resource/session provisioning) is done — release the
-		// "Starting Autumn" bootstrap card before the first turn runs.
-		await onAgentReady?.();
+		const existingSession =
+			claudeManagedSession ??
+			(await perf.time("lookup_session", () =>
+				getClaudeManagedSession({
+					db,
+					env,
+					orgId: org.id,
+					thread,
+					userId: autumnUserId,
+				}),
+			));
+		const sessionRef = existingSession ?? (await startFreshSession());
 		perf.done("leaf.cma_setup_latency", {
-			new_session: newSession,
+			new_session: sessionRef.newSession,
 			provider: thread.provider,
 		});
 
-		const content = buildUserMessageContent({
-			attachments: params.attachments,
-			text: buildHarnessMessageText({
-				env,
-				newSession,
-				orgContext,
-				params,
-			}),
-		});
+		const attempt = await runOnSession({ sessionRef });
+		// A dead session poisons every later turn in the thread, so drop the row
+		// even when this turn still produced an answer.
+		if (attempt.sessionDead) {
+			await dropSessionRow({ sessionId: sessionRef.sessionId });
+		}
+		if (attempt.output) return attempt.output;
+		// Only a resumed session is worth healing; a session created this turn
+		// dying again means the failure isn't the stale id.
+		if (sessionRef.newSession)
+			throw deadSessionFailure(attempt.deadSessionError);
 
-		return runEngineLoop({
-			braintrust: braintrustEnabled
-				? {
-						braintrustParent,
-						persistBraintrustParent: (parent) =>
-							cmaRepo.setBraintrustParent({
-								db,
-								env,
-								orgId: org.id,
-								parent,
-								threadKey,
-							}),
-						spanName: "leaf-claude-managed-message",
-					}
-				: undefined,
-			ctx,
-			interrupt: () =>
-				client.beta.sessions.events
-					.send(activeSessionId, { events: [{ type: "user.interrupt" }] })
-					.then(() => undefined),
-			newSession,
-			params,
-			runTurn: ({ onTurnEnd, span }) =>
-				runClaudeManagedTurn({
-					client,
-					content,
-					env,
-					logger,
-					onAction,
-					onActionKeyed,
-					onThinking,
-					onTurnEnd,
-					orgId: org.id,
-					sessionId: activeSessionId,
-					span,
-				}),
-			sessionId: activeSessionId,
+		logger.info("Retrying the turn on a fresh Claude Managed session", {
+			event: "leaf.cma_session_healed",
+			context: { env, org_id: org.id },
+			data: { dead_session_id: sessionRef.sessionId },
 		});
+		const retry = await runOnSession({ sessionRef: await startFreshSession() });
+		if (retry.output) return retry.output;
+		throw deadSessionFailure(retry.deadSessionError);
 	},
 };

--- a/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
+++ b/apps/leaf/src/agent/runMessage/engines/claudeManagedEngine.ts
@@ -273,8 +273,10 @@ export const claudeManagedEngine: AgentEngine = {
 
 		const attempt = await runOnSession({ sessionRef });
 		// A dead session poisons every later turn in the thread, so drop the row
-		// even when this turn still produced an answer.
-		if (attempt.sessionDead) {
+		// even when this turn still produced an answer — but an interrupted run
+		// can end its stream early without the session actually being gone.
+		const stopped = attempt.output?.finishReason === "stopped";
+		if (attempt.sessionDead && !stopped) {
 			await dropSessionRow({ sessionId: sessionRef.sessionId });
 		}
 		if (attempt.output) return attempt.output;

--- a/apps/leaf/src/bot.ts
+++ b/apps/leaf/src/bot.ts
@@ -202,7 +202,10 @@ const slackRunKey = ({
 const ERROR_NOTICE_MAX = 160;
 
 const EMPTY_REPLY_NOTICE =
-	"I lost my working session for this thread and couldn't produce a reply — please send that message again.";
+	"I couldn't produce a reply to that — please send it again.";
+
+const LOST_SESSION_NOTICE =
+	"I lost my working session for this thread and started a new one, but it still couldn't answer — please send that message again.";
 
 /** One clean, human line about what failed — never a stack or a shrug. */
 const errorNotice = (error: unknown) => {
@@ -566,11 +569,15 @@ const runAndReply = async ({
 		if (!output.text?.trim()) {
 			await finishLoading(target, loading, "No reply produced.");
 			await target.post({
-				markdown: `:warning: ${EMPTY_REPLY_NOTICE}`,
+				markdown: `:warning: ${output.sessionDead ? LOST_SESSION_NOTICE : EMPTY_REPLY_NOTICE}`,
 			});
 			logger.warn("Agent produced no reply", {
 				event: "leaf.slack_empty_response",
-				data: { finish_reason: output.finishReason, run_id: output.runId },
+				data: {
+					finish_reason: output.finishReason,
+					run_id: output.runId,
+					session_dead: Boolean(output.sessionDead),
+				},
 			});
 			return;
 		}

--- a/apps/leaf/src/bot.ts
+++ b/apps/leaf/src/bot.ts
@@ -201,6 +201,9 @@ const slackRunKey = ({
 
 const ERROR_NOTICE_MAX = 160;
 
+const EMPTY_REPLY_NOTICE =
+	"I lost my working session for this thread and couldn't produce a reply — please send that message again.";
+
 /** One clean, human line about what failed — never a stack or a shrug. */
 const errorNotice = (error: unknown) => {
 	const message = error instanceof Error ? error.message : String(error);
@@ -559,13 +562,26 @@ const runAndReply = async ({
 		});
 		if (postedApproval) return;
 
+		// Empty output with nothing to show is a failed run, not a silent success.
+		if (!output.text?.trim()) {
+			await finishLoading(target, loading, "No reply produced.");
+			await target.post({
+				markdown: `:warning: ${EMPTY_REPLY_NOTICE}`,
+			});
+			logger.warn("Agent produced no reply", {
+				event: "leaf.slack_empty_response",
+				data: { finish_reason: output.finishReason, run_id: output.runId },
+			});
+			return;
+		}
+
 		await finishLoading(target, loading, "Done.");
 
-		await target.post({ markdown: output.text || "Done." });
+		await target.post({ markdown: output.text });
 		logger.info("Posted Slack response", {
 			event: "leaf.slack_response_posted",
 			data: {
-				has_text: Boolean(output.text),
+				has_text: true,
 			},
 		});
 	} catch (error) {

--- a/apps/leaf/src/harness/claudeManaged/repos/claudeManagedRepo.ts
+++ b/apps/leaf/src/harness/claudeManaged/repos/claudeManagedRepo.ts
@@ -88,6 +88,30 @@ export const cmaRepo = {
 			);
 	},
 
+	// Drops a thread's session row so the next turn starts a fresh session.
+	// Scoped by session id so a concurrently created replacement survives.
+	deleteSessionById: async ({
+		db,
+		env,
+		orgId,
+		sessionId,
+	}: {
+		db: ChatDb;
+		env: AppEnv;
+		orgId: string;
+		sessionId: string;
+	}) => {
+		await db
+			.delete(cmaSessions)
+			.where(
+				and(
+					eq(cmaSessions.org_id, orgId),
+					eq(cmaSessions.env, env),
+					eq(cmaSessions.session_id, sessionId),
+				),
+			);
+	},
+
 	getVaultId: async ({
 		chatInstallationId,
 		db,

--- a/apps/leaf/src/harness/claudeManaged/session/denyExtraSuspendedCalls.ts
+++ b/apps/leaf/src/harness/claudeManaged/session/denyExtraSuspendedCalls.ts
@@ -1,0 +1,53 @@
+import type Anthropic from "@anthropic-ai/sdk";
+import type { AutumnLogger } from "@autumn/logging";
+import type { SessionTurnOutcome } from "../../common/types.js";
+
+const ONE_AT_A_TIME_DENY_MESSAGE =
+	"Autumn confirms one gated write at a time. This call was not run — ask for it again once the pending confirmation is resolved.";
+
+/**
+ * Leaf can only surface one approval card per turn, and the session stays
+ * blocked until every awaited confirmation is answered — so deny the extras
+ * instead of leaving the turn wedged behind a card that will never appear.
+ */
+export const denyExtraSuspendedCalls = async ({
+	client,
+	logger,
+	outcome,
+	sessionId,
+}: {
+	client: Anthropic;
+	logger: AutumnLogger;
+	outcome: SessionTurnOutcome;
+	sessionId: string;
+}) => {
+	const [firstCall, ...extraCalls] = outcome.suspendedQueue ?? [];
+	if (!firstCall || extraCalls.length === 0) return;
+
+	try {
+		await client.beta.sessions.events.send(sessionId, {
+			events: extraCalls.map((call) => ({
+				deny_message: ONE_AT_A_TIME_DENY_MESSAGE,
+				result: "deny" as const,
+				tool_use_id: call.toolCallId,
+				type: "user.tool_confirmation" as const,
+			})),
+		});
+	} catch (error) {
+		logger.warn("Could not deny the extra suspended tool calls", {
+			event: "leaf.session_extra_suspended_deny_failed",
+			data: { session_id: sessionId },
+			error,
+		});
+		return;
+	}
+
+	outcome.suspendedQueue = [firstCall];
+	logger.info("Denied extra suspended tool calls", {
+		event: "leaf.session_extra_suspended_denied",
+		data: {
+			denied_tools: extraCalls.map((call) => call.toolName),
+			session_id: sessionId,
+		},
+	});
+};

--- a/apps/leaf/src/harness/claudeManaged/session/driveSessionTurn.ts
+++ b/apps/leaf/src/harness/claudeManaged/session/driveSessionTurn.ts
@@ -107,6 +107,9 @@ export const driveSessionTurn = async ({
 
 	const verbose = Boolean(process.env.LEAF_PERF_VERBOSE);
 	let lastEventAt = performance.now();
+	// A turn must end on an explicit terminal event; falling out of the loop any
+	// other way means the stream died and the outcome is not a real answer.
+	let reachedTerminalEvent = false;
 	for await (const event of stream) {
 		if (verbose) {
 			const now = performance.now();
@@ -217,7 +220,16 @@ export const driveSessionTurn = async ({
 			} else {
 				outcome.errorMessage = error.message ?? "Session error";
 			}
-		} else if (event.type === "session.status_terminated") {
+		} else if (
+			event.type === "session.status_terminated" ||
+			event.type === "session.deleted"
+		) {
+			outcome.sessionDead = true;
+			outcome.errorMessage ??=
+				event.type === "session.deleted"
+					? "The agent session no longer exists."
+					: "The agent session terminated before finishing the turn.";
+			reachedTerminalEvent = true;
 			break;
 		} else if (event.type === "session.status_idle") {
 			if (event.stop_reason.type === "requires_action") {
@@ -234,6 +246,7 @@ export const driveSessionTurn = async ({
 				if (queue.length > 0) {
 					outcome.suspendedQueue = queue;
 				}
+				reachedTerminalEvent = true;
 				break;
 			}
 			if (event.stop_reason.type === "end_turn" && onTurnEnd) {
@@ -245,8 +258,14 @@ export const driveSessionTurn = async ({
 				}
 			}
 			// end_turn and retries_exhausted are turn-terminal.
+			reachedTerminalEvent = true;
 			break;
 		}
+	}
+	if (!reachedTerminalEvent) {
+		outcome.sessionDead = true;
+		outcome.errorMessage ??=
+			"The agent session stream ended before the turn finished.";
 	}
 	const turnPerf = {
 		label: perfLabel ?? "turn",
@@ -258,6 +277,7 @@ export const driveSessionTurn = async ({
 		autumn_tool_calls: outcome.toolResults?.length ?? 0,
 		input_tokens: outcome.usage.inputTokens,
 		cache_read_tokens: outcome.usage.cacheReadInputTokens,
+		session_dead: Boolean(outcome.sessionDead),
 		suspended: Boolean(outcome.suspendedQueue?.length),
 	};
 	rootLogger.info("[perf] session turn", {

--- a/apps/leaf/src/harness/claudeManaged/session/runManagedTurn.ts
+++ b/apps/leaf/src/harness/claudeManaged/session/runManagedTurn.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../internal/approvals/utils/toolRegistry.js";
 import type { KeyedActionLogger } from "../../../ui/progress.js";
 import { claudeManagedConfig } from "../config.js";
+import { denyExtraSuspendedCalls } from "./denyExtraSuspendedCalls.js";
 import {
 	driveSessionTurn,
 	type SessionTurnOutcome,
@@ -193,6 +194,7 @@ export const runClaudeManagedTurn = async ({
 	};
 
 	const outcome = await driveTurnWithInterruptRetry({ content, span });
+	await denyExtraSuspendedCalls({ client, logger, outcome, sessionId });
 
 	// Attach the captured preview to the suspended write so the card shows cost.
 	const suspended = outcome.suspendedQueue?.[0];

--- a/apps/leaf/src/harness/common/deadSession.ts
+++ b/apps/leaf/src/harness/common/deadSession.ts
@@ -1,0 +1,16 @@
+const SESSION_NOT_FOUND_STATUS = 404;
+const MISSING_SESSION_MESSAGE = /session[^:]*not found|no such session/i;
+
+/** True when a sessions API call failed because the session id is unknown —
+ * the persisted session was deleted or expired server-side. */
+export const isMissingSessionApiError = (error: unknown) => {
+	if (
+		typeof error === "object" &&
+		error !== null &&
+		"status" in error &&
+		(error as { status?: unknown }).status === SESSION_NOT_FOUND_STATUS
+	) {
+		return true;
+	}
+	return error instanceof Error && MISSING_SESSION_MESSAGE.test(error.message);
+};

--- a/apps/leaf/src/harness/common/deadSession.ts
+++ b/apps/leaf/src/harness/common/deadSession.ts
@@ -1,8 +1,11 @@
 const SESSION_NOT_FOUND_STATUS = 404;
 const MISSING_SESSION_MESSAGE = /session[^:]*not found|no such session/i;
+// A malformed persisted id is rejected with 400 before any existence check;
+// it can never resume, so it is as dead as a 404.
+const INVALID_SESSION_MESSAGE = /invalid session id/i;
 
-/** True when a sessions API call failed because the session id is unknown —
- * the persisted session was deleted or expired server-side. */
+/** True when a sessions API call failed because the persisted session id can
+ * never resume — unknown (deleted/expired server-side) or malformed. */
 export const isMissingSessionApiError = (error: unknown) => {
 	if (
 		typeof error === "object" &&
@@ -12,5 +15,9 @@ export const isMissingSessionApiError = (error: unknown) => {
 	) {
 		return true;
 	}
-	return error instanceof Error && MISSING_SESSION_MESSAGE.test(error.message);
+	return (
+		error instanceof Error &&
+		(MISSING_SESSION_MESSAGE.test(error.message) ||
+			INVALID_SESSION_MESSAGE.test(error.message))
+	);
 };

--- a/apps/leaf/src/harness/common/types.ts
+++ b/apps/leaf/src/harness/common/types.ts
@@ -16,6 +16,9 @@ export type SuspendedToolCall = {
 /** Harness-agnostic outcome of one driven agent turn. */
 export type SessionTurnOutcome = {
 	errorMessage?: string;
+	/** The session can no longer answer (terminated, deleted, or the stream
+	 * ended mid-turn) — the caller must start a fresh one to make progress. */
+	sessionDead?: boolean;
 	/** All confirmations the turn is waiting on. */
 	suspendedQueue?: SuspendedToolCall[];
 	textParts: string[];

--- a/apps/leaf/src/harness/eve/adoptPostedSession.ts
+++ b/apps/leaf/src/harness/eve/adoptPostedSession.ts
@@ -1,0 +1,32 @@
+import type { EveSessionRef, EveSessionState } from "./types.js";
+
+export type PostedEveSession = {
+	continuationToken: string;
+	sessionId: string;
+};
+
+/**
+ * Applies a posted session response to the in-memory session. Eve silently
+ * re-homes a dead run onto a NEW session id whose journal restarts at 0, so
+ * carrying the old stream cursor over would stream past every event forever.
+ */
+export const adoptPostedEveSession = ({
+	posted,
+	session,
+	status,
+}: {
+	posted: PostedEveSession;
+	session: EveSessionRef;
+	status?: EveSessionState["status"];
+}) => {
+	const rehomed = posted.sessionId !== session.sessionId;
+	session.sessionId = posted.sessionId;
+	session.state = {
+		...session.state,
+		continuationToken: posted.continuationToken,
+		lastEventAt: Date.now(),
+		...(status ? { status } : {}),
+		...(rehomed ? { streamIndex: 0 } : {}),
+	};
+	return { rehomed };
+};

--- a/apps/leaf/src/harness/eve/approval.ts
+++ b/apps/leaf/src/harness/eve/approval.ts
@@ -7,6 +7,10 @@ import { getOrgInstallationToken } from "../../internal/installations/actions/ge
 import { db } from "../../lib/db.js";
 import { logger } from "../../lib/logger.js";
 import {
+	adoptPostedEveSession,
+	type PostedEveSession,
+} from "./adoptPostedSession.js";
+import {
 	EveStreamIdleTimeoutError,
 	postEveInputResponse,
 	resyncEveStreamIndex,
@@ -14,6 +18,10 @@ import {
 } from "./client.js";
 import { approvalOptionIds, type EveInputRequest } from "./events.js";
 import { getEveSessionBySessionId, upsertEveSession } from "./repo.js";
+import {
+	EveSessionRequestError,
+	isEveInputResponseRehomeRefusal,
+} from "./streamErrors.js";
 import type { EveAuthContext, EveSessionRef } from "./types.js";
 
 /** A gated write the resumed turn parked on after the answered one. */
@@ -57,6 +65,10 @@ const MAX_DRAIN_DENIES = 3;
 /** Drain discards a dead-end turn — give up on silence much sooner than a
  * live run would, an incomplete drain beats blocking the user's message. */
 const DRAIN_IDLE_TIMEOUT_MS = 60_000;
+/** ~5s of reconnects while a resumed turn spins up — shorter than the engine's
+ * budget because a click is already showing a running card. */
+const MAX_COLLECT_STREAM_ATTEMPTS = 10;
+const COLLECT_RETRY_DELAY_MS = 500;
 
 /** Consumes (and discards) the turn that resumes after a deny, so its reply
  * never posts and the next user message streams from a clean park. Any gated
@@ -94,7 +106,7 @@ export const drainParkedEveTurn = async ({
 							request.action?.toolName &&
 							normalizeToolName(request.action.toolName) !== "ask_question",
 					);
-					if (gated?.requestId && denies < MAX_DRAIN_DENIES) {
+					if (gated?.requestId) {
 						denies += 1;
 						const options = approvalOptionIds(gated);
 						const posted = await postEveInputResponse({
@@ -104,8 +116,17 @@ export const drainParkedEveTurn = async ({
 							requestId: gated.requestId,
 							session,
 						});
-						session.sessionId = posted.sessionId;
-						session.state.continuationToken = posted.continuationToken;
+						adoptPostedEveSession({ posted, session });
+						// Past the cap the model is ping-ponging requests: the deny is
+						// still delivered so nothing stays parked, but stop draining.
+						if (denies >= MAX_DRAIN_DENIES) {
+							logger.warn("Stopped draining after repeated gated requests", {
+								event: "leaf.eve_drain_deny_limit",
+								data: { denies, session_id: session.sessionId },
+							});
+							session.state.status = "waiting";
+							break;
+						}
 						parkedAgain = true;
 						break;
 					}
@@ -175,9 +196,7 @@ export const withdrawEveSuspension = async ({
 		requestId: suspension.toolCallId,
 		session,
 	});
-	session.sessionId = posted.sessionId;
-	session.state.continuationToken = posted.continuationToken;
-	session.state.status = "running";
+	adoptPostedEveSession({ posted, session, status: "running" });
 	await drainParkedEveTurn({ auth, orgId, session });
 	return true;
 };
@@ -204,85 +223,124 @@ const collectText = async ({
 	let pendingText = "";
 	let chained: ChainedPendingRequest | undefined;
 	let question: PendingQuestion | undefined;
-	// Stale tail events from the parked turn replay first (see engine.ts) —
-	// only honor terminal events once the resumed turn's turn.started arrives.
-	let turnStarted = false;
-	for await (const event of streamEveEvents({ auth, session })) {
-		session.state.streamIndex += 1;
-		session.state.lastEventAt = Date.now();
-		if (event.type === "turn.started") {
-			turnStarted = true;
-		} else if (event.type === "input.requested") {
-			// The resumed turn can chain straight into another gated write, parked
-			// where nobody streams. Capture it so a fresh approval row exists.
-			const requests = (event.data?.requests ?? []) as EveInputRequest[];
-			const found = requests.find(
-				(request) =>
-					request.requestId &&
-					request.requestId !== skipRequestId &&
-					request.action?.toolName &&
-					normalizeToolName(request.action.toolName) !== "ask_question",
-			);
-			if (found?.requestId && found.action?.toolName) {
-				chained = {
-					input: found.action.input,
-					options: found.options,
-					requestId: found.requestId,
-					toolName: found.action.toolName,
-				};
+
+	// One pass over the resumed turn's stream. `parked` means the turn reached
+	// an end state; anything else is a stream that closed early.
+	const readStreamOnce = async () => {
+		let parked = false;
+		let sawEvent = false;
+		// Stale tail events from the parked turn replay first (see engine.ts) —
+		// only honor terminal events once the resumed turn's turn.started arrives.
+		let turnStarted = false;
+		for await (const event of streamEveEvents({ auth, session })) {
+			sawEvent = true;
+			session.state.streamIndex += 1;
+			session.state.lastEventAt = Date.now();
+			if (event.type === "turn.started") {
+				turnStarted = true;
+			} else if (event.type === "input.requested") {
+				// The resumed turn can chain straight into another gated write, parked
+				// where nobody streams. Capture it so a fresh approval row exists.
+				const requests = (event.data?.requests ?? []) as EveInputRequest[];
+				const found = requests.find(
+					(request) =>
+						request.requestId &&
+						request.requestId !== skipRequestId &&
+						request.action?.toolName &&
+						normalizeToolName(request.action.toolName) !== "ask_question",
+				);
+				if (found?.requestId && found.action?.toolName) {
+					chained = {
+						input: found.action.input,
+						options: found.options,
+						requestId: found.requestId,
+						toolName: found.action.toolName,
+					};
+					parked = true;
+					break;
+				}
+				// An optioned ask_question also parks the session — capture it so
+				// button-driven surfaces can render answer chips instead of dead text.
+				const optioned = requests.find(
+					(request) =>
+						request.requestId !== skipRequestId &&
+						request.prompt &&
+						(request.options?.length ?? 0) > 0,
+				);
+				if (optioned?.requestId && optioned.prompt) {
+					question = {
+						options: optioned.options ?? [],
+						prompt: optioned.prompt,
+						requestId: optioned.requestId,
+					};
+					session.state.status = "waiting";
+					parked = true;
+					break;
+				}
+			} else if (event.type === "message.appended" && turnStarted) {
+				const messageSoFar = event.data?.messageSoFar;
+				pendingText =
+					typeof messageSoFar === "string"
+						? messageSoFar
+						: `${pendingText}${String(event.data?.messageDelta ?? "")}`;
+			} else if (event.type === "message.completed" && turnStarted) {
+				if (event.data?.finishReason !== "tool-calls") {
+					text = String(event.data?.message ?? pendingText);
+				}
+				pendingText = "";
+			} else if (
+				turnStarted &&
+				(event.type === "session.waiting" || event.type === "session.completed")
+			) {
+				session.state.status =
+					event.type === "session.completed" ? "completed" : "waiting";
+				parked = true;
 				break;
+			} else if (
+				turnStarted &&
+				(event.type === "turn.failed" || event.type === "session.failed")
+			) {
+				session.state.status = "failed";
+				throw new Error(String(event.data?.message ?? "Eve failed"));
 			}
-			// An optioned ask_question also parks the session — capture it so
-			// button-driven surfaces can render answer chips instead of dead text.
-			const optioned = requests.find(
-				(request) =>
-					request.requestId !== skipRequestId &&
-					request.prompt &&
-					(request.options?.length ?? 0) > 0,
-			);
-			if (optioned?.requestId && optioned.prompt) {
-				question = {
-					options: optioned.options ?? [],
-					prompt: optioned.prompt,
-					requestId: optioned.requestId,
-				};
-				session.state.status = "waiting";
-				break;
-			}
-		} else if (event.type === "message.appended" && turnStarted) {
-			const messageSoFar = event.data?.messageSoFar;
-			pendingText =
-				typeof messageSoFar === "string"
-					? messageSoFar
-					: `${pendingText}${String(event.data?.messageDelta ?? "")}`;
-		} else if (event.type === "message.completed" && turnStarted) {
-			if (event.data?.finishReason !== "tool-calls") {
-				text = String(event.data?.message ?? pendingText);
-			}
-			pendingText = "";
-		} else if (
-			turnStarted &&
-			(event.type === "session.waiting" || event.type === "session.completed")
-		) {
-			session.state.status =
-				event.type === "session.completed" ? "completed" : "waiting";
-			break;
-		} else if (
-			turnStarted &&
-			(event.type === "turn.failed" || event.type === "session.failed")
-		) {
-			session.state.status = "failed";
-			throw new Error(String(event.data?.message ?? "Eve failed"));
 		}
+		return { parked, sawEvent };
+	};
+
+	// Eve resumes a turn asynchronously, so the first stream after an answer can
+	// close before the turn produces anything — reconnect instead of reporting
+	// an empty resume, and heal the cursor once if nothing ever arrives.
+	let attempts = 0;
+	let sawAnyEvent = false;
+	let resyncedAfterSilence = false;
+	while (attempts < MAX_COLLECT_STREAM_ATTEMPTS) {
+		const { parked, sawEvent } = await readStreamOnce();
+		if (sawEvent) sawAnyEvent = true;
+		if (parked) break;
+		attempts += 1;
+		const silentlyExhausted =
+			attempts >= MAX_COLLECT_STREAM_ATTEMPTS &&
+			!(sawAnyEvent || resyncedAfterSilence);
+		if (silentlyExhausted) {
+			resyncedAfterSilence = true;
+			await resyncEveStreamIndex({ auth, session });
+			attempts = 0;
+			continue;
+		}
+		await new Promise((resolve) => setTimeout(resolve, COLLECT_RETRY_DELAY_MS));
 	}
-	await upsertEveSession({
-		db,
-		env: session.env,
-		orgId,
-		sessionId: session.sessionId,
-		state: session.state,
-		threadKey: session.threadKey,
-	});
+	// Nothing was read, so nothing advanced — never persist a cursor the turn
+	// did not actually reach.
+	if (sawAnyEvent) {
+		await upsertEveSession({
+			db,
+			env: session.env,
+			orgId,
+			sessionId: session.sessionId,
+			state: session.state,
+			threadKey: session.threadKey,
+		});
+	}
 	return { chained, question, text: text || pendingText };
 };
 
@@ -317,16 +375,34 @@ const answerEveApproval = async ({
 		};
 	}
 	const auth = authFromApproval(approval, providerUserId);
-	const posted = await postEveInputResponse({
-		auth,
-		note,
-		optionId,
-		requestId: approval.tool_call_id,
-		session,
-	});
-	session.sessionId = posted.sessionId;
-	session.state.continuationToken = posted.continuationToken;
-	session.state.status = "running";
+	let posted: PostedEveSession;
+	try {
+		posted = await postEveInputResponse({
+			auth,
+			note,
+			optionId,
+			requestId: approval.tool_call_id,
+			session,
+		});
+	} catch (error) {
+		// Eve rejected the answer outright (most often refusing to re-home it
+		// onto a replacement run), so nothing was written — keep the approval
+		// clickable instead of reporting a failed write.
+		if (!(error instanceof EveSessionRequestError)) throw error;
+		logger.warn("Eve rejected the approval answer", {
+			event: "leaf.eve_input_response_rejected",
+			approval_id: approval.id,
+			data: { session_id: session.sessionId, status: error.status },
+		});
+		return {
+			error: true,
+			message: isEveInputResponseRehomeRefusal(error)
+				? "Eve restarted this conversation's run, so the approval couldn't be delivered."
+				: `Eve rejected the approval (${error.status}).`,
+			retryable: true,
+		};
+	}
+	adoptPostedEveSession({ posted, session, status: "running" });
 	await upsertEveSession({
 		db,
 		env: session.env,
@@ -466,9 +542,7 @@ export const answerEveQuestion = async ({
 		requestId,
 		session,
 	});
-	session.sessionId = posted.sessionId;
-	session.state.continuationToken = posted.continuationToken;
-	session.state.status = "running";
+	adoptPostedEveSession({ posted, session, status: "running" });
 	await upsertEveSession({
 		db,
 		env: session.env,

--- a/apps/leaf/src/harness/eve/approval.ts
+++ b/apps/leaf/src/harness/eve/approval.ts
@@ -11,6 +11,11 @@ import {
 	type PostedEveSession,
 } from "./adoptPostedSession.js";
 import {
+	type ChainedPendingRequest,
+	classifyParkedEveInput,
+	type PendingQuestion,
+} from "./classifyParkedInput.js";
+import {
 	EveStreamIdleTimeoutError,
 	postEveInputResponse,
 	resyncEveStreamIndex,
@@ -23,14 +28,6 @@ import {
 	isEveInputResponseRehomeRefusal,
 } from "./streamErrors.js";
 import type { EveAuthContext, EveSessionRef } from "./types.js";
-
-/** A gated write the resumed turn parked on after the answered one. */
-export type ChainedPendingRequest = {
-	input?: Record<string, unknown>;
-	options?: { id?: string; label?: string }[];
-	requestId: string;
-	toolName: string;
-};
 
 export const approveOptionFromApproval = (approval: ChatApproval) => {
 	const args = approval.tool_args as Record<string, unknown>;
@@ -201,13 +198,6 @@ export const withdrawEveSuspension = async ({
 	return true;
 };
 
-/** An optioned ask_question the resumed turn parked on. */
-export type PendingQuestion = {
-	options: { id?: string; label?: string }[];
-	prompt: string;
-	requestId: string;
-};
-
 const collectText = async ({
 	auth,
 	orgId,
@@ -239,40 +229,25 @@ const collectText = async ({
 			if (event.type === "turn.started") {
 				turnStarted = true;
 			} else if (event.type === "input.requested") {
-				// The resumed turn can chain straight into another gated write, parked
-				// where nobody streams. Capture it so a fresh approval row exists.
-				const requests = (event.data?.requests ?? []) as EveInputRequest[];
-				const found = requests.find(
-					(request) =>
-						request.requestId &&
-						request.requestId !== skipRequestId &&
-						request.action?.toolName &&
-						normalizeToolName(request.action.toolName) !== "ask_question",
-				);
-				if (found?.requestId && found.action?.toolName) {
-					chained = {
-						input: found.action.input,
-						options: found.options,
-						requestId: found.requestId,
-						toolName: found.action.toolName,
-					};
+				// The resumed turn parks where nobody streams — every shape has to be
+				// captured here or the request is orphaned and the thread wedges.
+				const parkedInput = classifyParkedEveInput({
+					requests: (event.data?.requests ?? []) as EveInputRequest[],
+					skipRequestId,
+				});
+				if (parkedInput?.kind === "gated") {
+					chained = parkedInput.chained;
 					parked = true;
 					break;
 				}
-				// An optioned ask_question also parks the session — capture it so
-				// button-driven surfaces can render answer chips instead of dead text.
-				const optioned = requests.find(
-					(request) =>
-						request.requestId !== skipRequestId &&
-						request.prompt &&
-						(request.options?.length ?? 0) > 0,
-				);
-				if (optioned?.requestId && optioned.prompt) {
-					question = {
-						options: optioned.options ?? [],
-						prompt: optioned.prompt,
-						requestId: optioned.requestId,
-					};
+				if (parkedInput?.kind === "question") {
+					question = parkedInput.question;
+					session.state.status = "waiting";
+					parked = true;
+					break;
+				}
+				if (parkedInput) {
+					text = parkedInput.text;
 					session.state.status = "waiting";
 					parked = true;
 					break;

--- a/apps/leaf/src/harness/eve/catalogDecision.ts
+++ b/apps/leaf/src/harness/eve/catalogDecision.ts
@@ -10,6 +10,7 @@ import { fetchApprovalPreview } from "../../internal/approvals/utils/fetchApprov
 import { db } from "../../lib/db.js";
 import type { Suspension } from "../../types.js";
 import { parsePreviewPayload } from "../../ui/previewContent.js";
+import { adoptPostedEveSession } from "./adoptPostedSession.js";
 import { postEveInputResponse } from "./client.js";
 import { getEveSessionBySessionId, upsertEveSession } from "./repo.js";
 import type { EveAuthContext } from "./types.js";
@@ -196,9 +197,7 @@ export const redirectCatalogSuspensionToDecision = async ({
 			requestId: suspension.toolCallId,
 			session,
 		});
-		session.sessionId = posted.sessionId;
-		session.state.continuationToken = posted.continuationToken;
-		session.state.status = "waiting";
+		adoptPostedEveSession({ posted, session, status: "waiting" });
 		await upsertEveSession({
 			db,
 			env: session.env,

--- a/apps/leaf/src/harness/eve/classifyParkedInput.ts
+++ b/apps/leaf/src/harness/eve/classifyParkedInput.ts
@@ -1,0 +1,79 @@
+import { normalizeToolName } from "../../agent/tools/toolPolicy.js";
+import { type EveInputRequest, textForInputRequests } from "./events.js";
+
+/** A gated write the resumed turn parked on after the answered one. */
+export type ChainedPendingRequest = {
+	input?: Record<string, unknown>;
+	options?: { id?: string; label?: string }[];
+	requestId: string;
+	toolName: string;
+};
+
+/** An optioned ask_question the resumed turn parked on. */
+export type PendingQuestion = {
+	options: { id?: string; label?: string }[];
+	prompt: string;
+	requestId: string;
+};
+
+export type ParkedEveInput =
+	| { chained: ChainedPendingRequest; kind: "gated" }
+	| { kind: "question"; question: PendingQuestion }
+	| { kind: "waiting"; text: string };
+
+const WAITING_FALLBACK_TEXT = "Eve is waiting for input.";
+
+/**
+ * What a resumed turn is parked on, ignoring the request just answered. A park
+ * that is neither a gated write nor an optioned question still blocks the run,
+ * so it is surfaced as text — dropping it orphans the request forever.
+ */
+export const classifyParkedEveInput = ({
+	requests,
+	skipRequestId,
+}: {
+	requests: EveInputRequest[];
+	skipRequestId?: string;
+}): ParkedEveInput | undefined => {
+	const pending = requests.filter(
+		(request) => request.requestId !== skipRequestId,
+	);
+	if (pending.length === 0) return undefined;
+
+	const gated = pending.find(
+		(request) =>
+			request.requestId &&
+			request.action?.toolName &&
+			normalizeToolName(request.action.toolName) !== "ask_question",
+	);
+	if (gated?.requestId && gated.action?.toolName) {
+		return {
+			chained: {
+				input: gated.action.input,
+				options: gated.options,
+				requestId: gated.requestId,
+				toolName: gated.action.toolName,
+			},
+			kind: "gated",
+		};
+	}
+
+	const optioned = pending.find(
+		(request) => request.prompt && (request.options?.length ?? 0) > 0,
+	);
+	if (optioned?.requestId && optioned.prompt) {
+		return {
+			kind: "question",
+			question: {
+				options: optioned.options ?? [],
+				prompt: optioned.prompt,
+				requestId: optioned.requestId,
+			},
+		};
+	}
+
+	return {
+		kind: "waiting",
+		text: textForInputRequests(pending) || WAITING_FALLBACK_TEXT,
+	};
+};

--- a/apps/leaf/src/harness/eve/client.ts
+++ b/apps/leaf/src/harness/eve/client.ts
@@ -1,5 +1,8 @@
 import { env } from "../../lib/env.js";
-import { isRetryableEveStreamError } from "./streamErrors.js";
+import {
+	EveSessionRequestError,
+	isRetryableEveStreamError,
+} from "./streamErrors.js";
 import type { EveAuthContext, EveSessionRef } from "./types.js";
 
 export type EveEvent = {
@@ -30,6 +33,8 @@ const eveHeaders = (auth: EveAuthContext, init?: HeadersInit) => {
 	return headers;
 };
 
+const ERROR_BODY_MAX_LENGTH = 200;
+
 const parseSessionResponse = async ({
 	existing,
 	response,
@@ -38,7 +43,11 @@ const parseSessionResponse = async ({
 	response: Response;
 }) => {
 	if (!response.ok) {
-		throw new Error(`Eve session request failed: ${response.status}`);
+		const body = await response.text().catch(() => "");
+		throw new EveSessionRequestError({
+			body: body.slice(0, ERROR_BODY_MAX_LENGTH),
+			status: response.status,
+		});
 	}
 	const body = (await response.json()) as {
 		continuationToken?: string;

--- a/apps/leaf/src/harness/eve/engine.ts
+++ b/apps/leaf/src/harness/eve/engine.ts
@@ -38,6 +38,7 @@ import {
 	textForInputRequests,
 } from "./events.js";
 import { deleteEveSession, getEveSession, upsertEveSession } from "./repo.js";
+import { eveTurnProducedOutput } from "./turnOutput.js";
 import type {
 	EveAuthContext,
 	EveSessionRef,
@@ -255,6 +256,7 @@ export const eveEngine: AgentEngine = {
 			let turnStarted = false;
 			let sawAnyEvent = false;
 			let resyncedAfterSilence = false;
+			let endedWithoutOutput = false;
 
 			try {
 				// Eve resumes turns asynchronously: right after posting a message or
@@ -462,14 +464,25 @@ export const eveEngine: AgentEngine = {
 								// versioning/variant/migration choices — surface the decision
 								// card now that the turn is genuinely over.
 								const decisionPlan = catalogPlanNeedingDecision(lastPreview);
-								return {
-									env,
-									runId: session.sessionId,
-									text: finalText,
-									catalogDecision: decisionPlan
-										? { plan: decisionPlan }
-										: undefined,
-								};
+								if (
+									eveTurnProducedOutput({
+										catalogDecision: decisionPlan,
+										text: finalText,
+									})
+								) {
+									return {
+										env,
+										runId: session.sessionId,
+										text: finalText,
+										catalogDecision: decisionPlan
+											? { plan: decisionPlan }
+											: undefined,
+									};
+								}
+								// The turn ended with nothing to show: the run is awake but
+								// stuck behind a request nobody can answer. Recover outside.
+								endedWithoutOutput = true;
+								break;
 							}
 
 							if (session.state.streamIndex % 10 === 0) {
@@ -526,6 +539,7 @@ export const eveEngine: AgentEngine = {
 						);
 					}
 					if (sawEvent) sawAnyEvent = true;
+					if (endedWithoutOutput) break;
 					idleRetries = sawEvent ? 0 : idleRetries + 1;
 					// Nothing at all came back: the cursor may have drifted past
 					// eve's replay buffer, so heal it once and re-arm the budget.
@@ -559,7 +573,7 @@ export const eveEngine: AgentEngine = {
 				session,
 				state: { status: "waiting" },
 			});
-			if (sawAnyEvent) {
+			if (eveTurnProducedOutput({ text: finalText })) {
 				return { env, runId: session.sessionId, text: finalText };
 			}
 			// A session created in this run can't be stale, so a second fresh one
@@ -573,12 +587,16 @@ export const eveEngine: AgentEngine = {
 				};
 			}
 
-			// The run behind this session is gone: eve answers every post with a
-			// 200 even when it silently re-homed, so silence is the only signal.
+			// Either the run is gone (eve answers every post with a 200 even when
+			// it silently re-homed) or it is awake but stuck behind an unanswered
+			// request. Neither can be talked out of; only a new session can.
 			restartedOnFreshSession = true;
-			logger.warn("Eve session produced no events; starting a fresh one", {
+			logger.warn("Eve session produced no reply; starting a fresh one", {
 				event: "leaf.eve_session_restarted",
-				data: { session_id: session.sessionId },
+				data: {
+					reason: sawAnyEvent ? "no_output" : "no_events",
+					session_id: session.sessionId,
+				},
 			});
 			await deleteEveSession({
 				db,

--- a/apps/leaf/src/harness/eve/engine.ts
+++ b/apps/leaf/src/harness/eve/engine.ts
@@ -12,6 +12,7 @@ import { env as leafEnv } from "../../lib/env.js";
 import { parsePreviewPayload } from "../../ui/previewContent.js";
 import { buildHarnessMessageText } from "../common/messageText.js";
 import { buildThreadKey } from "../common/threadKey.js";
+import { adoptPostedEveSession } from "./adoptPostedSession.js";
 import { denyOptionFromApproval, drainParkedEveTurn } from "./approval.js";
 import {
 	catalogPlanNeedingDecision,
@@ -36,12 +37,18 @@ import {
 	labelForResult,
 	textForInputRequests,
 } from "./events.js";
-import { getEveSession, upsertEveSession } from "./repo.js";
+import { deleteEveSession, getEveSession, upsertEveSession } from "./repo.js";
 import type {
 	EveAuthContext,
 	EveSessionRef,
 	EveSessionState,
 } from "./types.js";
+
+/** ~10s of reconnects: eve resumes turns asynchronously, so the first stream
+ * after a post can legitimately close empty a few times. */
+const MAX_IDLE_RETRIES = 20;
+const STREAM_RETRY_DELAY_MS = 500;
+const MAX_STREAM_DISCONNECT_RETRIES = 5;
 
 const initialState = (continuationToken: string): EveSessionState => ({
 	version: 1,
@@ -132,13 +139,7 @@ export const eveEngine: AgentEngine = {
 								requestId: approval.tool_call_id,
 								session,
 							});
-							session.sessionId = posted.sessionId;
-							session.state = {
-								...session.state,
-								continuationToken: posted.continuationToken,
-								status: "running",
-								lastEventAt: Date.now(),
-							};
+							adoptPostedEveSession({ posted, session, status: "running" });
 							// Discard the withdrawal turn's reply — without this, its
 							// text would end THIS run and the user's actual message
 							// would be processed with nobody streaming.
@@ -164,361 +165,430 @@ export const eveEngine: AgentEngine = {
 			}
 		}
 
-		let messageText = buildHarnessMessageText({
-			env,
-			newSession,
-			orgContext,
-			params,
-		});
 		// Binary attachments ride as file parts (base64 data: URLs) beside the
 		// text; eve stages them for the model call. Behind a flag until eve's
 		// queue boundary stops corrupting file bytes — meanwhile the model gets
 		// an honest note instead of a hard turn failure.
 		const sendFileParts =
 			Boolean(params.attachments?.length) && leafEnv.EVE_ATTACHMENTS_ENABLED;
-		if (params.attachments?.length && !sendFileParts) {
-			const names = params.attachments
-				.map((attachment) => attachment.name ?? attachment.mimeType)
-				.join(", ");
-			messageText = `${messageText}\n\n(The user attached file(s) — ${names} — but file ingestion isn't available on this channel yet. Acknowledge this and ask them to paste the relevant content as text.)`;
-		}
-		const message: EveMessageContent = sendFileParts
-			? [
-					{ text: messageText, type: "text" as const },
-					...(params.attachments ?? []).map((attachment) => ({
-						data: `data:${attachment.mimeType};base64,${attachment.data.toString("base64")}`,
-						filename: attachment.name,
-						mediaType: attachment.mimeType,
-						type: "file" as const,
-					})),
-				]
-			: messageText;
-		// A chip answer resolves the parked request structurally; sending the
-		// wrapped message too would replay it as a second user turn.
-		const answeringQuestion = Boolean(params.questionResponse && session);
-		const posted = await postEveMessage({
-			auth,
-			clientContext: params.clientContext,
-			inputResponses: answeringQuestion
-				? [params.questionResponse as { optionId: string; requestId: string }]
-				: undefined,
-			message: answeringQuestion ? undefined : message,
-			session,
-		});
-		if (!session) {
-			session = {
+		const composeEveMessage = ({
+			isNewSession,
+		}: {
+			isNewSession: boolean;
+		}): EveMessageContent => {
+			let messageText = buildHarnessMessageText({
 				env,
-				newSession: true,
-				sessionId: posted.sessionId,
-				state: initialState(posted.continuationToken),
-				threadKey: buildThreadKey({ env, thread }),
-			};
-		} else {
-			session.sessionId = posted.sessionId;
-			session.state = {
-				...session.state,
-				continuationToken: posted.continuationToken,
-				status: "running",
-				lastEventAt: Date.now(),
-			};
-		}
-		await upsertEveSession({
-			db,
-			env,
-			orgId: org.id,
-			sessionId: session.sessionId,
-			state: session.state,
-			threadKey: session.threadKey,
-		});
-		run?.resolveSessionId(session.sessionId);
-		await onAgentReady?.();
+				newSession: isNewSession,
+				orgContext,
+				params,
+			});
+			if (params.attachments?.length && !sendFileParts) {
+				const names = params.attachments
+					.map((attachment) => attachment.name ?? attachment.mimeType)
+					.join(", ");
+				messageText = `${messageText}\n\n(The user attached file(s) — ${names} — but file ingestion isn't available on this channel yet. Acknowledge this and ask them to paste the relevant content as text.)`;
+			}
+			return sendFileParts
+				? [
+						{ text: messageText, type: "text" as const },
+						...(params.attachments ?? []).map((attachment) => ({
+							data: `data:${attachment.mimeType};base64,${attachment.data.toString("base64")}`,
+							filename: attachment.name,
+							mediaType: attachment.mimeType,
+							type: "file" as const,
+						})),
+					]
+				: messageText;
+		};
+		let message = composeEveMessage({ isNewSession: newSession });
+		let restartedOnFreshSession = false;
 
-		const abortController = new AbortController();
-		let finalText = "";
-		let pendingText = "";
-		let lastPreview: unknown;
-		let reasoningStreamId: string | undefined;
-		const toolLabels = new Map<string, string>();
-		const toolInputs = new Map<string, Record<string, unknown>>();
-		// The previous turn's tail (step/turn.completed, session.waiting) lands
-		// AFTER input.requested, past where the last run stopped consuming — so it
-		// replays at the start of this run's stream. Ignore terminal events until
-		// this turn's own turn.started arrives, or a stale session.waiting ends
-		// the run before the resumed turn's events ever show up.
-		let turnStarted = false;
+		// Outer attempt: a session whose stream never yields a single event is
+		// dead, and only a brand-new eve session can answer the message.
+		while (true) {
+			// A chip answer resolves the parked request structurally; sending the
+			// wrapped message too would replay it as a second user turn.
+			const answeringQuestion = Boolean(params.questionResponse && session);
+			const posted = await postEveMessage({
+				auth,
+				clientContext: params.clientContext,
+				inputResponses: answeringQuestion
+					? [params.questionResponse as { optionId: string; requestId: string }]
+					: undefined,
+				message: answeringQuestion ? undefined : message,
+				session,
+			});
+			if (session) {
+				adoptPostedEveSession({ posted, session, status: "running" });
+			} else {
+				session = {
+					env,
+					newSession: true,
+					sessionId: posted.sessionId,
+					state: initialState(posted.continuationToken),
+					threadKey: buildThreadKey({ env, thread }),
+				};
+			}
+			await upsertEveSession({
+				db,
+				env,
+				orgId: org.id,
+				sessionId: session.sessionId,
+				state: session.state,
+				threadKey: session.threadKey,
+			});
+			run?.resolveSessionId(session.sessionId);
+			await onAgentReady?.();
 
-		try {
-			// Eve resumes turns asynchronously: right after posting a message or
-			// input response the session can still look idle, and the event stream
-			// closes with nothing. Reconnect through that window instead of
-			// returning an empty turn; give up only after sustained silence.
-			let idleRetries = 0;
-			let disconnectRetries = 0;
-			while (idleRetries < 20) {
-				let sawEvent = false;
-				try {
-					for await (const event of streamEveEvents({
-						auth,
-						session,
-						signal: abortController.signal,
-					})) {
-						sawEvent = true;
-						session.state.streamIndex += 1;
-						session.state.lastEventAt = Date.now();
-						if (run?.stop) {
-							abortController.abort();
-							await updateState({
-								orgId: org.id,
-								session,
-								state: { status: "waiting" },
-							});
-							return {
-								env,
-								finishReason: "stopped",
-								stopReason: run.stop.reason,
-								text: finalText,
-							};
-						}
+			const abortController = new AbortController();
+			let finalText = "";
+			let pendingText = "";
+			let lastPreview: unknown;
+			let reasoningStreamId: string | undefined;
+			const toolLabels = new Map<string, string>();
+			const toolInputs = new Map<string, Record<string, unknown>>();
+			// The previous turn's tail (step/turn.completed, session.waiting) lands
+			// AFTER input.requested, past where the last run stopped consuming — so it
+			// replays at the start of this run's stream. Ignore terminal events until
+			// this turn's own turn.started arrives, or a stale session.waiting ends
+			// the run before the resumed turn's events ever show up.
+			let turnStarted = false;
+			let sawAnyEvent = false;
+			let resyncedAfterSilence = false;
 
-						if (event.type === "turn.started") {
-							turnStarted = true;
-							// A follow-up turn must not inherit the prior turn's preview,
-							// or a preview-less turn ends on a stale catalog decision.
-							lastPreview = undefined;
-						} else if (event.type === "step.started") {
-							if (turnStarted) onThinking?.();
-						} else if (event.type === "actions.requested") {
-							const actions = (event.data?.actions ?? []) as EveAction[];
-							for (const action of actions) {
-								const label = displayEveToolLabel(action);
-								// Utility tools (date converters) aren't worth a status blip.
-								const silent = action.toolName && isSilentTool(action.toolName);
-								if (turnStarted && !silent) await onAction?.(label);
-								if (action.callId) {
-									toolLabels.set(action.callId, label);
-									if (action.input && typeof action.input === "object") {
-										toolInputs.set(
-											action.callId,
-											action.input as Record<string, unknown>,
-										);
-									}
-								}
-							}
-						} else if (event.type === "action.result") {
-							const result = event.data?.result as EveActionResult | undefined;
-							if (
-								event.data?.status === "completed" &&
-								result?.toolName &&
-								isPreviewToolName(result.toolName)
-							) {
-								// Enriched (variant/version flags forced) so the approval card and
-								// the suspension-point decision gate both see the full preview.
-								// Returning mid-turn here would abandon the still-running eve
-								// turn — the decision gate lives at the updateCatalog suspension
-								// in streamWebChat, the one point that pauses the run for real.
-								lastPreview = await enrichCatalogPreview({
-									executeTool: (call) =>
-										executeAutumnMcpTool({ env, token, ...call }),
-									input: result.callId
-										? toolInputs.get(result.callId)
-										: undefined,
-									preview: parsePreviewPayload(result.output) ?? result.output,
-								});
-							}
-							if (result?.callId) {
-								// actions.requested already surfaced this tool as a step;
-								// onAction here again would render every call twice. Only
-								// surface results that never had a requested event.
-								if (turnStarted && !toolLabels.has(result.callId)) {
-									await onAction?.(displayEveToolLabel(labelForResult(result)));
-								}
-								toolLabels.delete(result.callId);
-							}
-						} else if (event.type === "message.appended" && turnStarted) {
-							const messageSoFar = event.data?.messageSoFar;
-							pendingText =
-								typeof messageSoFar === "string"
-									? messageSoFar
-									: `${pendingText}${String(event.data?.messageDelta ?? "")}`;
-							reasoningStreamId ??= crypto.randomUUID();
-							onReasoning?.({ id: reasoningStreamId, text: pendingText });
-						} else if (event.type === "message.completed" && turnStarted) {
-							const message = String(event.data?.message ?? pendingText);
-							pendingText = "";
-							if (event.data?.finishReason === "tool-calls") {
-								reasoningStreamId ??= crypto.randomUUID();
-								onReasoning?.({ id: reasoningStreamId, text: message });
-							} else {
-								if (reasoningStreamId) {
-									onReasoning?.({ id: reasoningStreamId, text: "" });
-								}
-								finalText = message;
-							}
-							reasoningStreamId = undefined;
-						} else if (event.type === "input.requested" && turnStarted) {
-							const requests = (event.data?.requests ??
-								[]) as EveInputRequest[];
-							// Eve's built-in `ask_question` also carries a populated
-							// `action.toolName` (its own), so exclude it — only a real
-							// approval-gated tool call should render as an approval card.
-							const approval = requests.find(
-								(request) =>
-									request.requestId &&
-									request.action?.toolName &&
-									normalizeToolName(request.action.toolName) !== "ask_question",
-							);
-							if (approval?.requestId && approval.action?.toolName) {
+			try {
+				// Eve resumes turns asynchronously: right after posting a message or
+				// input response the session can still look idle, and the event stream
+				// closes with nothing. Reconnect through that window instead of
+				// returning an empty turn; give up only after sustained silence.
+				let idleRetries = 0;
+				let disconnectRetries = 0;
+				while (idleRetries < MAX_IDLE_RETRIES) {
+					let sawEvent = false;
+					try {
+						for await (const event of streamEveEvents({
+							auth,
+							session,
+							signal: abortController.signal,
+						})) {
+							sawEvent = true;
+							session.state.streamIndex += 1;
+							session.state.lastEventAt = Date.now();
+							if (run?.stop) {
+								abortController.abort();
 								await updateState({
 									orgId: org.id,
 									session,
 									state: { status: "waiting" },
 								});
-								const options = approvalOptionIds(approval);
+								return {
+									env,
+									finishReason: "stopped",
+									stopReason: run.stop.reason,
+									text: finalText,
+								};
+							}
+
+							if (event.type === "turn.started") {
+								turnStarted = true;
+								// A follow-up turn must not inherit the prior turn's preview,
+								// or a preview-less turn ends on a stale catalog decision.
+								lastPreview = undefined;
+							} else if (event.type === "step.started") {
+								if (turnStarted) onThinking?.();
+							} else if (event.type === "actions.requested") {
+								const actions = (event.data?.actions ?? []) as EveAction[];
+								for (const action of actions) {
+									const label = displayEveToolLabel(action);
+									// Utility tools (date converters) aren't worth a status blip.
+									const silent =
+										action.toolName && isSilentTool(action.toolName);
+									if (turnStarted && !silent) await onAction?.(label);
+									if (action.callId) {
+										toolLabels.set(action.callId, label);
+										if (action.input && typeof action.input === "object") {
+											toolInputs.set(
+												action.callId,
+												action.input as Record<string, unknown>,
+											);
+										}
+									}
+								}
+							} else if (event.type === "action.result") {
+								const result = event.data?.result as
+									| EveActionResult
+									| undefined;
+								if (
+									event.data?.status === "completed" &&
+									result?.toolName &&
+									isPreviewToolName(result.toolName)
+								) {
+									// Enriched (variant/version flags forced) so the approval card and
+									// the suspension-point decision gate both see the full preview.
+									// Returning mid-turn here would abandon the still-running eve
+									// turn — the decision gate lives at the updateCatalog suspension
+									// in streamWebChat, the one point that pauses the run for real.
+									lastPreview = await enrichCatalogPreview({
+										executeTool: (call) =>
+											executeAutumnMcpTool({ env, token, ...call }),
+										input: result.callId
+											? toolInputs.get(result.callId)
+											: undefined,
+										preview:
+											parsePreviewPayload(result.output) ?? result.output,
+									});
+								}
+								if (result?.callId) {
+									// actions.requested already surfaced this tool as a step;
+									// onAction here again would render every call twice. Only
+									// surface results that never had a requested event.
+									if (turnStarted && !toolLabels.has(result.callId)) {
+										await onAction?.(
+											displayEveToolLabel(labelForResult(result)),
+										);
+									}
+									toolLabels.delete(result.callId);
+								}
+							} else if (event.type === "message.appended" && turnStarted) {
+								const messageSoFar = event.data?.messageSoFar;
+								pendingText =
+									typeof messageSoFar === "string"
+										? messageSoFar
+										: `${pendingText}${String(event.data?.messageDelta ?? "")}`;
+								reasoningStreamId ??= crypto.randomUUID();
+								onReasoning?.({ id: reasoningStreamId, text: pendingText });
+							} else if (event.type === "message.completed" && turnStarted) {
+								const message = String(event.data?.message ?? pendingText);
+								pendingText = "";
+								if (event.data?.finishReason === "tool-calls") {
+									reasoningStreamId ??= crypto.randomUUID();
+									onReasoning?.({ id: reasoningStreamId, text: message });
+								} else {
+									if (reasoningStreamId) {
+										onReasoning?.({ id: reasoningStreamId, text: "" });
+									}
+									finalText = message;
+								}
+								reasoningStreamId = undefined;
+							} else if (event.type === "input.requested" && turnStarted) {
+								const requests = (event.data?.requests ??
+									[]) as EveInputRequest[];
+								// Eve's built-in `ask_question` also carries a populated
+								// `action.toolName` (its own), so exclude it — only a real
+								// approval-gated tool call should render as an approval card.
+								const approval = requests.find(
+									(request) =>
+										request.requestId &&
+										request.action?.toolName &&
+										normalizeToolName(request.action.toolName) !==
+											"ask_question",
+								);
+								if (approval?.requestId && approval.action?.toolName) {
+									await updateState({
+										orgId: org.id,
+										session,
+										state: { status: "waiting" },
+									});
+									const options = approvalOptionIds(approval);
+									return {
+										env,
+										runId: session.sessionId,
+										text: finalText,
+										suspension: {
+											toolCallId: approval.requestId,
+											toolName: approval.action.toolName,
+											toolArgs: {
+												...(approval.action.input ?? {}),
+												_eveApproveOptionId: options.approve,
+												_eveDenyOptionId: options.deny,
+											},
+											preview: parsePreviewPayload(lastPreview),
+										},
+									};
+								}
+								finalText =
+									textForInputRequests(requests) || "Eve is waiting for input.";
+								await updateState({
+									orgId: org.id,
+									session,
+									state: { status: "waiting" },
+								});
+								// Surface the first optioned question structurally so rich surfaces
+								// can render answer buttons; `text` keeps the flat fallback.
+								const optioned = requests.find(
+									(request) => (request.options?.length ?? 0) > 0,
+								);
 								return {
 									env,
 									runId: session.sessionId,
 									text: finalText,
-									suspension: {
-										toolCallId: approval.requestId,
-										toolName: approval.action.toolName,
-										toolArgs: {
-											...(approval.action.input ?? {}),
-											_eveApproveOptionId: options.approve,
-											_eveDenyOptionId: options.deny,
-										},
-										preview: parsePreviewPayload(lastPreview),
+									question:
+										optioned?.prompt && optioned.options && optioned.requestId
+											? {
+													options: optioned.options,
+													prompt: optioned.prompt,
+													requestId: optioned.requestId,
+												}
+											: undefined,
+								};
+							} else if (
+								turnStarted &&
+								(event.type === "turn.failed" ||
+									event.type === "session.failed")
+							) {
+								await updateState({
+									orgId: org.id,
+									session,
+									state: { status: "failed" },
+								});
+								throw new Error(String(event.data?.message ?? "Eve failed"));
+							} else if (
+								turnStarted &&
+								(event.type === "session.waiting" ||
+									event.type === "session.completed")
+							) {
+								if (pendingText) finalText = pendingText;
+								await updateState({
+									orgId: org.id,
+									session,
+									state: {
+										status:
+											event.type === "session.completed"
+												? "completed"
+												: "waiting",
 									},
+								});
+								// The model may (correctly) stop after a preview that needs
+								// versioning/variant/migration choices — surface the decision
+								// card now that the turn is genuinely over.
+								const decisionPlan = catalogPlanNeedingDecision(lastPreview);
+								return {
+									env,
+									runId: session.sessionId,
+									text: finalText,
+									catalogDecision: decisionPlan
+										? { plan: decisionPlan }
+										: undefined,
 								};
 							}
-							finalText =
-								textForInputRequests(requests) || "Eve is waiting for input.";
-							await updateState({
-								orgId: org.id,
-								session,
-								state: { status: "waiting" },
-							});
-							// Surface the first optioned question structurally so rich surfaces
-							// can render answer buttons; `text` keeps the flat fallback.
-							const optioned = requests.find(
-								(request) => (request.options?.length ?? 0) > 0,
-							);
-							return {
-								env,
-								runId: session.sessionId,
-								text: finalText,
-								question:
-									optioned?.prompt && optioned.options && optioned.requestId
-										? {
-												options: optioned.options,
-												prompt: optioned.prompt,
-												requestId: optioned.requestId,
-											}
-										: undefined,
-							};
-						} else if (
-							turnStarted &&
-							(event.type === "turn.failed" || event.type === "session.failed")
-						) {
-							await updateState({
-								orgId: org.id,
-								session,
-								state: { status: "failed" },
-							});
-							throw new Error(String(event.data?.message ?? "Eve failed"));
-						} else if (
-							turnStarted &&
-							(event.type === "session.waiting" ||
-								event.type === "session.completed")
-						) {
-							if (pendingText) finalText = pendingText;
-							await updateState({
-								orgId: org.id,
-								session,
-								state: {
-									status:
-										event.type === "session.completed"
-											? "completed"
-											: "waiting",
+
+							if (session.state.streamIndex % 10 === 0) {
+								await upsertEveSession({
+									db,
+									env,
+									orgId: org.id,
+									sessionId: session.sessionId,
+									state: session.state,
+									threadKey: session.threadKey,
+								});
+							}
+						}
+					} catch (error) {
+						if (error instanceof EveStreamDisconnectedError) {
+							disconnectRetries += 1;
+							logger.warn("Eve stream disconnected; reconnecting", {
+								event: "leaf.eve_stream_disconnected",
+								data: {
+									attempt: disconnectRetries,
+									error: error instanceof Error ? error.message : String(error),
+									session_id: session.sessionId,
+									stream_index: session.state.streamIndex,
 								},
 							});
-							// The model may (correctly) stop after a preview that needs
-							// versioning/variant/migration choices — surface the decision
-							// card now that the turn is genuinely over.
-							const decisionPlan = catalogPlanNeedingDecision(lastPreview);
-							return {
-								env,
-								runId: session.sessionId,
-								text: finalText,
-								catalogDecision: decisionPlan
-									? { plan: decisionPlan }
-									: undefined,
-							};
+							if (disconnectRetries >= MAX_STREAM_DISCONNECT_RETRIES) {
+								throw error;
+							}
+							continue;
 						}
-
-						if (session.state.streamIndex % 10 === 0) {
-							await upsertEveSession({
-								db,
-								env,
-								orgId: org.id,
-								sessionId: session.sessionId,
-								state: session.state,
-								threadKey: session.threadKey,
-							});
-						}
-					}
-				} catch (error) {
-					if (error instanceof EveStreamDisconnectedError) {
-						disconnectRetries += 1;
-						logger.warn("Eve stream disconnected; reconnecting", {
-							event: "leaf.eve_stream_disconnected",
+						if (!(error instanceof EveStreamIdleTimeoutError)) throw error;
+						// Silence this long means the cursor drifted past eve's replay
+						// buffer or the turn died without a terminal event — heal the
+						// cursor and fail visibly rather than spin forever.
+						logger.warn("Eve stream went idle; resyncing cursor", {
+							event: "leaf.eve_stream_idle_timeout",
 							data: {
-								attempt: disconnectRetries,
-								error: error instanceof Error ? error.message : String(error),
 								session_id: session.sessionId,
 								stream_index: session.state.streamIndex,
 							},
 						});
-						if (disconnectRetries >= 5) throw error;
+						await resyncEveStreamIndex({ auth, session });
+						await updateState({
+							orgId: org.id,
+							session,
+							state: { status: "waiting" },
+						});
+						const partialText = finalText || pendingText;
+						if (partialText) {
+							return { env, runId: session.sessionId, text: partialText };
+						}
+						throw new Error(
+							"Eve stopped responding mid-turn — please send your message again.",
+						);
+					}
+					if (sawEvent) sawAnyEvent = true;
+					idleRetries = sawEvent ? 0 : idleRetries + 1;
+					// Nothing at all came back: the cursor may have drifted past
+					// eve's replay buffer, so heal it once and re-arm the budget.
+					const silentlyExhausted =
+						idleRetries >= MAX_IDLE_RETRIES &&
+						!(sawAnyEvent || resyncedAfterSilence);
+					if (silentlyExhausted) {
+						resyncedAfterSilence = true;
+						logger.warn("Eve stream produced nothing; resyncing cursor", {
+							event: "leaf.eve_stream_silent_resync",
+							data: {
+								session_id: session.sessionId,
+								stream_index: session.state.streamIndex,
+							},
+						});
+						await resyncEveStreamIndex({ auth, session });
+						idleRetries = 0;
 						continue;
 					}
-					if (!(error instanceof EveStreamIdleTimeoutError)) throw error;
-					// Silence this long means the cursor drifted past eve's replay
-					// buffer or the turn died without a terminal event — heal the
-					// cursor and fail visibly rather than spin forever.
-					logger.warn("Eve stream went idle; resyncing cursor", {
-						event: "leaf.eve_stream_idle_timeout",
-						data: {
-							session_id: session.sessionId,
-							stream_index: session.state.streamIndex,
-						},
-					});
-					await resyncEveStreamIndex({ auth, session });
-					await updateState({
-						orgId: org.id,
-						session,
-						state: { status: "waiting" },
-					});
-					const partialText = finalText || pendingText;
-					if (partialText) {
-						return { env, runId: session.sessionId, text: partialText };
-					}
-					throw new Error(
-						"Eve stopped responding mid-turn — please send your message again.",
+					await new Promise((resolve) =>
+						setTimeout(resolve, STREAM_RETRY_DELAY_MS),
 					);
 				}
-				idleRetries = sawEvent ? 0 : idleRetries + 1;
-				await new Promise((resolve) => setTimeout(resolve, 500));
+			} finally {
+				abortController.abort();
 			}
-		} finally {
-			abortController.abort();
-		}
 
-		if (pendingText) finalText = pendingText;
-		await updateState({
-			orgId: org.id,
-			session,
-			state: { status: "waiting" },
-		});
-		return { env, runId: session.sessionId, text: finalText };
+			if (pendingText) finalText = pendingText;
+			await updateState({
+				orgId: org.id,
+				session,
+				state: { status: "waiting" },
+			});
+			if (sawAnyEvent) {
+				return { env, runId: session.sessionId, text: finalText };
+			}
+			// A session created in this run can't be stale, so a second fresh one
+			// would go the same way.
+			if (restartedOnFreshSession || session.newSession) {
+				return {
+					env,
+					runId: session.sessionId,
+					sessionDead: restartedOnFreshSession,
+					text: finalText,
+				};
+			}
+
+			// The run behind this session is gone: eve answers every post with a
+			// 200 even when it silently re-homed, so silence is the only signal.
+			restartedOnFreshSession = true;
+			logger.warn("Eve session produced no events; starting a fresh one", {
+				event: "leaf.eve_session_restarted",
+				data: { session_id: session.sessionId },
+			});
+			await deleteEveSession({
+				db,
+				env,
+				orgId: org.id,
+				threadKey: session.threadKey,
+			});
+			session = undefined;
+			orgContext = await autumnOrgContextService.load({ env, logger, token });
+			message = composeEveMessage({ isNewSession: true });
+		}
 	},
 };

--- a/apps/leaf/src/harness/eve/repo.ts
+++ b/apps/leaf/src/harness/eve/repo.ts
@@ -137,6 +137,29 @@ export const upsertEveSession = async ({
 		});
 };
 
+/** Drops a thread's session so the next message opens a brand-new eve run. */
+export const deleteEveSession = async ({
+	db,
+	env,
+	orgId,
+	threadKey,
+}: {
+	db: ChatDb;
+	env: AppEnv;
+	orgId: string;
+	threadKey: string;
+}) => {
+	await db
+		.delete(harnessSessions)
+		.where(
+			and(
+				eq(harnessSessions.org_id, orgId),
+				eq(harnessSessions.env, env),
+				eq(harnessSessions.thread_key, threadKey),
+			),
+		);
+};
+
 export const listHarnessSessions = async ({
 	db,
 	env,

--- a/apps/leaf/src/harness/eve/streamErrors.ts
+++ b/apps/leaf/src/harness/eve/streamErrors.ts
@@ -12,3 +12,24 @@ export const isRetryableEveStreamError = (error: unknown) => {
 		message.toLowerCase().includes(candidate),
 	);
 };
+
+const REHOME_REFUSAL_PATTERN = /cannot deliver inputresponses/i;
+
+/** A non-2xx from an eve session POST — carries the body, which is the only
+ * place eve explains itself (e.g. its refusal to re-home input responses). */
+export class EveSessionRequestError extends Error {
+	readonly body: string;
+	readonly status: number;
+	constructor({ body, status }: { body: string; status: number }) {
+		super(`Eve session request failed: ${status}${body ? ` — ${body}` : ""}`);
+		this.name = "EveSessionRequestError";
+		this.body = body;
+		this.status = status;
+	}
+}
+
+/** Eve cannot deliver an answer to a request that belonged to a run it has
+ * since replaced — the answered tool call is gone, so nothing was written. */
+export const isEveInputResponseRehomeRefusal = (error: unknown) =>
+	error instanceof EveSessionRequestError &&
+	REHOME_REFUSAL_PATTERN.test(error.body);

--- a/apps/leaf/src/harness/eve/turnOutput.ts
+++ b/apps/leaf/src/harness/eve/turnOutput.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether a finished turn left the user anything. Eve can end a turn cleanly
+ * while parked on an unanswered request: the run wakes, says nothing, and the
+ * thread would silently wedge unless the caller treats that as a failure.
+ */
+export const eveTurnProducedOutput = ({
+	catalogDecision,
+	question,
+	suspension,
+	text,
+}: {
+	catalogDecision?: unknown;
+	question?: unknown;
+	suspension?: unknown;
+	text?: string;
+}) => Boolean(text?.trim() || catalogDecision || question || suspension);

--- a/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
@@ -39,7 +39,12 @@ export const resolveApproval = async ({
 
 	let result: ApprovalRunResult;
 	try {
-		result = await resume({ approval, onProgress, providerUserId, approverToken });
+		result = await resume({
+			approval,
+			onProgress,
+			providerUserId,
+			approverToken,
+		});
 	} catch (error) {
 		// A thrown resumer error means the write never ran — keep the approval
 		// pending so the user can retry.
@@ -50,14 +55,21 @@ export const resolveApproval = async ({
 		return approvalErrorResult(error, { retryable: true });
 	}
 
-	// Retryable errors leave the row pending; everything else is finalized.
-	if (!("error" in result && result.retryable)) {
-		await chatApprovalRepo.finalize({
+	// A retryable error means the write never ran — hand the row back to
+	// 'pending' so the card can be clicked again; everything else is finalized.
+	if ("error" in result && result.retryable) {
+		await chatApprovalRepo.release({
 			approvalId: approval.id,
 			db,
 			providerUserId,
-			status: "error" in result ? "failed" : "approved",
 		});
+		return result;
 	}
+	await chatApprovalRepo.finalize({
+		approvalId: approval.id,
+		db,
+		providerUserId,
+		status: "error" in result ? "failed" : "approved",
+	});
 	return result;
 };

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -9,10 +9,12 @@ import { resolveSlackCallerAuth } from "../../../../agent/runMessage/setup/resol
 import { denyEveApproval } from "../../../../harness/eve/approval.js";
 import { db } from "../../../../lib/db.js";
 import { logger as rootLogger } from "../../../../lib/logger.js";
-import { approvalStatusCard } from "../../../../ui/blocks.js";
+import { approvalCard, approvalStatusCard } from "../../../../ui/blocks.js";
 import { questionCard } from "../../../../ui/eveCards.js";
 import { createThrottledCardEditor } from "../../../../ui/throttledEditor.js";
 import { getInstallationOAuthAccessToken } from "../../../installations/actions/getInstallationOAuthAccessToken.js";
+import { runExclusiveThreadTask } from "../../../runs/runCoordinator.js";
+import { runKeyForThread } from "../../../runs/runRegistry.js";
 import { validateSlackAdminAccess } from "../../../slackAdmin/access.js";
 import { isInternalAutumnSlackProvider } from "../../../slackAdmin/provider.js";
 import { resolveApproval } from "../../actions/resolveApproval.js";
@@ -21,6 +23,7 @@ import type {
 	ApprovalActionDeps,
 	ApprovalAuthorization,
 	ApprovalCardStatus,
+	ApprovalRunResult,
 } from "../../types.js";
 import {
 	approvalErrorResult,
@@ -39,6 +42,27 @@ const detailsFromApproval = ({ approval }: { approval?: ChatApproval }) => ({
 	env: approval?.env,
 	preview: approval?.preview ?? undefined,
 });
+
+const isRetryableApprovalResult = (
+	result: ApprovalRunResult,
+): result is { error: true; message: string; retryable?: boolean } =>
+	"error" in result && result.retryable === true;
+
+// A resume drives the same session as a message run, so it takes the thread's
+// run slot rather than racing an in-flight turn (or a second approver's click).
+const approvalThreadRunKey = ({
+	approval,
+	event,
+}: {
+	approval: ChatApproval;
+	event: ActionEvent;
+}) =>
+	runKeyForThread({
+		channelId: approval.channel_id,
+		provider: approval.provider,
+		threadId: event.threadId,
+		workspaceId: approval.workspace_id,
+	});
 
 const authorizeSlackApprovalClicker = async ({
 	approval,
@@ -319,16 +343,20 @@ export const handleApprovalActionWithDeps = async ({
 		const heartbeat = setInterval(() => editor.requestEdit(), 10_000);
 		let result: Awaited<ReturnType<ApprovalActionDeps["resolveApproval"]>>;
 		try {
-			result = await deps.resolveApproval({
-				approval: claimed,
-				onProgress: (line) => {
-					statusText = line;
-					editor.requestEdit();
-				},
-				providerUserId,
-				approverToken: authorization?.allowed
-					? authorization.approverToken
-					: undefined,
+			result = await runExclusiveThreadTask({
+				runKey: approvalThreadRunKey({ approval: claimed, event }),
+				task: () =>
+					deps.resolveApproval({
+						approval: claimed,
+						onProgress: (line) => {
+							statusText = line;
+							editor.requestEdit();
+						},
+						providerUserId,
+						approverToken: authorization?.allowed
+							? authorization.approverToken
+							: undefined,
+					}),
 			});
 		} finally {
 			clearInterval(heartbeat);
@@ -341,6 +369,27 @@ export const handleApprovalActionWithDeps = async ({
 			status: failed ? "failed" : "approved",
 			tool: details.toolName,
 		});
+
+		// A retryable failure means the write never ran and the row went back to
+		// pending — keep the buttons so the same card can be approved again.
+		if (isRetryableApprovalResult(result)) {
+			await deps.editActionMessage({
+				content: approvalCard({
+					env: claimed.env,
+					id: approvalId,
+					preview: claimed.preview ?? undefined,
+					requesterId: claimed.provider_user_id,
+					toolArgs: details.toolArgs,
+					toolName: claimed.tool_name,
+				}),
+				event,
+			});
+			await deps.postThreadReply({
+				event,
+				markdown: `I couldn't complete that action (${result.message}) and nothing was written. The approval is still open — approve it again to retry.`,
+			});
+			return;
+		}
 
 		// The agent's continuation is conversation — it belongs in the thread,
 		// while the card stays a compact record of what ran.

--- a/apps/leaf/src/internal/runs/runCoordinator.ts
+++ b/apps/leaf/src/internal/runs/runCoordinator.ts
@@ -31,6 +31,30 @@ const queuedCounts = new Map<string, number>();
 export const hasQueuedThreadMessage = (runKey: string) =>
 	(queuedCounts.get(runKey) ?? 0) > 0;
 
+/** Runs `task` after the thread's current run, and holds the thread until it
+ * finishes — the engine can't drive two turns on one session. */
+export const runExclusiveThreadTask = async <T>({
+	runKey,
+	task,
+}: {
+	runKey: string;
+	task: () => Promise<T>;
+}): Promise<T> => {
+	const tail = newRunTails.get(runKey) ?? Promise.resolve();
+	const result = tail.then(task);
+	// The tail must never reject, or every task queued behind it is skipped.
+	const next = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	newRunTails.set(runKey, next);
+	try {
+		return await result;
+	} finally {
+		if (newRunTails.get(runKey) === next) newRunTails.delete(runKey);
+	}
+};
+
 export const dispatchThreadMessage = async ({
 	hasAttachments,
 	onFollowUpInjected,
@@ -85,20 +109,14 @@ export const dispatchThreadMessage = async ({
 
 	// New runs (and non-injectable messages) wait for the thread's current
 	// run — the engine can't drive two turns on one session.
-	const tail = newRunTails.get(runKey) ?? Promise.resolve();
 	queuedCounts.set(runKey, (queuedCounts.get(runKey) ?? 0) + 1);
-	const next = tail
-		.then(() => {
+	await runExclusiveThreadTask({
+		runKey,
+		task: async () => {
 			const remaining = (queuedCounts.get(runKey) ?? 1) - 1;
 			if (remaining > 0) queuedCounts.set(runKey, remaining);
 			else queuedCounts.delete(runKey);
-			return runNewMessage();
-		})
-		.catch(() => {});
-	newRunTails.set(runKey, next);
-	try {
-		await next;
-	} finally {
-		if (newRunTails.get(runKey) === next) newRunTails.delete(runKey);
-	}
+			await runNewMessage();
+		},
+	}).catch(() => {});
 };

--- a/apps/leaf/src/types.ts
+++ b/apps/leaf/src/types.ts
@@ -31,6 +31,7 @@ export const agentOutputSchema = z.preprocess(
 			finishReason: payload.finishReason,
 			stopReason: payload.stopReason,
 			runId: payload.runId,
+			sessionDead: payload.sessionDead,
 			suspension: suspension && {
 				toolCallId: suspension.toolCallId,
 				toolName: suspension.toolName,
@@ -53,6 +54,9 @@ export const agentOutputSchema = z.preprocess(
 		finishReason: z.string().optional(),
 		stopReason: z.enum(["timeout", "user"]).optional(),
 		runId: z.string().optional(),
+		// Set when the harness had to abandon the thread's session — an empty
+		// reply then means "lost the session", not "nothing to say".
+		sessionDead: z.boolean().optional(),
 		// Set when the agent paused on a destructive write awaiting approval.
 		suspension: z
 			.strictObject({

--- a/apps/leaf/tests/unit/harness/adopt-posted-eve-session.test.ts
+++ b/apps/leaf/tests/unit/harness/adopt-posted-eve-session.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import { adoptPostedEveSession } from "../../../src/harness/eve/adoptPostedSession.js";
+import type { EveSessionRef } from "../../../src/harness/eve/types.js";
+
+const sessionAt = (streamIndex: number): EveSessionRef => ({
+	env: AppEnv.Sandbox,
+	newSession: false,
+	sessionId: "eve_session_1",
+	state: {
+		version: 1,
+		continuationToken: "token_1",
+		streamIndex,
+		status: "waiting",
+		lastEventAt: 0,
+	},
+	threadKey: "sandbox:slack:T1:C1:thread_1",
+});
+
+describe("adoptPostedEveSession", () => {
+	test("rewinds the stream cursor when eve re-homed onto a new run", () => {
+		const session = sessionAt(42);
+
+		const { rehomed } = adoptPostedEveSession({
+			posted: { continuationToken: "token_2", sessionId: "eve_session_2" },
+			session,
+			status: "running",
+		});
+
+		expect(rehomed).toBe(true);
+		expect(session.sessionId).toBe("eve_session_2");
+		expect(session.state.streamIndex).toBe(0);
+		expect(session.state.continuationToken).toBe("token_2");
+		expect(session.state.status).toBe("running");
+	});
+
+	test("keeps the cursor when the same run answered", () => {
+		const session = sessionAt(42);
+
+		const { rehomed } = adoptPostedEveSession({
+			posted: { continuationToken: "token_2", sessionId: "eve_session_1" },
+			session,
+			status: "running",
+		});
+
+		expect(rehomed).toBe(false);
+		expect(session.state.streamIndex).toBe(42);
+		expect(session.state.continuationToken).toBe("token_2");
+	});
+
+	test("leaves the status alone when the caller does not set one", () => {
+		const session = sessionAt(7);
+
+		adoptPostedEveSession({
+			posted: { continuationToken: "token_2", sessionId: "eve_session_1" },
+			session,
+		});
+
+		expect(session.state.status).toBe("waiting");
+		expect(session.state.lastEventAt).toBeGreaterThan(0);
+	});
+});

--- a/apps/leaf/tests/unit/harness/classify-parked-eve-input.test.ts
+++ b/apps/leaf/tests/unit/harness/classify-parked-eve-input.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { classifyParkedEveInput } from "../../../src/harness/eve/classifyParkedInput.js";
+
+describe("classifyParkedEveInput", () => {
+	test("surfaces an ask_question with no options instead of dropping it", () => {
+		const parked = classifyParkedEveInput({
+			requests: [
+				{
+					action: { toolName: "ask_question" },
+					prompt: "Which plan should I migrate them onto?",
+					requestId: "req_2",
+				},
+			],
+			skipRequestId: "req_1",
+		});
+
+		expect(parked).toEqual({
+			kind: "waiting",
+			text: "Which plan should I migrate them onto?",
+		});
+	});
+
+	test("falls back to a generic line when the park carries no prompt", () => {
+		const parked = classifyParkedEveInput({
+			requests: [{ requestId: "req_2" }],
+		});
+
+		expect(parked).toEqual({
+			kind: "waiting",
+			text: "Eve is waiting for input.",
+		});
+	});
+
+	test("captures a chained gated write", () => {
+		const parked = classifyParkedEveInput({
+			requests: [
+				{
+					action: { input: { plan_id: "pro" }, toolName: "autumn__attach" },
+					requestId: "req_2",
+				},
+			],
+			skipRequestId: "req_1",
+		});
+
+		expect(parked).toEqual({
+			chained: {
+				input: { plan_id: "pro" },
+				options: undefined,
+				requestId: "req_2",
+				toolName: "autumn__attach",
+			},
+			kind: "gated",
+		});
+	});
+
+	test("captures an optioned question", () => {
+		const parked = classifyParkedEveInput({
+			requests: [
+				{
+					action: { toolName: "ask_question" },
+					options: [{ id: "yes", label: "Yes" }],
+					prompt: "Apply now?",
+					requestId: "req_2",
+				},
+			],
+		});
+
+		expect(parked).toEqual({
+			kind: "question",
+			question: {
+				options: [{ id: "yes", label: "Yes" }],
+				prompt: "Apply now?",
+				requestId: "req_2",
+			},
+		});
+	});
+
+	test("ignores the request that was just answered", () => {
+		expect(
+			classifyParkedEveInput({
+				requests: [
+					{
+						action: { toolName: "autumn__attach" },
+						prompt: "Approve?",
+						requestId: "req_1",
+					},
+				],
+				skipRequestId: "req_1",
+			}),
+		).toBeUndefined();
+	});
+});

--- a/apps/leaf/tests/unit/harness/dead-session.test.ts
+++ b/apps/leaf/tests/unit/harness/dead-session.test.ts
@@ -16,6 +16,19 @@ describe("isMissingSessionApiError", () => {
 		).toBe(true);
 	});
 
+	test("recognises a 400 invalid-session-id rejection", () => {
+		expect(
+			isMissingSessionApiError(
+				Object.assign(
+					new Error(
+						'400 {"type":"error","error":{"type":"invalid_request_error","message":"Invalid session ID: session_dead_test"}}',
+					),
+					{ status: 400 },
+				),
+			),
+		).toBe(true);
+	});
+
 	test("does not swallow unrelated failures", () => {
 		expect(
 			isMissingSessionApiError(

--- a/apps/leaf/tests/unit/harness/dead-session.test.ts
+++ b/apps/leaf/tests/unit/harness/dead-session.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { isMissingSessionApiError } from "../../../src/harness/common/deadSession.js";
+
+describe("isMissingSessionApiError", () => {
+	test("recognises a 404 from the sessions API", () => {
+		expect(
+			isMissingSessionApiError(
+				Object.assign(new Error("Not Found"), { status: 404 }),
+			),
+		).toBe(true);
+	});
+
+	test("recognises a not-found message without a status", () => {
+		expect(
+			isMissingSessionApiError(new Error("Session sesn_1 not found")),
+		).toBe(true);
+	});
+
+	test("does not swallow unrelated failures", () => {
+		expect(
+			isMissingSessionApiError(
+				Object.assign(new Error("Overloaded"), { status: 529 }),
+			),
+		).toBe(false);
+		expect(isMissingSessionApiError(new Error("customer not found"))).toBe(
+			false,
+		);
+	});
+});

--- a/apps/leaf/tests/unit/harness/deny-extra-suspended-calls.test.ts
+++ b/apps/leaf/tests/unit/harness/deny-extra-suspended-calls.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import type Anthropic from "@anthropic-ai/sdk";
+import type { AutumnLogger } from "@autumn/logging";
+import { denyExtraSuspendedCalls } from "../../../src/harness/claudeManaged/session/denyExtraSuspendedCalls.js";
+import type { SessionTurnOutcome } from "../../../src/harness/common/types.js";
+
+const testLogger = {
+	child: () => testLogger,
+	debug: () => {},
+	error: () => {},
+	info: () => {},
+	warn: () => {},
+	warning: () => {},
+} as unknown as AutumnLogger;
+
+const clientCapturingSends = (sends: unknown[], send?: () => Promise<void>) =>
+	({
+		beta: {
+			sessions: {
+				events: {
+					send: async (_sessionId: string, body: { events: unknown[] }) => {
+						sends.push(...body.events);
+						await send?.();
+					},
+				},
+			},
+		},
+	}) as unknown as Anthropic;
+
+const suspendedOutcome = (
+	queue: Array<{ toolCallId: string; toolName: string }>,
+): SessionTurnOutcome => ({
+	suspendedQueue: queue.map((call) => ({ ...call, args: {} })),
+	textParts: [],
+	usage: {
+		cacheCreationInputTokens: 0,
+		cacheReadInputTokens: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+	},
+});
+
+describe("denyExtraSuspendedCalls", () => {
+	test("denies every suspended call after the first", async () => {
+		const sends: unknown[] = [];
+		const outcome = suspendedOutcome([
+			{ toolCallId: "call_1", toolName: "attach" },
+			{ toolCallId: "call_2", toolName: "updateSubscription" },
+			{ toolCallId: "call_3", toolName: "createPlan" },
+		]);
+
+		await denyExtraSuspendedCalls({
+			client: clientCapturingSends(sends),
+			logger: testLogger,
+			outcome,
+			sessionId: "sesn_1",
+		});
+
+		expect(sends).toHaveLength(2);
+		expect(sends).toEqual([
+			{
+				deny_message: expect.stringContaining("one gated write at a time"),
+				result: "deny",
+				tool_use_id: "call_2",
+				type: "user.tool_confirmation",
+			},
+			{
+				deny_message: expect.stringContaining("one gated write at a time"),
+				result: "deny",
+				tool_use_id: "call_3",
+				type: "user.tool_confirmation",
+			},
+		]);
+		expect(outcome.suspendedQueue).toEqual([
+			{ args: {}, toolCallId: "call_1", toolName: "attach" },
+		]);
+	});
+
+	test("leaves a single suspended call untouched", async () => {
+		const sends: unknown[] = [];
+		const outcome = suspendedOutcome([
+			{ toolCallId: "call_1", toolName: "attach" },
+		]);
+
+		await denyExtraSuspendedCalls({
+			client: clientCapturingSends(sends),
+			logger: testLogger,
+			outcome,
+			sessionId: "sesn_1",
+		});
+
+		expect(sends).toEqual([]);
+		expect(outcome.suspendedQueue).toHaveLength(1);
+	});
+
+	test("keeps the queue intact when the deny cannot be sent", async () => {
+		const sends: unknown[] = [];
+		const outcome = suspendedOutcome([
+			{ toolCallId: "call_1", toolName: "attach" },
+			{ toolCallId: "call_2", toolName: "createPlan" },
+		]);
+
+		await denyExtraSuspendedCalls({
+			client: clientCapturingSends(sends, async () => {
+				throw new Error("session unreachable");
+			}),
+			logger: testLogger,
+			outcome,
+			sessionId: "sesn_1",
+		});
+
+		expect(outcome.suspendedQueue).toHaveLength(2);
+	});
+});

--- a/apps/leaf/tests/unit/harness/driveSessionTurn.test.ts
+++ b/apps/leaf/tests/unit/harness/driveSessionTurn.test.ts
@@ -141,6 +141,93 @@ describe("driveSessionTurn", () => {
 		expect(outcome.textParts).toEqual(["second turn"]);
 	});
 
+	test("leaves a turn that ends normally usable", async () => {
+		const outcome = await driveSessionTurn({
+			autumnMcpServerName: "autumn",
+			client: clientWithEvents([
+				{ type: "agent.message", content: [{ type: "text", text: "hi" }] },
+				idleEndTurn,
+			]),
+			kickoff: async () => {},
+			sessionId: "sesn_1",
+		});
+
+		expect(outcome.sessionDead).toBeUndefined();
+		expect(outcome.errorMessage).toBeUndefined();
+	});
+
+	test("reports a terminated session as dead instead of an empty answer", async () => {
+		const outcome = await driveSessionTurn({
+			autumnMcpServerName: "autumn",
+			client: clientWithEvents([{ type: "session.status_terminated" }]),
+			kickoff: async () => {},
+			sessionId: "sesn_1",
+		});
+
+		expect(outcome.sessionDead).toBe(true);
+		expect(outcome.errorMessage).toBe(
+			"The agent session terminated before finishing the turn.",
+		);
+		expect(outcome.textParts).toEqual([]);
+	});
+
+	test("reports a deleted session as dead", async () => {
+		const outcome = await driveSessionTurn({
+			autumnMcpServerName: "autumn",
+			client: clientWithEvents([{ type: "session.deleted" }]),
+			kickoff: async () => {},
+			sessionId: "sesn_1",
+		});
+
+		expect(outcome.sessionDead).toBe(true);
+		expect(outcome.errorMessage).toBe("The agent session no longer exists.");
+	});
+
+	test("reports a stream that ends without a terminal event as dead", async () => {
+		const outcome = await driveSessionTurn({
+			autumnMcpServerName: "autumn",
+			client: clientWithEvents([
+				{
+					type: "agent.message",
+					content: [{ type: "text", text: "half an answer" }],
+				},
+			]),
+			kickoff: async () => {},
+			sessionId: "sesn_1",
+		});
+
+		expect(outcome.sessionDead).toBe(true);
+		expect(outcome.errorMessage).toBe(
+			"The agent session stream ended before the turn finished.",
+		);
+		expect(outcome.textParts).toEqual(["half an answer"]);
+	});
+
+	test("keeps a suspended turn alive", async () => {
+		const outcome = await driveSessionTurn({
+			autumnMcpServerName: "autumn",
+			client: clientWithEvents([
+				{
+					type: "agent.mcp_tool_use",
+					id: "t1",
+					name: "attach",
+					mcp_server_name: "autumn",
+					input: { plan_id: "pro" },
+					evaluated_permission: "ask",
+				},
+				{
+					type: "session.status_idle",
+					stop_reason: { type: "requires_action", event_ids: ["t1"] },
+				},
+			]),
+			kickoff: async () => {},
+			sessionId: "sesn_1",
+		});
+
+		expect(outcome.sessionDead).toBeUndefined();
+		expect(outcome.suspendedQueue).toHaveLength(1);
+	});
+
 	test("keeps terminal session errors as turn failures", async () => {
 		const outcome = await driveSessionTurn({
 			autumnMcpServerName: "autumn",

--- a/apps/leaf/tests/unit/harness/eve-session-errors.test.ts
+++ b/apps/leaf/tests/unit/harness/eve-session-errors.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+	EveSessionRequestError,
+	isEveInputResponseRehomeRefusal,
+} from "../../../src/harness/eve/streamErrors.js";
+
+describe("EveSessionRequestError", () => {
+	test("carries the status and body eve explained itself with", () => {
+		const error = new EveSessionRequestError({
+			body: 'Cannot deliver inputResponses to a new run for session "s_1"',
+			status: 400,
+		});
+
+		expect(error.status).toBe(400);
+		expect(error.message).toContain("400");
+		expect(error.message).toContain("Cannot deliver inputResponses");
+	});
+});
+
+describe("isEveInputResponseRehomeRefusal", () => {
+	test("recognises eve refusing to re-home an answer", () => {
+		expect(
+			isEveInputResponseRehomeRefusal(
+				new EveSessionRequestError({
+					body: "Cannot deliver inputResponses to a new run",
+					status: 400,
+				}),
+			),
+		).toBe(true);
+	});
+
+	test("does not match other session failures", () => {
+		expect(
+			isEveInputResponseRehomeRefusal(
+				new EveSessionRequestError({ body: "internal error", status: 500 }),
+			),
+		).toBe(false);
+		expect(isEveInputResponseRehomeRefusal(new Error("network down"))).toBe(
+			false,
+		);
+	});
+});

--- a/apps/leaf/tests/unit/harness/eve-turn-output.test.ts
+++ b/apps/leaf/tests/unit/harness/eve-turn-output.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { eveTurnProducedOutput } from "../../../src/harness/eve/turnOutput.js";
+
+describe("eveTurnProducedOutput", () => {
+	test("a turn that ends with no text and nothing pending recovers", () => {
+		expect(eveTurnProducedOutput({ text: "" })).toBe(false);
+		expect(eveTurnProducedOutput({ text: "   \n" })).toBe(false);
+		expect(eveTurnProducedOutput({})).toBe(false);
+	});
+
+	test("any user-visible result keeps the turn", () => {
+		expect(eveTurnProducedOutput({ text: "Attached pro." })).toBe(true);
+		expect(
+			eveTurnProducedOutput({ catalogDecision: { id: "pro" }, text: "" }),
+		).toBe(true);
+		expect(eveTurnProducedOutput({ question: { prompt: "Which?" } })).toBe(
+			true,
+		);
+		expect(eveTurnProducedOutput({ suspension: { toolName: "attach" } })).toBe(
+			true,
+		);
+	});
+});

--- a/apps/leaf/tests/unit/runs/runCoordinator.test.ts
+++ b/apps/leaf/tests/unit/runs/runCoordinator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	dispatchThreadMessage,
 	isStopMessage,
+	runExclusiveThreadTask,
 } from "../../../src/internal/runs/runCoordinator.js";
 import {
 	closeRun,
@@ -160,6 +161,77 @@ describe("dispatchThreadMessage", () => {
 
 		expect(newRuns).toBe(1);
 		closeRun({ key: "co5", run });
+	});
+
+	test("holds a new run until an exclusive thread task finishes", async () => {
+		const order: string[] = [];
+		const approvalResume = runExclusiveThreadTask({
+			runKey: "co7",
+			task: async () => {
+				order.push("approval:start");
+				await Bun.sleep(20);
+				order.push("approval:end");
+				return "resumed";
+			},
+		});
+		const message = dispatchThreadMessage({
+			hasAttachments: false,
+			providerUserId: "U1",
+			runKey: "co7",
+			runNewMessage: async () => {
+				order.push("message:start");
+			},
+			text: "and now cancel it",
+		});
+
+		const [resumeResult] = await Promise.all([approvalResume, message]);
+		expect(resumeResult).toBe("resumed");
+		expect(order).toEqual(["approval:start", "approval:end", "message:start"]);
+	});
+
+	test("serializes two approval resumes on one thread", async () => {
+		const order: string[] = [];
+		const resume = (label: string) =>
+			runExclusiveThreadTask({
+				runKey: "co8",
+				task: async () => {
+					order.push(`${label}:start`);
+					await Bun.sleep(10);
+					order.push(`${label}:end`);
+				},
+			});
+
+		await Promise.all([resume("first"), resume("second")]);
+
+		expect(order).toEqual([
+			"first:start",
+			"first:end",
+			"second:start",
+			"second:end",
+		]);
+	});
+
+	test("frees the thread when an exclusive task throws", async () => {
+		const failing = runExclusiveThreadTask({
+			runKey: "co9",
+			task: async () => {
+				throw new Error("resume failed");
+			},
+		});
+
+		await expect(failing).rejects.toThrow("resume failed");
+		let newRuns = 0;
+		await dispatchThreadMessage({
+			hasAttachments: false,
+			providerUserId: "U1",
+			runKey: "co9",
+			runNewMessage: async () => {
+				newRuns += 1;
+			},
+			text: "try again",
+		});
+
+		expect(newRuns).toBe(1);
 	});
 
 	test("does not inject a different sender's message into the owner's run", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Heals broken Claude Managed and Eve sessions so threads don’t wedge or post empty replies, and serializes approval resumes so only one turn runs per thread.

- **Bug Fixes**
  - Managed sessions: treat terminated/deleted/truncated streams as failures (`sessionDead`), detect missing/invalid IDs, drop the dead row, and retry once on a fresh session; skip dropping on interrupted runs (`finishReason: "stopped"`).
  - Eve sessions: resync the stream cursor on idle/silent resumes, adopt re-homed session IDs and rewind the cursor, and restart the session once if a turn ends with no user-visible output.
  - Never drop parked Eve requests: classify gated writes and optioned questions, and surface other parks as text so nothing wedges.
  - Map rejected Eve approval answers (e.g. rehome refusals) to retryable errors and keep the approval card clickable.
  - Post a clear warning when no reply is produced, and a specific notice when the session was lost, instead of "Done."
  - Deny extra suspended tool calls after the first so a turn can’t wedge behind unseen approvals.

- **New Features**
  - Per-thread exclusive task lane to serialize approval resumes with message runs.
  - Repo method to delete a session by id, enabling self-heal on the next turn.

<sup>Written for commit e9ef032db18ea2e71c8684ac651033c61edc3ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

