### PR TITLE
fix: show currency edits in plan review

### DIFF
--- a/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.currency.test.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.currency.test.ts
@@ -29,6 +29,18 @@ const featurePriceItem = (
 		],
 	}) as unknown as FeaturePriceItem;
 
+const flatFeaturePriceItem = (
+	currencies?: { currency: string; amount: number }[],
+): FeaturePriceItem =>
+	({
+		feature_id: "words",
+		included_usage: 0,
+		interval: "month",
+		usage_model: "usage_based",
+		price: 0.5,
+		additional_currencies: currencies,
+	}) as unknown as FeaturePriceItem;
+
 describe("comparators detect currency-only edits", () => {
 	test("priceItemsAreSame: false when additional_currencies differ", () => {
 		expect(
@@ -64,6 +76,14 @@ describe("comparators detect currency-only edits", () => {
 		const result = featurePriceItemsAreSame({
 			item1: featurePriceItem([{ currency: "eur", amount: 0.4 }]),
 			item2: featurePriceItem([{ currency: "eur", amount: 4 }]),
+		});
+		expect(result.same).toBe(false);
+	});
+
+	test("featurePriceItemsAreSame: false when a flat currency amount changes", () => {
+		const result = featurePriceItemsAreSame({
+			item1: flatFeaturePriceItem([{ currency: "eur", amount: 0.4 }]),
+			item2: flatFeaturePriceItem([{ currency: "eur", amount: 4 }]),
 		});
 		expect(result.same).toBe(false);
 	});

--- a/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
@@ -398,6 +398,13 @@ export const featurePriceItemsAreSame = ({
 			condition: item1.price == item2.price,
 			message: `Price different: ${item1.price} != ${item2.price}`,
 		},
+		additional_currencies: {
+			condition: additionalCurrenciesAreSame(
+				item1.additional_currencies,
+				item2.additional_currencies,
+			),
+			message: `Additional currencies different`,
+		},
 		tiers: {
 			condition: tiersAreSame(item1.tiers || null, item2.tiers || null),
 			message: `Tiers different`,

--- a/vite/src/components/forms/shared/plan-items/PlanItemRow.tsx
+++ b/vite/src/components/forms/shared/plan-items/PlanItemRow.tsx
@@ -1,5 +1,5 @@
 import type { Feature, FeatureOptions, ProductItem } from "@autumn/shared";
-import { featureToOptions, UsageModel } from "@autumn/shared";
+import { featureToOptions, itemsAreSame, UsageModel } from "@autumn/shared";
 import { motion } from "motion/react";
 import type { UseAttachForm } from "@/components/forms/attach-v2/hooks/useAttachForm";
 import { SubscriptionItemRow } from "@/components/forms/update-subscription-v2/components/SubscriptionItemRow";
@@ -49,23 +49,7 @@ export function hasItemChanged({
 	originalItem: ProductItem;
 	updatedItem: ProductItem;
 }): boolean {
-	if (originalItem.price !== updatedItem.price) return true;
-	if (originalItem.included_usage !== updatedItem.included_usage) return true;
-	if (originalItem.billing_units !== updatedItem.billing_units) return true;
-	if (originalItem.usage_model !== updatedItem.usage_model) return true;
-
-	const oldTiers = originalItem.tiers ?? [];
-	const newTiers = updatedItem.tiers ?? [];
-	if (oldTiers.length !== newTiers.length) return true;
-	for (let i = 0; i < oldTiers.length; i++) {
-		if (
-			oldTiers[i].amount !== newTiers[i].amount ||
-			oldTiers[i].to !== newTiers[i].to
-		)
-			return true;
-	}
-
-	return false;
+	return !itemsAreSame({ item1: originalItem, item2: updatedItem }).same;
 }
 
 export function PlanItemRow({
@@ -105,6 +89,7 @@ export function PlanItemRow({
 				featureId,
 				prepaidOptions,
 				initialPrepaidOptions,
+				existingOptions,
 				features,
 			})
 		: undefined;

--- a/vite/src/components/v2/PlanItemLabel.tsx
+++ b/vite/src/components/v2/PlanItemLabel.tsx
@@ -16,7 +16,9 @@ import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { cn } from "@/lib/utils";
 import { intervalIsNone } from "@/utils/product/productItemUtils";
+import { AdditionalCurrenciesHint } from "@/views/products/plan/components/plan-card/AdditionalCurrenciesHint";
 import { PlanFeatureIcon } from "@/views/products/plan/components/plan-card/PlanFeatureIcon";
+import { getItemAdditionalCurrencies } from "./planItemCurrencyUtils";
 
 export const CustomDotIcon = () => (
 	<div className="w-[2px] h-[2px] mx-0.5 bg-current rounded-full" />
@@ -346,6 +348,7 @@ export function PlanItemLabel({
 	const hasFeatureName = feature?.name && feature.name.trim() !== "";
 	const displayText = hasFeatureName ? display.primary_text : unnamedText;
 	const rollover = itemCanRollOver(item) ? item.config?.rollover : undefined;
+	const additionalCurrencies = getItemAdditionalCurrencies(item);
 
 	const icons = showFeatureIcons ? (
 		<FeatureIconCluster item={item} leftIcon={featureIcon} />
@@ -380,6 +383,9 @@ export function PlanItemLabel({
 					/>
 				)}
 			</p>
+			{additionalCurrencies.length > 0 && (
+				<AdditionalCurrenciesHint currencies={additionalCurrencies} />
+			)}
 			{rollover && <RolloverIndicator rollover={rollover} />}
 		</>
 	);

--- a/vite/src/components/v2/planItemCurrencyUtils.ts
+++ b/vite/src/components/v2/planItemCurrencyUtils.ts
@@ -3,15 +3,18 @@ import type { AdditionalCurrencyPrice, ProductItem } from "@autumn/shared";
 export const getItemAdditionalCurrencies = (
 	item: ProductItem,
 ): AdditionalCurrencyPrice[] => {
-	const entries =
-		item.additional_currencies ??
-		(item.tiers?.length === 1
-			? item.tiers[0].additional_currencies
-			: undefined);
+	const currencies = new Map<string, AdditionalCurrencyPrice>();
+	const entries = [
+		...(item.additional_currencies ?? []),
+		...(item.tiers ?? []).flatMap((tier) => tier.additional_currencies ?? []),
+	];
 
-	return (entries ?? []).flatMap((entry) =>
-		entry.amount == null
-			? []
-			: [{ currency: entry.currency, amount: entry.amount }],
-	);
+	for (const entry of entries) {
+		const code = entry.currency.toLowerCase();
+		if (entry.amount != null && !currencies.has(code)) {
+			currencies.set(code, { currency: entry.currency, amount: entry.amount });
+		}
+	}
+
+	return [...currencies.values()];
 };

--- a/vite/src/components/v2/planItemCurrencyUtils.ts
+++ b/vite/src/components/v2/planItemCurrencyUtils.ts
@@ -1,0 +1,17 @@
+import type { AdditionalCurrencyPrice, ProductItem } from "@autumn/shared";
+
+export const getItemAdditionalCurrencies = (
+	item: ProductItem,
+): AdditionalCurrencyPrice[] => {
+	const entries =
+		item.additional_currencies ??
+		(item.tiers?.length === 1
+			? item.tiers[0].additional_currencies
+			: undefined);
+
+	return (entries ?? []).flatMap((entry) =>
+		entry.amount == null
+			? []
+			: [{ currency: entry.currency, amount: entry.amount }],
+	);
+};

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -25,7 +25,6 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { PlanPriceHeader } from "@/components/forms/shared/plan-items/PlanPriceHeader";
-import { ItemChangeList } from "@/components/v2/ItemChangeList";
 import { LAYOUT_TRANSITION } from "@/components/v2/sheets/SharedSheetComponents";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
@@ -50,8 +49,8 @@ import {
 	useHasLicenseChanges,
 } from "../components/plan-licenses/useLicenseSaveRegistry";
 import {
-	buildSelectedLicenseParentUpdates,
 	buildMigrateTargets,
+	buildSelectedLicenseParentUpdates,
 	getLicenseParentTargetId,
 } from "./buildMigrateTargets";
 import {
@@ -62,6 +61,7 @@ import {
 import { getDefaultPropagationTargetIds } from "./getDefaultPropagationTargetIds";
 import { LicenseChangeList } from "./LicenseChangeList";
 import { MigrateTargetsStep } from "./MigrateTargetsStep";
+import { PlanItemChanges } from "./PlanItemChanges";
 import {
 	PlanSettingsChanges,
 	previousAttributesToSettingChanges,
@@ -429,7 +429,7 @@ export default function PlanChangeDialog({
 	const applyChanges = async ({ migrate }: { migrate: boolean }) => {
 		// Type-to-confirm only gates the migration step (the only point where
 		// existing customers are moved). Lower-impact applies skip it.
-		if (step === "migrate" && !confirmed) {
+		if (step === "migrate" && migrateNeeded && !confirmed) {
 			toast.error("Confirmation text is incorrect");
 			return;
 		}
@@ -631,8 +631,11 @@ export default function PlanChangeDialog({
 													currency={currency}
 												/>
 											)}
-											<ItemChangeList
-												itemChanges={preview?.item_changes ?? []}
+											<PlanItemChanges
+												product={product}
+												originalItems={baseProduct?.items}
+												features={features}
+												currency={currency}
 											/>
 											<PlanSettingsChanges changes={settingsChanges} />
 											<LicenseChangeList
@@ -771,6 +774,12 @@ export default function PlanChangeDialog({
 															currency={currency}
 														/>
 													)}
+													<PlanItemChanges
+														product={product}
+														originalItems={baseProduct?.items}
+														features={features}
+														currency={currency}
+													/>
 													<PlanSettingsChanges changes={settingsChanges} />
 												</div>
 											) : (
@@ -846,7 +855,7 @@ export default function PlanChangeDialog({
 					</motion.div>
 				</div>
 
-				{step === "migrate" && (
+				{step === "migrate" && migrateNeeded && (
 					<div className="px-4 pt-3 pb-2">
 						<ConfirmInput
 							productId={product.id}
@@ -879,7 +888,9 @@ export default function PlanChangeDialog({
 						metaShortcut="enter"
 						onClick={advance}
 						isLoading={isLoading}
-						disabled={isLoading || (step === "migrate" && !confirmed)}
+						disabled={
+							isLoading || (step === "migrate" && migrateNeeded && !confirmed)
+						}
 						className="flex-1 justify-center"
 					>
 						{primaryText}

--- a/vite/src/views/products/plan/versioning/PlanItemChanges.tsx
+++ b/vite/src/views/products/plan/versioning/PlanItemChanges.tsx
@@ -1,0 +1,33 @@
+import type { Feature, FrontendProduct, ProductItem } from "@autumn/shared";
+import { PlanItemsSection } from "@/components/forms/shared";
+
+const EMPTY_OPTIONS = {};
+
+export function PlanItemChanges({
+	product,
+	originalItems,
+	features,
+	currency,
+}: {
+	product: FrontendProduct;
+	originalItems?: ProductItem[];
+	features: Feature[];
+	currency: string;
+}) {
+	return (
+		<PlanItemsSection
+			product={product}
+			originalItems={originalItems}
+			features={features}
+			prepaidOptions={EMPTY_OPTIONS}
+			initialPrepaidOptions={EMPTY_OPTIONS}
+			showDiff
+			changesOnly
+			readOnly
+			currency={currency}
+			onEditPlan={() => {}}
+			showPriceHeader={false}
+			showEditButton={false}
+		/>
+	);
+}

--- a/vite/tests/components/forms/shared/plan-item-currency-diff.test.ts
+++ b/vite/tests/components/forms/shared/plan-item-currency-diff.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import type { FrontendProduct, ProductItem } from "@autumn/shared";
+import { getPlanItemsDiff } from "@/components/forms/shared/PlanItemsSection";
+import { getItemAdditionalCurrencies } from "@/components/v2/planItemCurrencyUtils";
+
+const topUpItem = (withSgd = false) =>
+	({
+		feature_id: "ai_credits",
+		included_usage: 0,
+		interval: null,
+		usage_model: "prepaid",
+		billing_units: 100,
+		tiers: [
+			{
+				to: "inf",
+				amount: 1,
+				...(withSgd
+					? { additional_currencies: [{ currency: "sgd", amount: 1.4 }] }
+					: {}),
+			},
+		],
+	}) as ProductItem;
+
+describe("plan item currency diffs", () => {
+	test("renders a single-tier currency addition as an item change", () => {
+		const originalItem = topUpItem();
+		const updatedItem = topUpItem(true);
+		const diff = getPlanItemsDiff({
+			product: { items: [updatedItem] } as FrontendProduct,
+			originalItems: [originalItem],
+			showDiff: true,
+		});
+
+		expect(diff.deletedItems).toEqual([originalItem]);
+		expect(diff.diffVisibleItems).toEqual([updatedItem]);
+		expect(getItemAdditionalCurrencies(updatedItem)).toEqual([
+			{ currency: "sgd", amount: 1.4 },
+		]);
+	});
+});

--- a/vite/tests/components/forms/shared/plan-item-currency-diff.test.ts
+++ b/vite/tests/components/forms/shared/plan-item-currency-diff.test.ts
@@ -37,4 +37,24 @@ describe("plan item currency diffs", () => {
 			{ currency: "sgd", amount: 1.4 },
 		]);
 	});
+
+	test("deduplicates currencies across multiple tiers", () => {
+		const item = topUpItem();
+		item.tiers = [
+			{
+				to: 100,
+				amount: 1,
+				additional_currencies: [{ currency: "eur", amount: 0.9 }],
+			},
+			{
+				to: "inf",
+				amount: 0.8,
+				additional_currencies: [{ currency: "EUR", amount: 0.7 }],
+			},
+		];
+
+		expect(getItemAdditionalCurrencies(item)).toEqual([
+			{ currency: "eur", amount: 0.9 },
+		]);
+	});
 });


### PR DESCRIPTION
## Summary

- show feature-price currency edits in both plan change review steps
- reuse the catalog item diff because newly added currencies intentionally do not create customer migration diffs
- display additional currency counts on feature price rows
- require type-to-confirm only when an actual customer migration will run

Follow-up to #2779.

## Testing

- `bun test vite/tests/components/forms/shared/plan-item-currency-diff.test.ts`
- `bun -F @autumn/vite ts`
- `bunx biome check` on changed files
- React Doctor scoped to changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows feature-price additional currency edits during plan review and only requires confirmation when a migration will run. Previously, these edits weren’t visible (especially on multi‑tier prices) and confirmation was always required.

- Replace `ItemChangeList` with `PlanItemChanges` to reuse `PlanItemsSection` in read-only, diff-only mode across both review steps; currency additions render as item changes but do not create migration diffs.
- Compare items with `itemsAreSame` from `@autumn/shared`; feature price comparators now include `additional_currencies` so flat-currency edits are detected.
- Extract and deduplicate item- and tier-level currencies with `getItemAdditionalCurrencies`, and display counts via `AdditionalCurrenciesHint` in `PlanItemLabel`.
- Gate type-to-confirm and primary action disablement by `migrateNeeded` on the migrate step.

<sup>Written for commit 3ffeaddb9157a844a179f82498ace62164ab500d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes currency-only plan edits visible during review and avoids unnecessary type-to-confirm prompts when no customer migration will run.
- **[Bug fixes]** Uses the full catalog-item comparison when determining whether a plan item changed.
- **[Improvements, Bug fixes]** Shows additional-currency information on plan-item rows in both review steps.
- **[Improvements]** Requires typed confirmation only when the operation will migrate customers.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because flat-amount-only currencies can still disappear from plan-review rows.

A tier currency such as EUR with `flat_amount` but no per-unit `amount` is filtered out before the count and tooltip render, leaving one previously reported display defect outstanding.

**Files Needing Attention:** vite/src/components/v2/planItemCurrencyUtils.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts | Extends flat feature-price comparison to detect item-level additional-currency edits. |
| vite/src/components/forms/shared/plan-items/PlanItemRow.tsx | Reuses the shared item comparator so currency-only edits participate in plan-item diffs. |
| vite/src/components/v2/planItemCurrencyUtils.ts | Collects currencies across all tiers, but still excludes valid flat-amount-only tier currencies. |
| vite/src/components/v2/PlanItemLabel.tsx | Displays the helper’s additional-currency collection as a count and tooltip on plan-item rows. |
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Uses catalog-item diffs in both review steps and gates typed confirmation on an actual migration. |
| vite/src/views/products/plan/versioning/PlanItemChanges.tsx | Adds a read-only, changes-only wrapper around the shared plan-items section. |

<sub>Reviews (3): Last reviewed commit: ["fix: 🐛 compare flat feature price curre..."](https://github.com/useautumn/autumn/commit/3ffeaddb9157a844a179f82498ace62164ab500d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52915112)</sub>

<!-- /greptile_comment -->