### PR TITLE
fix: detect currency edits on single-tier prices

### DIFF
--- a/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.currency.test.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.currency.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import type { ProductV2 } from "../../../models/productV2Models/productV2Models.js";
+import { productsAreSame } from "./compareProductUtils.js";
+
+const topUpPlan = (withSgd = false) =>
+	({
+		id: "topup_credits",
+		name: "Top-up credits",
+		items: [
+			{
+				feature_id: "ai_credits",
+				included_usage: 0,
+				interval: null,
+				usage_model: "prepaid",
+				billing_units: 100,
+				tiers: [
+					{
+						to: "inf",
+						amount: 1,
+						...(withSgd
+							? {
+									additional_currencies: [{ currency: "sgd", amount: 1.4 }],
+								}
+							: {}),
+					},
+				],
+				...(withSgd ? { base_currency: "usd" } : {}),
+			},
+		],
+	}) as ProductV2;
+
+describe("productsAreSame currency edits", () => {
+	test("detects adding a currency to a one-off single-tier feature price", () => {
+		const comparison = productsAreSame({
+			curProductV2: topUpPlan(),
+			newProductV2: topUpPlan(true),
+			features: [],
+		});
+
+		expect(comparison.itemsSame).toBe(false);
+	});
+});

--- a/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareProductUtils.ts
@@ -31,7 +31,10 @@ const sanitizeItems = ({
 	features: Feature[];
 }) => {
 	return items.map((item) => {
-		const priceData = itemToPriceOrTiers({ item });
+		const priceData =
+			item.tiers?.length === 1 && item.tiers[0].additional_currencies?.length
+				? { price: undefined, tiers: item.tiers }
+				: itemToPriceOrTiers({ item });
 		const newItem = {
 			...item,
 			reset_usage_when_enabled: getResetUsage({


### PR DESCRIPTION
## Summary

- preserve single-tier tier data when additional currencies are present
- add a regression test for adding SGD to a one-off prepaid AI Credits price
- ensure the plan editor detects the change and displays the save footer

Context: https://autumnpricing.slack.com/archives/C0BAL549LMT/p1786609353814389

## Testing

- bun test shared/utils/productV2Utils/compareProductUtils/compareProductUtils.currency.test.ts shared/utils/productV2Utils/compareProductUtils/compareItemUtils.currency.test.ts shared/utils/productV2Utils/compareProductUtils/generateItemChanges.currency.test.ts (8 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects currency edits on one-off single-tier prices so the plan editor shows the save footer. Previously, adding or changing additional currencies on a single-tier item was ignored; now the comparison preserves tier data and flags the change.

- Adjusts `sanitizeItems` to bypass `itemToPriceOrTiers` when an item has exactly one tier with `additional_currencies`, comparing tiers directly.
- Adds a regression test that verifies `productsAreSame.itemsSame` is false when adding SGD to a prepaid one-off AI Credits price.

<sup>Written for commit c47a54e1f12b479053d610127540a5a13b6f15d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes change detection for additional currencies on single-tier prices and adds focused regression coverage.
- **Bug fixes:** Preserve single-tier data containing additional currencies so currency edits reach the item comparator.
- **Improvements:** Add a regression test confirming that adding SGD to a one-off prepaid price displays the product as changed.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The updated normalization retains additional-currency data for comparison while preserving existing behavior for ordinary single-tier prices, and the regression test covers the reported editor workflow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productV2Utils/compareProductUtils/compareProductUtils.ts | Preserves currency-bearing single tiers during comparison normalization, allowing additional-currency changes to be detected. |
| shared/utils/productV2Utils/compareProductUtils/compareProductUtils.currency.test.ts | Adds focused regression coverage for adding SGD to a single-tier prepaid feature price. |

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 detect currency edits on single-..."](https://github.com/useautumn/autumn/commit/c47a54e1f12b479053d610127540a5a13b6f15d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52904724)</sub>

<!-- /greptile_comment -->