### PR TITLE
Fix atmn config round-trip stability

### DIFF
--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
@@ -160,7 +160,10 @@ export function parseExistingConfig({
 		// Import statement
 		if (trimmed.startsWith("import ")) {
 			const startLine = i;
-			while (i < lines.length && !/(?:["'];?|;)\s*$/.test(lines[i]!)) {
+			while (
+				i < lines.length &&
+				!/(?:["'];?|;)\s*(?:\/\/.*|\/\*.*\*\/)?$/.test(lines[i]!)
+			) {
 				i++;
 			}
 			const endLine = i;

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
@@ -162,7 +162,7 @@ export function parseExistingConfig({
 			const startLine = i;
 			while (
 				i < lines.length &&
-				!/(?:["'];?|;)\s*(?:\/\/.*|\/\*.*\*\/)?$/.test(lines[i]!)
+				!/(?:["'];?|;)\s*(?:\/\/.*|\/\*.*)?$/.test(lines[i]!)
 			) {
 				i++;
 			}

--- a/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
+++ b/packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts
@@ -160,8 +160,7 @@ export function parseExistingConfig({
 		// Import statement
 		if (trimmed.startsWith("import ")) {
 			const startLine = i;
-			// Import can span multiple lines until semicolon
-			while (i < lines.length && !lines[i]!.includes(";")) {
+			while (i < lines.length && !/(?:["'];?|;)\s*$/.test(lines[i]!)) {
 				i++;
 			}
 			const endLine = i;
@@ -226,8 +225,7 @@ export function parseExistingConfig({
 					}
 				}
 
-				// End when we close all braces and see semicolon
-				if (foundStart && depth === 0 && currentLine.includes(";")) {
+				if (foundStart && depth === 0) {
 					break;
 				}
 				i++;

--- a/packages/atmn/test/integration/catalog/discord-constant-config.test.ts
+++ b/packages/atmn/test/integration/catalog/discord-constant-config.test.ts
@@ -131,4 +131,22 @@ export const addOnPayrollPlan = plan({
 		headless: true,
 		workspace,
 	});
+	expect(await readFile(workspace.configPath, "utf8")).toBe(pulled);
+	const repushedPlans = await fetchPlans({ secretKey: ctx.orgSecretKey });
+	const repushedBaseYearly = repushedPlans.find(
+		({ id }) => id === "base-yearly",
+	);
+	expect(repushedBaseYearly?.variant_details?.customize?.free_trial).toBeNull();
+	expect(repushedBaseYearly?.auto_enable).toBe(false);
+	for (const id of [
+		"base",
+		"base-yearly",
+		"premium",
+		"premium-yearly",
+		"add-on-projects",
+		"add-on-ip-box",
+		"add-on-payroll",
+	]) {
+		expect(repushedPlans.filter((plan) => plan.id === id)).toHaveLength(1);
+	}
 });

--- a/packages/atmn/test/integration/catalog/discord-constant-config.test.ts
+++ b/packages/atmn/test/integration/catalog/discord-constant-config.test.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fetchPlans } from "../../../src/lib/api/endpoints/plans.js";
+import { setCliContext } from "../../../src/lib/env/index.js";
+import {
+	createCleanAtmnIntegrationContext,
+	prepareAtmnIntegrationWorkspace,
+	runAtmnWorkspaceCli,
+} from "../utils/atmnTestWorkspace.js";
+
+/** Red: semicolonless constants duplicated entities and lost null trial overrides.
+ * Green: the exact push → pull → push remains stable. */
+test("CLI round-trips the reported constant-backed config", async () => {
+	const ctx = await createCleanAtmnIntegrationContext();
+	const workspace = await prepareAtmnIntegrationWorkspace({
+		secretKey: ctx.orgSecretKey,
+	});
+	await writeFile(
+		join(workspace.workspaceDir, "catalog.ts"),
+		`export const FEATURE_IDS = { employees: "employees", projects: "projects", ipBox: "ip-box", payroll: "payroll" } as const;
+export const METER_PRICES = { employees: 5 } as const;
+export const PLAN_IDS = { base: "base", baseYearly: "base-yearly", premium: "premium", premiumYearly: "premium-yearly", addOnProjects: "add-on-projects", addOnIpBox: "add-on-ip-box", addOnPayroll: "add-on-payroll" } as const;
+export const PLAN_PRICES = { base: 10, "base-yearly": 100, premium: 20, "premium-yearly": 200, "add-on-projects": 5, "add-on-ip-box": 5 } as const;
+`,
+	);
+	await writeFile(
+		workspace.configPath,
+		`import { feature, item, plan } from "atmn"
+
+import { FEATURE_IDS, METER_PRICES, PLAN_IDS, PLAN_PRICES } from "./catalog"
+
+export const employees = feature({ id: FEATURE_IDS.employees, name: "Employees", type: "metered", consumable: false })
+export const projectsFeature = feature({ id: FEATURE_IDS.projects, name: "Projects", type: "boolean" })
+export const ipBoxFeature = feature({ id: FEATURE_IDS.ipBox, name: "IP-box", type: "boolean" })
+export const payrollFeature = feature({ id: FEATURE_IDS.payroll, name: "Payroll", type: "boolean" })
+
+export const basePlan = plan({
+	id: PLAN_IDS.base,
+	name: "Base Plan",
+	addOn: false,
+	autoEnable: true,
+	price: { amount: PLAN_PRICES[PLAN_IDS.base], interval: "month" },
+	freeTrial: { durationLength: 30, durationType: "day", cardRequired: false },
+})
+export const basePlanYearly = basePlan.variant({
+	id: PLAN_IDS.baseYearly,
+	name: "Base Plan",
+	customize: { price: { amount: PLAN_PRICES[PLAN_IDS.baseYearly], interval: "year" }, freeTrial: null },
+})
+export const premiumPlan = plan({
+	id: PLAN_IDS.premium,
+	name: "Premium Plan",
+	addOn: false,
+	autoEnable: false,
+	price: { amount: PLAN_PRICES[PLAN_IDS.premium], interval: "month" },
+})
+export const premiumPlanYearly = premiumPlan.variant({
+	id: PLAN_IDS.premiumYearly,
+	name: "Premium Plan",
+	customize: { price: { amount: PLAN_PRICES[PLAN_IDS.premiumYearly], interval: "year" } },
+})
+export const addOnProjectsPlan = plan({
+	id: PLAN_IDS.addOnProjects,
+	name: "Add-on: Projects",
+	addOn: true,
+	autoEnable: false,
+	price: { amount: PLAN_PRICES[PLAN_IDS.addOnProjects], interval: "month" },
+	items: [item({ featureId: projectsFeature.id })],
+})
+export const addOnIpBoxPlan = plan({
+	id: PLAN_IDS.addOnIpBox,
+	name: "Add-on: IP-box",
+	addOn: true,
+	autoEnable: false,
+	price: { amount: PLAN_PRICES[PLAN_IDS.addOnIpBox], interval: "month" },
+	items: [item({ featureId: ipBoxFeature.id })],
+})
+export const addOnPayrollPlan = plan({
+	id: PLAN_IDS.addOnPayroll,
+	name: "Add-on: Payroll",
+	addOn: true,
+	autoEnable: false,
+	items: [
+		item({ featureId: payrollFeature.id }),
+		item({ featureId: employees.id, included: 0, price: { amount: METER_PRICES[FEATURE_IDS.employees], interval: "month", billingUnits: 1, billingMethod: "usage_based" } }),
+	],
+})
+`,
+	);
+
+	await runAtmnWorkspaceCli({
+		args: ["--yes"],
+		command: "push",
+		headless: true,
+		workspace,
+	});
+	setCliContext({ local: true });
+	const remotePlans = await fetchPlans({ secretKey: ctx.orgSecretKey });
+	const remoteBaseYearly = remotePlans.find(({ id }) => id === "base-yearly");
+	expect(remoteBaseYearly?.variant_details?.customize?.free_trial).toBeNull();
+	expect(remoteBaseYearly?.auto_enable).toBe(false);
+	await runAtmnWorkspaceCli({
+		args: ["--no-declaration-file"],
+		command: "pull",
+		headless: true,
+		workspace,
+	});
+	const pulled = await readFile(workspace.configPath, "utf8");
+	const exports = [...pulled.matchAll(/export const (\w+)/g)].map(
+		([, name]) => name,
+	);
+	for (const name of [
+		"employees",
+		"projectsFeature",
+		"ipBoxFeature",
+		"payrollFeature",
+		"basePlan",
+		"basePlanYearly",
+		"premiumPlan",
+		"premiumPlanYearly",
+		"addOnProjectsPlan",
+		"addOnIpBoxPlan",
+		"addOnPayrollPlan",
+	]) {
+		expect(exports.filter((candidate) => candidate === name)).toHaveLength(1);
+	}
+	await runAtmnWorkspaceCli({
+		args: ["--yes"],
+		command: "push",
+		headless: true,
+		workspace,
+	});
+});

--- a/packages/atmn/test/pull/config-pipeline.test.ts
+++ b/packages/atmn/test/pull/config-pipeline.test.ts
@@ -142,8 +142,9 @@ export const keepMe = "custom";
  * Existing exports must remain unique across repeated in-place rewrites. */
 test("in-place updates match semicolonless exports with constant IDs", async () => {
 	await withConfigWorkspace(
-		`import { feature, plan } from "./builders" // config builders
-import { FEATURE_IDS, PLAN_IDS } from "./ids"
+		`import { feature, plan } from "./builders" /* config
+builders */
+import { FEATURE_IDS, PLAN_IDS } from "./ids" // catalog IDs
 export const employees = feature({ id: FEATURE_IDS.EMPLOYEES, name: "Employees", type: "metered", consumable: false })
 export const basePlan = plan({ id: PLAN_IDS.BASE, name: "Base Plan", items: [] })
 export const basePlanYearly = basePlan.variant({ id: PLAN_IDS.BASE_YEARLY, name: "Base Plan Yearly" })

--- a/packages/atmn/test/pull/config-pipeline.test.ts
+++ b/packages/atmn/test/pull/config-pipeline.test.ts
@@ -140,13 +140,13 @@ export const keepMe = "custom";
 
 /** Previously, constant IDs were unmatched and rewrites appended suffixed declarations.
  * Existing exports must remain unique across repeated in-place rewrites. */
-test("in-place updates match exports with constant IDs", async () => {
+test("in-place updates match semicolonless exports with constant IDs", async () => {
 	await withConfigWorkspace(
-		`import { feature, plan } from "./builders";
-import { FEATURE_IDS, PLAN_IDS } from "./ids";
-export const employees = feature({ id: FEATURE_IDS.EMPLOYEES, name: "Employees", type: "metered", consumable: false });
-export const basePlan = plan({ id: PLAN_IDS.BASE, name: "Base Plan", items: [] });
-export const basePlanYearly = basePlan.variant({ id: PLAN_IDS.BASE_YEARLY, name: "Base Plan Yearly" });
+		`import { feature, plan } from "./builders"
+import { FEATURE_IDS, PLAN_IDS } from "./ids"
+export const employees = feature({ id: FEATURE_IDS.EMPLOYEES, name: "Employees", type: "metered", consumable: false })
+export const basePlan = plan({ id: PLAN_IDS.BASE, name: "Base Plan", items: [] })
+export const basePlanYearly = basePlan.variant({ id: PLAN_IDS.BASE_YEARLY, name: "Base Plan Yearly" })
 `,
 		async (cwd) => {
 			writeFileSync(

--- a/packages/atmn/test/pull/config-pipeline.test.ts
+++ b/packages/atmn/test/pull/config-pipeline.test.ts
@@ -142,7 +142,7 @@ export const keepMe = "custom";
  * Existing exports must remain unique across repeated in-place rewrites. */
 test("in-place updates match semicolonless exports with constant IDs", async () => {
 	await withConfigWorkspace(
-		`import { feature, plan } from "./builders"
+		`import { feature, plan } from "./builders" // config builders
 import { FEATURE_IDS, PLAN_IDS } from "./ids"
 export const employees = feature({ id: FEATURE_IDS.EMPLOYEES, name: "Employees", type: "metered", consumable: false })
 export const basePlan = plan({ id: PLAN_IDS.BASE, name: "Base Plan", items: [] })

--- a/server/src/internal/product/actions/common/planTransformUtils.ts
+++ b/server/src/internal/product/actions/common/planTransformUtils.ts
@@ -152,9 +152,11 @@ export const buildProductUpdatesFromApiPlan = ({
 			description: plan.description,
 			group: plan.group ?? "",
 			add_on: plan.add_on,
+			auto_enable: plan.auto_enable,
 			items: plan.items,
 			price: plan.price,
-			free_trial: plan.free_trial,
+			free_trial:
+				plan.free_trial ?? (currentFullProduct.free_trial ? null : undefined),
 			config: plan.config,
 			billing_controls: plan.billing_controls,
 			metadata: plan.metadata,

--- a/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
@@ -109,6 +109,7 @@ export const previewAffectedVariants = async ({
 						}),
 						id: variant.id,
 						name: variant.name,
+						auto_enable: false,
 					}
 				: applyDiffToVariantPlan({
 						plan: currentPlan,

--- a/server/src/internal/product/actions/updateVariants/updateVariants.ts
+++ b/server/src/internal/product/actions/updateVariants/updateVariants.ts
@@ -65,6 +65,7 @@ const buildVariantTargetPlan = ({
 	}),
 	id: variant.id,
 	name: variantUpdate.name ?? variant.name,
+	auto_enable: false,
 });
 
 const ensureMissingVariantName = ({


### PR DESCRIPTION
## Summary
- parse semicolonless imports and managed exports as complete blocks so constant-backed IDs resolve to existing declarations
- preserve explicit variant free-trial removal and auto-enable invariants during catalog updates
- add the reported constants/add-ons/metered-item config as a push → pull → push integration regression

## Validation
- package and server typechecks
- 33 atmn pull/codegen tests
- 16 server variant/catalog unit tests
- exact config against the worktree API: push → pull (0 additions) → push, 13 assertions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `atmn` config round‑trips for semicolonless files with trailing comments and preserves plan variant invariants during updates. Previously, semicolonless imports/managed exports could swallow following declarations and duplicate exports, and explicit `free_trial: null` or non‑auto‑enabled variants were lost; now boundaries are correct and server updates carry `auto_enable` and `free_trial` as intended.

- Parser: treat semicolonless imports as complete when a line ends with a quote or semicolon (allow trailing `//`/`/* */`); end managed exports on closing brace only. Fixes constant‑backed ID matching and prevents duplicate exports.
- Server: include `auto_enable` in plan updates; force variant targets to `auto_enable: false` in preview/update; preserve explicit `free_trial: null` vs omitted.
- Tests: add push → pull → push regression that verifies no duplicates, file stays unchanged after repush, and remote `free_trial: null` and `auto_enable: false` persist; update rewrite tests to semicolonless inputs with trailing line/multiline comments.
- No migration required.

<sup>Written for commit 4dc9270ad674fd6ba6a0fae96a5f5bef005e97fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR stabilizes CLI catalog round trips for semicolonless configuration files and preserves variant settings during updates.

- **[Bug fixes]** Recognizes semicolonless imports with trailing line or multiline block comments without consuming subsequent declarations.
- **[Bug fixes]** Ends semicolonless managed exports when their balanced expression closes, allowing constant-backed IDs to match existing declarations.
- **[Bug fixes, API changes]** Preserves explicit free-trial removal and keeps variants from being automatically enabled during preview and update operations.
- **[Improvements]** Adds focused and integration coverage for repeated push → pull → push workflows with constants, add-ons, and metered items.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because both previously reported import-boundary failures are fixed and no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/lib/transforms/inPlaceUpdate/parseConfig.ts | Correctly bounds the inline and multiline commented imports from both previous reports and supports semicolonless managed exports. |
| packages/atmn/test/integration/catalog/discord-constant-config.test.ts | Adds an end-to-end round-trip regression covering constant IDs, explicit trial removal, variant auto-enable behavior, and declaration uniqueness. |
| packages/atmn/test/pull/config-pipeline.test.ts | Extends in-place generation coverage to semicolonless imports and exports with trailing comments and constant-backed IDs. |
| server/src/internal/product/actions/common/planTransformUtils.ts | Includes auto-enable in product updates and distinguishes omitted free-trial values from explicit removal. |
| server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts | Ensures explicitly customized variants preview with automatic enablement disabled. |
| server/src/internal/product/actions/updateVariants/updateVariants.ts | Ensures explicitly updated variant targets persist with automatic enablement disabled. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config[Semicolonless catalog config] --> Push1[Push]
  Push1 --> API[Catalog API]
  API --> Pull[Pull and parse existing blocks]
  Pull --> Stable[Preserved declarations and variant settings]
  Stable --> Push2[Push again]
  Push2 --> API
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test: 💍 verify config state after repus..."](https://github.com/useautumn/autumn/commit/4dc9270ad674fd6ba6a0fae96a5f5bef005e97fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52618655)</sub>

<!-- /greptile_comment -->