### PR TITLE
perf(hooks): cache knip with Turborepo

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@ infisical scan git-changes --staged --redact --verbose --silent --telemetry=fals
 
 changed_files="$(git diff --cached --name-only)"
 
-bun knip
+bunx turbo run knip
 
 if printf '%s\n' "$changed_files" | grep -q '^server/'; then
 	bunx turbo run ts --filter=@autumn/server

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://turbo.build/schema.json",
 	"tasks": {
+		"//#knip": {
+			"outputs": []
+		},
 		"ts": {
 			"outputs": []
 		},


### PR DESCRIPTION
Run the pre-commit Knip check as a registered Turborepo root task so unchanged worktrees reuse the local task result across sequential commits.

Infisical secret scanning and the existing conditional typechecks remain unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up pre-commit by caching the `knip` check via `turbo`. Previously the hook ran `knip` every commit; now it runs `bunx turbo run knip` and reuses the local cache when inputs are unchanged. Secret scanning and the conditional server typecheck are unchanged.

- Adds a root `//#knip` task in `turbo.json` with `outputs: []` to enable caching without artifacts.
- Updates `.husky/pre-commit` to call `bunx turbo run knip`; existing `infisical` scan and `bunx turbo run ts --filter=@autumn/server` remain intact.
- No developer action required; `bunx` will fetch `turbo` if missing.

<sup>Written for commit 57e917a0308a6dbcecf9278dfb5da87f8c679c62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes the pre-commit Knip check through a Turborepo root task to reuse cached results across commits.

- **Improvements:** Registers Knip as a Turborepo root task and invokes it through Turbo from the pre-commit hook.
- **Bug fixes:** None.
- **API changes:** None.
</details>

<h3>Confidence Score: 4/5</h3>

This PR should not merge until the Knip task hash includes all analyzed workspace files, otherwise a simple second commit can bypass the pre-commit check.

The new root task caches a repository-wide analysis while its default inputs omit workspace source directories, allowing a prior successful result to be reused after relevant code changes.

**Files Needing Attention:** turbo.json and .husky/pre-commit

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .husky/pre-commit | Replaces the direct Knip invocation with the cached Turborepo task, exposing the hook to the task's incomplete input hash. |
| turbo.json | Adds the root Knip task without declaring the workspace source files required for correct cache invalidation. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Pre-commit hook] --> B[Turbo root Knip task]
  B --> C{Task hash cached?}
  C -->|Yes| D[Replay previous result]
  C -->|No| E[Run repository-wide Knip]
  F[Workspace source change] -. missing from default root inputs .-> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
turbo.json:4-6
**Workspace changes miss cache hash**

When a developer changes analyzed code under `server`, `vite`, `apps`, or `packages` without changing a root-package file, this root task reuses the previous successful Knip result because those workspace files are absent from its inputs, allowing dead code or unused dependencies to be committed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(hooks): cache knip with Turborepo"](https://github.com/useautumn/autumn/commit/57e917a0308a6dbcecf9278dfb5da87f8c679c62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52615484)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->