### PR TITLE
feat(shared): carry license customize through the plan schemas

### DIFF
--- a/shared/api/catalog/utils/buildMigrationDraft.ts
+++ b/shared/api/catalog/utils/buildMigrationDraft.ts
@@ -25,6 +25,9 @@ export interface CombinedVariantMigrationTarget {
 
 export interface AllVersionsUpdateMigrationTarget {
 	id: string;
+	/** Pins the op to one version. Targets without it sweep every version;
+	 * license-parent targets set it because a link pins the version it offers. */
+	version?: number;
 	customize: DiffedCustomizePlanV1 | null;
 }
 
@@ -35,6 +38,15 @@ export const planDiffHasBillingChanges = (
 ): boolean => {
 	if (diff.price !== undefined) return true;
 	if (diff.add_items?.some((item) => item.price != null)) return true;
+	if (
+		diff.upsert_licenses?.some(
+			(license) =>
+				license.customize?.price != null ||
+				license.customize?.add_items?.some((item) => item.price != null),
+		)
+	) {
+		return true;
+	}
 	// Remove filters can omit billing_method even when priced, so check the
 	// source items by feature_id rather than the lossy filter.
 	const removedFeatureIds = new Set(
@@ -57,6 +69,9 @@ const migratablePlanDiff = (
 		: {}),
 	...(diff.update_items !== undefined
 		? { update_items: diff.update_items }
+		: {}),
+	...(diff.upsert_licenses !== undefined
+		? { upsert_licenses: diff.upsert_licenses }
 		: {}),
 });
 
@@ -218,11 +233,19 @@ export const buildAllVersionsUpdateMigrationDraft = ({
 	const ops = groupTargetsByCustomize(targets).map(
 		({ customize, targets }): UpdatePlanOp => {
 			const ids = targets.map((target) => target.id);
+			const pinnedVersions = new Set(targets.map((target) => target.version));
+			const sharedVersion =
+				pinnedVersions.size === 1 ? [...pinnedVersions][0] : undefined;
 			return {
 				type: "update_plan",
 				plan_filter: withCustomGuard({
 					includeCustom,
-					planFilter: { plan_id: planMatcher(ids) },
+					planFilter: {
+						plan_id: planMatcher(ids),
+						// Only when every target in the group pins the SAME version; a
+						// mixed group has to stay version-less to stay correct.
+						...(sharedVersion === undefined ? {} : { version: sharedVersion }),
+					},
 				}),
 				customize,
 			};

--- a/shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts
+++ b/shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts
@@ -1,5 +1,9 @@
 import { BasePriceParamsSchema } from "@api/products/components/basePrice/basePrice";
 import { PlanItemFilterSchema } from "@api/products/items/filter/planItemFilter";
+import {
+	CustomizePlanLicenseSchema,
+	licensePatchIssues,
+} from "@models/licenseModels/licenseModels.js";
 import { z } from "zod/v4";
 import { UpdatePlanItemParamsV1Schema } from "../../../../billing/common/customizePlan/customizePlanV1.js";
 import { CreatePlanItemParamsV1Schema } from "../../../../products/items/crud/createPlanItemParamsV1.js";
@@ -20,18 +24,30 @@ export const MigrationUpdatePlanCustomizeSchema = z
 				"Deprecated. Use remove_items and add_items to replace matched plan items.",
 			deprecated: true,
 		}),
+		upsert_licenses: z.array(CustomizePlanLicenseSchema).optional().meta({
+			description:
+				"License links to add or override on each matched customer product, keyed by license_plan_id. A bare entry restores the license to pure catalog inheritance.",
+		}),
 	})
 	.refine(
 		(data) =>
 			data.price !== undefined ||
 			data.add_items !== undefined ||
 			data.remove_items !== undefined ||
-			data.update_items !== undefined,
+			data.update_items !== undefined ||
+			data.upsert_licenses !== undefined,
 		{
 			message:
-				"update_plan.customize requires at least one of price, add_items, remove_items, or deprecated update_items",
+				"update_plan.customize requires at least one of price, add_items, remove_items, upsert_licenses, or deprecated update_items",
 		},
-	);
+	)
+	.superRefine((data, refinementCtx) => {
+		for (const issue of licensePatchIssues({
+			upsertLicenses: data.upsert_licenses,
+		})) {
+			refinementCtx.addIssue({ code: "custom", ...issue });
+		}
+	});
 
 export const FeatureQuantityStrategySchema = z.enum(["round_to_lowest_price"]);
 

--- a/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanLicenses.ts
@@ -1,0 +1,63 @@
+import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
+import type { CustomizePlanLicense } from "@models/licenseModels/licenseModels.js";
+
+type ApiPlanLicense = NonNullable<ApiPlanV1["licenses"]>[number];
+type CustomizeEqual = (args: {
+	left?: ApiPlanLicense["customize"];
+	right?: ApiPlanLicense["customize"];
+}) => boolean;
+
+const byLicensePlanId = (licenses: ApiPlanV1["licenses"]) =>
+	new Map(
+		(licenses ?? []).map((license) => [license.license_plan_id, license]),
+	);
+
+/** A cleared customize is expressed as null so the op restores inheritance. */
+const toCustomizeParams = (
+	license: ApiPlanLicense,
+): CustomizePlanLicense["customize"] => {
+	const customize = license.customize;
+	if (!customize) return null;
+	return {
+		...(customize.price !== undefined ? { price: customize.price } : {}),
+		...(customize.add_items !== undefined
+			? { add_items: customize.add_items }
+			: {}),
+		...(customize.remove_items !== undefined
+			? { remove_items: customize.remove_items }
+			: {}),
+	};
+};
+
+/** Links present on both sides whose customize changed. Added and removed links
+ * are link lifecycle, not plan terms, so they produce no entry. */
+export const diffPlanLicenses = ({
+	from,
+	to,
+	customizeEqual,
+}: {
+	from: ApiPlanV1;
+	to: ApiPlanV1;
+	customizeEqual: CustomizeEqual;
+}): CustomizePlanLicense[] => {
+	const fromByPlanId = byLicensePlanId(from.licenses);
+
+	const changed: CustomizePlanLicense[] = [];
+	for (const toLicense of to.licenses ?? []) {
+		const fromLicense = fromByPlanId.get(toLicense.license_plan_id);
+		if (!fromLicense) continue;
+		if (
+			customizeEqual({
+				left: fromLicense.customize,
+				right: toLicense.customize,
+			})
+		) {
+			continue;
+		}
+		changed.push({
+			license_plan_id: toLicense.license_plan_id,
+			customize: toCustomizeParams(toLicense),
+		});
+	}
+	return changed;
+};

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -9,19 +9,24 @@ import type { ApiPlanV1 } from "@api/products/apiPlanV1.js";
 import type { BasePriceParams } from "@api/products/components/basePrice/basePrice.js";
 import type { CreatePlanItemParamsV1 } from "@api/products/items/crud/createPlanItemParamsV1.js";
 import type { PlanItemFilter } from "@api/products/items/filter/planItemFilter.js";
+import type { CustomizePlanLicense } from "@models/licenseModels/licenseModels.js";
 import { FreeTrialDuration } from "@models/productModels/freeTrialModels/freeTrialEnums.js";
 import { TierBehavior } from "@models/productModels/priceModels/priceConfig/usagePriceConfig.js";
 import type { z } from "zod/v4";
+import { diffPlanLicenses } from "./diffPlanLicenses.js";
 
+// A versioned license customize diffs into `upsert_licenses`, so the key has
+// to survive validation — omitting it made every preview of such a plan 500.
 export const DiffedCustomizePlanV1Schema = refineCustomizePlanV1Schema(
-	CustomizePlanV1BaseSchema.omit({
-		items: true,
-		upsert_licenses: true,
-	}).strict(),
-	{ includeItems: false, includeLicenses: false },
+	CustomizePlanV1BaseSchema.omit({ items: true }).strict(),
+	{ includeItems: false, includeLicenses: true },
 );
 
-export type DiffedCustomizePlanV1 = z.infer<typeof DiffedCustomizePlanV1Schema>;
+export type DiffedCustomizePlanV1 = z.infer<
+	typeof DiffedCustomizePlanV1Schema
+> & {
+	upsert_licenses?: CustomizePlanLicense[];
+};
 
 type ApiPlanItem = ApiPlanV1["items"][number];
 type PlanItemInput = ApiPlanItem | CreatePlanItemParamsV1;
@@ -414,6 +419,13 @@ export const diffPlanV1 = ({
 			diff.free_trial = on_end == null ? rest : { ...rest, on_end };
 		}
 	}
+
+	const upsertLicenses = diffPlanLicenses({
+		from,
+		to,
+		customizeEqual: customizePlanV1DiffsEqual,
+	});
+	if (upsertLicenses.length > 0) diff.upsert_licenses = upsertLicenses;
 
 	return diff;
 };


### PR DESCRIPTION
**Stack 1/6** — foundation. Both the server and the dashboard read these, so they land first.

`upsert_licenses` had no representation in the `update_plan` operation schema or the plan diff, so a license change could not be expressed as a migration operation and was dropped from any diff either consumer computed.

`diffPlanLicenses` pairs a plan's license links by `license_plan_id` and emits the customize entries a migration needs.

---
**Stack**
1. **#2784 — shared schemas** ← you are here
2. #2785 — parent migration draft
3. #2786 — per-customer lane
4. #2787 — batch lane (src)
5. #2788 — batch lane (tests)
6. #2789 — dashboard

Re-slices the earlier stack (#2675 → #2748) by concern. Those PRs remain open for reference and will be closed once this stack is reviewed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds license customization changes to shared plan-diff and migration-operation schemas. The dashboard's separate migration builder still drops those changes.

- **[API changes]** Adds `upsert_licenses` to the `update_plan` customization schema and validates license patches.
- **[Improvements]** Computes license customization differences and carries them through shared migration drafts.
- **[Bug fixes]** Recognizes license pricing changes when classifying shared migration drafts.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because dashboard-created migrations still discard license customization changes.

The shared schema and builder now carry `upsert_licenses`, but the dashboard continues to filter plan diffs through a separate projection that omits this field, leaving existing customers with outdated license terms after migration.

**Files Needing Attention:** vite/src/views/products/plan/versioning/buildMigrationDraft.ts and shared/api/catalog/utils/buildMigrationDraft.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/catalog/utils/buildMigrationDraft.ts | Preserves license changes and detects license pricing in shared drafts, but this does not update the dashboard's separate migration builder. |
| shared/api/migrations/operations/customer/updatePlan/updatePlanOp.ts | Extends the update-plan customization schema to accept and validate license upserts. |
| shared/utils/planV1Utils/diff/diffPlanLicenses.ts | Adds license customization diffing for links present in both source and target plans. |
| shared/utils/planV1Utils/diff/diffPlanV1.ts | Includes changed license customizations in plan diffs and permits the field during validation. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Plan license customization changes] --> B[diffPlanV1 emits upsert_licenses]
  B --> C[Shared migration builder]
  C --> D[Update operation preserves license changes]
  B --> E[Dashboard migration builder]
  E --> F[Local projection drops upsert_licenses]
  F --> G[Existing customers retain old license terms]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
shared/api/catalog/utils/buildMigrationDraft.ts:73-75
**Dashboard drops license migrations**

When a dashboard user creates a migration after changing an existing license customization, the dashboard's separate migratable-diff projection strips `upsert_licenses`, causing existing customers to retain their previous license terms.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(shared): carry license customize th..."](https://github.com/useautumn/autumn/commit/25334ff56bd821711543c844011794101c09f755) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52927105)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->