### PR TITLE
feat: open mobile command palette on shake

### DIFF
--- a/vite/src/views/command-bar/CommandBar.tsx
+++ b/vite/src/views/command-bar/CommandBar.tsx
@@ -1,11 +1,13 @@
 import { AppEnv, type Customer } from "@autumn/shared";
 import {
+	Command,
 	CommandDialog,
 	CommandEmpty,
 	CommandGroup,
 	CommandInput,
 	CommandList,
 	Skeleton,
+	useIsMobile,
 } from "@autumn/ui";
 import {
 	ArrowsClockwiseIcon,
@@ -26,6 +28,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
+import { Drawer as DrawerPrimitive } from "vaul";
 import { useTheme } from "@/contexts/ThemeProvider";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
@@ -40,7 +43,9 @@ import { impersonateUser } from "@/views/admin/adminUtils";
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { CommandRow } from "@/views/command-bar/command-row";
 import { calculateRelevanceScore } from "@/views/command-bar/commandUtils";
+import { isMobilePhone } from "@/views/command-bar/shakeDetection";
 import { useCommandBarHotkeys } from "@/views/command-bar/useCommandBarHotkeys";
+import { useShakeToOpenCommandBar } from "@/views/command-bar/useShakeToOpenCommandBar";
 import { useOrgSwitch } from "@/views/main-sidebar/components/OrgDropdown";
 import { useEnvChange } from "@/views/main-sidebar/EnvDropdown";
 
@@ -64,6 +69,10 @@ type Org = {
 const CommandBar = () => {
 	const open = useCommandBarStore((state) => state.open);
 	const setOpen = useCommandBarStore((state) => state.setOpen);
+	const openCommandBar = useCommandBarStore((state) => state.openCommandBar);
+	const isMobile = useIsMobile() || isMobilePhone(navigator.userAgent);
+	const { permission: motionPermission, requestPermission } =
+		useShakeToOpenCommandBar(openCommandBar);
 	const [search, setSearch] = useState("");
 	const [debouncedSearch, setDebouncedSearch] = useState("");
 	const [currentPage, setCurrentPage] = useState<
@@ -859,8 +868,8 @@ const CommandBar = () => {
 		[closeDialog, setOpen],
 	);
 
-	return (
-		<CommandDialog open={open} onOpenChange={handleOpenChange}>
+	const commandContent = (
+		<>
 			<CommandInput
 				placeholder={
 					currentPage === "main"
@@ -872,13 +881,68 @@ const CommandBar = () => {
 				value={search}
 				onValueChange={setSearch}
 				onKeyDown={handleInputKeyDown}
+				className={isMobile ? "text-base" : undefined}
 			/>
-			<CommandList>
+			<CommandList
+				className={
+					isMobile ? "max-h-none flex-1 overscroll-contain" : undefined
+				}
+			>
 				{/* Use last rendered content during transition to prevent flash */}
 				{isTransitioningRef.current && lastRenderedContentRef.current
 					? lastRenderedContentRef.current
 					: currentContent}
 			</CommandList>
+		</>
+	);
+
+	if (isMobile) {
+		return (
+			<DrawerPrimitive.Root
+				open={open}
+				onOpenChange={handleOpenChange}
+				repositionInputs
+			>
+				<DrawerPrimitive.Portal>
+					<DrawerPrimitive.Overlay className="fixed inset-0 z-[170] bg-black/50 dark:bg-black/80" />
+					<DrawerPrimitive.Content className="fixed inset-x-0 bottom-0 z-[180] flex h-[min(82dvh,42rem)] flex-col overflow-hidden rounded-t-2xl bg-interactive-secondary shadow-2xl outline-none">
+						<DrawerPrimitive.Handle className="mt-2.5 mb-1 h-1 w-10 shrink-0 rounded-full bg-border" />
+						<div className="flex h-10 shrink-0 items-center justify-between px-4">
+							<DrawerPrimitive.Title className="text-sm font-medium text-foreground">
+								Command palette
+							</DrawerPrimitive.Title>
+							<DrawerPrimitive.Description className="sr-only">
+								Search for customers, plans, and commands
+							</DrawerPrimitive.Description>
+							{motionPermission === "prompt" ||
+							motionPermission === "requesting" ? (
+								<button
+									type="button"
+									onClick={requestPermission}
+									disabled={motionPermission === "requesting"}
+									className="min-h-8 rounded-md bg-accent px-2.5 text-xs font-medium text-foreground disabled:opacity-50"
+								>
+									{motionPermission === "requesting"
+										? "Enabling…"
+										: "Enable shake"}
+								</button>
+							) : null}
+						</div>
+						<Command
+							shouldFilter={false}
+							className="min-h-0 flex-1 rounded-none pb-[env(safe-area-inset-bottom)] [&_[cmdk-item]]:min-h-11 [&_[cmdk-item]]:px-3 [&_[cmdk-item]]:py-2.5"
+						>
+							{commandContent}
+						</Command>
+					</DrawerPrimitive.Content>
+				</DrawerPrimitive.Portal>
+			</DrawerPrimitive.Root>
+		);
+	}
+
+	return (
+		<CommandDialog open={open} onOpenChange={handleOpenChange}>
+			{commandContent}
 		</CommandDialog>
 	);
 };

--- a/vite/src/views/command-bar/command-row.tsx
+++ b/vite/src/views/command-bar/command-row.tsx
@@ -1,4 +1,4 @@
-import { CommandItem } from "@autumn/ui";
+import { CommandItem, useIsMobile } from "@autumn/ui";
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
@@ -63,6 +63,8 @@ export const CommandRow = React.forwardRef<HTMLDivElement, CommandRowProps>(
 		},
 		ref,
 	) => {
+		const isMobile = useIsMobile();
+
 		const renderIcon = (icon: React.ReactNode) => {
 			if (!icon) return null;
 
@@ -81,6 +83,8 @@ export const CommandRow = React.forwardRef<HTMLDivElement, CommandRowProps>(
 		};
 
 		const renderShortcuts = () => {
+			if (isMobile) return null;
+
 			// Custom shortcuts take precedence
 			if (customShortcuts && customShortcuts.length > 0) {
 				return (

--- a/vite/src/views/command-bar/shakeDetection.ts
+++ b/vite/src/views/command-bar/shakeDetection.ts
@@ -1,0 +1,62 @@
+export type MotionSample = {
+	x: number;
+	y: number;
+	z: number;
+	timestamp: number;
+};
+
+export const isMobilePhone = (userAgent: string) =>
+	/iPhone|iPod/i.test(userAgent) || /Android.+Mobile/i.test(userAgent);
+
+export const createShakeDetector = ({
+	onShake,
+	threshold = 18,
+	requiredPeaks = 2,
+	peakWindowMs = 600,
+	cooldownMs = 1_500,
+}: {
+	onShake: () => void;
+	threshold?: number;
+	requiredPeaks?: number;
+	peakWindowMs?: number;
+	cooldownMs?: number;
+}) => {
+	let previousSample: MotionSample | null = null;
+	let peakCount = 0;
+	let lastPeakAt = Number.NEGATIVE_INFINITY;
+	let lastShakeAt = Number.NEGATIVE_INFINITY;
+
+	return (sample: MotionSample) => {
+		if (!previousSample) {
+			previousSample = sample;
+			return;
+		}
+
+		const delta = Math.hypot(
+			sample.x - previousSample.x,
+			sample.y - previousSample.y,
+			sample.z - previousSample.z,
+		);
+		previousSample = sample;
+
+		if (delta < threshold) return;
+
+		if (sample.timestamp - lastPeakAt > peakWindowMs) {
+			peakCount = 0;
+		}
+
+		peakCount += 1;
+		lastPeakAt = sample.timestamp;
+
+		if (
+			peakCount < requiredPeaks ||
+			sample.timestamp - lastShakeAt < cooldownMs
+		) {
+			return;
+		}
+
+		peakCount = 0;
+		lastShakeAt = sample.timestamp;
+		onShake();
+	};
+};

--- a/vite/src/views/command-bar/useShakeToOpenCommandBar.ts
+++ b/vite/src/views/command-bar/useShakeToOpenCommandBar.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+	createShakeDetector,
+	isMobilePhone,
+} from "@/views/command-bar/shakeDetection";
+
+type MotionPermission =
+	| "unsupported"
+	| "prompt"
+	| "requesting"
+	| "granted"
+	| "denied";
+
+type DeviceMotionEventConstructor = typeof DeviceMotionEvent & {
+	requestPermission?: () => Promise<"granted" | "denied">;
+};
+
+export const useShakeToOpenCommandBar = (onShake: () => void) => {
+	const [permission, setPermission] = useState<MotionPermission>("unsupported");
+
+	useEffect(() => {
+		if (
+			!isMobilePhone(navigator.userAgent) ||
+			typeof window.DeviceMotionEvent === "undefined"
+		) {
+			setPermission("unsupported");
+			return;
+		}
+
+		const DeviceMotion =
+			window.DeviceMotionEvent as DeviceMotionEventConstructor;
+		setPermission(
+			typeof DeviceMotion.requestPermission === "function"
+				? "prompt"
+				: "granted",
+		);
+	}, []);
+
+	useEffect(() => {
+		if (permission !== "granted") return;
+
+		const detectShake = createShakeDetector({ onShake });
+		const handleMotion = (event: DeviceMotionEvent) => {
+			const acceleration =
+				event.acceleration ?? event.accelerationIncludingGravity;
+			if (
+				acceleration?.x == null ||
+				acceleration.y == null ||
+				acceleration.z == null
+			) {
+				return;
+			}
+
+			detectShake({
+				x: acceleration.x,
+				y: acceleration.y,
+				z: acceleration.z,
+				timestamp: event.timeStamp,
+			});
+		};
+
+		window.addEventListener("devicemotion", handleMotion);
+		return () => window.removeEventListener("devicemotion", handleMotion);
+	}, [onShake, permission]);
+
+	const requestPermission = useCallback(async () => {
+		const DeviceMotion =
+			window.DeviceMotionEvent as DeviceMotionEventConstructor;
+		if (typeof DeviceMotion?.requestPermission !== "function") return;
+
+		setPermission("requesting");
+		try {
+			setPermission(await DeviceMotion.requestPermission());
+		} catch {
+			setPermission("denied");
+		}
+	}, []);
+
+	return { permission, requestPermission };
+};

--- a/vite/src/views/main-sidebar/MobileTopBar.tsx
+++ b/vite/src/views/main-sidebar/MobileTopBar.tsx
@@ -1,7 +1,10 @@
-import { ListIcon } from "@phosphor-icons/react";
+import { ListIcon, MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { useCommandBarStore } from "@/hooks/stores/useCommandBarStore";
 
 /** Thin sticky bar shown only on mobile with hamburger menu trigger. */
 export function MobileTopBar({ onMenuClick }: { onMenuClick: () => void }) {
+	const openCommandBar = useCommandBarStore((state) => state.openCommandBar);
+
 	return (
 		<div className="sticky top-0 z-50 flex items-center h-11 px-3 bg-background border-b border-border/40 sm:hidden">
 			<button
@@ -11,6 +14,14 @@ export function MobileTopBar({ onMenuClick }: { onMenuClick: () => void }) {
 				aria-label="Open menu"
 			>
 				<ListIcon size={18} weight="bold" />
+			</button>
+			<button
+				type="button"
+				onClick={openCommandBar}
+				className="ml-auto flex items-center justify-center size-8 -mr-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+				aria-label="Open command palette"
+			>
+				<MagnifyingGlassIcon size={18} weight="bold" />
 			</button>
 		</div>
 	);

--- a/vite/tests/command-bar/shake-detection.test.ts
+++ b/vite/tests/command-bar/shake-detection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	createShakeDetector,
+	isMobilePhone,
+} from "@/views/command-bar/shakeDetection";
+
+describe("isMobilePhone", () => {
+	test("accepts iPhone and Android phone user agents", () => {
+		expect(
+			isMobilePhone(
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+			),
+		).toBe(true);
+		expect(
+			isMobilePhone(
+				"Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 Chrome/128.0 Mobile Safari/537.36",
+			),
+		).toBe(true);
+	});
+
+	test("rejects tablets and desktop browsers", () => {
+		expect(
+			isMobilePhone(
+				"Mozilla/5.0 (iPad; CPU OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+			),
+		).toBe(false);
+		expect(
+			isMobilePhone(
+				"Mozilla/5.0 (Linux; Android 15; Pixel Tablet) AppleWebKit/537.36 Chrome/128.0 Safari/537.36",
+			),
+		).toBe(false);
+		expect(
+			isMobilePhone("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
+		).toBe(false);
+	});
+});
+
+describe("createShakeDetector", () => {
+	test("requires two strong direction changes inside the peak window", () => {
+		const onShake = mock();
+		const detectShake = createShakeDetector({ onShake });
+
+		detectShake({ x: 0, y: 0, z: 9.8, timestamp: 0 });
+		detectShake({ x: 21, y: 0, z: 9.8, timestamp: 100 });
+		expect(onShake).not.toHaveBeenCalled();
+		detectShake({ x: -21, y: 0, z: 9.8, timestamp: 250 });
+
+		expect(onShake).toHaveBeenCalledTimes(1);
+	});
+
+	test("ignores ordinary movement and enforces a cooldown", () => {
+		const onShake = mock();
+		const detectShake = createShakeDetector({ onShake });
+
+		detectShake({ x: 0, y: 0, z: 9.8, timestamp: 0 });
+		detectShake({ x: 2, y: 1, z: 10, timestamp: 100 });
+		detectShake({ x: 22, y: 0, z: 9.8, timestamp: 200 });
+		detectShake({ x: -22, y: 0, z: 9.8, timestamp: 300 });
+		detectShake({ x: 22, y: 0, z: 9.8, timestamp: 400 });
+		detectShake({ x: -22, y: 0, z: 9.8, timestamp: 500 });
+
+		expect(onShake).toHaveBeenCalledTimes(1);
+
+		detectShake({ x: 22, y: 0, z: 9.8, timestamp: 2_000 });
+		detectShake({ x: -22, y: 0, z: 9.8, timestamp: 2_100 });
+		expect(onShake).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
Adds phone-only shake detection for iOS and Android and opens the existing command palette in a bottom drawer with larger touch targets and safe-area handling.

On iOS, the drawer exposes an explicit permission button because Safari requires a user gesture before motion events are available. Android starts listening when motion events are supported. A mobile search button provides a deterministic way to open the drawer and grant iOS permission.

Includes focused coverage for phone detection, shake thresholds, peak timing, and cooldown behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the command palette on phones by shaking the device and renders the palette as a bottom drawer. Previously the palette used the desktop dialog and had no motion trigger; now mobile uses a drawer with larger touch targets and safe‑area padding, plus a top‑bar search button. iOS shows an “Enable shake” button due to Safari’s motion permission; Android listens automatically. Desktop behavior is unchanged.

- Hides keyboard shortcut hints on mobile.

**Review focus**
- Mobile gating and UI: `@autumn/ui` `useIsMobile` + `isMobilePhone` path, drawer via `vaul`, safe‑area padding, and `CommandRow` shortcut hiding.
- Shake logic: `shakeDetection.ts` thresholds/peaks/cooldown and `useShakeToOpenCommandBar` iOS permission (`DeviceMotionEvent.requestPermission`), listener setup/cleanup.
- Entry points: Mobile top bar search button opens the palette and provides a user gesture for iOS permission.

**QA / rollout**
- iOS Safari: open via the search button, tap “Enable shake,” then confirm shake opens the drawer; verify button states (“Enabling…” etc.).
- Android Chrome: no permission prompt; confirm shake opens the drawer and no false positives during normal use.
- Desktop/tablets: no shake behavior; palette opens as before via existing hotkeys. No migration required.

<sup>Written for commit a57d0cbba97d3a208649051d691dd59fc56f8d52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds phone shake detection and a mobile command-palette drawer, with an explicit iOS motion-permission flow and a mobile search button.

- **Improvements:** Opens the command palette from a phone shake or the mobile top-bar search button.
- **Improvements:** Presents mobile commands in a bottom drawer with larger touch targets and safe-area spacing.
- **Improvements:** Adds focused tests for phone identification, thresholds, timing, and cooldown behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking shake-detection issue that can open the palette after two quick jolts rather than a true back-and-forth shake.

The mobile drawer and permission lifecycle have no established blocking failure, but the new detector counts unsigned acceleration peaks despite describing direction changes as required.

**Files Needing Attention:** vite/src/views/command-bar/shakeDetection.ts, vite/tests/command-bar/shake-detection.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/command-bar/CommandBar.tsx | Adds the responsive Vaul drawer, motion-permission control, and mobile-specific command sizing while retaining the desktop dialog. |
| vite/src/views/command-bar/shakeDetection.ts | Adds phone user-agent detection and a threshold/peak/cooldown detector, but peak counting does not enforce the documented direction changes. |
| vite/src/views/command-bar/useShakeToOpenCommandBar.ts | Initializes platform-specific motion permission and manages the device-motion listener lifecycle. |
| vite/src/views/main-sidebar/MobileTopBar.tsx | Adds an accessible search button that deterministically opens the command palette. |
| vite/tests/command-bar/shake-detection.test.ts | Covers phone detection and basic shake timing but omits same-direction peak and gravity-fallback cases. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Mobile top-bar search button] --> D[Open command palette]
    B[iOS permission button] --> C{Motion permission granted?}
    C -- Yes --> E[Listen for device motion]
    C -- No --> F[Shake opening unavailable]
    G[Android motion support] --> E
    E --> H[Shake detector]
    H -- Two threshold peaks --> D
    D --> I[Mobile bottom drawer]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/command-bar/shakeDetection.ts:44-49
**Peaks ignore motion direction**

The detector counts any two large acceleration deltas within 600 ms without checking for a direction reversal, so two quick knocks or same-direction jolts can open the command palette without a back-and-forth shake.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: open mobile command palette on sha..."](https://github.com/useautumn/autumn/commit/a57d0cbba97d3a208649051d691dd59fc56f8d52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52658810)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->