### PR TITLE
feat(sync): auto-import custom base + usage prices from Stripe

### DIFF
--- a/server/src/internal/billing/v2/actions/sync/detect/detectSubscriptionMatch.ts
+++ b/server/src/internal/billing/v2/actions/sync/detect/detectSubscriptionMatch.ts
@@ -71,7 +71,7 @@ export const detectSubscriptionMatch = async ({
 			),
 			org: ctx.org,
 		});
-		const plans = itemDiffsToMatchedPlans({ itemDiffs });
+		const plans = itemDiffsToMatchedPlans({ ctx, itemDiffs });
 		return {
 			start_date: snapshot.start_date,
 			end_date: snapshot.end_date,

--- a/server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/decidePlanBase.ts
+++ b/server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/decidePlanBase.ts
@@ -7,6 +7,10 @@ import type { StripeItemSnapshot } from "@/internal/billing/v2/providers/stripe/
 import type { ItemDiff, PlanBase, PlanWarning } from "../types";
 import { stripeItemToCustomBasePrice } from "./stripeItemToCustomBasePrice";
 
+/** A flat, non-metered Stripe line (Stripe's "licensed" usage type). */
+const isFlatFeeItem = ({ item }: { item: StripeItemSnapshot }): boolean =>
+	item.recurring_usage_type === "licensed";
+
 export type PlanBaseDecision = {
 	base: PlanBase;
 	customize?: CustomizePlanV1;
@@ -32,8 +36,12 @@ export const decidePlanBase = ({
 	const baseHits = diffs.flatMap((diff) =>
 		isBasePriceMatch(diff.match) ? [{ diff, price: diff.match.price }] : [],
 	);
-	const customBaseCandidates = diffs.filter((diff) =>
-		isCustomBaseMatch(diff.match),
+	// A flat, licensed line on a plan with no catalog base IS that plan's base
+	// fee — even when it matched a usage price via a shared Stripe product.
+	const customBaseCandidates = diffs.filter(
+		(diff) =>
+			isCustomBaseMatch(diff.match) ||
+			(basePrice === null && isFlatFeeItem({ item: diff.stripe })),
 	);
 
 	if (baseHits.length > 0) {

--- a/server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/itemDiffsToMatchedPlans.ts
+++ b/server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/itemDiffsToMatchedPlans.ts
@@ -1,9 +1,21 @@
-import { type FullProduct, productToBasePrice } from "@autumn/shared";
-import { isFeaturePriceMatch } from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/classifyItemMatch";
+import {
+	BillingMethod,
+	type CreatePlanItemParamsV1,
+	type CustomizePlanV1,
+	type FullProduct,
+	isUsagePrice,
+	productToBasePrice,
+	type SharedContext,
+} from "@autumn/shared";
+import {
+	isFeaturePriceMatch,
+	matchesOnStripePriceId,
+} from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/classifyItemMatch";
 import type { ItemDiff, MatchedPlan, PlanExtra, PlanFeature } from "../types";
 import { decidePlanBase } from "./decidePlanBase";
 import { derivePlanQuantity } from "./derivePlanQuantity";
 import { rollupPlanLicenses } from "./rollupPlanLicenses";
+import { stripeItemToCustomFeaturePrice } from "./stripeItemToCustomFeaturePrice";
 import { derivePlanWarnings, groupItemDiffsByPlan } from "./utils/rollupUtils";
 
 /**
@@ -12,32 +24,82 @@ import { derivePlanWarnings, groupItemDiffsByPlan } from "./utils/rollupUtils";
  * ② derive — base, quantity, features, licenses, extras, warnings.
  */
 export const itemDiffsToMatchedPlans = ({
+	ctx,
 	itemDiffs,
 }: {
+	ctx: SharedContext;
 	itemDiffs: ItemDiff[];
 }): MatchedPlan[] => {
 	const itemDiffsByPlan = groupItemDiffsByPlan({ itemDiffs });
 
 	const matchedPlans: MatchedPlan[] = [];
 	for (const { product, diffs } of itemDiffsByPlan) {
-		matchedPlans.push(diffsToMatchedPlan({ product, diffs }));
+		matchedPlans.push(diffsToMatchedPlan({ ctx, product, diffs }));
 	}
 	return matchedPlans;
 };
 
+/** A usage feature price whose Stripe amount may differ from the catalog:
+ * matched via product id (not price id), so the amount isn't guaranteed equal.
+ * Rebuilds it as a custom item carrying the Stripe amount. */
+const diffToCustomUsageItem = ({
+	ctx,
+	diff,
+	baseStripeItemId,
+}: {
+	ctx: SharedContext;
+	diff: ItemDiff;
+	baseStripeItemId: string | undefined;
+}): CreatePlanItemParamsV1 | null => {
+	if (!isFeaturePriceMatch(diff.match)) return null;
+	if (diff.stripe.id === baseStripeItemId) return null;
+	if (matchesOnStripePriceId(diff.match)) return null;
+	if (!isUsagePrice({ price: diff.match.price })) return null;
+
+	return stripeItemToCustomFeaturePrice({
+		ctx,
+		item: diff.stripe,
+		matchedPrice: diff.match.price,
+		product: diff.match.product,
+	});
+};
+
+/** Fold the custom base (customize.price) and custom usage prices
+ * (add_items, replacing their catalog counterparts) into one patch. */
+const buildCustomize = ({
+	baseCustomize,
+	customUsageItems,
+}: {
+	baseCustomize: CustomizePlanV1 | undefined;
+	customUsageItems: CreatePlanItemParamsV1[];
+}): CustomizePlanV1 | undefined => {
+	if (customUsageItems.length === 0) return baseCustomize;
+	return {
+		...baseCustomize,
+		add_items: customUsageItems,
+		remove_items: customUsageItems.map((item) => ({
+			feature_id: item.feature_id,
+			billing_method: BillingMethod.UsageBased,
+		})),
+	};
+};
+
 const diffsToMatchedPlan = ({
+	ctx,
 	product,
 	diffs,
 }: {
+	ctx: SharedContext;
 	product: FullProduct;
 	diffs: ItemDiff[];
 }): MatchedPlan => {
 	const basePrice = productToBasePrice({ product });
 
 	const baseDecision = decidePlanBase({ diffs, basePrice });
+	const baseStripeItemId = baseDecision.baseStripeItem?.id;
 
 	const features: PlanFeature[] = diffs.flatMap((diff) =>
-		isFeaturePriceMatch(diff.match)
+		isFeaturePriceMatch(diff.match) && diff.stripe.id !== baseStripeItemId
 			? [
 					{
 						stripe_item_id: diff.stripe.id,
@@ -46,6 +108,10 @@ const diffsToMatchedPlan = ({
 				]
 			: [],
 	);
+	const customUsageItems = diffs.flatMap((diff) => {
+		const item = diffToCustomUsageItem({ ctx, diff, baseStripeItemId });
+		return item ? [item] : [];
+	});
 	const extras: PlanExtra[] = baseDecision.extraDiffs.map((diff) => ({
 		stripe_item_id: diff.stripe.id,
 	}));
@@ -63,7 +129,10 @@ const diffsToMatchedPlan = ({
 		base: baseDecision.base,
 		features,
 		extras,
-		customize: baseDecision.customize,
+		customize: buildCustomize({
+			baseCustomize: baseDecision.customize,
+			customUsageItems,
+		}),
 		warnings: [
 			...derivePlanWarnings({
 				baseDecision,

--- a/server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/stripeItemToCustomFeaturePrice.ts
+++ b/server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/stripeItemToCustomFeaturePrice.ts
@@ -1,0 +1,92 @@
+import {
+	type CreatePlanItemParamsV1,
+	type FullProduct,
+	mapToProductItems,
+	type Price,
+	type SharedContext,
+	stripeToAtmnAmount,
+	TierBehavior,
+} from "@autumn/shared";
+import { productItemToPlanItemParamsV1 } from "@shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemParamsV1";
+import type { StripeItemSnapshot } from "@/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/types";
+
+type StripePriceOverride =
+	| { amount: number }
+	| { tiers: { to: number | "inf"; amount: number }[] };
+
+/** Read the amount off a Stripe line, as either a flat amount or usage tiers. */
+const stripePriceOverride = ({
+	item,
+}: {
+	item: StripeItemSnapshot;
+}): StripePriceOverride | null => {
+	if (!item.currency) return null;
+
+	if (item.tiers && item.tiers.length > 0) {
+		const tiers = item.tiers.map((tier) => ({
+			to: tier.up_to ?? ("inf" as const),
+			amount: stripeToAtmnAmount({
+				amount: Number(tier.unit_amount_decimal ?? tier.unit_amount ?? 0),
+				currency: item.currency as string,
+			}),
+		}));
+		return { tiers };
+	}
+
+	const rawAmount = item.unit_amount_decimal ?? item.unit_amount;
+	if (rawAmount === null) return null;
+	const amount = Number(rawAmount);
+	if (!Number.isFinite(amount)) return null;
+	return { amount: stripeToAtmnAmount({ amount, currency: item.currency }) };
+};
+
+/**
+ * Rebuild a matched usage price as a custom plan item: keep the catalog
+ * feature, included allowance, reset and units, and take only the amount
+ * from Stripe. Returns null when the item can't express an Autumn price.
+ */
+export const stripeItemToCustomFeaturePrice = ({
+	ctx,
+	item,
+	matchedPrice,
+	product,
+}: {
+	ctx: SharedContext;
+	item: StripeItemSnapshot;
+	matchedPrice: Price;
+	product: FullProduct;
+}): CreatePlanItemParamsV1 | null => {
+	const entitlement = product.entitlements.find(
+		(ent) => ent.id === matchedPrice.entitlement_id,
+	);
+	if (!entitlement) return null;
+
+	const [productItem] = mapToProductItems({
+		prices: [matchedPrice],
+		entitlements: [entitlement],
+		features: ctx.features,
+	});
+	if (!productItem) return null;
+
+	const params = productItemToPlanItemParamsV1({ ctx, item: productItem });
+	if (!params.price) return null;
+
+	const override = stripePriceOverride({ item });
+	if (!override) return null;
+
+	const { amount: _amount, tiers: _tiers, ...priceRest } = params.price;
+	const tierBehavior =
+		"tiers" in override && item.tiers_mode === "volume"
+			? { tier_behavior: TierBehavior.VolumeBased }
+			: {};
+
+	return {
+		...params,
+		price: {
+			...priceRest,
+			...override,
+			...tierBehavior,
+			stripe_price_id: item.stripe_price_id,
+		},
+	};
+};

--- a/server/src/internal/billing/v2/actions/sync/setup/restampSyncedStripeResources.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/restampSyncedStripeResources.ts
@@ -1,0 +1,227 @@
+import {
+	type Feature,
+	type FixedPriceConfig,
+	isFixedPrice,
+	isPrepaidPrice,
+	isUsagePrice,
+	type Price,
+	stripeToAtmnAmount,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import type { StripeItemSnapshot } from "@/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/types";
+
+const AMOUNT_EPSILON = 1e-9;
+const amountsEqual = (a: number, b: number) => Math.abs(a - b) < AMOUNT_EPSILON;
+
+const snapshotUnitAmount = ({
+	snapshot,
+}: {
+	snapshot: StripeItemSnapshot;
+}): number | null => {
+	const raw = snapshot.unit_amount_decimal ?? snapshot.unit_amount;
+	if (raw === null || !snapshot.currency) return null;
+	const amount = Number(raw);
+	if (!Number.isFinite(amount)) return null;
+	return stripeToAtmnAmount({ amount, currency: snapshot.currency });
+};
+
+/** internal_feature_id → the feature's Stripe product, read off catalog usage
+ * prices — the same link detection uses to match a line to a feature. */
+const buildFeatureStripeProductIds = ({
+	catalogPrices,
+}: {
+	catalogPrices: Price[];
+}): Map<string, string> => {
+	const byFeature = new Map<string, string>();
+	for (const price of catalogPrices) {
+		if (!isUsagePrice({ price })) continue;
+		const config = price.config as UsagePriceConfig;
+		if (config.internal_feature_id && config.stripe_product_id) {
+			byFeature.set(config.internal_feature_id, config.stripe_product_id);
+		}
+	}
+	return byFeature;
+};
+
+const usageTiersMatchSnapshot = ({
+	config,
+	snapshot,
+}: {
+	config: UsagePriceConfig;
+	snapshot: StripeItemSnapshot;
+}): boolean => {
+	if (!snapshot.currency) return false;
+	if (snapshot.tiers && snapshot.tiers.length > 0) {
+		if (config.usage_tiers.length !== snapshot.tiers.length) return false;
+		return config.usage_tiers.every((tier, index) => {
+			const stripeTier = snapshot.tiers?.[index];
+			if (!stripeTier) return false;
+			const stripeAmount = stripeToAtmnAmount({
+				amount: Number(
+					stripeTier.unit_amount_decimal ?? stripeTier.unit_amount ?? 0,
+				),
+				currency: snapshot.currency as string,
+			});
+			return (
+				amountsEqual(tier.amount, stripeAmount) &&
+				tier.to === (stripeTier.up_to ?? "inf")
+			);
+		});
+	}
+	if (config.usage_tiers.length !== 1) return false;
+	const amount = snapshotUnitAmount({ snapshot });
+	return amount !== null && amountsEqual(config.usage_tiers[0].amount, amount);
+};
+
+/** A flat base price maps to a licensed line with the same amount. */
+const licensedSnapshotForFixedPrice = ({
+	config,
+	snapshots,
+	claimed,
+}: {
+	config: FixedPriceConfig;
+	snapshots: StripeItemSnapshot[];
+	claimed: Set<string>;
+}): StripeItemSnapshot | undefined =>
+	snapshots.find((snapshot) => {
+		if (claimed.has(snapshot.id)) return false;
+		if (snapshot.recurring_usage_type !== "licensed") return false;
+		const amount = snapshotUnitAmount({ snapshot });
+		return amount !== null && amountsEqual(config.amount, amount);
+	});
+
+/** A usage price maps to its feature's line: metered for pay-as-you-go,
+ * licensed for prepaid. The feature is matched by its Stripe product (or meter
+ * for pay-as-you-go), and the amount must still match so an edited price mints
+ * a fresh Stripe price instead of reusing the wrong one. */
+const snapshotForUsagePrice = ({
+	price,
+	config,
+	snapshots,
+	featureStripeProductIds,
+	features,
+	claimed,
+}: {
+	price: Price;
+	config: UsagePriceConfig;
+	snapshots: StripeItemSnapshot[];
+	featureStripeProductIds: Map<string, string>;
+	features: Feature[];
+	claimed: Set<string>;
+}): StripeItemSnapshot | undefined => {
+	const prepaid = isPrepaidPrice(price);
+	const wantsUsageType = prepaid ? "licensed" : "metered";
+
+	const productId = featureStripeProductIds.get(config.internal_feature_id);
+	const meterId = prepaid
+		? undefined
+		: features.find(
+				(feature) => feature.internal_id === config.internal_feature_id,
+			)?.stripe_meter?.id;
+
+	return snapshots.find((snapshot) => {
+		if (claimed.has(snapshot.id)) return false;
+		if (snapshot.recurring_usage_type !== wantsUsageType) return false;
+		const matchesFeature =
+			(productId != null && snapshot.stripe_product_id === productId) ||
+			(meterId != null && snapshot.stripe_meter_id === meterId);
+		return matchesFeature && usageTiersMatchSnapshot({ config, snapshot });
+	});
+};
+
+/** Find the Stripe line a custom price came from: base → licensed, usage →
+ * metered/licensed for its feature. Everything else has no line to reuse. */
+const findSnapshotForCustomPrice = ({
+	price,
+	snapshots,
+	featureStripeProductIds,
+	features,
+	claimed,
+}: {
+	price: Price;
+	snapshots: StripeItemSnapshot[];
+	featureStripeProductIds: Map<string, string>;
+	features: Feature[];
+	claimed: Set<string>;
+}): StripeItemSnapshot | undefined => {
+	if (isFixedPrice(price)) {
+		return licensedSnapshotForFixedPrice({
+			config: price.config,
+			snapshots,
+			claimed,
+		});
+	}
+	if (isUsagePrice({ price })) {
+		return snapshotForUsagePrice({
+			price,
+			config: price.config as UsagePriceConfig,
+			snapshots,
+			featureStripeProductIds,
+			features,
+			claimed,
+		});
+	}
+	return undefined;
+};
+
+const stampStripeIdsFromSnapshot = ({
+	price,
+	snapshot,
+}: {
+	price: Price;
+	snapshot: StripeItemSnapshot;
+}): void => {
+	price.config.stripe_price_id = snapshot.stripe_price_id;
+	price.config.stripe_product_id ??= snapshot.stripe_product_id;
+	if (isUsagePrice({ price }) && snapshot.stripe_meter_id) {
+		(price.config as UsagePriceConfig).stripe_meter_id =
+			snapshot.stripe_meter_id;
+	}
+};
+
+/**
+ * Stamp Stripe resource ids onto sync-created custom prices from the live
+ * subscription. The dashboard round-trip drops the internal `stripe_price_id`
+ * from `customize`, so any custom price missing one is re-linked here to the
+ * Stripe line it came from. Mutates config in place — `customPrices` and
+ * `fullProduct.prices` share the same price references.
+ */
+export const restampSyncedStripeResources = ({
+	customPrices,
+	snapshots,
+	features,
+	catalogPrices,
+}: {
+	customPrices: Price[];
+	snapshots: StripeItemSnapshot[];
+	features: Feature[];
+	catalogPrices: Price[];
+}): void => {
+	const featureStripeProductIds = buildFeatureStripeProductIds({
+		catalogPrices,
+	});
+	const claimed = new Set<string>();
+
+	// Usage prices claim first: they match a specific Stripe product/meter, so
+	// they take their line before the amount-only base match can.
+	const usageFirst = [
+		...customPrices.filter((price) => isUsagePrice({ price })),
+		...customPrices.filter((price) => !isUsagePrice({ price })),
+	];
+
+	for (const price of usageFirst) {
+		if (price.config.stripe_price_id) continue;
+
+		const snapshot = findSnapshotForCustomPrice({
+			price,
+			snapshots,
+			featureStripeProductIds,
+			features,
+			claimed,
+		});
+		if (!snapshot) continue;
+
+		claimed.add(snapshot.id);
+		stampStripeIdsFromSnapshot({ price, snapshot });
+	}
+};

--- a/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
+++ b/server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts
@@ -1,31 +1,35 @@
 import {
-    cp,
-    type Entity,
-    EntityNotFoundError,
-    ErrCode,
-    type FullCusProduct,
-    type FullCustomer,
-    RecaseError,
-    type SyncBillingContext,
-    type SyncParamsV1,
-    type SyncPhaseContext,
-    type SyncPlanInstance,
-    type SyncProductContext,
+	cp,
+	type Entity,
+	EntityNotFoundError,
+	ErrCode,
+	type FullCusProduct,
+	type FullCustomer,
+	RecaseError,
+	type SyncBillingContext,
+	type SyncParamsV1,
+	type SyncPhaseContext,
+	type SyncPlanInstance,
+	type SyncProductContext,
 } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupAttachProductContext } from "@/internal/billing/v2/actions/attach/setup/setupAttachProductContext";
 import { setupAttachTransitionContext } from "@/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext";
 import {
-    fetchStripeSyncSchedule,
-    fetchStripeSyncSubscription,
+	fetchStripeSyncSchedule,
+	fetchStripeSyncSubscription,
 } from "@/internal/billing/v2/providers/stripe/utils/sync/fetchStripeSyncObjects";
+import { normalizeSubscriptionPhases } from "@/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/normalizeSubscriptionPhases";
 import { resolveStripeSyncCurrency } from "@/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/resolveStripeSyncCurrency";
+import type { StripeItemSnapshot } from "@/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/types";
 import { setupCustomerLicenseQuantityContext } from "@/internal/billing/v2/setup/setupCustomerLicenseQuantityContext";
 import { setupFeatureQuantitiesContext } from "@/internal/billing/v2/setup/setupFeatureQuantitiesContext";
 import { setupFullCustomerContext } from "@/internal/billing/v2/setup/setupFullCustomerContext";
 import { resolveCarryOverUsagesParam } from "@/internal/billing/v2/utils/handleCarryOvers/resolveCarryOverUsagesParam";
+import { ProductService } from "@/internal/products/ProductService";
 import { prepareSyncedCustomBasePrice } from "./prepareSyncedCustomBasePrice";
+import { restampSyncedStripeResources } from "./restampSyncedStripeResources";
 
 const resolvePlanEntity = ({
 	plan,
@@ -71,6 +75,7 @@ const buildProductContext = async ({
 	shouldFindCurrentCustomerProduct,
 	accessStartsAt,
 	stripeSubscriptionId,
+	stripeSnapshots,
 }: {
 	ctx: AutumnContext;
 	fullCustomer: FullCustomer;
@@ -78,6 +83,7 @@ const buildProductContext = async ({
 	shouldFindCurrentCustomerProduct: boolean;
 	accessStartsAt?: number;
 	stripeSubscriptionId?: string;
+	stripeSnapshots: StripeItemSnapshot[];
 }): Promise<SyncProductContext> => {
 	const {
 		fullProduct,
@@ -130,6 +136,23 @@ const buildProductContext = async ({
 		fullProduct,
 		customPrices,
 		plan,
+	});
+
+	// The dashboard round-trip drops the internal stripe_price_id from
+	// customize, so re-link custom prices to their Stripe lines from the sub.
+	// The un-customized catalog resolves each feature's Stripe product.
+	const catalogFullProduct = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: plan.plan_id,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version: plan.version,
+	});
+	restampSyncedStripeResources({
+		customPrices: preparedCustomBase.customPrices,
+		snapshots: stripeSnapshots,
+		features: ctx.features,
+		catalogPrices: catalogFullProduct.prices,
 	});
 
 	return {
@@ -197,6 +220,12 @@ export const setupSyncContext = async ({
 		customerCurrency: fullCustomer.currency,
 	});
 
+	const stripeSnapshots = normalizeSubscriptionPhases({
+		subscription: stripeSubscription ?? undefined,
+		schedule: stripeSchedule ?? undefined,
+		billingCurrency: currency,
+	}).flatMap((phase) => phase.items);
+
 	const currentEpochMs = Date.now();
 	const inputPhases = params.phases ?? [];
 	const firstPhaseIsImmediate = inputPhases[0]?.starts_at === "now";
@@ -229,6 +258,7 @@ export const setupSyncContext = async ({
 							? currentEpochMs
 							: undefined,
 						stripeSubscriptionId: params.stripe_subscription_id,
+						stripeSnapshots,
 					}),
 				),
 			);

--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/stripePriceToSnapshotFields.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/stripePriceToSnapshotFields.ts
@@ -68,5 +68,6 @@ export const stripePriceToSnapshotFields = ({
 		recurring_interval: price.recurring?.interval ?? null,
 		recurring_interval_count: price.recurring?.interval_count ?? null,
 		recurring_usage_type: price.recurring?.usage_type ?? null,
+		stripe_meter_id: price.recurring?.meter ?? null,
 	};
 };

--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/types.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/stripeItemSnapshot/types.ts
@@ -22,6 +22,7 @@ export type StripeItemSnapshot = {
 	recurring_interval: Stripe.Price.Recurring.Interval | null;
 	recurring_interval_count: number | null;
 	recurring_usage_type: "licensed" | "metered" | null;
+	stripe_meter_id: string | null;
 	metadata: Stripe.Metadata;
 };
 

--- a/server/tests/unit/billing/stripe/match-utils/find-product-level-match-for-stripe-item.spec.ts
+++ b/server/tests/unit/billing/stripe/match-utils/find-product-level-match-for-stripe-item.spec.ts
@@ -90,6 +90,7 @@ const stripeItem = ({
 	recurring_interval: interval,
 	recurring_interval_count: intervalCount,
 	recurring_usage_type: usageType,
+	stripe_meter_id: null,
 	metadata: {},
 });
 

--- a/server/tests/unit/billing/sync/climb-license-match.test.ts
+++ b/server/tests/unit/billing/sync/climb-license-match.test.ts
@@ -61,6 +61,7 @@ const stripeItem = ({
 	recurring_interval: interval,
 	recurring_interval_count: 1,
 	recurring_usage_type: "licensed",
+	stripe_meter_id: null,
 	metadata: {},
 });
 

--- a/server/tests/unit/billing/sync/stripe-sync-currency.test.ts
+++ b/server/tests/unit/billing/sync/stripe-sync-currency.test.ts
@@ -5,6 +5,7 @@ import {
 	type FullProduct,
 	type Price,
 	PriceType,
+	type SharedContext,
 	type SyncBillingContext,
 } from "@autumn/shared";
 import type Stripe from "stripe";
@@ -156,6 +157,7 @@ const snapshot = {
 	recurring_interval: "month",
 	recurring_interval_count: 3,
 	recurring_usage_type: "licensed",
+	stripe_meter_id: null,
 	metadata: {},
 } satisfies StripeItemSnapshot;
 
@@ -181,9 +183,12 @@ const itemDiff = ({
 	},
 });
 
+const testCtx = { features: [], expand: [] } as unknown as SharedContext;
+
 describe("Stripe sync base rollup", () => {
 	test("keeps an exact source Price ID as a catalog match", () => {
 		const [plan] = itemDiffsToMatchedPlans({
+			ctx: testCtx,
 			itemDiffs: [itemDiff({ exact: true })],
 		});
 
@@ -193,6 +198,7 @@ describe("Stripe sync base rollup", () => {
 
 	test("preserves a shape-matched source as a JPY quarterly custom base", () => {
 		const [plan] = itemDiffsToMatchedPlans({
+			ctx: testCtx,
 			itemDiffs: [itemDiff({ exact: false })],
 		});
 
@@ -208,6 +214,7 @@ describe("Stripe sync base rollup", () => {
 
 	test("does not coerce a missing Stripe amount to zero", () => {
 		const [plan] = itemDiffsToMatchedPlans({
+			ctx: testCtx,
 			itemDiffs: [
 				itemDiff({
 					exact: false,

--- a/vite/src/views/customers2/components/sync-stripe-v2/syncPlanRowUtils.ts
+++ b/vite/src/views/customers2/components/sync-stripe-v2/syncPlanRowUtils.ts
@@ -4,18 +4,31 @@ import {
 	formatAmount,
 	formatInterval,
 	isPriceItem,
-	planItemV0ToProductItem,
-	planItemV1ToV0,
 	type ProductItem,
 	type ProductV2,
+	planItemV0ToProductItem,
+	planItemV1ToV0,
 	type SharedContext,
 } from "@autumn/shared";
+
+/** A remove_items filter matches a feature item by its feature. */
+const removesFeatureItem = ({
+	filter,
+	item,
+}: {
+	filter: NonNullable<CustomizePlanV1["remove_items"]>[number];
+	item: ProductItem;
+}): boolean =>
+	filter.feature_id !== undefined && item.feature_id === filter.feature_id;
 
 /**
  * Apply a `customize` block to a `ProductV2`, returning the effective
  * product. `customize.items` are V1 plan items (feature items only) — they
  * must be converted back to `ProductItem` shape, else the editor reads
  * `included_usage`/`price` off the wrong shape and renders NaN.
+ *
+ * Supports both PUT-style (`items`) and PATCH-style (`add_items` /
+ * `remove_items`) customize, matching what the sync action applies.
  */
 export const applyCustomizeToProduct = ({
 	product,
@@ -31,22 +44,39 @@ export const applyCustomizeToProduct = ({
 	const ctx = { features } as unknown as SharedContext;
 	const productItems = product.items ?? [];
 
-	const featureItems: ProductItem[] = customize.items
-		? customize.items.flatMap((item) => {
-				try {
-					return [
-						planItemV0ToProductItem({
-							ctx,
-							planItem: planItemV1ToV0({ ctx, item }),
-						}),
-					];
-				} catch {
-					// Conversion throws if the feature referenced in `customize` has been
-				// deleted since it was saved; drop that item instead of crashing the editor.
-					return [];
-				}
-			})
-		: productItems.filter((item) => !isPriceItem(item));
+	const toProductItem = (
+		item: NonNullable<CustomizePlanV1["add_items"]>[number],
+	): ProductItem[] => {
+		try {
+			return [
+				planItemV0ToProductItem({
+					ctx,
+					planItem: planItemV1ToV0({ ctx, item }),
+				}),
+			];
+		} catch {
+			// Conversion throws if the feature referenced in `customize` has been
+			// deleted since it was saved; drop that item instead of crashing the editor.
+			return [];
+		}
+	};
+
+	const catalogFeatureItems = productItems.filter((item) => !isPriceItem(item));
+
+	let featureItems: ProductItem[];
+	if (customize.items) {
+		featureItems = customize.items.flatMap(toProductItem);
+	} else {
+		const removeFilters = customize.remove_items ?? [];
+		const keptItems = catalogFeatureItems.filter(
+			(item) =>
+				!removeFilters.some((filter) => removesFeatureItem({ filter, item })),
+		);
+		featureItems = [
+			...keptItems,
+			...(customize.add_items ?? []).flatMap(toProductItem),
+		];
+	}
 
 	let priceItems: ProductItem[];
 	if (customize.price === undefined) {


### PR DESCRIPTION
## Goal

When importing an existing Stripe subscription into Autumn, automatically bring over the customer's custom prices (flat base fee + usage rates) instead of dropping them and making someone re-enter them by hand.

## What changed (in sync-flow order)

- **`stripePriceToSnapshotFields.ts` / snapshot type** — Reads each Stripe line, now also capturing its meter id (a signal used to match a usage charge to the right feature).
- **`decidePlanBase.ts`** — Recognizes a flat Stripe charge as the plan's base fee, even when it shares a Stripe product with the usage charges.
- **`itemDiffsToMatchedPlans.ts`** — When a usage charge's amount differs from the catalog default, captures the customer's actual rate as a custom price.
- **`stripeItemToCustomFeaturePrice.ts`** _(new)_ — Builds that custom usage price from the Stripe line, reusing the catalog price as a template so only the amount changes.
- **`restampSyncedStripeResources.ts`** _(new)_ — Re-links each custom price to its real Stripe price id from the live subscription (base→flat line, pay-per-use→metered, prepaid→licensed), with an amount check so an edited price never reuses the wrong Stripe price.
- **`setupSyncContext.ts`** — Runs the re-link step on every sync (dashboard, auto-sync webhook, direct API), so custom prices are linked even though the dashboard round-trip drops the internal id.
- **`syncPlanRowUtils.ts`** _(frontend)_ — Makes the sync preview display the overridden prices instead of catalog defaults.

## Notes

- The re-stamp only *links* Stripe ids; the base/usage detection runs in the proposal + webhook flows, not the raw sync endpoint.
- Type-checks clean (server + vite); existing sync unit tests pass; core matching verified against the reported customer scenario (base, pay-per-use, prepaid, edited-amount guard).
- Integration sync suite not run here (needs the dev stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-imports custom base fees and usage rates from existing Stripe subscriptions during sync, preserving negotiated pricing without manual re-entry. Previously, flat fees and non-catalog usage rates were dropped; now a flat “licensed” line becomes the plan base, usage amounts are rebuilt as custom items, and both are re-linked to live Stripe price IDs.

- Detection and proposal
  - Treats a flat “licensed” Stripe line as the plan’s base fee even when it shares a product with usage charges.
  - Builds custom usage items when the Stripe line matches by product (not price) and the amount/tiers differ from the catalog; skips exact price-id matches.
  - Captures Stripe meter IDs on snapshots and respects tiers/volume behavior when rebuilding custom usage prices.
  - `itemDiffsToMatchedPlans` now takes `ctx` to build custom items and exclude the base line from features.

- Re-linking and preview
  - Re-stamps custom prices with Stripe resource IDs on every sync (dashboard, webhook, API): base → licensed line, pay-as-you-go → metered line, prepaid → licensed line, guarded by amount/tier equality so edited prices don’t reuse the wrong Stripe price.
  - Claims usage lines before base to avoid amount-only collisions; stamps `stripe_price_id`, `stripe_product_id`, and `stripe_meter_id` where applicable.
  - Sync preview applies `customize.add_items`/`remove_items` to render overridden usage prices instead of catalog defaults.

<sup>Written for commit e2aa3a5eb310a98d665cfc3888e101b708567d7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR imports customer-specific base and usage prices while syncing existing Stripe subscriptions and displays those overrides in the dashboard preview.

- **Bug fixes, Improvements:** Detects shared-product flat fees and converts non-catalog Stripe usage rates into custom plan items.
- **Improvements:** Captures Stripe meter IDs and re-links imported custom prices to their live subscription resources.
- **Improvements:** Applies PATCH-style customization data in the dashboard preview.
- **API changes:** Threads shared sync context and Stripe snapshots through matching and setup.
</details>

<h3>Confidence Score: 3/5</h3>

The PR should not merge until tier flat charges are preserved and the dashboard applies customization removal filters with the same semantics as the server.

Stripe tiers containing flat charges are imported at the wrong rate, and plans with prepaid and usage-based prices for one feature can show a preview that differs from the plan ultimately applied.

**Files Needing Attention:** server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/stripeItemToCustomFeaturePrice.ts; vite/src/views/customers2/components/sync-stripe-v2/syncPlanRowUtils.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/stripeItemToCustomFeaturePrice.ts | Converts Stripe usage lines into custom prices, but tier conversion drops Stripe flat charges. |
| server/src/internal/billing/v2/actions/sync/setup/restampSyncedStripeResources.ts | Matches custom base and usage prices back to live Stripe resources using feature, usage type, and amount checks. |
| server/src/internal/billing/v2/actions/sync/setup/setupSyncContext.ts | Normalizes live Stripe phases and runs resource re-linking for every synchronized plan. |
| server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/itemDiffsToMatchedPlans.ts | Builds custom usage-price patches and excludes a detected custom base line from feature matching. |
| vite/src/views/customers2/components/sync-stripe-v2/syncPlanRowUtils.ts | Adds PATCH-style preview support, but removal matching ignores billing method and can hide unrelated sibling prices. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Stripe
  participant Detect as Match detection
  participant Preview as Dashboard preview
  participant Setup as Sync setup
  participant Billing as Customer billing state
  Stripe->>Detect: Subscription lines and meter IDs
  Detect->>Detect: Identify base and custom usage rates
  Detect-->>Preview: Plan customization proposal
  Preview->>Preview: Render effective customized plan
  Preview->>Setup: Confirm sync
  Setup->>Stripe: Read live subscription snapshots
  Setup->>Setup: Re-link custom prices to Stripe IDs
  Setup->>Billing: Apply synchronized plan
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/customers2/components/sync-stripe-v2/syncPlanRowUtils.ts:22
**Removal filter drops billing method**

When a feature has both prepaid and usage-based prices, this matcher ignores the removal filter's `billing_method` and removes both from the preview, even though the server removes only the usage-based price. This makes the displayed plan differ from the plan applied by sync.

### Issue 2
server/src/internal/billing/v2/actions/sync/detect/itemDiffsToMatchedPlans/stripeItemToCustomFeaturePrice.ts:26-32
**Tier flat charges are dropped**

When an imported Stripe tier contains a `flat_amount`, this conversion replaces the catalog tiers with objects containing only the per-unit amount. A tier charging $5 on entry plus $1 per unit is therefore imported as only $1 per unit, causing the synchronized price to undercharge.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(sync): auto-import custom base + us..."](https://github.com/useautumn/autumn/commit/e2aa3a5eb310a98d665cfc3888e101b708567d7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52688673)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->