### PR TITLE
chore: upgrade Turborepo to 2.10.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "knip": "^6.7.0",
         "trigger.dev": "4.5.10",
         "ts-to-zod": "^5.1.0",
-        "turbo": "^2.9.6",
+        "turbo": "2.10.9",
       },
     },
     "apps/checkout": {
@@ -2794,17 +2794,17 @@
 
     "@tsconfig/node16": ["@tsconfig/node16@1.0.4", "", {}, "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-/c9cSBRermWDv85oufLhoH6XRLOVbvzJLRd+WLyfJCP+i0HFLQj4PVNDrHcY17/ve5l8X0Oua4bJBqJUgJPnZA=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jh+pTGXLNz8+1tkUU13TI/f+ZOI+OvC4YbHi1H+57iSpLt5DR3xgptd+4sA07RdjdRR/RX/01uQQu2OkbzIefA=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8lpCCGWZBl9PIF8w8f2iEWrLMbHBWIfJeV6l2UEGqysD6HRIM4ySj/8R7HGEzbECJ4r/gnJcHmxEoG8yjFe64A=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aqtpPkiIC4IUas8Vv27oJ3aDfTuP1d5wofd01dZ7gfhHRrIKuFdqQb4imvNnVFahcOViF9Jh8Oi7feDoz8/ciA=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.10.7", "", { "os": "linux", "cpu": "x64" }, "sha512-Midw9Ed00yw9rqkWN82fY3LmLNFQ6yiL1GXB56DJKUEjWaEd27zh7ohCxzzrjfjQVrEeVWd3UPytTAV16XDQlA=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.9", "", { "os": [ "linux", "android", ], "cpu": "x64" }, "sha512-XyAneUBsS5uNOUOjBSs81zyigMVwwhVUd3u7F2JFMKGQk6F7eNAiOEBASJ+aHLldjYsOEjhfW+5gWIqwziyFFw=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-UVEy+MW/xn4BcsiV3v3uv0/oObyaQgVtRT+Jj4WE53rNH05VEYEc1Z13q3zV6276wCZR4Yxc4hiTTcjw7PjSpg=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.9", "", { "os": [ "linux", "android", ], "cpu": "arm64" }, "sha512-5jAcldLnkuWIjujGhCn2MGIeUwW8IVNOq9Sce4EEzzgLcxmhTasbV0RiW6ZkaRdOjmOCGzeNXPLkDJEOIucOLw=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.10.7", "", { "os": "win32", "cpu": "x64" }, "sha512-l2nH9KGLV46SWjcXvyc2+xo5gdf5J0NVADknQk9OCJhzJBpiNl/byd26yIfwZBjLupdqT6UOdPhPxcpUPxRykQ=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.9", "", { "os": "win32", "cpu": "x64" }, "sha512-u1xGpGlefzuhBedbt/VR2nWdftfFVZwPeDg9e5uZl68sV1fL3HNYTNr5VyHkzgtPK2VTYg1x4OKZuGrh1Gvhtg=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-qjE1apG6RThuX49vUJd5ks2dV2ndXC2qktDChQonFMvUzrMrEnZMQzO+IgxBiYq1j+NbXQcRwj84nGnk1TBw1g=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-W2Ub165Qv0iMFljbYKxxbZN+2dVSngnzEjQNEFXtnz5oJVx9XSypmNmUvMtuYMeZ3kdVC1zI7yd/rtuX+SDnbg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -6308,7 +6308,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.10.7", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.7", "@turbo/darwin-arm64": "2.10.7", "@turbo/linux-64": "2.10.7", "@turbo/linux-arm64": "2.10.7", "@turbo/windows-64": "2.10.7", "@turbo/windows-arm64": "2.10.7" }, "bin": { "turbo": "bin/turbo" } }, "sha512-GHx6WExIFSKNJ5qMlzDpXBXlu9ApxaMjqxAVrCNcW94xf/+uqgIz41SAuRUMbXva2ExNAaY/h8V0q90SWSzmRw=="],
+    "turbo": ["turbo@2.10.9", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.9", "@turbo/darwin-arm64": "2.10.9", "@turbo/linux-64": "2.10.9", "@turbo/linux-arm64": "2.10.9", "@turbo/windows-64": "2.10.9", "@turbo/windows-arm64": "2.10.9" }, "bin": { "turbo": "bin/turbo" } }, "sha512-Yl9+ukxH+UmPtKidpDkjn82tvPoEvFNb9UACd9vUomN1Ft0cwl3rx0P8yC1D93W9EOsWRMjllvIDG8y25sFOog=="],
 
     "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
 

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
 		"knip": "^6.7.0",
 		"trigger.dev": "4.5.10",
 		"ts-to-zod": "^5.1.0",
-		"turbo": "^2.9.6"
+		"turbo": "2.10.9"
 	},
 	"trustedDependencies": [
 		"@infisical/cli"

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://turbo.build/schema.json",
+	"$schema": "https://v2-10-9.turborepo.dev/schema.json",
 	"tasks": {
 		"ts": {
 			"outputs": []


### PR DESCRIPTION
Upgrade Turborepo from 2.9.6 to 2.10.9 using the official codemod.

- Pin the workspace dev dependency and refresh Bun's platform-specific lockfile entries.
- Use the codemod-generated versioned schema URL for configuration validation.
- Keep the existing task configuration unchanged; no migration transforms were required across these versions.

Validated the resolved 2.10.9 binary, frozen lockfile install, task graph generation, workspace type checks, and Turborepo unit-test graph.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `turbo` from 2.9.6 to 2.10.9 to ensure consistent builds and version-accurate config validation. Previously we used a caret range and the unversioned schema; now we pin the version and use the 2.10.9 schema. Task behavior is unchanged.

- Pin `turbo` in `package.json` to 2.10.9 and refresh platform-specific entries in `bun.lock`.
- Update `$schema` in `turbo.json` to `https://v2-10-9.turborepo.dev/schema.json`.
- Validated binary resolution, frozen installs, task graph generation, and unit-test graph.
- Action: run `bun install` after merge to pick up the new `turbo` binary.

<sup>Written for commit 811bdc86dc457eff03ec7e6aef40cf799d7a337d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR safely pins Turborepo 2.10.9 and aligns its lockfile and configuration schema without changing the existing task graph.

- **Improvements:** Pins the workspace Turborepo dependency to exactly 2.10.9.
- **Improvements:** Refreshes all supported platform-specific Turborepo binaries and integrity hashes in Bun's lockfile.
- **Improvements:** Uses the version-matched Turborepo schema URL while retaining the existing `ts` and `test:unit` task configuration.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the dependency, lockfile, platform binaries, and schema metadata consistently aligned to Turborepo 2.10.9.

The task definitions are unchanged, current CI invocations use supported basic Turborepo behavior, all relevant platform binaries remain represented, and no concrete changed-code failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Pins the Turborepo development dependency to 2.10.9; existing workspace commands remain compatible. |
| bun.lock | Consistently resolves Turborepo and all six platform binaries to 2.10.9 with updated integrity hashes. |
| turbo.json | Changes only the editor-validation schema URL to the version matching the installed CLI. |

<sub>Reviews (1): Last reviewed commit: ["chore: upgrade Turborepo to 2.10.9"](https://github.com/useautumn/autumn/commit/811bdc86dc457eff03ec7e6aef40cf799d7a337d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52617555)</sub>

<!-- /greptile_comment -->