### PR TITLE
fix: sync balances around attach billing

### DIFF
--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -122,6 +122,7 @@ export const autoTopup = async ({
 				ctx,
 				billingContext: autoTopupContext,
 				billingPlan: { autumn: autumnBillingPlan, stripe: stripeBillingPlan },
+				clearCache: false,
 			});
 		} catch (error) {
 			// A throw here means the attempt still reached Stripe (and may have

--- a/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts
@@ -17,6 +17,7 @@ import {
 	getUpdateCustomerProducts,
 } from "@/internal/billing/v2/utils/billingPlan/customerProductPlanMutations";
 import { CusService } from "@/internal/customers/CusService";
+import { invalidateCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/invalidate/invalidateFullSubject";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService";
 import { replaceScheduledPhaseCustomerProductIds } from "@/internal/customers/schedules/repos/replaceScheduledPhaseCustomerProductIds";
@@ -33,14 +34,24 @@ export const executeAutumnBillingPlan = async ({
 	stripeInvoice,
 	stripeInvoiceItems,
 	autumnInvoice,
+	clearCache = true,
 }: {
 	ctx: AutumnContext;
 	autumnBillingPlan: AutumnBillingPlan;
 	stripeInvoice?: Stripe.Invoice;
 	stripeInvoiceItems?: Stripe.InvoiceItem[];
 	autumnInvoice?: Invoice;
+	clearCache?: boolean;
 }) => {
 	const { db } = ctx;
+	const clearCustomerCache = () =>
+		invalidateCachedFullSubject({
+			ctx,
+			customerId: autumnBillingPlan.customerId,
+			source: "executeAutumnBillingPlan",
+			flushBalances: true,
+		});
+	if (clearCache) await clearCustomerCache();
 	const {
 		insertCustomerProducts,
 		customPrices,
@@ -241,4 +252,6 @@ export const executeAutumnBillingPlan = async ({
 			billingLineItems: autumnBillingPlan.lineItems,
 		});
 	}
+
+	if (clearCache) await clearCustomerCache();
 };

--- a/server/src/internal/billing/v2/execute/executeBillingPlan.ts
+++ b/server/src/internal/billing/v2/execute/executeBillingPlan.ts
@@ -17,11 +17,13 @@ export const executeBillingPlan = async ({
 	billingContext,
 	billingPlan,
 	checkoutLockParamsHash,
+	clearCache = true,
 }: {
 	ctx: AutumnContext;
 	billingContext: BillingContext;
 	billingPlan: BillingPlan;
 	checkoutLockParamsHash?: string;
+	clearCache?: boolean;
 }): Promise<BillingResult> => {
 	const stripeBillingResult: StripeBillingPlanResult =
 		billingContext.skipBillingChanges
@@ -77,6 +79,7 @@ export const executeBillingPlan = async ({
 		stripeInvoice: stripeBillingResult.stripeInvoice,
 		stripeInvoiceItems: stripeBillingResult.stripeInvoiceItems,
 		autumnInvoice: stripeBillingResult.autumnInvoice,
+		clearCache,
 	});
 
 	// Queue webhooks after Autumn billing plan is executed


### PR DESCRIPTION
## Summary

- Sync and invalidate cached balances immediately before and after every Autumn billing plan execution.
- Keep the behavior enabled by default through `executeBillingPlan`.
- Skip cache clearing for auto top-ups, which already patches the affected cached customer product directly.

## Testing

- `bunx biome check` on changed files
- `bun run test:unit` — 2,632 passed, 0 failed
- Commit hooks: knip and server typecheck

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR coordinates customer-balance cache invalidation around billing-plan execution while preserving auto-top-up’s existing cache-update flow.
- **[Bug fixes]** Flushes live cached balances before billing mutations and invalidates again afterward so accepted usage survives attach-related cache refreshes.
- **[Improvements]** Threads an optional cache-clearing control through billing-plan execution.
- **[Improvements]** Keeps automatic top-ups on their dedicated inline balance and customer-product cache update path.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/autoTopup.ts | Auto-top-up opts out of general invalidation because its balance and customer-product changes update the cache directly. |
| server/src/internal/billing/v2/execute/executeAutumnBillingPlan.ts | Billing execution now flushes and invalidates the customer cache before and after applying the Autumn plan. |
| server/src/internal/billing/v2/execute/executeBillingPlan.ts | The billing-plan wrapper exposes and forwards the cache-clearing option without changing its default callers. |

<sub>Reviews (4): Last reviewed commit: ["fix: 🐛 sync balances around attach bill..."](https://github.com/useautumn/autumn/commit/7f4f536bf8a116d68a118e2c830ca5e8221b5951) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52658800)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->