### PR TITLE
perf(sync): reduce customer dirty coalescing window

### DIFF
--- a/server/src/internal/balances/utils/sync/syncItemV5.ts
+++ b/server/src/internal/balances/utils/sync/syncItemV5.ts
@@ -11,7 +11,7 @@ const COALESCE_WINDOW_MS =
 	process.env.NODE_ENV === "test" ||
 	process.env.NODE_ENV === "development"
 		? 500
-		: 3_000;
+		: 1_000;
 
 export interface SyncCustomerDirtyPayload {
 	customerId: string;


### PR DESCRIPTION
Reduce the production `SyncCustomerDirty` drain coalescing window from three seconds to one second. Development and test environments retain the existing 500 ms window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce the coalescing window for `SyncCustomerDirty` in production from 3s to 1s to lower sync delay and surface customer balance updates faster. Dev and test remain at 500ms.

<sup>Written for commit 4c15e2b2a546504a3f316645ccc81a1a201a143a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Reduces the production customer-balance synchronization coalescing delay while preserving the existing development and test delay.

- **[Improvements]** Changes the production `SyncCustomerDirty` coalescing window from three seconds to one second.
- **[Improvements]** Keeps the development and test coalescing window at 500 ms.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness or security issue identified.

Per-customer synchronization remains serialized and atomically claimed; the change only shortens how long production waits to combine dirty updates.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/sync/syncItemV5.ts | Reduces the production drain delay from 3,000 ms to 1,000 ms without changing synchronization or environment-selection logic. |

<sub>Reviews (1): Last reviewed commit: ["perf(sync): reduce dirty coalescing wind..."](https://github.com/useautumn/autumn/commit/4c15e2b2a546504a3f316645ccc81a1a201a143a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52571525)</sub>

<!-- /greptile_comment -->