### PR TITLE
Allow external billing schedules without Stripe

### DIFF
--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -35,6 +35,10 @@ import {
 	handleFreeTrialParam,
 } from "@/internal/billing/v2/setup/trialContext";
 
+type ImmediateMultiProductParams = MultiAttachParamsV0 & {
+	no_billing_changes?: boolean;
+};
+
 const getSubscriptionTarget = ({
 	productContext,
 }: {
@@ -153,7 +157,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 	includeScheduledProductsForScheduleLookup,
 }: {
 	ctx: AutumnContext;
-	params: MultiAttachParamsV0;
+	params: ImmediateMultiProductParams;
 	preview?: boolean;
 	billingStartsAt?: number;
 	billingStartsAtToleranceMs?: number;
@@ -284,7 +288,8 @@ export const setupImmediateMultiProductBillingContext = async ({
 		),
 		newBillingSubscription: forceNewSubscription || undefined,
 		includeScheduledProductsForScheduleLookup,
-		createStripeCustomerIfMissing: !preview,
+		createStripeCustomerIfMissing:
+			!preview && params.no_billing_changes !== true,
 	});
 
 	const invoiceMode = await setupInvoiceModeContext({ ctx, params });
@@ -380,7 +385,8 @@ export const setupImmediateMultiProductBillingContext = async ({
 		customPrices,
 		customEnts,
 		trialContext,
-		skipBillingChanges: trialContext?.onEnd === "revert",
+		skipBillingChanges:
+			params.no_billing_changes === true || trialContext?.onEnd === "revert",
 		isCustom: customPrices.length > 0 || customEnts.length > 0,
 		checkoutMode: setupImmediateMultiProductCheckoutMode({
 			paymentMethod,

--- a/server/src/internal/billing/v2/actions/createSchedule/compute/computeImmediatePhaseCustomerProducts.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/compute/computeImmediatePhaseCustomerProducts.ts
@@ -61,6 +61,7 @@ const insertImmediateCustomerProducts = ({
 		const newCustomerProduct = computeAttachNewCustomerProduct({
 			ctx,
 			attachBillingContext,
+			params: { no_billing_changes: billingContext.skipBillingChanges },
 		});
 
 		if (expiredSameProduct) {
@@ -73,6 +74,10 @@ const insertImmediateCustomerProducts = ({
 			// boundary as its end date.
 			endedAt: productContext.unscheduled ? null : (nextPhaseStartsAt ?? null),
 		});
+		if (billingContext.skipBillingChanges) {
+			newCustomerProduct.scheduled_ids =
+				attachBillingContext.currentCustomerProduct?.scheduled_ids;
+		}
 
 		return {
 			customerProduct: newCustomerProduct,

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -14,6 +14,7 @@ import { setupAnchorResetRefund } from "@/internal/billing/v2/setup/setupAnchorR
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import { setupResetCycleAnchor } from "@/internal/billing/v2/setup/setupResetCycleAnchor";
 import { setupReplacedScheduleCustomerProductIds } from "@/internal/customers/schedules/setup/setupReplacedScheduleCustomerProductIds";
+import { isStripeConnected } from "@/internal/orgs/orgUtils";
 import { setupImmediateMultiProductBillingContext } from "../../common/immediateMultiProduct/setupImmediateMultiProductBillingContext";
 import { FIRST_PHASE_TOLERANCE_MS } from "../errors/handleFirstPhaseStartDateErrors";
 import {
@@ -39,6 +40,18 @@ type CreateScheduleCheckoutModeContext = Pick<
 	| "trialContext"
 	| "invoiceMode"
 >;
+
+const resolveNoBillingChanges = ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: CreateScheduleParamsV0;
+}) =>
+	params.no_billing_changes === true ||
+	(!isStripeConnected({ org: ctx.org, env: ctx.env }) &&
+		params.billing_behavior === "none" &&
+		params.redirect_mode === "never");
 
 const setupCreateScheduleCheckoutMode = ({
 	billingContext,
@@ -81,14 +94,18 @@ const setupCreateScheduleCheckoutMode = ({
 };
 
 const phaseToImmediateParams = ({
+	ctx,
 	params,
 	phase,
 }: {
+	ctx: AutumnContext;
 	params: CreateScheduleParamsV0;
 	phase: CreateScheduleParamsV0["phases"][number];
-}): MultiAttachParamsV0 => ({
+}): MultiAttachParamsV0 &
+	Pick<CreateScheduleParamsV0, "no_billing_changes"> => ({
 	customer_id: params.customer_id,
 	entity_id: params.entity_id,
+	no_billing_changes: resolveNoBillingChanges({ ctx, params }),
 	// Unscheduled plans bill with the immediate phase, so they attach alongside
 	// it — always last, which is how the contexts are told apart afterwards.
 	plans: [...phase.plans, ...(params.unscheduled_plans ?? [])].map((plan) => ({
@@ -157,7 +174,11 @@ const setupCreateScheduleImmediatePhase = async ({
 			? billingContext
 			: await setupImmediateMultiProductBillingContext({
 					ctx,
-					params: phaseToImmediateParams({ params, phase: immediatePhase }),
+					params: phaseToImmediateParams({
+						ctx,
+						params,
+						phase: immediatePhase,
+					}),
 					preview,
 					billingStartsAt: immediatePhase.starts_at,
 					billingStartsAtToleranceMs: FIRST_PHASE_TOLERANCE_MS,
@@ -190,7 +211,7 @@ export const setupCreateScheduleBillingContext = async ({
 
 	let billingContext = await setupImmediateMultiProductBillingContext({
 		ctx,
-		params: phaseToImmediateParams({ params, phase: initialPhase }),
+		params: phaseToImmediateParams({ ctx, params, phase: initialPhase }),
 		preview,
 		billingStartsAt: phaseHasNumericStart(initialPhase)
 			? initialPhase.starts_at

--- a/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts
@@ -287,10 +287,12 @@ export const setupCreateScheduleBillingContext = async ({
 	const scheduleBillingContext: CreateScheduleBillingContext = {
 		...billingContext,
 		replacedScheduleCustomerProductIds,
-		checkoutMode: setupCreateScheduleCheckoutMode({
-			billingContext,
-			redirectMode: params.redirect_mode,
-		}),
+		checkoutMode: billingContext.skipBillingChanges
+			? null
+			: setupCreateScheduleCheckoutMode({
+					billingContext,
+					redirectMode: params.redirect_mode,
+				}),
 		customPrices: [
 			...(billingContext.customPrices ?? []),
 			...scheduledCustomPrices,

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-no-billing-changes.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-no-billing-changes.test.ts
@@ -1,0 +1,211 @@
+// Red: external schedules require Stripe. Green: explicit and inferred
+// database-only create/preview flows work while connected schedules use Stripe.
+
+import { expect, test } from "bun:test";
+import { type CreateScheduleParamsV0, customerProducts } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { billingActions } from "@/internal/billing/v2/actions";
+import { getCustomerProductEntitlementBalances } from "../utils/createScheduleTestHelpers";
+
+const withoutStripe = (ctx: TestContext): TestContext => ({
+	...ctx,
+	org: {
+		...ctx.org,
+		stripe_connected: false,
+		stripe_config: null,
+		test_stripe_connect: {},
+	},
+});
+
+const setupExternalSchedule = async ({
+	suffix,
+	noBillingChanges,
+	historicalPhase,
+}: {
+	suffix: string;
+	noBillingChanges?: boolean;
+	historicalPhase?: boolean;
+}) => {
+	const customerId = `create-schedule-no-stripe-${suffix}`;
+	const pro = products[historicalPhase ? "pro" : "base"]({
+		id: `pro-no-stripe-schedule-${suffix}`,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const { ctx } = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [pro] })],
+		actions: [],
+	});
+	const noStripeCtx = withoutStripe(ctx);
+
+	await billingActions.attach({
+		ctx: noStripeCtx,
+		params: {
+			customer_id: customerId,
+			plan_id: pro.id,
+			no_billing_changes: true,
+			redirect_mode: "never",
+		},
+	});
+
+	const now = Date.now();
+	const currentPhase = {
+		starts_at: now,
+		plans: [{ plan_id: pro.id }],
+	};
+	const futurePhase = {
+		starts_at: now + 31 * 24 * 60 * 60 * 1000,
+		plans: [
+			{
+				plan_id: pro.id,
+				customize: {
+					items: [itemsV2.monthlyMessages({ included: 200 })],
+				},
+			},
+		],
+	};
+	const phases: CreateScheduleParamsV0["phases"] = historicalPhase
+		? [
+				{
+					starts_at: now - 31 * 24 * 60 * 60 * 1000,
+					plans: [{ plan_id: pro.id }],
+				},
+				currentPhase,
+				futurePhase,
+			]
+		: [currentPhase, futurePhase];
+	const params: CreateScheduleParamsV0 = {
+		customer_id: customerId,
+		...(noBillingChanges && { no_billing_changes: true }),
+		billing_behavior: "none",
+		redirect_mode: "never",
+		phases,
+	};
+
+	return { ctx, noStripeCtx, params };
+};
+
+const expectScheduleCreated = async ({
+	ctx,
+	response,
+}: {
+	ctx: TestContext;
+	response: Awaited<ReturnType<typeof billingActions.createSchedule>>;
+}) => {
+	expect(response.status).toBe("created");
+	expect(response.phases).toHaveLength(2);
+	const futureCustomerProductId = response.phases[1]!.customer_product_ids[0]!;
+	expect(
+		await getCustomerProductEntitlementBalances({
+			ctx,
+			customerProductId: futureCustomerProductId,
+		}),
+	).toEqual([{ feature_id: TestFeature.Messages, balance: 200 }]);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule external billing: explicit no_billing_changes works without Stripe")}`,
+	async () => {
+		const { ctx, noStripeCtx, params } = await setupExternalSchedule({
+			suffix: "explicit",
+			noBillingChanges: true,
+		});
+		const response = await billingActions.createSchedule({
+			ctx: noStripeCtx,
+			params,
+		});
+
+		await expectScheduleCreated({ ctx, response });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule external billing: exact no-Stripe payload creates a schedule")}`,
+	async () => {
+		const { ctx, noStripeCtx, params } = await setupExternalSchedule({
+			suffix: "inferred",
+		});
+		const response = await billingActions.createSchedule({
+			ctx: noStripeCtx,
+			params,
+		});
+
+		await expectScheduleCreated({ ctx, response });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("preview-create-schedule external billing: exact no-Stripe payload previews")}`,
+	async () => {
+		const { noStripeCtx, params } = await setupExternalSchedule({
+			suffix: "preview",
+			historicalPhase: true,
+		});
+		const preview = await billingActions.previewCreateSchedule({
+			ctx: noStripeCtx,
+			params,
+		});
+
+		expect(preview.total).toBe(0);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule billing_behavior none: connected organizations still update Stripe")}`,
+	async () => {
+		const customerId = "create-schedule-none-connected-stripe";
+		const pro = products.pro({
+			id: "create-schedule-none-connected-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = products.premium({
+			id: "create-schedule-none-connected-premium",
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+		const { ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+		const now = Date.now();
+
+		const response = await billingActions.createSchedule({
+			ctx,
+			params: {
+				customer_id: customerId,
+				billing_behavior: "none",
+				redirect_mode: "never",
+				phases: [
+					{ starts_at: now, plans: [{ plan_id: pro.id }] },
+					{
+						starts_at: now + 31 * 24 * 60 * 60 * 1000,
+						plans: [{ plan_id: premium.id }],
+					},
+				],
+			},
+		});
+		const [activeCustomerProduct] = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(
+				eq(customerProducts.id, response.phases[0]!.customer_product_ids[0]!),
+			);
+		const stripeSubscriptionId = activeCustomerProduct?.subscription_ids?.[0];
+
+		expect(stripeSubscriptionId).toBeDefined();
+		const stripeSubscription = await ctx.stripeCli.subscriptions.retrieve(
+			stripeSubscriptionId!,
+		);
+		expect(stripeSubscription.schedule).toBeTruthy();
+	},
+);

--- a/server/tests/integration/billing/create-schedule/params/create-schedule-no-billing-changes.test.ts
+++ b/server/tests/integration/billing/create-schedule/params/create-schedule-no-billing-changes.test.ts
@@ -28,13 +28,15 @@ const setupExternalSchedule = async ({
 	suffix,
 	noBillingChanges,
 	historicalPhase,
+	paid,
 }: {
 	suffix: string;
 	noBillingChanges?: boolean;
 	historicalPhase?: boolean;
+	paid?: boolean;
 }) => {
 	const customerId = `create-schedule-no-stripe-${suffix}`;
-	const pro = products[historicalPhase ? "pro" : "base"]({
+	const pro = products[historicalPhase || paid ? "pro" : "base"]({
 		id: `pro-no-stripe-schedule-${suffix}`,
 		items: [items.monthlyMessages({ includedUsage: 100 })],
 	});
@@ -158,7 +160,27 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("create-schedule billing_behavior none: connected organizations still update Stripe")}`,
+	`${chalk.yellowBright("create-schedule external billing: no_billing_changes persists without checkout")}`,
+	async () => {
+		const { ctx, noStripeCtx, params } = await setupExternalSchedule({
+			suffix: "checkout",
+			noBillingChanges: true,
+			paid: true,
+		});
+		params.enable_plan_immediately = true;
+		params.redirect_mode = "if_required";
+
+		const response = await billingActions.createSchedule({
+			ctx: noStripeCtx,
+			params,
+		});
+
+		await expectScheduleCreated({ ctx, response });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("create-schedule billing linkage: connected schedules use Stripe and no-billing updates preserve IDs")}`,
 	async () => {
 		const customerId = "create-schedule-none-connected-stripe";
 		const pro = products.pro({
@@ -207,5 +229,38 @@ test.concurrent(
 			stripeSubscriptionId!,
 		);
 		expect(stripeSubscription.schedule).toBeTruthy();
+
+		const replacement = await billingActions.createSchedule({
+			ctx: withoutStripe(ctx),
+			params: {
+				customer_id: customerId,
+				no_billing_changes: true,
+				billing_behavior: "none",
+				redirect_mode: "never",
+				phases: [
+					{ starts_at: now, plans: [{ plan_id: pro.id }] },
+					{
+						starts_at: now + 31 * 24 * 60 * 60 * 1000,
+						plans: [{ plan_id: premium.id }],
+					},
+				],
+			},
+		});
+		const [replacementCustomerProduct] = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(
+				eq(
+					customerProducts.id,
+					replacement.phases[0]!.customer_product_ids[0]!,
+				),
+			);
+
+		expect(replacementCustomerProduct?.subscription_ids).toEqual(
+			activeCustomerProduct?.subscription_ids,
+		);
+		expect(replacementCustomerProduct?.scheduled_ids).toEqual(
+			activeCustomerProduct?.scheduled_ids,
+		);
 	},
 );

--- a/shared/api/billing/createSchedule/createScheduleParamsV0.ts
+++ b/shared/api/billing/createSchedule/createScheduleParamsV0.ts
@@ -143,6 +143,9 @@ export const CreateScheduleParamsV0Schema = z
 			description:
 				"Whether to prorate the immediate phase. 'none' skips proration charges and credits.",
 		}),
+		no_billing_changes: z.boolean().optional().meta({
+			description: "If true, skips any billing changes for the schedule.",
+		}),
 		billing_cycle_anchor: BillingCycleAnchorSchema.optional().meta({
 			description:
 				"Pass 'now' to reset the billing cycle anchor of the immediate phase to the current time.",


### PR DESCRIPTION
## Summary

- add explicit no_billing_changes support to create/preview schedule
- infer database-only scheduling for unconnected organizations using billing_behavior: none and redirect_mode: never
- persist no-billing schedules without entering checkout
- preserve existing Stripe subscription and schedule linkage when billing writes are skipped
- preserve Stripe schedule behavior for connected organizations

## Tests

- bunx tsgo --build --noEmit
- create-schedule no-billing matrix: 5 passed
- attach no-billing regressions: 4 passed
- update no-billing regressions: 5 passed
- relative schedule regression: 1 passed
- biome check and git diff --check

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up completes support for database-only billing schedules and fixes the previously reported checkout-path conflict.

- **[API changes, Improvements]** Adds `no_billing_changes` to schedule creation and preview parameters.
- **[Bug fixes]** Prevents database-only schedules from entering Stripe or Autumn Checkout, allowing them to persist immediately.
- **[Improvements]** Infers database-only scheduling for Stripe-disconnected organizations using `billing_behavior: "none"` and `redirect_mode: "never"`.
- **[Improvements]** Preserves existing Stripe subscription and schedule identifiers while replacing schedules without billing changes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported checkout conflict is resolved and no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/createSchedule/setup/setupCreateScheduleBillingContext.ts | Infers database-only scheduling, propagates the no-billing flag, and clears checkout mode so skipped billing cannot defer persistence. |
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts | Avoids creating Stripe customers and marks the billing context to skip billing operations when explicitly requested. |
| server/src/internal/billing/v2/actions/createSchedule/compute/computeImmediatePhaseCustomerProducts.ts | Preserves existing schedule linkage identifiers when computing database-only replacement products. |
| shared/api/billing/createSchedule/createScheduleParamsV0.ts | Adds the optional public `no_billing_changes` schedule parameter. |
| server/tests/integration/billing/create-schedule/params/create-schedule-no-billing-changes.test.ts | Covers explicit and inferred database-only creation, preview, checkout avoidance, and connected-Stripe regression behavior. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create or preview schedule] --> B{Skip billing changes?}
  B -->|Yes| C[Set checkout mode to null]
  C --> D[Skip Stripe billing execution]
  D --> E[Persist or preview database schedule]
  B -->|No| F[Resolve normal checkout mode]
  F --> G[Execute connected Stripe schedule flow]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 handle no-billing schedule edge ..."](https://github.com/useautumn/autumn/commit/7ecdee17ff8aa88243e5d69ccddc0ce16d9837ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52699418)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->