### PR TITLE
chore: silence configured OAuth metadata warning

### DIFF
--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -283,6 +283,9 @@ const options = {
 		oauthProvider({
 			loginPage: `${process.env.CLIENT_URL}/sign-in`,
 			consentPage: `${process.env.CLIENT_URL}/consent`,
+			silenceWarnings: {
+				oauthAuthServerConfig: true,
+			},
 			// Resource-based scopes with R/W actions (plus legacy CRUDL +
 			// meta scopes — see shared/utils/scopeDefinitions.ts).
 			scopes: [...ALL_SCOPES],


### PR DESCRIPTION
The RFC 8414 authorization-server metadata route is already registered at `/.well-known/oauth-authorization-server/api/auth` and returns the configured issuer and OAuth endpoints. Confirm that setup in the Better Auth OAuth provider options so startup no longer emits the configuration warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the startup warning about configured OAuth authorization-server metadata by acknowledging our RFC 8414 setup in the `oauthProvider` options. Previously startup logged a warning; now it is suppressed with no behavior change.

- Adds `silenceWarnings: { oauthAuthServerConfig: true }` to `oauthProvider` configuration.
- Confirms we already serve metadata at `/.well-known/oauth-authorization-server/api/auth` with the correct issuer and endpoints.
- No auth flow or endpoint changes; only reduces log noise.

<sup>Written for commit d79c3fbb8840ffa55b0b6c5716ef5c953fb9ab86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR confirms the application's custom OAuth metadata setup to Better Auth, preventing an unnecessary startup warning.
- **Improvements:** Suppresses the OAuth authorization-server configuration warning after the required metadata route has already been registered.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only suppresses a warning for an OAuth metadata route that is already explicitly registered.

The metadata endpoints remain generated from the same authentication instance and the change does not alter authentication, discovery responses, endpoint registration, or authorization behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/utils/auth.ts | Adds the supported OAuth provider option to silence a warning for the application's explicitly registered authorization-server metadata route; no functional issue was identified. |

<sub>Reviews (1): Last reviewed commit: ["chore: silence configured OAuth metadata..."](https://github.com/useautumn/autumn/commit/d79c3fbb8840ffa55b0b6c5716ef5c953fb9ab86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52923924)</sub>

<!-- /greptile_comment -->