### PR TITLE
feat(customers): expose who referred this customer via referred_by expand (#2395)

### DIFF
--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpand.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpand.ts
@@ -11,6 +11,7 @@ import { getCusAutoTopupPurchaseLimits } from "../cusResponseUtils/getCusAutoTop
 import { getCusInvoicePreviews } from "../cusResponseUtils/getCusInvoicePreviews.js";
 import { getCusPaymentMethodRes } from "../cusResponseUtils/getCusPaymentMethodRes.js";
 import { getCusReferrals } from "../cusResponseUtils/getCusReferrals.js";
+import { getCusReferredBy } from "../cusResponseUtils/getCusReferredBy.js";
 import { getCusRewards } from "../cusResponseUtils/getCusRewards.js";
 import { getCusTrialsUsed } from "../cusResponseUtils/getCusTrialsUsed.js";
 import type { ApiCustomerExpandResult } from "./getApiCustomerExpandV2.js";
@@ -61,6 +62,7 @@ export const getApiCustomerExpand = async ({
 	const [
 		rewards,
 		referrals,
+		referredBy,
 		paymentMethod,
 		trialsUsed,
 		autoTopupsWithLimits,
@@ -76,6 +78,11 @@ export const getApiCustomerExpand = async ({
 			expand: cusExpand,
 		}),
 		getCusReferrals({
+			db,
+			fullCus,
+			expand: cusExpand,
+		}),
+		getCusReferredBy({
 			db,
 			fullCus,
 			expand: cusExpand,
@@ -110,6 +117,7 @@ export const getApiCustomerExpand = async ({
 		rewards: rewards ?? undefined,
 		invoice_previews: invoicePreviews ?? undefined,
 		referrals: referrals ?? undefined,
+		referred_by: referredBy ?? undefined,
 		payment_method: paymentMethod ?? undefined,
 		billing_controls_override: autoTopupsWithLimits
 			? { auto_topups: autoTopupsWithLimits }

--- a/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpandV2.ts
+++ b/server/src/internal/customers/cusUtils/apiCusUtils/getApiCustomerExpandV2.ts
@@ -14,6 +14,7 @@ import { getCusAutoTopupPurchaseLimits } from "../cusResponseUtils/getCusAutoTop
 import { getCusInvoicePreviews } from "../cusResponseUtils/getCusInvoicePreviews.js";
 import { getCusPaymentMethodRes } from "../cusResponseUtils/getCusPaymentMethodRes.js";
 import { getCusReferrals } from "../cusResponseUtils/getCusReferrals.js";
+import { getCusReferredBy } from "../cusResponseUtils/getCusReferredBy.js";
 import { getCusRewards } from "../cusResponseUtils/getCusRewards.js";
 import { getCusTrialsUsed } from "../cusResponseUtils/getCusTrialsUsed.js";
 
@@ -84,6 +85,7 @@ export const getApiCustomerExpandV2 = async ({
 		entities,
 		rewards,
 		referrals,
+		referredBy,
 		paymentMethod,
 		trialsUsed,
 		autoTopupsWithLimits,
@@ -98,6 +100,11 @@ export const getApiCustomerExpandV2 = async ({
 			expand: cusExpand,
 		}),
 		getCusReferrals({
+			db: ctx.db,
+			fullCus,
+			expand: cusExpand,
+		}),
+		getCusReferredBy({
 			db: ctx.db,
 			fullCus,
 			expand: cusExpand,
@@ -132,6 +139,7 @@ export const getApiCustomerExpandV2 = async ({
 		entities: entities ?? undefined,
 		rewards: rewards ?? undefined,
 		referrals: referrals ?? undefined,
+		referred_by: referredBy ?? undefined,
 		payment_method: paymentMethod ?? undefined,
 		billing_controls_override: autoTopupsWithLimits
 			? { auto_topups: autoTopupsWithLimits }

--- a/server/src/internal/customers/cusUtils/cusResponseUtils/getCusReferredBy.ts
+++ b/server/src/internal/customers/cusUtils/cusResponseUtils/getCusReferredBy.ts
@@ -1,0 +1,44 @@
+import {
+	ApiCusReferredBySchema,
+	CustomerExpand,
+	type FullCustomer,
+} from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { redemptionRepo } from "@/internal/rewards/repos/index.js";
+
+export const getCusReferredBy = async ({
+	db,
+	fullCus,
+	expand,
+}: {
+	db: DrizzleCli;
+	fullCus: FullCustomer;
+	expand?: CustomerExpand[];
+}) => {
+	if (
+		!expand?.includes(CustomerExpand.Referrals) &&
+		!expand?.includes(CustomerExpand.ReferredBy)
+	) {
+		return undefined;
+	}
+
+	const redemptions = await redemptionRepo.getByRedeemer({
+		db,
+		internalCustomerId: fullCus.internal_id,
+		withRewardProgram: true,
+		limit: 100,
+	});
+
+	return redemptions.map((r) =>
+		ApiCusReferredBySchema.parse({
+			program_id: r.reward_program?.id,
+			referrer: {
+				id: r.referrer.id,
+				name: r.referrer.name,
+				email: r.referrer.email,
+			},
+			reward_applied: r.redeemer_applied,
+			created_at: r.created_at,
+		}),
+	);
+};

--- a/server/src/internal/customers/cusUtils/cusResponseUtils/getCusReferredBy.ts
+++ b/server/src/internal/customers/cusUtils/cusResponseUtils/getCusReferredBy.ts
@@ -15,10 +15,7 @@ export const getCusReferredBy = async ({
 	fullCus: FullCustomer;
 	expand?: CustomerExpand[];
 }) => {
-	if (
-		!expand?.includes(CustomerExpand.Referrals) &&
-		!expand?.includes(CustomerExpand.ReferredBy)
-	) {
+	if (!expand?.includes(CustomerExpand.ReferredBy)) {
 		return undefined;
 	}
 

--- a/server/src/internal/rewards/repos/getRedemptionsByRedeemer.ts
+++ b/server/src/internal/rewards/repos/getRedemptionsByRedeemer.ts
@@ -1,11 +1,5 @@
-import {
-	customers,
-	referralCodes,
-	rewardPrograms,
-	rewardRedemptions,
-} from "@autumn/shared";
-import { eq } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { queryRelationshipRedemptions } from "./queryRelationshipRedemptions.js";
 
 /** Find redemptions where the given customer is the redeemer */
 export const getRedemptionsByRedeemer = async ({
@@ -19,38 +13,16 @@ export const getRedemptionsByRedeemer = async ({
 	withRewardProgram?: boolean;
 	limit?: number;
 }) => {
-	let query = db
-		.select()
-		.from(rewardRedemptions)
-		.innerJoin(
-			referralCodes,
-			eq(rewardRedemptions.referral_code_id, referralCodes.id),
-		)
-		.innerJoin(
-			customers,
-			eq(referralCodes.internal_customer_id, customers.internal_id),
-		);
+	const data = await queryRelationshipRedemptions({
+		db,
+		internalCustomerId,
+		direction: "redeemer",
+		withRewardProgram,
+		limit,
+	});
 
-	if (withRewardProgram) {
-		query = query.innerJoin(
-			rewardPrograms,
-			eq(
-				rewardRedemptions.internal_reward_program_id,
-				rewardPrograms.internal_id,
-			),
-		);
-	}
-
-	const data = await query
-		.where(eq(rewardRedemptions.internal_customer_id, internalCustomerId))
-		.limit(limit);
-
-	const processed = data.map((d) => ({
-		...d.reward_redemptions,
-		referral_code: d.referral_codes,
-		referrer: d.customers,
-		reward_program: withRewardProgram ? (d as any).reward_programs : undefined,
+	return data.map((d) => ({
+		...d,
+		referrer: d.related_customer,
 	}));
-
-	return processed;
 };

--- a/server/src/internal/rewards/repos/getRedemptionsByRedeemer.ts
+++ b/server/src/internal/rewards/repos/getRedemptionsByRedeemer.ts
@@ -1,0 +1,56 @@
+import {
+	customers,
+	referralCodes,
+	rewardPrograms,
+	rewardRedemptions,
+} from "@autumn/shared";
+import { eq } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/** Find redemptions where the given customer is the redeemer */
+export const getRedemptionsByRedeemer = async ({
+	db,
+	internalCustomerId,
+	withRewardProgram = false,
+	limit = 100,
+}: {
+	db: DrizzleCli;
+	internalCustomerId: string;
+	withRewardProgram?: boolean;
+	limit?: number;
+}) => {
+	let query = db
+		.select()
+		.from(rewardRedemptions)
+		.innerJoin(
+			referralCodes,
+			eq(rewardRedemptions.referral_code_id, referralCodes.id),
+		)
+		.innerJoin(
+			customers,
+			eq(referralCodes.internal_customer_id, customers.internal_id),
+		);
+
+	if (withRewardProgram) {
+		query = query.innerJoin(
+			rewardPrograms,
+			eq(
+				rewardRedemptions.internal_reward_program_id,
+				rewardPrograms.internal_id,
+			),
+		);
+	}
+
+	const data = await query
+		.where(eq(rewardRedemptions.internal_customer_id, internalCustomerId))
+		.limit(limit);
+
+	const processed = data.map((d) => ({
+		...d.reward_redemptions,
+		referral_code: d.referral_codes,
+		referrer: d.customers,
+		reward_program: withRewardProgram ? (d as any).reward_programs : undefined,
+	}));
+
+	return processed;
+};

--- a/server/src/internal/rewards/repos/getRedemptionsByRedeemer.ts
+++ b/server/src/internal/rewards/repos/getRedemptionsByRedeemer.ts
@@ -21,8 +21,8 @@ export const getRedemptionsByRedeemer = async ({
 		limit,
 	});
 
-	return data.map((d) => ({
+	return data.map(({ related_customer, ...d }) => ({
 		...d,
-		referrer: d.related_customer,
+		referrer: related_customer,
 	}));
 };

--- a/server/src/internal/rewards/repos/getRedemptionsByReferrer.ts
+++ b/server/src/internal/rewards/repos/getRedemptionsByReferrer.ts
@@ -21,8 +21,8 @@ export const getRedemptionsByReferrer = async ({
 		limit,
 	});
 
-	return data.map((d) => ({
+	return data.map(({ related_customer, ...d }) => ({
 		...d,
-		customer: d.related_customer,
+		customer: related_customer,
 	}));
 };

--- a/server/src/internal/rewards/repos/getRedemptionsByReferrer.ts
+++ b/server/src/internal/rewards/repos/getRedemptionsByReferrer.ts
@@ -1,11 +1,5 @@
-import {
-	customers,
-	referralCodes,
-	rewardPrograms,
-	rewardRedemptions,
-} from "@autumn/shared";
-import { eq } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { queryRelationshipRedemptions } from "./queryRelationshipRedemptions.js";
 
 /** Find redemptions where the given customer is the referrer */
 export const getRedemptionsByReferrer = async ({
@@ -19,38 +13,16 @@ export const getRedemptionsByReferrer = async ({
 	withRewardProgram?: boolean;
 	limit?: number;
 }) => {
-	let query = db
-		.select()
-		.from(rewardRedemptions)
-		.innerJoin(
-			referralCodes,
-			eq(rewardRedemptions.referral_code_id, referralCodes.id),
-		)
-		.innerJoin(
-			customers,
-			eq(rewardRedemptions.internal_customer_id, customers.internal_id),
-		);
+	const data = await queryRelationshipRedemptions({
+		db,
+		internalCustomerId,
+		direction: "referrer",
+		withRewardProgram,
+		limit,
+	});
 
-	if (withRewardProgram) {
-		query = query.innerJoin(
-			rewardPrograms,
-			eq(
-				rewardRedemptions.internal_reward_program_id,
-				rewardPrograms.internal_id,
-			),
-		);
-	}
-
-	const data = await query
-		.where(eq(referralCodes.internal_customer_id, internalCustomerId))
-		.limit(limit);
-
-	const processed = data.map((d) => ({
-		...d.reward_redemptions,
-		referral_code: d.referral_codes,
-		customer: d.customers,
-		reward_program: withRewardProgram ? (d as any).reward_programs : undefined,
+	return data.map((d) => ({
+		...d,
+		customer: d.related_customer,
 	}));
-
-	return processed;
 };

--- a/server/src/internal/rewards/repos/index.ts
+++ b/server/src/internal/rewards/repos/index.ts
@@ -5,6 +5,7 @@ import { getCustomerRewardRedemption } from "./getCustomerRewardRedemption.js";
 import { getPromoCodeRedemptionCount } from "./getPromoCodeRedemptionCount.js";
 import { getRedemptionById } from "./getRedemptionById.js";
 import { getRedemptionsByCustomer } from "./getRedemptionsByCustomer.js";
+import { getRedemptionsByRedeemer } from "./getRedemptionsByRedeemer.js";
 import { getRedemptionsByReferrer } from "./getRedemptionsByReferrer.js";
 import { getReferralCode } from "./getReferralCode.js";
 import { getReferralCodeByCustomerAndProgram } from "./getReferralCodeByCustomerAndProgram.js";
@@ -61,6 +62,7 @@ export const redemptionRepo = {
 	getById: getRedemptionById,
 	getByCustomer: getRedemptionsByCustomer,
 	getByReferrer: getRedemptionsByReferrer,
+	getByRedeemer: getRedemptionsByRedeemer,
 	getByCustomerAndReward: getCustomerRewardRedemption,
 	getPromoCodeRedemptionCount: getPromoCodeRedemptionCount,
 	insert: insertRedemption,

--- a/server/src/internal/rewards/repos/queryRelationshipRedemptions.ts
+++ b/server/src/internal/rewards/repos/queryRelationshipRedemptions.ts
@@ -1,0 +1,68 @@
+import {
+	customers,
+	referralCodes,
+	rewardPrograms,
+	rewardRedemptions,
+} from "@autumn/shared";
+import { eq } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export type RelationshipDirection = "referrer" | "redeemer";
+
+export const queryRelationshipRedemptions = async ({
+	db,
+	internalCustomerId,
+	direction,
+	withRewardProgram = false,
+	limit = 100,
+}: {
+	db: DrizzleCli;
+	internalCustomerId: string;
+	direction: RelationshipDirection;
+	withRewardProgram?: boolean;
+	limit?: number;
+}) => {
+	const isReferrer = direction === "referrer";
+
+	let query = db
+		.select()
+		.from(rewardRedemptions)
+		.innerJoin(
+			referralCodes,
+			eq(rewardRedemptions.referral_code_id, referralCodes.id),
+		)
+		.innerJoin(
+			customers,
+			eq(
+				isReferrer
+					? rewardRedemptions.internal_customer_id
+					: referralCodes.internal_customer_id,
+				customers.internal_id,
+			),
+		);
+
+	if (withRewardProgram) {
+		query = query.innerJoin(
+			rewardPrograms,
+			eq(
+				rewardRedemptions.internal_reward_program_id,
+				rewardPrograms.internal_id,
+			),
+		);
+	}
+
+	const filterColumn = isReferrer
+		? referralCodes.internal_customer_id
+		: rewardRedemptions.internal_customer_id;
+
+	const data = await query
+		.where(eq(filterColumn, internalCustomerId))
+		.limit(limit);
+
+	return data.map((d) => ({
+		...d.reward_redemptions,
+		referral_code: d.referral_codes,
+		related_customer: d.customers,
+		reward_program: withRewardProgram ? (d as any).reward_programs : undefined,
+	}));
+};

--- a/server/tests/unit/customers/getCusReferredBy.test.ts
+++ b/server/tests/unit/customers/getCusReferredBy.test.ts
@@ -8,8 +8,8 @@ const mockGetByRedeemer = mock(async () => [
 		referral_code_id: "rc_123",
 		internal_customer_id: "cus_redeemer_int_id",
 		internal_reward_program_id: "prog_int_123",
-		applied: true, // referrer applied
-		redeemer_applied: true, // redeemer applied
+		applied: false, // referrer applied is false
+		redeemer_applied: true, // redeemer applied is true
 		created_at: 1718000000,
 		referrer: {
 			id: "cus_referrer_1",
@@ -34,35 +34,20 @@ const { getCusReferredBy } = await import(
 );
 
 describe("getCusReferredBy", () => {
-	test("returns undefined when expand is empty or does not include referrals/referred_by", async () => {
-		const res = await getCusReferredBy({
+	test("returns undefined when expand is empty or does not include referred_by", async () => {
+		const resInvoices = await getCusReferredBy({
 			db: {} as never,
 			fullCus: { internal_id: "cus_redeemer_int_id" } as never,
 			expand: [CustomerExpand.Invoices],
 		});
+		expect(resInvoices).toBeUndefined();
 
-		expect(res).toBeUndefined();
-	});
-
-	test("returns referred_by records when expand includes CustomerExpand.Referrals", async () => {
-		const res = await getCusReferredBy({
+		const resReferrals = await getCusReferredBy({
 			db: {} as never,
 			fullCus: { internal_id: "cus_redeemer_int_id" } as never,
 			expand: [CustomerExpand.Referrals],
 		});
-
-		expect(res).toBeDefined();
-		expect(res).toHaveLength(1);
-		expect(res![0]).toEqual({
-			program_id: "prog_public_id",
-			referrer: {
-				id: "cus_referrer_1",
-				name: "Alice Referrer",
-				email: "alice@example.com",
-			},
-			reward_applied: true,
-			created_at: 1718000000,
-		});
+		expect(resReferrals).toBeUndefined();
 	});
 
 	test("returns referred_by records when expand includes CustomerExpand.ReferredBy", async () => {
@@ -81,7 +66,7 @@ describe("getCusReferredBy", () => {
 				name: "Alice Referrer",
 				email: "alice@example.com",
 			},
-			reward_applied: true,
+			reward_applied: true, // verifies mapping from redeemer_applied (true) rather than applied (false)
 			created_at: 1718000000,
 		});
 	});

--- a/server/tests/unit/customers/getCusReferredBy.test.ts
+++ b/server/tests/unit/customers/getCusReferredBy.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { CustomerExpand } from "@autumn/shared";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const mockGetByRedeemer = mock(async () => [
+	{
+		id: "rr_123",
+		referral_code_id: "rc_123",
+		internal_customer_id: "cus_redeemer_int_id",
+		internal_reward_program_id: "prog_int_123",
+		applied: true, // referrer applied
+		redeemer_applied: true, // redeemer applied
+		created_at: 1718000000,
+		referrer: {
+			id: "cus_referrer_1",
+			name: "Alice Referrer",
+			email: "alice@example.com",
+		},
+		reward_program: {
+			id: "prog_public_id",
+		},
+	},
+]);
+
+await mockModuleWithRestore("@/internal/rewards/repos/index.js", () => ({
+	redemptionRepo: {
+		getByRedeemer: mockGetByRedeemer,
+		getByReferrer: mock(async () => []),
+	},
+}));
+
+const { getCusReferredBy } = await import(
+	"@/internal/customers/cusUtils/cusResponseUtils/getCusReferredBy.js"
+);
+
+describe("getCusReferredBy", () => {
+	test("returns undefined when expand is empty or does not include referrals/referred_by", async () => {
+		const res = await getCusReferredBy({
+			db: {} as never,
+			fullCus: { internal_id: "cus_redeemer_int_id" } as never,
+			expand: [CustomerExpand.Invoices],
+		});
+
+		expect(res).toBeUndefined();
+	});
+
+	test("returns referred_by records when expand includes CustomerExpand.Referrals", async () => {
+		const res = await getCusReferredBy({
+			db: {} as never,
+			fullCus: { internal_id: "cus_redeemer_int_id" } as never,
+			expand: [CustomerExpand.Referrals],
+		});
+
+		expect(res).toBeDefined();
+		expect(res).toHaveLength(1);
+		expect(res![0]).toEqual({
+			program_id: "prog_public_id",
+			referrer: {
+				id: "cus_referrer_1",
+				name: "Alice Referrer",
+				email: "alice@example.com",
+			},
+			reward_applied: true,
+			created_at: 1718000000,
+		});
+	});
+
+	test("returns referred_by records when expand includes CustomerExpand.ReferredBy", async () => {
+		const res = await getCusReferredBy({
+			db: {} as never,
+			fullCus: { internal_id: "cus_redeemer_int_id" } as never,
+			expand: [CustomerExpand.ReferredBy],
+		});
+
+		expect(res).toBeDefined();
+		expect(res).toHaveLength(1);
+		expect(res![0]).toEqual({
+			program_id: "prog_public_id",
+			referrer: {
+				id: "cus_referrer_1",
+				name: "Alice Referrer",
+				email: "alice@example.com",
+			},
+			reward_applied: true,
+			created_at: 1718000000,
+		});
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/shared/api/customers/apiCustomer.ts
+++ b/shared/api/customers/apiCustomer.ts
@@ -3,7 +3,10 @@ import { ApiCusRewardsSchema } from "@api/others/apiDiscount";
 import { ApiInvoiceV1Schema } from "@api/others/apiInvoice/apiInvoiceV1";
 import { z } from "zod/v4";
 import { BaseApiCustomerSchema } from "./baseApiCustomer";
-import { ApiCusReferralSchema } from "./components/apiCusReferral";
+import {
+	ApiCusReferralSchema,
+	ApiCusReferredBySchema,
+} from "./components/apiCusReferral";
 import { ApiInvoicePreviewV0Schema } from "./components/apiInvoicePreview/apiInvoicePreviewV0";
 import { ApiTrialsUsedV1Schema } from "./components/apiTrialsUsed/apiTrialsUsedV1";
 import { ApiBalanceSchema } from "./cusFeatures/apiBalance";
@@ -33,6 +36,9 @@ export const ApiCusExpandSchema = z.object({
 	}),
 	referrals: z.array(ApiCusReferralSchema).optional().meta({
 		description: "Referral records for this customer.",
+	}),
+	referred_by: z.array(ApiCusReferredBySchema).optional().meta({
+		description: "Referral records where this customer was referred.",
 	}),
 	payment_method: z.any().nullish().meta({
 		description: "The customer's default payment method.",

--- a/shared/api/customers/changes/V1.2_CustomerChange.ts
+++ b/shared/api/customers/changes/V1.2_CustomerChange.ts
@@ -115,6 +115,7 @@ export const V1_2_CustomerChange = defineVersionChange({
 				) ?? undefined,
 			rewards: input.rewards ?? undefined,
 			referrals: input.referrals ?? undefined,
+			referred_by: input.referred_by ?? undefined,
 			payment_method: input.payment_method ?? undefined,
 		} satisfies z.infer<typeof ApiCustomerV3Schema>;
 	},

--- a/shared/api/customers/components/apiCusReferral.ts
+++ b/shared/api/customers/components/apiCusReferral.ts
@@ -12,3 +12,17 @@ export const ApiCusReferralSchema = z.object({
 });
 
 export type ApiCusReferralResponse = z.infer<typeof ApiCusReferralSchema>;
+
+export const ApiCusReferredBySchema = z.object({
+	program_id: z.string(),
+	referrer: z.object({
+		id: z.string(),
+		name: z.string().nullish(),
+		email: z.string().nullish(),
+	}),
+	reward_applied: z.boolean(),
+	created_at: z.number(),
+});
+
+export type ApiCusReferredBy = z.infer<typeof ApiCusReferredBySchema>;
+

--- a/shared/api/customers/components/customerExpand/customerExpand.ts
+++ b/shared/api/customers/components/customerExpand/customerExpand.ts
@@ -8,6 +8,7 @@ export enum CustomerExpand {
 	Rewards = "rewards",
 	Entities = "entities",
 	Referrals = "referrals",
+	ReferredBy = "referred_by",
 	PaymentMethod = "payment_method",
 	SubscriptionsPlan = "subscriptions.plan",
 	PurchasesPlan = "purchases.plan",

--- a/shared/api/customers/previousVersions/apiCustomerV2.ts
+++ b/shared/api/customers/previousVersions/apiCustomerV2.ts
@@ -1,4 +1,7 @@
-import { ApiCusReferralSchema } from "@api/customers/components/apiCusReferral";
+import {
+	ApiCusReferralSchema,
+	ApiCusReferredBySchema,
+} from "@api/customers/components/apiCusReferral";
 import { ApiCusUpcomingInvoiceSchema } from "@api/customers/components/apiCusUpcomingInvoice";
 import { ApiTrialsUsedV0Schema } from "@api/customers/components/apiTrialsUsed/prevVersions/apiTrialsUsedV0";
 import { ApiCusFeatureV2Schema } from "@api/customers/cusFeatures/previousVersions/apiCusFeatureV2";
@@ -51,6 +54,7 @@ export const ApiCustomerV2Schema = z.object({
 	metadata: z.record(z.any(), z.any()).default({}),
 	entities: z.array(ApiBaseEntitySchema).optional(),
 	referrals: z.array(ApiCusReferralSchema).optional(),
+	referred_by: z.array(ApiCusReferredBySchema).optional(),
 	upcoming_invoice: ApiCusUpcomingInvoiceSchema.nullish(),
 	payment_method: z.any().nullish(),
 });

--- a/shared/api/customers/previousVersions/apiCustomerV3.ts
+++ b/shared/api/customers/previousVersions/apiCustomerV3.ts
@@ -118,7 +118,7 @@ const cusDescriptions = {
 	referrals:
 		"The referrals for the customer. Returned only if referrals is provided in the expand parameter.",
 	referred_by:
-		"The referral records where this customer was referred. Returned only if referrals or referred_by is provided in the expand parameter.",
+		"The referral records where this customer was referred. Returned only if referred_by is provided in the expand parameter.",
 	upcoming_invoice:
 		"The upcoming invoice for the customer. Returned only if upcoming_invoice is provided in the expand parameter.",
 	payment_method:

--- a/shared/api/customers/previousVersions/apiCustomerV3.ts
+++ b/shared/api/customers/previousVersions/apiCustomerV3.ts
@@ -1,4 +1,7 @@
-import { ApiCusReferralSchema } from "@api/customers/components/apiCusReferral";
+import {
+	ApiCusReferralSchema,
+	ApiCusReferredBySchema,
+} from "@api/customers/components/apiCusReferral";
 import { ApiCusUpcomingInvoiceSchema } from "@api/customers/components/apiCusUpcomingInvoice";
 import { ApiBaseEntitySchema } from "@api/entities/apiEntity";
 import { ApiCusRewardsSchema } from "@api/others/apiDiscount";
@@ -114,6 +117,8 @@ const cusDescriptions = {
 		"The rewards for the customer. Returned only if rewards is provided in the expand parameter.",
 	referrals:
 		"The referrals for the customer. Returned only if referrals is provided in the expand parameter.",
+	referred_by:
+		"The referral records where this customer was referred. Returned only if referrals or referred_by is provided in the expand parameter.",
 	upcoming_invoice:
 		"The upcoming invoice for the customer. Returned only if upcoming_invoice is provided in the expand parameter.",
 	payment_method:
@@ -135,6 +140,9 @@ export const ApiCusExpandV3Schema = z.object({
 	}),
 	referrals: z.array(ApiCusReferralSchema).optional().meta({
 		description: cusDescriptions.referrals,
+	}),
+	referred_by: z.array(ApiCusReferredBySchema).optional().meta({
+		description: cusDescriptions.referred_by,
 	}),
 	upcoming_invoice: ApiCusUpcomingInvoiceSchema.nullish().meta({
 		description: cusDescriptions.upcoming_invoice,


### PR DESCRIPTION
## Summary
Fixes #2395

Previously, `customers.get({ customerId, expand: ['referrals'] })` only returned referrals where the customer was the referrer (the customers they referred). If called on a customer who was referred by someone else (the redeemer/referee), the response was empty, leaving no way to determine who referred them.

This PR adds support for exposing the redeemer-side relationship:
- Added `ApiCusReferredBySchema` and `ApiCusReferredBy` type in `@autumn/shared`.
- Added `CustomerExpand.ReferredBy = "referred_by"`.
- Added `referred_by` to `ApiCusExpandSchema` and legacy version schemas/transforms.
- Added `redemptionRepo.getByRedeemer` to query redemptions joined with the referrer customer.
- Created `getCusReferredBy` response utility and wired it to customer expand.
- Added unit tests in `getCusReferredBy.test.ts`.

## Test Plan
- Unit tests in `server/tests/unit/customers/getCusReferredBy.test.ts` verifying that `referred_by` is properly populated with the referrer's information and reward status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes who referred a customer via a new `referred_by` expand so clients can see the referrer and whether the reward was applied. Previously this info was inaccessible; now it is returned only when `expand` includes `referred_by` (requests with only `referrals` do not include it).

- Adds `CustomerExpand.ReferredBy` and `referred_by` to customer expand schemas (current and legacy) in `@autumn/shared`.
- Populates `referred_by` in v1/v2 expand via `redemptionRepo.getByRedeemer` and a schema-validated mapper.
- Deduplicates redemption queries with `queryRelationshipRedemptions`; refactors `getByReferrer`, adds `getByRedeemer`, and omits `related_customer` to preserve previous response shapes.
- Migration: Clients must include `referred_by` in `expand` to receive referrer info; `expand: ['referrals']` does not return it.

<sup>Written for commit 31411b1f3af0606217fbb39e70b65f20bc736789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

