### PR TITLE
docs: clarify preview amount units

### DIFF
--- a/apps/docs/mintlify/api-reference/billing/import.mdx
+++ b/apps/docs/mintlify/api-reference/billing/import.mdx
@@ -2755,15 +2755,15 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicResponseField>
 
         <DynamicResponseField name="currency" type="string">
-          The three-letter ISO currency code (e.g., 'usd').
+          The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The total before discounts, in major currency units.
+          The total before discounts.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The total after discounts, in major currency units.
+          The total after discounts.
         </DynamicResponseField>
 
         <DynamicResponseField name="line_items" type="object[]">
@@ -2778,11 +2778,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicResponseField>
 
             <DynamicResponseField name="subtotal" type="number">
-              The amount in cents before discounts and tax for this line item.
+              The amount before discounts and tax for this line item.
             </DynamicResponseField>
 
             <DynamicResponseField name="total" type="number">
-              The final amount in cents after discounts and tax for this line item.
+              The final amount after discounts and tax for this line item.
             </DynamicResponseField>
 
             <DynamicResponseField name="discounts" type="object[]">

--- a/apps/docs/mintlify/api-reference/billing/previewAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewAttach.mdx
@@ -962,11 +962,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The amount in cents before discounts and tax for this line item.
+      The amount before discounts and tax for this line item.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The final amount in cents after discounts and tax for this line item.
+      The final amount after discounts and tax for this line item.
     </DynamicResponseField>
 
     <DynamicResponseField name="discounts" type="object[]">
@@ -1013,15 +1013,15 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 </DynamicResponseField>
 
 <DynamicResponseField name="subtotal" type="number">
-  The total amount in cents before discounts and tax for the current billing period.
+  The total amount before discounts and tax for the current billing period.
 </DynamicResponseField>
 
 <DynamicResponseField name="total" type="number">
-  The final amount in cents after discounts and tax for the current billing period.
+  The final amount after discounts and tax for the current billing period.
 </DynamicResponseField>
 
 <DynamicResponseField name="currency" type="string">
-  The three-letter ISO currency code (e.g., 'usd').
+  The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
 </DynamicResponseField>
 
 <DynamicResponseField name="next_cycle" type="object">
@@ -1032,11 +1032,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The total amount in cents before discounts and tax for the next cycle.
+      The total amount before discounts and tax for the next cycle.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The final amount in cents after discounts and tax for the next cycle.
+      The final amount after discounts and tax for the next cycle.
     </DynamicResponseField>
 
     <DynamicResponseField name="line_items" type="object[]">
@@ -1051,11 +1051,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The amount in cents before discounts and tax for this line item.
+          The amount before discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The final amount in cents after discounts and tax for this line item.
+          The final amount after discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="discounts" type="object[]">

--- a/apps/docs/mintlify/api-reference/billing/previewMultiAttach.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewMultiAttach.mdx
@@ -670,11 +670,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The amount in cents before discounts and tax for this line item.
+      The amount before discounts and tax for this line item.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The final amount in cents after discounts and tax for this line item.
+      The final amount after discounts and tax for this line item.
     </DynamicResponseField>
 
     <DynamicResponseField name="discounts" type="object[]">
@@ -721,15 +721,15 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 </DynamicResponseField>
 
 <DynamicResponseField name="subtotal" type="number">
-  The total amount in cents before discounts and tax for the current billing period.
+  The total amount before discounts and tax for the current billing period.
 </DynamicResponseField>
 
 <DynamicResponseField name="total" type="number">
-  The final amount in cents after discounts and tax for the current billing period.
+  The final amount after discounts and tax for the current billing period.
 </DynamicResponseField>
 
 <DynamicResponseField name="currency" type="string">
-  The three-letter ISO currency code (e.g., 'usd').
+  The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
 </DynamicResponseField>
 
 <DynamicResponseField name="next_cycle" type="object">
@@ -740,11 +740,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The total amount in cents before discounts and tax for the next cycle.
+      The total amount before discounts and tax for the next cycle.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The final amount in cents after discounts and tax for the next cycle.
+      The final amount after discounts and tax for the next cycle.
     </DynamicResponseField>
 
     <DynamicResponseField name="line_items" type="object[]">
@@ -759,11 +759,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The amount in cents before discounts and tax for this line item.
+          The amount before discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The final amount in cents after discounts and tax for this line item.
+          The final amount after discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="discounts" type="object[]">

--- a/apps/docs/mintlify/api-reference/billing/previewMultiUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewMultiUpdate.mdx
@@ -51,7 +51,7 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 </DynamicResponseField>
 
 <DynamicResponseField name="currency" type="string">
-  The three-letter ISO currency code (e.g., 'usd').
+  The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
 </DynamicResponseField>
 
 <DynamicResponseField name="total" type="number">
@@ -77,11 +77,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The amount in cents before discounts and tax for this line item.
+          The amount before discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The final amount in cents after discounts and tax for this line item.
+          The final amount after discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="discounts" type="object[]">
@@ -128,15 +128,15 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The total amount in cents before discounts and tax for the current billing period.
+      The total amount before discounts and tax for the current billing period.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The final amount in cents after discounts and tax for the current billing period.
+      The final amount after discounts and tax for the current billing period.
     </DynamicResponseField>
 
     <DynamicResponseField name="currency" type="string">
-      The three-letter ISO currency code (e.g., 'usd').
+      The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
     </DynamicResponseField>
 
     <DynamicResponseField name="next_cycle" type="object">
@@ -147,11 +147,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The total amount in cents before discounts and tax for the next cycle.
+          The total amount before discounts and tax for the next cycle.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The final amount in cents after discounts and tax for the next cycle.
+          The final amount after discounts and tax for the next cycle.
         </DynamicResponseField>
 
         <DynamicResponseField name="line_items" type="object[]">
@@ -166,11 +166,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
             </DynamicResponseField>
 
             <DynamicResponseField name="subtotal" type="number">
-              The amount in cents before discounts and tax for this line item.
+              The amount before discounts and tax for this line item.
             </DynamicResponseField>
 
             <DynamicResponseField name="total" type="number">
-              The final amount in cents after discounts and tax for this line item.
+              The final amount after discounts and tax for this line item.
             </DynamicResponseField>
 
             <DynamicResponseField name="discounts" type="object[]">

--- a/apps/docs/mintlify/api-reference/billing/previewUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewUpdate.mdx
@@ -901,11 +901,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The amount in cents before discounts and tax for this line item.
+      The amount before discounts and tax for this line item.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The final amount in cents after discounts and tax for this line item.
+      The final amount after discounts and tax for this line item.
     </DynamicResponseField>
 
     <DynamicResponseField name="discounts" type="object[]">
@@ -952,15 +952,15 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 </DynamicResponseField>
 
 <DynamicResponseField name="subtotal" type="number">
-  The total amount in cents before discounts and tax for the current billing period.
+  The total amount before discounts and tax for the current billing period.
 </DynamicResponseField>
 
 <DynamicResponseField name="total" type="number">
-  The final amount in cents after discounts and tax for the current billing period.
+  The final amount after discounts and tax for the current billing period.
 </DynamicResponseField>
 
 <DynamicResponseField name="currency" type="string">
-  The three-letter ISO currency code (e.g., 'usd').
+  The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
 </DynamicResponseField>
 
 <DynamicResponseField name="next_cycle" type="object">
@@ -971,11 +971,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The total amount in cents before discounts and tax for the next cycle.
+      The total amount before discounts and tax for the next cycle.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The final amount in cents after discounts and tax for the next cycle.
+      The final amount after discounts and tax for the next cycle.
     </DynamicResponseField>
 
     <DynamicResponseField name="line_items" type="object[]">
@@ -990,11 +990,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The amount in cents before discounts and tax for this line item.
+          The amount before discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The final amount in cents after discounts and tax for this line item.
+          The final amount after discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="discounts" type="object[]">

--- a/apps/docs/mintlify/api-reference/customers/getCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/getCustomer.mdx
@@ -2574,15 +2574,15 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
     </DynamicResponseField>
 
     <DynamicResponseField name="currency" type="string">
-      The three-letter ISO currency code (e.g., 'usd').
+      The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The total before discounts, in major currency units.
+      The total before discounts.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The total after discounts, in major currency units.
+      The total after discounts.
     </DynamicResponseField>
 
     <DynamicResponseField name="line_items" type="object[]">
@@ -2597,11 +2597,11 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The amount in cents before discounts and tax for this line item.
+          The amount before discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The final amount in cents after discounts and tax for this line item.
+          The final amount after discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="discounts" type="object[]">

--- a/apps/docs/mintlify/api-reference/customers/getOrCreateCustomer.mdx
+++ b/apps/docs/mintlify/api-reference/customers/getOrCreateCustomer.mdx
@@ -2782,15 +2782,15 @@ Pass `currency` to bill this customer in a currency other than your organization
     </DynamicResponseField>
 
     <DynamicResponseField name="currency" type="string">
-      The three-letter ISO currency code (e.g., 'usd').
+      The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).
     </DynamicResponseField>
 
     <DynamicResponseField name="subtotal" type="number">
-      The total before discounts, in major currency units.
+      The total before discounts.
     </DynamicResponseField>
 
     <DynamicResponseField name="total" type="number">
-      The total after discounts, in major currency units.
+      The total after discounts.
     </DynamicResponseField>
 
     <DynamicResponseField name="line_items" type="object[]">
@@ -2805,11 +2805,11 @@ Pass `currency` to bill this customer in a currency other than your organization
         </DynamicResponseField>
 
         <DynamicResponseField name="subtotal" type="number">
-          The amount in cents before discounts and tax for this line item.
+          The amount before discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="total" type="number">
-          The final amount in cents after discounts and tax for this line item.
+          The final amount after discounts and tax for this line item.
         </DynamicResponseField>
 
         <DynamicResponseField name="discounts" type="object[]">

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -1016,13 +1016,14 @@ components:
                 description: Unix timestamp (milliseconds) when this invoice will be created.
               currency:
                 type: string
-                description: The three-letter ISO currency code (e.g., 'usd').
+                description: The three-letter ISO currency code. All amounts are in the currency's
+                  major unit (e.g., dollars for USD).
               subtotal:
                 type: number
-                description: The total before discounts, in major currency units.
+                description: The total before discounts.
               total:
                 type: number
-                description: The total after discounts, in major currency units.
+                description: The total after discounts.
               line_items:
                 type: array
                 items:
@@ -1038,10 +1039,10 @@ components:
                       description: A detailed description of the line item.
                     subtotal:
                       type: number
-                      description: The amount in cents before discounts and tax for this line item.
+                      description: The amount before discounts and tax for this line item.
                     total:
                       type: number
-                      description: The final amount in cents after discounts and tax for this line
+                      description: The final amount after discounts and tax for this line
                         item.
                     discounts:
                       type: array
@@ -3997,13 +3998,14 @@ paths:
                           description: Unix timestamp (milliseconds) when this invoice will be created.
                         currency:
                           type: string
-                          description: The three-letter ISO currency code (e.g., 'usd').
+                          description: The three-letter ISO currency code. All amounts are in the
+                            currency's major unit (e.g., dollars for USD).
                         subtotal:
                           type: number
-                          description: The total before discounts, in major currency units.
+                          description: The total before discounts.
                         total:
                           type: number
-                          description: The total after discounts, in major currency units.
+                          description: The total after discounts.
                         line_items:
                           type: array
                           items:
@@ -4019,10 +4021,10 @@ paths:
                                 description: A detailed description of the line item.
                               subtotal:
                                 type: number
-                                description: The amount in cents before discounts and tax for this line item.
+                                description: The amount before discounts and tax for this line item.
                               total:
                                 type: number
-                                description: The final amount in cents after discounts and tax for this line
+                                description: The final amount after discounts and tax for this line
                                   item.
                               discounts:
                                 type: array
@@ -21322,10 +21324,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
+                          description: The final amount after discounts and tax for this line
                             item.
                         discounts:
                           type: array
@@ -21378,15 +21380,16 @@ paths:
                         - quantity
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
+                    description: The total amount before discounts and tax for the current
                       billing period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
+                    description: The final amount after discounts and tax for the current
                       billing period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the currency's
+                      major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -21395,11 +21398,11 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
+                        description: The total amount before discounts and tax for the next
                           cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
+                        description: The final amount after discounts and tax for the next
                           cycle.
                       line_items:
                         type: array
@@ -21416,10 +21419,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
+                              description: The final amount after discounts and tax for this line
                                 item.
                             discounts:
                               type: array
@@ -22371,10 +22374,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
+                          description: The final amount after discounts and tax for this line
                             item.
                         discounts:
                           type: array
@@ -22427,15 +22430,16 @@ paths:
                         - quantity
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
+                    description: The total amount before discounts and tax for the current
                       billing period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
+                    description: The final amount after discounts and tax for the current
                       billing period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the currency's
+                      major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -22444,11 +22448,11 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
+                        description: The total amount before discounts and tax for the next
                           cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
+                        description: The final amount after discounts and tax for the next
                           cycle.
                       line_items:
                         type: array
@@ -22465,10 +22469,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
+                              description: The final amount after discounts and tax for this line
                                 item.
                             discounts:
                               type: array
@@ -25478,10 +25482,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
+                          description: The final amount after discounts and tax for this line
                             item.
                         discounts:
                           type: array
@@ -25535,15 +25539,16 @@ paths:
                     description: List of line items for the current billing period.
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
+                    description: The total amount before discounts and tax for the current
                       billing period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
+                    description: The final amount after discounts and tax for the current
                       billing period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the currency's
+                      major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -25552,11 +25557,11 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
+                        description: The total amount before discounts and tax for the next
                           cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
+                        description: The final amount after discounts and tax for the next
                           cycle.
                       line_items:
                         type: array
@@ -25573,10 +25578,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
+                              description: The final amount after discounts and tax for this line
                                 item.
                             discounts:
                               type: array
@@ -26195,7 +26200,8 @@ paths:
                     description: The ID of the customer the preview applies to.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the currency's
+                      major unit (e.g., dollars for USD).
                   total:
                     type: number
                     description: The combined amount due today across all subscriptions (sum of
@@ -26223,10 +26229,10 @@ paths:
                                 description: A detailed description of the line item.
                               subtotal:
                                 type: number
-                                description: The amount in cents before discounts and tax for this line item.
+                                description: The amount before discounts and tax for this line item.
                               total:
                                 type: number
-                                description: The final amount in cents after discounts and tax for this line
+                                description: The final amount after discounts and tax for this line
                                   item.
                               discounts:
                                 type: array
@@ -26280,15 +26286,16 @@ paths:
                           description: List of line items for the current billing period.
                         subtotal:
                           type: number
-                          description: The total amount in cents before discounts and tax for the current
+                          description: The total amount before discounts and tax for the current
                             billing period.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for the current
+                          description: The final amount after discounts and tax for the current
                             billing period.
                         currency:
                           type: string
-                          description: The three-letter ISO currency code (e.g., 'usd').
+                          description: The three-letter ISO currency code. All amounts are in the
+                            currency's major unit (e.g., dollars for USD).
                         next_cycle:
                           type: object
                           properties:
@@ -26297,11 +26304,11 @@ paths:
                               description: Unix timestamp (milliseconds) when the next billing cycle starts.
                             subtotal:
                               type: number
-                              description: The total amount in cents before discounts and tax for the next
+                              description: The total amount before discounts and tax for the next
                                 cycle.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for the next
+                              description: The final amount after discounts and tax for the next
                                 cycle.
                             line_items:
                               type: array
@@ -26318,10 +26325,10 @@ paths:
                                     description: A detailed description of the line item.
                                   subtotal:
                                     type: number
-                                    description: The amount in cents before discounts and tax for this line item.
+                                    description: The amount before discounts and tax for this line item.
                                   total:
                                     type: number
-                                    description: The final amount in cents after discounts and tax for this line
+                                    description: The final amount after discounts and tax for this line
                                       item.
                                   discounts:
                                     type: array

--- a/apps/docs/mintlify/documentation/customers/payment-flow.mdx
+++ b/apps/docs/mintlify/documentation/customers/payment-flow.mdx
@@ -71,7 +71,7 @@ const preview = await autumn.billing.previewAttach({
 });
 
 // preview.lineItems  — array of charges and credits
-// preview.total      — net amount in cents
+// preview.total      — net amount
 // preview.currency   — e.g. "usd"
 ```
 

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -1016,13 +1016,14 @@ components:
                 description: Unix timestamp (milliseconds) when this invoice will be created.
               currency:
                 type: string
-                description: The three-letter ISO currency code (e.g., 'usd').
+                description: The three-letter ISO currency code. All amounts are in the
+                  currency's major unit (e.g., dollars for USD).
               subtotal:
                 type: number
-                description: The total before discounts, in major currency units.
+                description: The total before discounts.
               total:
                 type: number
-                description: The total after discounts, in major currency units.
+                description: The total after discounts.
               line_items:
                 type: array
                 items:
@@ -1038,11 +1039,10 @@ components:
                       description: A detailed description of the line item.
                     subtotal:
                       type: number
-                      description: The amount in cents before discounts and tax for this line item.
+                      description: The amount before discounts and tax for this line item.
                     total:
                       type: number
-                      description: The final amount in cents after discounts and tax for this line
-                        item.
+                      description: The final amount after discounts and tax for this line item.
                     discounts:
                       type: array
                       items:
@@ -3972,13 +3972,14 @@ paths:
                           description: Unix timestamp (milliseconds) when this invoice will be created.
                         currency:
                           type: string
-                          description: The three-letter ISO currency code (e.g., 'usd').
+                          description: The three-letter ISO currency code. All amounts are in the
+                            currency's major unit (e.g., dollars for USD).
                         subtotal:
                           type: number
-                          description: The total before discounts, in major currency units.
+                          description: The total before discounts.
                         total:
                           type: number
-                          description: The total after discounts, in major currency units.
+                          description: The total after discounts.
                         line_items:
                           type: array
                           items:
@@ -3994,11 +3995,10 @@ paths:
                                 description: A detailed description of the line item.
                               subtotal:
                                 type: number
-                                description: The amount in cents before discounts and tax for this line item.
+                                description: The amount before discounts and tax for this line item.
                               total:
                                 type: number
-                                description: The final amount in cents after discounts and tax for this line
-                                  item.
+                                description: The final amount after discounts and tax for this line item.
                               discounts:
                                 type: array
                                 items:
@@ -20828,11 +20828,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
-                            item.
+                          description: The final amount after discounts and tax for this line item.
                         discounts:
                           type: array
                           items:
@@ -20884,15 +20883,16 @@ paths:
                         - quantity
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
-                      billing period.
+                    description: The total amount before discounts and tax for the current billing
+                      period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
-                      billing period.
+                    description: The final amount after discounts and tax for the current billing
+                      period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -20901,12 +20901,10 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
-                          cycle.
+                        description: The total amount before discounts and tax for the next cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
-                          cycle.
+                        description: The final amount after discounts and tax for the next cycle.
                       line_items:
                         type: array
                         items:
@@ -20922,11 +20920,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
-                                item.
+                              description: The final amount after discounts and tax for this line item.
                             discounts:
                               type: array
                               items:
@@ -21853,11 +21850,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
-                            item.
+                          description: The final amount after discounts and tax for this line item.
                         discounts:
                           type: array
                           items:
@@ -21909,15 +21905,16 @@ paths:
                         - quantity
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
-                      billing period.
+                    description: The total amount before discounts and tax for the current billing
+                      period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
-                      billing period.
+                    description: The final amount after discounts and tax for the current billing
+                      period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -21926,12 +21923,10 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
-                          cycle.
+                        description: The total amount before discounts and tax for the next cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
-                          cycle.
+                        description: The final amount after discounts and tax for the next cycle.
                       line_items:
                         type: array
                         items:
@@ -21947,11 +21942,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
-                                item.
+                              description: The final amount after discounts and tax for this line item.
                             discounts:
                               type: array
                               items:
@@ -24874,11 +24868,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
-                            item.
+                          description: The final amount after discounts and tax for this line item.
                         discounts:
                           type: array
                           items:
@@ -24931,15 +24924,16 @@ paths:
                     description: List of line items for the current billing period.
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
-                      billing period.
+                    description: The total amount before discounts and tax for the current billing
+                      period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
-                      billing period.
+                    description: The final amount after discounts and tax for the current billing
+                      period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -24948,12 +24942,10 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
-                          cycle.
+                        description: The total amount before discounts and tax for the next cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
-                          cycle.
+                        description: The final amount after discounts and tax for the next cycle.
                       line_items:
                         type: array
                         items:
@@ -24969,11 +24961,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
-                                item.
+                              description: The final amount after discounts and tax for this line item.
                             discounts:
                               type: array
                               items:
@@ -25514,7 +25505,8 @@ paths:
                     description: The ID of the customer the preview applies to.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   total:
                     type: number
                     description: The combined amount due today across all subscriptions (sum of
@@ -25542,11 +25534,10 @@ paths:
                                 description: A detailed description of the line item.
                               subtotal:
                                 type: number
-                                description: The amount in cents before discounts and tax for this line item.
+                                description: The amount before discounts and tax for this line item.
                               total:
                                 type: number
-                                description: The final amount in cents after discounts and tax for this line
-                                  item.
+                                description: The final amount after discounts and tax for this line item.
                               discounts:
                                 type: array
                                 items:
@@ -25599,15 +25590,16 @@ paths:
                           description: List of line items for the current billing period.
                         subtotal:
                           type: number
-                          description: The total amount in cents before discounts and tax for the current
-                            billing period.
+                          description: The total amount before discounts and tax for the current billing
+                            period.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for the current
-                            billing period.
+                          description: The final amount after discounts and tax for the current billing
+                            period.
                         currency:
                           type: string
-                          description: The three-letter ISO currency code (e.g., 'usd').
+                          description: The three-letter ISO currency code. All amounts are in the
+                            currency's major unit (e.g., dollars for USD).
                         next_cycle:
                           type: object
                           properties:
@@ -25616,12 +25608,10 @@ paths:
                               description: Unix timestamp (milliseconds) when the next billing cycle starts.
                             subtotal:
                               type: number
-                              description: The total amount in cents before discounts and tax for the next
-                                cycle.
+                              description: The total amount before discounts and tax for the next cycle.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for the next
-                                cycle.
+                              description: The final amount after discounts and tax for the next cycle.
                             line_items:
                               type: array
                               items:
@@ -25637,11 +25627,10 @@ paths:
                                     description: A detailed description of the line item.
                                   subtotal:
                                     type: number
-                                    description: The amount in cents before discounts and tax for this line item.
+                                    description: The amount before discounts and tax for this line item.
                                   total:
                                     type: number
-                                    description: The final amount in cents after discounts and tax for this line
-                                      item.
+                                    description: The final amount after discounts and tax for this line item.
                                   discounts:
                                     type: array
                                     items:

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -1016,13 +1016,14 @@ components:
                 description: Unix timestamp (milliseconds) when this invoice will be created.
               currency:
                 type: string
-                description: The three-letter ISO currency code (e.g., 'usd').
+                description: The three-letter ISO currency code. All amounts are in the
+                  currency's major unit (e.g., dollars for USD).
               subtotal:
                 type: number
-                description: The total before discounts, in major currency units.
+                description: The total before discounts.
               total:
                 type: number
-                description: The total after discounts, in major currency units.
+                description: The total after discounts.
               line_items:
                 type: array
                 items:
@@ -1038,11 +1039,10 @@ components:
                       description: A detailed description of the line item.
                     subtotal:
                       type: number
-                      description: The amount in cents before discounts and tax for this line item.
+                      description: The amount before discounts and tax for this line item.
                     total:
                       type: number
-                      description: The final amount in cents after discounts and tax for this line
-                        item.
+                      description: The final amount after discounts and tax for this line item.
                     discounts:
                       type: array
                       items:
@@ -4044,13 +4044,14 @@ paths:
                           description: Unix timestamp (milliseconds) when this invoice will be created.
                         currency:
                           type: string
-                          description: The three-letter ISO currency code (e.g., 'usd').
+                          description: The three-letter ISO currency code. All amounts are in the
+                            currency's major unit (e.g., dollars for USD).
                         subtotal:
                           type: number
-                          description: The total before discounts, in major currency units.
+                          description: The total before discounts.
                         total:
                           type: number
-                          description: The total after discounts, in major currency units.
+                          description: The total after discounts.
                         line_items:
                           type: array
                           items:
@@ -4066,11 +4067,10 @@ paths:
                                 description: A detailed description of the line item.
                               subtotal:
                                 type: number
-                                description: The amount in cents before discounts and tax for this line item.
+                                description: The amount before discounts and tax for this line item.
                               total:
                                 type: number
-                                description: The final amount in cents after discounts and tax for this line
-                                  item.
+                                description: The final amount after discounts and tax for this line item.
                               discounts:
                                 type: array
                                 items:
@@ -21518,11 +21518,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
-                            item.
+                          description: The final amount after discounts and tax for this line item.
                         discounts:
                           type: array
                           items:
@@ -21574,15 +21573,16 @@ paths:
                         - quantity
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
-                      billing period.
+                    description: The total amount before discounts and tax for the current billing
+                      period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
-                      billing period.
+                    description: The final amount after discounts and tax for the current billing
+                      period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -21591,12 +21591,10 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
-                          cycle.
+                        description: The total amount before discounts and tax for the next cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
-                          cycle.
+                        description: The final amount after discounts and tax for the next cycle.
                       line_items:
                         type: array
                         items:
@@ -21612,11 +21610,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
-                                item.
+                              description: The final amount after discounts and tax for this line item.
                             discounts:
                               type: array
                               items:
@@ -22559,11 +22556,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
-                            item.
+                          description: The final amount after discounts and tax for this line item.
                         discounts:
                           type: array
                           items:
@@ -22615,15 +22611,16 @@ paths:
                         - quantity
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
-                      billing period.
+                    description: The total amount before discounts and tax for the current billing
+                      period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
-                      billing period.
+                    description: The final amount after discounts and tax for the current billing
+                      period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -22632,12 +22629,10 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
-                          cycle.
+                        description: The total amount before discounts and tax for the next cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
-                          cycle.
+                        description: The final amount after discounts and tax for the next cycle.
                       line_items:
                         type: array
                         items:
@@ -22653,11 +22648,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
-                                item.
+                              description: The final amount after discounts and tax for this line item.
                             discounts:
                               type: array
                               items:
@@ -25756,11 +25750,10 @@ paths:
                           description: A detailed description of the line item.
                         subtotal:
                           type: number
-                          description: The amount in cents before discounts and tax for this line item.
+                          description: The amount before discounts and tax for this line item.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for this line
-                            item.
+                          description: The final amount after discounts and tax for this line item.
                         discounts:
                           type: array
                           items:
@@ -25813,15 +25806,16 @@ paths:
                     description: List of line items for the current billing period.
                   subtotal:
                     type: number
-                    description: The total amount in cents before discounts and tax for the current
-                      billing period.
+                    description: The total amount before discounts and tax for the current billing
+                      period.
                   total:
                     type: number
-                    description: The final amount in cents after discounts and tax for the current
-                      billing period.
+                    description: The final amount after discounts and tax for the current billing
+                      period.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   next_cycle:
                     type: object
                     properties:
@@ -25830,12 +25824,10 @@ paths:
                         description: Unix timestamp (milliseconds) when the next billing cycle starts.
                       subtotal:
                         type: number
-                        description: The total amount in cents before discounts and tax for the next
-                          cycle.
+                        description: The total amount before discounts and tax for the next cycle.
                       total:
                         type: number
-                        description: The final amount in cents after discounts and tax for the next
-                          cycle.
+                        description: The final amount after discounts and tax for the next cycle.
                       line_items:
                         type: array
                         items:
@@ -25851,11 +25843,10 @@ paths:
                               description: A detailed description of the line item.
                             subtotal:
                               type: number
-                              description: The amount in cents before discounts and tax for this line item.
+                              description: The amount before discounts and tax for this line item.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for this line
-                                item.
+                              description: The final amount after discounts and tax for this line item.
                             discounts:
                               type: array
                               items:
@@ -26410,7 +26401,8 @@ paths:
                     description: The ID of the customer the preview applies to.
                   currency:
                     type: string
-                    description: The three-letter ISO currency code (e.g., 'usd').
+                    description: The three-letter ISO currency code. All amounts are in the
+                      currency's major unit (e.g., dollars for USD).
                   total:
                     type: number
                     description: The combined amount due today across all subscriptions (sum of
@@ -26438,11 +26430,10 @@ paths:
                                 description: A detailed description of the line item.
                               subtotal:
                                 type: number
-                                description: The amount in cents before discounts and tax for this line item.
+                                description: The amount before discounts and tax for this line item.
                               total:
                                 type: number
-                                description: The final amount in cents after discounts and tax for this line
-                                  item.
+                                description: The final amount after discounts and tax for this line item.
                               discounts:
                                 type: array
                                 items:
@@ -26495,15 +26486,16 @@ paths:
                           description: List of line items for the current billing period.
                         subtotal:
                           type: number
-                          description: The total amount in cents before discounts and tax for the current
-                            billing period.
+                          description: The total amount before discounts and tax for the current billing
+                            period.
                         total:
                           type: number
-                          description: The final amount in cents after discounts and tax for the current
-                            billing period.
+                          description: The final amount after discounts and tax for the current billing
+                            period.
                         currency:
                           type: string
-                          description: The three-letter ISO currency code (e.g., 'usd').
+                          description: The three-letter ISO currency code. All amounts are in the
+                            currency's major unit (e.g., dollars for USD).
                         next_cycle:
                           type: object
                           properties:
@@ -26512,12 +26504,10 @@ paths:
                               description: Unix timestamp (milliseconds) when the next billing cycle starts.
                             subtotal:
                               type: number
-                              description: The total amount in cents before discounts and tax for the next
-                                cycle.
+                              description: The total amount before discounts and tax for the next cycle.
                             total:
                               type: number
-                              description: The final amount in cents after discounts and tax for the next
-                                cycle.
+                              description: The final amount after discounts and tax for the next cycle.
                             line_items:
                               type: array
                               items:
@@ -26533,11 +26523,10 @@ paths:
                                     description: A detailed description of the line item.
                                   subtotal:
                                     type: number
-                                    description: The amount in cents before discounts and tax for this line item.
+                                    description: The amount before discounts and tax for this line item.
                                   total:
                                     type: number
-                                    description: The final amount in cents after discounts and tax for this line
-                                      item.
+                                    description: The final amount after discounts and tax for this line item.
                                   discounts:
                                     type: array
                                     items:

--- a/shared/api/billing/common/billingPreviewResponse.ts
+++ b/shared/api/billing/common/billingPreviewResponse.ts
@@ -68,12 +68,10 @@ export const ExtPreviewLineItemSchema = z.object({
 		.string()
 		.meta({ description: "A detailed description of the line item." }),
 	subtotal: z.number().meta({
-		description:
-			"The amount in cents before discounts and tax for this line item.",
+		description: "The amount before discounts and tax for this line item.",
 	}),
 	total: z.number().meta({
-		description:
-			"The final amount in cents after discounts and tax for this line item.",
+		description: "The final amount after discounts and tax for this line item.",
 	}),
 	discounts: z.array(PreviewLineItemDiscountSchema).default([]).meta({
 		description: "List of discounts applied to this line item.",
@@ -123,16 +121,17 @@ export const ExtBillingPreviewResponseSchema = z.object({
 	}),
 	subtotal: z.number().meta({
 		description:
-			"The total amount in cents before discounts and tax for the current billing period.",
+			"The total amount before discounts and tax for the current billing period.",
 	}),
 
 	total: z.number().meta({
 		description:
-			"The final amount in cents after discounts and tax for the current billing period.",
+			"The final amount after discounts and tax for the current billing period.",
 	}),
 
 	currency: z.string().meta({
-		description: "The three-letter ISO currency code (e.g., 'usd').",
+		description:
+			"The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).",
 	}),
 
 	next_cycle: z
@@ -143,11 +142,11 @@ export const ExtBillingPreviewResponseSchema = z.object({
 			}),
 			subtotal: z.number().meta({
 				description:
-					"The total amount in cents before discounts and tax for the next cycle.",
+					"The total amount before discounts and tax for the next cycle.",
 			}),
 			total: z.number().meta({
 				description:
-					"The final amount in cents after discounts and tax for the next cycle.",
+					"The final amount after discounts and tax for the next cycle.",
 			}),
 			line_items: z.array(PreviewLineItemSchema).meta({
 				description: "List of line items for the next billing cycle.",

--- a/shared/api/billing/multiUpdate/multiUpdatePreviewResponseV0.ts
+++ b/shared/api/billing/multiUpdate/multiUpdatePreviewResponseV0.ts
@@ -24,7 +24,8 @@ const multiUpdatePreviewBase = {
 		description: "The ID of the customer the preview applies to.",
 	}),
 	currency: z.string().meta({
-		description: "The three-letter ISO currency code (e.g., 'usd').",
+		description:
+			"The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).",
 	}),
 	total: z.number().meta({
 		description:

--- a/shared/api/customers/components/apiInvoicePreview/apiInvoicePreviewV0.ts
+++ b/shared/api/customers/components/apiInvoicePreview/apiInvoicePreviewV0.ts
@@ -17,15 +17,16 @@ export const ApiInvoicePreviewV0Schema = z.object({
 		example: 1788220800000,
 	}),
 	currency: z.string().meta({
-		description: "The three-letter ISO currency code (e.g., 'usd').",
+		description:
+			"The three-letter ISO currency code. All amounts are in the currency's major unit (e.g., dollars for USD).",
 		example: "usd",
 	}),
 	subtotal: z.number().meta({
-		description: "The total before discounts, in major currency units.",
+		description: "The total before discounts.",
 		example: 15,
 	}),
 	total: z.number().meta({
-		description: "The total after discounts, in major currency units.",
+		description: "The total after discounts.",
 		example: 15,
 	}),
 	line_items: z.array(ExtPreviewLineItemSchema).meta({


### PR DESCRIPTION
## Summary

- keep billing preview amount descriptions concise
- clarify once on each preview currency field that amounts use the currency's major unit, such as dollars for USD
- update generated OpenAPI/reference pages and the payment-flow example

## Validation

- `bunx --bun mint validate`
- `bunx biome check shared/api/billing/common/billingPreviewResponse.ts shared/api/billing/multiUpdate/multiUpdatePreviewResponseV0.ts shared/api/customers/components/apiInvoicePreview/apiInvoicePreviewV0.ts`
- `git diff --check`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects and consolidates the unit descriptions for billing-preview amounts across source schemas, generated OpenAPI specifications, API reference pages, and the payment-flow example.

- [Bug fixes] Replaces incorrect references to cents with descriptions matching major currency units.
- [Improvements] Explains once per preview response that amounts use the selected currency's major unit, with USD dollars as an example.
- [API changes] Regenerates OpenAPI and API reference outputs so downstream documentation exposes the corrected descriptions.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/billing/common/billingPreviewResponse.ts | Corrects preview amount metadata and uses currency-neutral major-unit wording, fully addressing the previous non-USD documentation issue. |
| shared/api/billing/multiUpdate/multiUpdatePreviewResponseV0.ts | Adds the same major-unit clarification to multi-update previews. |
| shared/api/customers/components/apiInvoicePreview/apiInvoicePreviewV0.ts | Consolidates invoice-preview unit information under the currency field without changing the response shape. |
| packages/openapi/openapi.yml | Propagates the corrected billing-preview descriptions through the generated public OpenAPI specification. |
| apps/docs/mintlify/documentation/customers/payment-flow.mdx | Removes the incorrect claim that the payment-flow preview total is expressed in cents. |

<sub>Reviews (2): Last reviewed commit: ["docs: ✏️ clarify preview amount units"](https://github.com/useautumn/autumn/commit/23b947f65b6ab83a230cfdd55645ca32a9958164) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52898205)</sub>

<!-- /greptile_comment -->