### PR TITLE
fix(entities): prevent double-counting entities when creating after base + add-on attach (#2709)

### DIFF
--- a/server/src/internal/entities/actions/batchCreateEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities.ts
@@ -9,7 +9,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { EntityService } from "@/internal/api/entities/EntityService";
 import { getApiEntity } from "../entityUtils/apiEntityUtils/getApiEntity";
 import { constructEntity } from "../entityUtils/entityUtils";
-import { createEntityForCusProduct } from "../handlers/handleCreateEntity/createEntityForCusProduct";
+import { createEntityForCusProduct, preflightCreateEntityForCusProduct } from "../handlers/handleCreateEntity/createEntityForCusProduct";
 import { validateAndGetInputEntities } from "../handlers/handleCreateEntity/getInputEntities";
 import { attachDefaultProductsToEntities } from "./batchCreateEntities/attachDefaultProductsToEntities";
 
@@ -42,6 +42,15 @@ const createEntities = async ({
 		customerData,
 		createEntityData,
 	});
+	// Preflight all products to catch missing pools early and avoid partial application
+	for (const cusProduct of cusProducts) {
+		preflightCreateEntityForCusProduct({
+			ctx,
+			customer: fullCus,
+			cusProduct,
+			inputEntities,
+		});
+	}
 
 	for (const cusProduct of cusProducts) {
 		await createEntityForCusProduct({

--- a/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
+++ b/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
@@ -68,6 +68,79 @@ const updateLinkedCusEnt = async ({
 
 	linkedCusEnt.entities = newEntities;
 };
+export const preflightCreateEntityForCusProduct = ({
+	ctx,
+	customer,
+	cusProduct,
+	inputEntities,
+	fromAutoCreate = false,
+}: CreateEntityParams) => {
+	const { features } = ctx;
+
+	const featureToEntities = inputEntities.reduce(
+		(acc, entity) => {
+			if (!acc[entity.feature_id]) {
+				acc[entity.feature_id] = [];
+			}
+			acc[entity.feature_id].push(entity);
+			return acc;
+		},
+		{} as Record<string, Partial<Entity>[]>,
+	);
+
+	for (const featureId in featureToEntities) {
+		const feature = findFeatureById({
+			features,
+			featureId,
+			errorOnNotFound: true,
+		});
+
+		const mainCusEnt = cusProduct.customer_entitlements.find(
+			(ce) => ce.entitlement.feature.id === feature.id,
+		);
+
+		let mainCusEntWithCusProduct: FullCusEntWithFullCusProduct | undefined;
+
+		if (mainCusEnt) {
+			mainCusEntWithCusProduct = addCusProductToCusEnt({
+				cusEnt: mainCusEnt,
+				cusProduct,
+			});
+
+			const cusPrice = cusEntToCusPrice({
+				cusEnt: mainCusEntWithCusProduct,
+			});
+
+			if (fromAutoCreate && cusPrice) {
+				throw new RecaseError({
+					message: `Failed to auto create entity for feature ${feature.name} because it is a paid feature.`,
+					code: ErrCode.InvalidInputs,
+					statusCode: 400,
+				});
+			}
+		}
+
+		const isPooled = mainCusEntWithCusProduct?.entitlement.pooled === true;
+
+		if (isPooled) {
+			const sourcePoolId =
+				mainCusEntWithCusProduct?.pooled_balance_contribution?.pooled_balance_id;
+			const foundPool = customer.pooled_customer_entitlements?.find(
+				(p) =>
+					p.pooled_balance_id === sourcePoolId ||
+					p.pooled_balance?.id === sourcePoolId,
+			);
+			if (!foundPool) {
+				throw new RecaseError({
+					message: `[createEntityForCusProduct] Synthetic pooled customer entitlement not found for poolId: ${sourcePoolId}. Cannot create entities without a valid pool to decrement.`,
+					code: ErrCode.InternalError,
+					statusCode: 500,
+				});
+			}
+		}
+	}
+};
+
 export const createEntityForCusProduct = async ({
 	ctx,
 	customer,

--- a/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
+++ b/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
@@ -49,7 +49,9 @@ const updateLinkedCusEnt = async ({
 			};
 			delete newEntities[replaceableId];
 		} else {
-			const balance = linkedCusEnt.entitlement.allowance ?? 0; // cannot be null, must be 0 in unlimited case.
+			const balance = linkedCusEnt.is_pooled_balance
+				? (linkedCusEnt.pooled_balance?.granted ?? 0)
+				: (linkedCusEnt.entitlement.allowance ?? 0);
 			newEntities[entity.id] = {
 				id: entity.id,
 				balance,
@@ -64,10 +66,8 @@ const updateLinkedCusEnt = async ({
 		updates: { entities: newEntities },
 	});
 
-	// The create response is built from this request's customer snapshot.
 	linkedCusEnt.entities = newEntities;
 };
-
 export const createEntityForCusProduct = async ({
 	ctx,
 	customer,
@@ -128,9 +128,27 @@ export const createEntityForCusProduct = async ({
 			}
 		}
 
-		// 1. If main cus ent:
+		const isPooled = mainCusEntWithCusProduct?.entitlement.pooled === true;
+		const targetCusEnt = isPooled
+			? (customer.pooled_customer_entitlements?.find(
+					(p) => p.entitlement.feature.id === feature.id,
+				) as FullCusEntWithFullCusProduct | undefined) || mainCusEntWithCusProduct
+			: mainCusEntWithCusProduct;
+
+		let newEntitiesToCreate = inputEntities;
+		if (isPooled && targetCusEnt) {
+			const existingEntities = targetCusEnt.entities || {};
+			newEntitiesToCreate = inputEntities.filter(
+				(e) => !e.id || !existingEntities[e.id],
+			);
+			if (newEntitiesToCreate.length === 0) {
+				continue;
+			}
+		}
+
+		// 1. If target cus ent:
 		let deletedReplaceables: Replaceable[] = [];
-		if (mainCusEntWithCusProduct) {
+		if (targetCusEnt) {
 			// Acquire lock to prevent race conditions on seat charging
 			const lockKey = `lock:create-entity:${org.id}:${env}:${customer.id}`;
 			await acquireLock({
@@ -141,25 +159,25 @@ export const createEntityForCusProduct = async ({
 			});
 
 			try {
-				const originalBalance = mainCusEntWithCusProduct.balance || 0;
-				const newBalance = originalBalance - inputEntities.length;
+				const originalBalance = targetCusEnt.balance || 0;
+				const newBalance = originalBalance - newEntitiesToCreate.length;
 
 				// Pre-compute reps only for the usage limit check —
 				// handleProratedUpgrade applies reps itself, so we must NOT
 				// pass an already-adjusted balance to adjustAllowance.
 				const repsLength = getReps({
-					cusEnt: mainCusEntWithCusProduct,
+					cusEnt: targetCusEnt,
 					prevBalance: originalBalance,
 					newBalance,
 				}).length;
 				const balanceAfterReps = newBalance + repsLength;
 
 				if (
-					notNullish(mainCusEntWithCusProduct.entitlement.usage_limit) &&
-					balanceAfterReps < -mainCusEntWithCusProduct.entitlement.usage_limit!
+					notNullish(targetCusEnt.entitlement.usage_limit) &&
+					balanceAfterReps < -targetCusEnt.entitlement.usage_limit!
 				) {
 					throw new RecaseError({
-						message: `Cannot create ${inputEntities.length} entities for feature ${feature.name} as it would exceed the usage limit.`,
+						message: `Cannot create ${newEntitiesToCreate.length} entities for feature ${feature.name} as it would exceed the usage limit.`,
 						code: ErrCode.FeatureLimitReached,
 						statusCode: 400,
 					});
@@ -171,7 +189,7 @@ export const createEntityForCusProduct = async ({
 						cusPrices,
 						customer,
 						affectedFeature: feature!,
-						cusEnt: mainCusEntWithCusProduct,
+						cusEnt: targetCusEnt,
 						originalBalance,
 						newBalance,
 						errorIfIncomplete: true,
@@ -181,9 +199,12 @@ export const createEntityForCusProduct = async ({
 
 				await CusEntService.decrement({
 					ctx,
-					id: mainCusEntWithCusProduct.id,
-					amount: inputEntities.length - deletedReplaceables.length,
+					id: targetCusEnt.id,
+					amount: newEntitiesToCreate.length - deletedReplaceables.length,
 				});
+
+				// Update in-memory balance
+				targetCusEnt.balance = (targetCusEnt.balance || 0) - (newEntitiesToCreate.length - deletedReplaceables.length);
 			} finally {
 				await clearLock({ lockKey });
 			}
@@ -192,23 +213,25 @@ export const createEntityForCusProduct = async ({
 		const entityToReplacement: Record<string, string> = {};
 		for (let i = 0; i < deletedReplaceables.length; i++) {
 			const replaceable = deletedReplaceables[i];
-			entityToReplacement[inputEntities[i].id!] = replaceable.id;
+			entityToReplacement[newEntitiesToCreate[i].id!] = replaceable.id;
 
-			if (i >= inputEntities.length) {
+			if (i >= newEntitiesToCreate.length) {
 				break;
 			}
 		}
 
-		const linkedCusEnts = findLinkedCusEnts({
-			cusEnts,
-			feature,
-		});
+		const linkedCusEnts = isPooled && targetCusEnt
+			? [targetCusEnt]
+			: findLinkedCusEnts({
+					cusEnts,
+					feature,
+				});
 
 		for (const linkedCusEnt of linkedCusEnts) {
 			await updateLinkedCusEnt({
 				ctx,
 				linkedCusEnt,
-				inputEntities,
+				inputEntities: newEntitiesToCreate,
 				entityToReplacement,
 			});
 		}

--- a/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
+++ b/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
@@ -129,22 +129,26 @@ export const createEntityForCusProduct = async ({
 		}
 
 		const isPooled = mainCusEntWithCusProduct?.entitlement.pooled === true;
-		const targetCusEnt = isPooled
-			? (customer.pooled_customer_entitlements?.find(
-					(p) => p.entitlement.feature.id === feature.id,
-				) as FullCusEntWithFullCusProduct | undefined) || mainCusEntWithCusProduct
-			: mainCusEntWithCusProduct;
+		let targetCusEnt = mainCusEntWithCusProduct;
 
-		let newEntitiesToCreate = inputEntities;
-		if (isPooled && targetCusEnt) {
-			const existingEntities = targetCusEnt.entities || {};
-			newEntitiesToCreate = inputEntities.filter(
-				(e) => !e.id || !existingEntities[e.id],
+		if (isPooled) {
+			const sourcePoolId =
+				mainCusEntWithCusProduct?.pooled_balance_contribution?.pooled_balance_id;
+			const foundPool = customer.pooled_customer_entitlements?.find(
+				(p) =>
+					p.pooled_balance_id === sourcePoolId ||
+					p.pooled_balance?.id === sourcePoolId,
 			);
-			if (newEntitiesToCreate.length === 0) {
+			if (!foundPool) {
+				logger.warn(
+					`[createEntityForCusProduct] Synthetic pooled customer entitlement not found for poolId: ${sourcePoolId}, skipping decrement/entities on source entitlement.`,
+				);
 				continue;
 			}
+			targetCusEnt = foundPool as FullCusEntWithFullCusProduct;
 		}
+
+		let newEntitiesToCreate = inputEntities;
 
 		// 1. If target cus ent:
 		let deletedReplaceables: Replaceable[] = [];
@@ -159,6 +163,31 @@ export const createEntityForCusProduct = async ({
 			});
 
 			try {
+				// Reload the target customer entitlement from the DB to get the latest state inside the lock
+				const reloadedCusEnts = await CusEntService.getByIds({
+					db,
+					ids: [targetCusEnt.id],
+				});
+				const latestCusEnt = reloadedCusEnts[0];
+				if (!latestCusEnt) {
+					throw new RecaseError({
+						message: "Customer entitlement not found",
+						statusCode: 404,
+					});
+				}
+				targetCusEnt.balance = latestCusEnt.balance;
+				targetCusEnt.entities = latestCusEnt.entities;
+
+				if (isPooled) {
+					const existingEntities = targetCusEnt.entities || {};
+					newEntitiesToCreate = inputEntities.filter(
+						(e) => !e.id || !existingEntities[e.id],
+					);
+					if (newEntitiesToCreate.length === 0) {
+						continue;
+					}
+				}
+
 				const originalBalance = targetCusEnt.balance || 0;
 				const newBalance = originalBalance - newEntitiesToCreate.length;
 

--- a/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
+++ b/server/src/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.ts
@@ -140,10 +140,11 @@ export const createEntityForCusProduct = async ({
 					p.pooled_balance?.id === sourcePoolId,
 			);
 			if (!foundPool) {
-				logger.warn(
-					`[createEntityForCusProduct] Synthetic pooled customer entitlement not found for poolId: ${sourcePoolId}, skipping decrement/entities on source entitlement.`,
-				);
-				continue;
+				throw new RecaseError({
+					message: `[createEntityForCusProduct] Synthetic pooled customer entitlement not found for poolId: ${sourcePoolId}. Cannot create entities without a valid pool to decrement.`,
+					code: ErrCode.InternalError,
+					statusCode: 500,
+				});
 			}
 			targetCusEnt = foundPool as FullCusEntWithFullCusProduct;
 		}

--- a/server/tests/unit/entities/createEntityForCusProduct.test.ts
+++ b/server/tests/unit/entities/createEntityForCusProduct.test.ts
@@ -11,7 +11,7 @@ const mockGetByIds = mock(async ({ ids }: { ids: string[] }) =>
 		.map((c) => JSON.parse(JSON.stringify(c))), // deep clone to simulate a DB snapshot
 );
 
-// latestCusEnts is populated per-test in beforeEach
+// latestCusEnts is populated per-test in the test body and reset in afterEach
 let latestCusEnts: any[] = [];
 
 await mockModuleWithRestore("@/external/redis/utils/lockUtils/acquireLock.js", () => ({

--- a/server/tests/unit/entities/createEntityForCusProduct.test.ts
+++ b/server/tests/unit/entities/createEntityForCusProduct.test.ts
@@ -6,6 +6,8 @@ const mockUpdate = mock(async () => {});
 const mockAdjustAllowance = mock(async () => ({ deletedReplaceables: [] }));
 const mockGetReps = mock(() => []);
 
+let latestCusEnts: any[] = [];
+
 await mockModuleWithRestore("@/external/redis/utils/lockUtils/acquireLock.js", () => ({
 	acquireLock: mock(async () => {}),
 }));
@@ -22,6 +24,9 @@ await mockModuleWithRestore("@/internal/customers/cusProducts/cusEnts/CusEntitle
 	CusEntService: {
 		decrement: mockDecrement,
 		update: mockUpdate,
+		getByIds: mock(async ({ ids }) => {
+			return latestCusEnts.filter((c) => ids.includes(c.id));
+		}),
 	},
 }));
 await mockModuleWithRestore("@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer", () => ({
@@ -54,6 +59,7 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 					balance: 10,
 					entities: {},
 					is_pooled_balance: true,
+					pooled_balance_id: "pool_123",
 					pooled_balance: {
 						granted: 10,
 					},
@@ -77,6 +83,9 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 					},
 					balance: 0,
 					entities: null,
+					pooled_balance_contribution: {
+						pooled_balance_id: "pool_123",
+					},
 				},
 			],
 			customer_prices: [],
@@ -98,6 +107,9 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 					},
 					balance: 0,
 					entities: null,
+					pooled_balance_contribution: {
+						pooled_balance_id: "pool_123",
+					},
 				},
 			],
 			customer_prices: [],
@@ -113,7 +125,19 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 					name: "Organization",
 				},
 			],
+			db: {} as any,
+			logger: {
+				info: () => {},
+				warn: () => {},
+				error: () => {},
+			},
 		};
+
+		latestCusEnts = [
+			customer.pooled_customer_entitlements[0],
+			cusProduct1.customer_entitlements[0],
+			cusProduct2.customer_entitlements[0],
+		];
 
 		const inputEntities = [{ id: "org_1", feature_id: "organization" }];
 

--- a/server/tests/unit/entities/createEntityForCusProduct.test.ts
+++ b/server/tests/unit/entities/createEntityForCusProduct.test.ts
@@ -1,11 +1,17 @@
-import { afterAll, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const mockDecrement = mock(async () => {});
 const mockUpdate = mock(async () => {});
 const mockAdjustAllowance = mock(async () => ({ deletedReplaceables: [] }));
 const mockGetReps = mock(() => []);
+const mockGetByIds = mock(async ({ ids }: { ids: string[] }) =>
+	latestCusEnts
+		.filter((c) => ids.includes(c.id))
+		.map((c) => JSON.parse(JSON.stringify(c))), // deep clone to simulate a DB snapshot
+);
 
+// latestCusEnts is populated per-test in beforeEach
 let latestCusEnts: any[] = [];
 
 await mockModuleWithRestore("@/external/redis/utils/lockUtils/acquireLock.js", () => ({
@@ -24,9 +30,7 @@ await mockModuleWithRestore("@/internal/customers/cusProducts/cusEnts/CusEntitle
 	CusEntService: {
 		decrement: mockDecrement,
 		update: mockUpdate,
-		getByIds: mock(async ({ ids }) => {
-			return latestCusEnts.filter((c) => ids.includes(c.id));
-		}),
+		getByIds: mockGetByIds,
 	},
 }));
 await mockModuleWithRestore("@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer", () => ({
@@ -38,6 +42,17 @@ const { createEntityForCusProduct } = await import(
 );
 
 describe("createEntityForCusProduct (pooled balance fix)", () => {
+	afterEach(() => {
+		// Reset mock call counts and shared state after each test so they never
+		// bleed into subsequent tests, regardless of how many tests are added.
+		mockDecrement.mockClear();
+		mockUpdate.mockClear();
+		mockGetByIds.mockClear();
+		mockAdjustAllowance.mockClear();
+		mockGetReps.mockClear();
+		latestCusEnts = [];
+	});
+
 	test("correctly decrements and records entities on the synthetic entitlement, and avoids duplicate processing across products", async () => {
 		const customer: any = {
 			id: "cus_123",
@@ -61,6 +76,7 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 					is_pooled_balance: true,
 					pooled_balance_id: "pool_123",
 					pooled_balance: {
+						id: "pool_123",
 						granted: 10,
 					},
 				},
@@ -133,6 +149,9 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 			},
 		};
 
+		// Populate the DB-snapshot list that the mock will deep-clone per call.
+		// This simulates the persisted state (including state updated by product 1's run
+		// when product 2 reloads) so dedup is validated against a genuine snapshot.
 		latestCusEnts = [
 			customer.pooled_customer_entitlements[0],
 			cusProduct1.customer_entitlements[0],
@@ -163,7 +182,7 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 			},
 		});
 
-		// Check in-memory updates
+		// Check in-memory updates on the customer object
 		const syntheticEnt = customer.pooled_customer_entitlements[0];
 		expect(syntheticEnt.balance).toBe(9);
 		expect(syntheticEnt.entities).toEqual({
@@ -174,11 +193,13 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 			},
 		});
 
-		// Reset mock counters
+		// Reset counts before product 2 so we can assert only on what product 2 does.
 		mockDecrement.mockClear();
 		mockUpdate.mockClear();
 
-		// 2. Process product 2: Should find org_1 already exists in memory syntheticEnt.entities, and skip
+		// 2. Process product 2: The deep-cloned reload from getByIds now reflects
+		// the entities map written by product 1 (because latestCusEnts[0] was mutated
+		// in-memory by step 1). The dedup filter should see org_1 already present and skip.
 		await createEntityForCusProduct({
 			ctx,
 			customer,
@@ -188,6 +209,60 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 
 		expect(mockDecrement).toHaveBeenCalledTimes(0);
 		expect(mockUpdate).toHaveBeenCalledTimes(0);
+	});
+
+	test("throws when synthetic pooled entitlement is not found (fail fast)", async () => {
+		const customer: any = {
+			id: "cus_123",
+			internal_id: "cus_int_123",
+			org_id: "org_123",
+			env: "sandbox",
+			// No matching pool for pool_xyz
+			pooled_customer_entitlements: [],
+		};
+
+		const cusProduct: any = {
+			id: "cp_1",
+			customer_entitlements: [
+				{
+					id: "cus_ent_source_1",
+					entitlement: {
+						id: "ent_source_1",
+						pooled: true,
+						feature: {
+							id: "organization",
+							internal_id: "feat_int_123",
+							name: "Organization",
+						},
+					},
+					balance: 0,
+					entities: null,
+					pooled_balance_contribution: {
+						pooled_balance_id: "pool_xyz",
+					},
+				},
+			],
+			customer_prices: [],
+		};
+
+		const ctx: any = {
+			org: { id: "org_123" },
+			env: "sandbox",
+			features: [
+				{
+					id: "organization",
+					internal_id: "feat_int_123",
+					name: "Organization",
+				},
+			],
+			db: {} as any,
+		};
+
+		const inputEntities = [{ id: "org_1", feature_id: "organization" }];
+
+		await expect(
+			createEntityForCusProduct({ ctx, customer, cusProduct, inputEntities }),
+		).rejects.toThrow("pool_xyz");
 	});
 });
 

--- a/server/tests/unit/entities/createEntityForCusProduct.test.ts
+++ b/server/tests/unit/entities/createEntityForCusProduct.test.ts
@@ -1,0 +1,169 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const mockDecrement = mock(async () => {});
+const mockUpdate = mock(async () => {});
+const mockAdjustAllowance = mock(async () => ({ deletedReplaceables: [] }));
+const mockGetReps = mock(() => []);
+
+await mockModuleWithRestore("@/external/redis/utils/lockUtils/acquireLock.js", () => ({
+	acquireLock: mock(async () => {}),
+}));
+await mockModuleWithRestore("@/external/redis/utils/lockUtils/clearLock.js", () => ({
+	clearLock: mock(async () => {}),
+}));
+await mockModuleWithRestore("@/internal/balances/utils/paidAllocatedFeature/adjustAllowance.js", () => ({
+	adjustAllowance: mockAdjustAllowance,
+}));
+await mockModuleWithRestore("@/internal/balances/utils/paidAllocatedFeature/createPaidAllocatedInvoice/handleProratedUpgrade.js", () => ({
+	getReps: mockGetReps,
+}));
+await mockModuleWithRestore("@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js", () => ({
+	CusEntService: {
+		decrement: mockDecrement,
+		update: mockUpdate,
+	},
+}));
+await mockModuleWithRestore("@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer", () => ({
+	deleteCachedFullCustomer: mock(async () => {}),
+}));
+
+const { createEntityForCusProduct } = await import(
+	"@/internal/entities/handlers/handleCreateEntity/createEntityForCusProduct.js"
+);
+
+describe("createEntityForCusProduct (pooled balance fix)", () => {
+	test("correctly decrements and records entities on the synthetic entitlement, and avoids duplicate processing across products", async () => {
+		const customer: any = {
+			id: "cus_123",
+			internal_id: "cus_int_123",
+			org_id: "org_123",
+			env: "sandbox",
+			pooled_customer_entitlements: [
+				{
+					id: "cus_ent_synthetic",
+					entitlement: {
+						id: "ent_synthetic",
+						pooled: true,
+						feature: {
+							id: "organization",
+							internal_id: "feat_int_123",
+							name: "Organization",
+						},
+					},
+					balance: 10,
+					entities: {},
+					is_pooled_balance: true,
+				},
+			],
+		};
+
+		const cusProduct1: any = {
+			id: "cp_1",
+			customer_entitlements: [
+				{
+					id: "cus_ent_source_1",
+					entitlement: {
+						id: "ent_source_1",
+						pooled: true,
+						feature: {
+							id: "organization",
+							internal_id: "feat_int_123",
+							name: "Organization",
+						},
+					},
+					balance: 0,
+					entities: null,
+				},
+			],
+			customer_prices: [],
+		};
+
+		const cusProduct2: any = {
+			id: "cp_2",
+			customer_entitlements: [
+				{
+					id: "cus_ent_source_2",
+					entitlement: {
+						id: "ent_source_2",
+						pooled: true,
+						feature: {
+							id: "organization",
+							internal_id: "feat_int_123",
+							name: "Organization",
+						},
+					},
+					balance: 0,
+					entities: null,
+				},
+			],
+			customer_prices: [],
+		};
+
+		const ctx: any = {
+			org: { id: "org_123" },
+			env: "sandbox",
+			features: [
+				{
+					id: "organization",
+					internal_id: "feat_int_123",
+					name: "Organization",
+				},
+			],
+		};
+
+		const inputEntities = [{ id: "org_1", feature_id: "organization" }];
+
+		// 1. Process product 1: Should decrement the pool and add org_1
+		await createEntityForCusProduct({
+			ctx,
+			customer,
+			cusProduct: cusProduct1,
+			inputEntities,
+		});
+
+		expect(mockDecrement).toHaveBeenCalledTimes(1);
+		expect(mockDecrement.mock.calls[0][0].id).toBe("cus_ent_synthetic");
+		expect(mockDecrement.mock.calls[0][0].amount).toBe(1);
+
+		expect(mockUpdate).toHaveBeenCalledTimes(1);
+		expect(mockUpdate.mock.calls[0][0].id).toBe("cus_ent_synthetic");
+		expect(mockUpdate.mock.calls[0][0].updates.entities).toEqual({
+			org_1: {
+				id: "org_1",
+				balance: 10, // from pooled_balance.granted
+				adjustment: 0,
+			},
+		});
+
+		// Check in-memory updates
+		const syntheticEnt = customer.pooled_customer_entitlements[0];
+		expect(syntheticEnt.balance).toBe(9);
+		expect(syntheticEnt.entities).toEqual({
+			org_1: {
+				id: "org_1",
+				balance: 10,
+				adjustment: 0,
+			},
+		});
+
+		// Reset mock counters
+		mockDecrement.mockClear();
+		mockUpdate.mockClear();
+
+		// 2. Process product 2: Should find org_1 already exists in memory syntheticEnt.entities, and skip
+		await createEntityForCusProduct({
+			ctx,
+			customer,
+			cusProduct: cusProduct2,
+			inputEntities,
+		});
+
+		expect(mockDecrement).toHaveBeenCalledTimes(0);
+		expect(mockUpdate).toHaveBeenCalledTimes(0);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/server/tests/unit/entities/createEntityForCusProduct.test.ts
+++ b/server/tests/unit/entities/createEntityForCusProduct.test.ts
@@ -54,6 +54,9 @@ describe("createEntityForCusProduct (pooled balance fix)", () => {
 					balance: 10,
 					entities: {},
 					is_pooled_balance: true,
+					pooled_balance: {
+						granted: 10,
+					},
 				},
 			],
 		};


### PR DESCRIPTION
## Summary
Fixes #2709

Previously, when a customer had multiple active products containing a pooled non-consumable entity feature (e.g. a base plan and an add-on plan), creating entities *after* attaching both plans resulted in double-counting/double-decrementing the usage. Each entity creation decremented the balance of the source customer entitlement on *every* product in the loop.

This PR fixes the issue by:
- Gating and targeting the synthetic pooled customer entitlement (`pooled_customer_entitlements`) for decrementing and checking limits of pooled features, rather than decrementing every individual source customer product entitlement.
- Checking for duplicate/existing entities in the pool to prevent multi-product double processing.
- Updating in-memory balances correctly during entity creation.
- Adding a comprehensive unit test verifying the fix under pooled scenarios.

## Test Plan
- Added `server/tests/unit/entities/createEntityForCusProduct.test.ts` testing the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double-decrementing and duplicate entity records when creating pooled non-consumable entities across a base plan and an add-on. Previously each create decremented every product entitlement and re-added the entity; now we operate on the synthetic pooled entitlement, dedupe under a lock, and fail fast when the pool is missing.

- For pooled features, find the pool by `pooled_balance_id` (or `pooled_balance.id`) and route usage checks, decrements, and entity writes to that pooled customer entitlement; non-pooled behavior is unchanged.
- Acquire a lock and reload the target entitlement inside the lock, then de-dupe input entities against the latest `entities`; skip work if all inputs already exist.
- Enforce usage limits and decrement by the number of new entities only; update the in-memory balance. When `is_pooled_balance`, set an entity’s balance from `pooled_balance.granted`.
- In batch create, preflight all products to validate that required pools exist and abort early to avoid partial application.
- Adds tests covering single decrement/dedup across products and fail-fast on missing pools.

<sup>Written for commit 01ad4d3f179abaaed7066baa8af9c178a23aa461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

