### PR TITLE
fix(atmn): request rewards scope at login so pull can list rewards

### DIFF
--- a/packages/atmn/package.json
+++ b/packages/atmn/package.json
@@ -34,7 +34,7 @@
 		"build": "bun run bun.config.ts",
 		"dev": "nodemon -e ts,tsx --watch src --ignore dist --exec \"bun run bun.config.ts\"",
 		"dev:bun": "bun run dev.ts",
-		"test": "bun test test/*.test.ts test/codegen test/nuke test/pull test/push test/workflow",
+		"test": "bun test test/*.test.ts test/auth test/codegen test/nuke test/pull test/push test/workflow",
 		"test:integration": "cd ../../server && ENV_FILE=.env infisical run --env=dev --recursive -- bun test --timeout 0 ../packages/atmn/test/integration",
 		"test:integration:cli": "cd ../../server && ENV_FILE=.env infisical run --env=dev --recursive -- bun ../packages/atmn/test/integration/cli.ts",
 		"test:unit": "bun test test/codegen",

--- a/packages/atmn/src/commands/auth/oauth.ts
+++ b/packages/atmn/src/commands/auth/oauth.ts
@@ -71,6 +71,31 @@ async function startCallbackServer(
 	});
 }
 
+const CLI_SCOPE_REQUESTS = [
+	{
+		resource: "customers",
+		actions: ["create", "read", "list", "update", "delete"],
+	},
+	{
+		resource: "features",
+		actions: ["create", "read", "list", "update", "delete"],
+	},
+	{
+		resource: "plans",
+		actions: ["create", "read", "list", "update", "delete"],
+	},
+	{ resource: "rewards", actions: ["read", "write"] },
+	{ resource: "apiKeys", actions: ["create", "read"] },
+	{ resource: "organisation", actions: ["read"] },
+] as const;
+
+/** Scopes the CLI requests at login, covering every resource `atmn pull` reads. */
+export function buildCliOAuthScopes(): string[] {
+	return CLI_SCOPE_REQUESTS.flatMap(({ resource, actions }) =>
+		actions.map((action) => `${resource}:${action}`),
+	);
+}
+
 /** Start OAuth flow and wait for callback */
 export async function startOAuthFlow(
 	clientId: string,
@@ -88,27 +113,7 @@ export async function startOAuthFlow(
 			state,
 			arctic.CodeChallengeMethod.S256,
 			codeVerifier,
-			[
-				// Dynamically construct scopes using CRUDL for each resource
-				...[
-					{
-						resource: "customers",
-						actions: ["create", "read", "list", "update", "delete"],
-					},
-					{
-						resource: "features",
-						actions: ["create", "read", "list", "update", "delete"],
-					},
-					{
-						resource: "plans",
-						actions: ["create", "read", "list", "update", "delete"],
-					},
-					{ resource: "apiKeys", actions: ["create", "read"] },
-					{ resource: "organisation", actions: ["read"] },
-				].flatMap(({ resource, actions }) =>
-					actions.map((action) => `${resource}:${action}`),
-				),
-			],
+			buildCliOAuthScopes(),
 		);
 		authUrl.searchParams.set("prompt", "consent");
 

--- a/packages/atmn/test/auth/auth-recovery.test.ts
+++ b/packages/atmn/test/auth/auth-recovery.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import type { ApiError } from "../../src/lib/api/client.js";
+import { isAuthError } from "../../src/lib/hooks/useAuthRecovery.js";
+
+const apiError = (status: number, response?: unknown): ApiError => {
+	const error = new Error(`API request failed: ${status}`) as ApiError;
+	error.status = status;
+	error.response = response;
+	return error;
+};
+
+test("401 is recoverable — re-authenticating mints a fresh session", () => {
+	expect(isAuthError(apiError(401))).toBe(true);
+});
+
+test("403 is not recoverable — re-auth remints the same insufficient scopes", () => {
+	const insufficientScopes = apiError(403, {
+		code: "insufficient_scopes",
+		message: "Missing required scope: rewards:read",
+	});
+	expect(isAuthError(insufficientScopes)).toBe(false);
+});
+
+test("non-auth failures are not routed through auth recovery", () => {
+	for (const status of [400, 404, 429, 500]) {
+		expect(isAuthError(apiError(status))).toBe(false);
+	}
+});
+
+test("non-API errors are not auth errors", () => {
+	expect(isAuthError(new Error("network down"))).toBe(false);
+	expect(isAuthError(null)).toBe(false);
+	expect(isAuthError(undefined)).toBe(false);
+});

--- a/packages/atmn/test/pull/login-scopes.test.ts
+++ b/packages/atmn/test/pull/login-scopes.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { isModernScope, LEGACY_SCOPE_ALIASES, Scopes } from "@autumn/shared";
+import { buildCliOAuthScopes } from "../../src/commands/auth/oauth.js";
+
+const resolve = (scope: string) => LEGACY_SCOPE_ALIASES[scope] ?? scope;
+const granted = new Set(buildCliOAuthScopes().map(resolve));
+
+test("login grants rewards:read, which pull needs to list rewards", () => {
+	expect(granted).toContain(Scopes.Rewards.Read);
+});
+
+test("login grants read access for every resource pull fetches", () => {
+	for (const scope of [
+		Scopes.Features.Read,
+		Scopes.Plans.Read,
+		Scopes.Rewards.Read,
+	]) {
+		expect(granted).toContain(scope);
+	}
+});
+
+test("every requested scope resolves to a known modern scope", () => {
+	for (const scope of granted) {
+		expect(isModernScope(scope)).toBe(true);
+	}
+});


### PR DESCRIPTION
## Problem

`atmn login` mints a key without `rewards:read`, so `atmn pull` fails with a 403.

`buildCliOAuthScopes` (previously inline in `startOAuthFlow`) requested scopes for `customers`, `features`, `plans`, `apiKeys` and `organisation`. But `pullFromEnvironment` calls `fetchRewards` and `fetchReferralPrograms` unconditionally, and `handleListRewards` declares `scopes: [Scopes.Rewards.Read]` — so a freshly minted key can never complete a pull.

Reported by Ayush in #team.

## Fix

Add `rewards` to the requested scopes, and extract the list into an exported `buildCliOAuthScopes()` so it can be asserted directly in tests.

Requested as `rewards:read` / `rewards:write` rather than the CRUDL shape the surrounding entries use. `LEGACY_SCOPE_ALIASES` maps CRUDL → modern read/write for every other resource, but has **no entries for `rewards:create/list/update/delete`** — requesting those would send four scopes the server cannot resolve. `read`/`write` are valid modern scopes.

The `rewards` resource covers "Referrals and reward codes", so this unblocks `fetchReferralPrograms` too.

## Tests

`test/pull/login-scopes.test.ts` — asserts the minted scope set covers every resource pull reads, and that each requested scope resolves to a known modern scope. Verified red before the fix (failed with `rewards:read` absent), green after. The third assertion is what surfaced the missing alias entries above.

`test/auth/auth-recovery.test.ts` — pins that 403 is *not* treated as a recoverable auth error. **These pass on `dev` without the fix**; they document existing correct behavior rather than covering a change. Included as regression cover, see below.

`test/auth` added to the `test` script, which enumerates directories explicitly.

## On the "retries forever" half of the report

The original report also said pull "gets stuck retrying forever". I could not reproduce that, and I don't believe it exists as described — every retry site in the CLI is bounded:

- `withAuthRecovery` — `maxRetries = 1`
- `QueryProvider` — `retry: false`
- `client.ts` — no retry
- OAuth port loop — bounded by `OAUTH_PORTS`, throws when exhausted

`isAuthError` already matches only `status === 401`, so a 403 is never routed into auth recovery.

More likely the 403 surfaced as an unhelpful message and read as a hang: `formatError` hides status and response body unless `ATMN_DEBUG` is set. Improving that is a plausible follow-up but is deliberately out of scope here.

## Verification

- `bun ts` clean
- New tests green; full `atmn` unit suite has 5 pre-existing failures from a missing `UNIT_TEST_AUTUMN_SECRET_KEY` (baseline on `dev` is 6 — this fixes one, adds none)
- Not exercised end-to-end against a live 403; the fix is proven at the scope-construction layer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `atmn login` to request `rewards:read` (and `rewards:write`) so `atmn pull` can list rewards and referral programs; previously, login minted keys without `rewards:read`, causing pull to fail with 403.

- Extracts scope construction into `buildCliOAuthScopes()` and wires it into `startOAuthFlow`, adding `rewards:read/write`. Uses read/write because no CRUDL aliases exist for `rewards`.
- Adds `test/pull/login-scopes.test.ts` to assert login scopes cover all resources used by pull and resolve to modern scopes.
- Adds `test/auth/auth-recovery.test.ts` to document that 403 is not treated as an auth-recoverable error; no behavior change.
- Updates `packages/atmn/package.json` test script to include `test/auth`.

<sup>Written for commit 814d4cc0e8e7552bf66f35379dcaea1b0e5d77fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes newly authenticated CLI sessions so `atmn pull` can retrieve rewards and referral programs.
- **[Bug fixes]** Requests `rewards:read` and `rewards:write` during CLI OAuth login.
- **[Improvements]** Extracts OAuth scope construction into a directly testable helper.
- **[Improvements]** Adds coverage for pull-required scopes, valid modern scope resolution, and authentication-error classification.
- **[Improvements]** Includes the new authentication tests in the package test command.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The new rewards scopes match the permissions required by reward and referral-program reads, and the accompanying tests are self-contained and included without overlapping existing test discovery.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/atmn/src/commands/auth/oauth.ts | Extracts CLI OAuth scope construction and adds modern rewards read/write scopes used by pull and catalog operations. |
| packages/atmn/test/pull/login-scopes.test.ts | Verifies login scopes cover every resource read by pull and resolve to recognized modern scopes. |
| packages/atmn/test/auth/auth-recovery.test.ts | Documents that only 401 responses trigger authentication recovery and that insufficient-scope 403 responses do not. |
| packages/atmn/package.json | Adds the new authentication test directory to the package’s explicit test targets. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Login[atmn login] --> Scopes[Build CLI OAuth scopes]
  Scopes --> OAuth[OAuth consent and key creation]
  OAuth --> Pull[atmn pull]
  Pull --> Features[Fetch features]
  Pull --> Plans[Fetch plans]
  Pull --> Rewards[Fetch rewards]
  Pull --> Referrals[Fetch referral programs]
  Scopes -. rewards:read .-> Rewards
  Scopes -. rewards:read .-> Referrals
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(atmn): request rewards scope at logi..."](https://github.com/useautumn/autumn/commit/814d4cc0e8e7552bf66f35379dcaea1b0e5d77fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52619828)</sub>

**Context used:**

- Knowledge Base — [`atmn` Catalog Configuration CLI](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/atmn-cli.md)

<!-- /greptile_comment -->