### PR TITLE
feat(migrations): draft a parent migration when a license plan changes

### DIFF
--- a/server/src/internal/customers/cusProducts/repos/getVersioningUsage.ts
+++ b/server/src/internal/customers/cusProducts/repos/getVersioningUsage.ts
@@ -2,7 +2,7 @@ import {
 	customerProducts,
 	VERSIONABLE_CUSTOMER_STATUSES,
 } from "@autumn/shared";
-import { countDistinct, inArray, sql } from "drizzle-orm";
+import { and, countDistinct, inArray, isNull, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export type CustomerProductVersioningUsage = {
@@ -20,9 +20,13 @@ const emptyUsage = (): CustomerProductVersioningUsage => ({
 export const getVersioningUsage = async ({
 	db,
 	internalProductIds,
+	excludeLicenseAssignments,
 }: {
 	db: DrizzleCli;
 	internalProductIds: string[];
+	/** Seat assignments live on the license plan but are migrated through the
+	 * parent's upsert_licenses, so a plan-scoped op can never reach them. */
+	excludeLicenseAssignments?: boolean;
 }): Promise<Map<string, CustomerProductVersioningUsage>> => {
 	const usage = new Map(
 		internalProductIds.map((internalProductId) => [
@@ -41,7 +45,14 @@ export const getVersioningUsage = async ({
 			).as("versionable_count"),
 		})
 		.from(customerProducts)
-		.where(inArray(customerProducts.internal_product_id, internalProductIds))
+		.where(
+			and(
+				inArray(customerProducts.internal_product_id, internalProductIds),
+				excludeLicenseAssignments
+					? isNull(customerProducts.customer_license_link_id)
+					: undefined,
+			),
+		)
 		.groupBy(customerProducts.internal_product_id);
 
 	for (const row of result) {
@@ -58,13 +69,16 @@ export const getVersioningUsage = async ({
 export const getVersioningUsageForProduct = async ({
 	db,
 	internalProductId,
+	excludeLicenseAssignments,
 }: {
 	db: DrizzleCli;
 	internalProductId: string;
+	excludeLicenseAssignments?: boolean;
 }): Promise<CustomerProductVersioningUsage> => {
 	const usageByProduct = await getVersioningUsage({
 		db,
 		internalProductIds: [internalProductId],
+		excludeLicenseAssignments,
 	});
 
 	return usageByProduct.get(internalProductId) ?? emptyUsage();

--- a/server/src/internal/licenses/actions/propagation/buildLicenseParentCustomize.ts
+++ b/server/src/internal/licenses/actions/propagation/buildLicenseParentCustomize.ts
@@ -1,0 +1,47 @@
+import type { ApiPlanV1, LicenseCustomize } from "@autumn/shared";
+import { applyLicenseCustomizeToBasePlan } from "@/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.js";
+import { diffLicensePlanCustomize } from "@/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.js";
+import { getApiPlanDiff } from "@/internal/product/actions/common/planTransformUtils.js";
+
+/** A customized link keeps its own overrides rebased onto the edited child; an
+ * uncustomized one simply follows the child. */
+export const buildLicenseParentTargetCustomize = ({
+	currentChildPlan,
+	editedChildPlan,
+	currentEffectivePlan,
+	customized,
+}: {
+	currentChildPlan: ApiPlanV1;
+	editedChildPlan: ApiPlanV1;
+	currentEffectivePlan: ApiPlanV1;
+	customized: boolean;
+}): {
+	targetEffectivePlan: ApiPlanV1;
+	targetCustomize: LicenseCustomize | undefined;
+	migrationCustomize: LicenseCustomize | undefined;
+} => {
+	const targetEffectivePlan = customized
+		? applyLicenseCustomizeToBasePlan({
+				basePlan: editedChildPlan,
+				customize: getApiPlanDiff({
+					from: currentChildPlan,
+					to: currentEffectivePlan,
+				}),
+			})
+		: editedChildPlan;
+
+	return {
+		targetEffectivePlan,
+		targetCustomize: diffLicensePlanCustomize({
+			basePlan: editedChildPlan,
+			effectivePlan: targetEffectivePlan,
+		}),
+		// A migration moves customers holding the OLD definition, so its delta is
+		// measured from what they have now — not from the edited catalog plan,
+		// against which an uncustomized link diffs to nothing.
+		migrationCustomize: diffLicensePlanCustomize({
+			basePlan: currentEffectivePlan,
+			effectivePlan: targetEffectivePlan,
+		}),
+	};
+};

--- a/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
+++ b/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
@@ -2,8 +2,11 @@ import {
 	type ApiPlanV1,
 	buildAllVersionsUpdateMigrationDraft,
 	buildCombinedVariantMigrationDraft,
+	type DiffedCustomizePlanV1,
 	diffPlanV1,
 	type FullProduct,
+	type LicenseCustomize,
+	type MigrationDraft,
 	type Operations,
 	type PlanFilter,
 	planDiffHasBillingChanges,
@@ -23,6 +26,12 @@ import {
 export type VariantMigrationSnapshot = {
 	product: FullProduct;
 	plan: ApiPlanV1;
+};
+
+export type LicenseParentMigrationTarget = {
+	planId: string;
+	version: number;
+	customize: LicenseCustomize | undefined;
 };
 
 const hasVersionableUsage = ({
@@ -51,10 +60,8 @@ const matchedPlanIds = (matcher: PlanFilter["plan_id"]): string[] => {
 
 const previousPriceKey = (price: PreviousBasePrice) => JSON.stringify(price);
 
-// Stamped onto price-change ops so the migration UI can show per-currency
-// diffs after the catalog has already been updated in place. An op covering
-// plans with differing previous prices is left unstamped rather than showing
-// the base plan's history for a variant.
+// An op covering plans with differing previous prices is left unstamped rather
+// than showing the base plan's history for a variant.
 const withPreviousPrice = <T extends { operations: Operations }>({
 	draft,
 	previousPriceByPlanId,
@@ -156,6 +163,39 @@ export const validateNoDirectVariantMigrationDrafts = ({
 	}
 };
 
+/** A parent's bill changes only if the license customize it receives carries a
+ * price — the child's own diff says nothing about the parent's invoice. */
+const licenseParentsHaveBillingChanges = (
+	parents: LicenseParentMigrationTarget[],
+) =>
+	parents.some(
+		(parent) =>
+			parent.customize?.price != null ||
+			parent.customize?.add_items?.some((item) => item.price != null),
+	);
+
+/** Always version-scoped, including in all_versions mode: a link pins a version,
+ * and a bare plan_id would let each op match the other version's customers. */
+const licenseParentTargets = ({
+	planId,
+	parents,
+}: {
+	planId: string;
+	parents: LicenseParentMigrationTarget[];
+}) =>
+	parents
+		// An entry without a customize resets the link to catalog inheritance.
+		.filter((parent) => parent.customize !== undefined)
+		.map((parent) => ({
+			id: parent.planId,
+			version: parent.version,
+			customize: {
+				upsert_licenses: [
+					{ license_plan_id: planId, customize: parent.customize },
+				],
+			} satisfies DiffedCustomizePlanV1,
+		}));
+
 export const createPlanMigrationDraft = async ({
 	ctx,
 	current,
@@ -164,6 +204,7 @@ export const createPlanMigrationDraft = async ({
 	includeCustom = false,
 	planId,
 	selectedVariantIds,
+	licenseParents = [],
 	toPlan,
 	variantsBefore = [],
 }: {
@@ -174,11 +215,15 @@ export const createPlanMigrationDraft = async ({
 	mode: "all_versions" | "version";
 	planId: string;
 	selectedVariantIds: string[];
+	licenseParents?: LicenseParentMigrationTarget[];
 	toPlan: ApiPlanV1;
 	variantsBefore?: VariantMigrationSnapshot[];
-}): Promise<string | undefined> => {
+}): Promise<string[]> => {
 	const baseDiff = diffPlanV1({ from: fromPlan, to: toPlan });
-	if (Object.keys(baseDiff).length === 0) return;
+	// Parents can need migrating even when the child's own diff is empty.
+	if (Object.keys(baseDiff).length === 0 && licenseParents.length === 0) {
+		return [];
+	}
 	const selectedVariantsBefore =
 		variantsBefore.length > 0 || selectedVariantIds.length === 0
 			? variantsBefore
@@ -187,10 +232,40 @@ export const createPlanMigrationDraft = async ({
 					variantIds: selectedVariantIds,
 				});
 
+	// Sequential: the ids are returned in draft order, and the child migration
+	// should exist before the parent one that follows it.
+	const insertDrafts = async (drafts: (MigrationDraft | null)[]) => {
+		const ids: string[] = [];
+		for (const draft of drafts.filter((draft) => draft !== null)) {
+			const migration = await migrationRepo.insert({
+				ctx,
+				insert: withPreviousPrice({
+					draft,
+					previousPriceByPlanId: buildPreviousPriceMap({
+						planId,
+						fromPlan,
+						variantsBefore: selectedVariantsBefore,
+					}),
+				}),
+			});
+			ids.push(migration.id);
+		}
+		return ids;
+	};
+
+	// Parents move a different customer population by a different operation, so
+	// they get their own migration — runnable and cancellable on its own.
+	const parentDraft = buildCombinedVariantMigrationDraft({
+		targets: licenseParentTargets({ planId, parents: licenseParents }),
+		hasBillingChanges: licenseParentsHaveBillingChanges(licenseParents),
+		includeCustom,
+	});
+
 	if (mode === "version") {
 		const baseUsage = await customerProductRepo.getVersioningUsageForProduct({
 			db: ctx.db,
 			internalProductId: current.internal_id,
+			excludeLicenseAssignments: true,
 		});
 		const targets = [
 			...(baseUsage.hasVersionableCustomerProducts
@@ -202,25 +277,14 @@ export const createPlanMigrationDraft = async ({
 				customize: baseDiff,
 			})),
 		];
-		const draft = buildCombinedVariantMigrationDraft({
-			targets,
-			hasBillingChanges: planDiffHasBillingChanges(baseDiff, fromPlan),
-			includeCustom,
-		});
-		if (!draft) return;
-
-		const migration = await migrationRepo.insert({
-			ctx,
-			insert: withPreviousPrice({
-				draft,
-				previousPriceByPlanId: buildPreviousPriceMap({
-					planId,
-					fromPlan,
-					variantsBefore: selectedVariantsBefore,
-				}),
+		return insertDrafts([
+			buildCombinedVariantMigrationDraft({
+				targets,
+				hasBillingChanges: planDiffHasBillingChanges(baseDiff, fromPlan),
+				includeCustom,
 			}),
-		});
-		return migration.id;
+			parentDraft,
+		]);
 	}
 
 	const baseVersions = await ProductService.listFull({
@@ -233,6 +297,7 @@ export const createPlanMigrationDraft = async ({
 	const usageByProduct = await customerProductRepo.getVersioningUsage({
 		db: ctx.db,
 		internalProductIds: baseVersions.map((product) => product.internal_id),
+		excludeLicenseAssignments: true,
 	});
 
 	const targets = [
@@ -244,23 +309,12 @@ export const createPlanMigrationDraft = async ({
 			customize: baseDiff,
 		})),
 	];
-	const draft = buildAllVersionsUpdateMigrationDraft({
-		targets,
-		hasBillingChanges: planDiffHasBillingChanges(baseDiff, fromPlan),
-		includeCustom,
-	});
-	if (!draft) return;
-
-	const migration = await migrationRepo.insert({
-		ctx,
-		insert: withPreviousPrice({
-			draft,
-			previousPriceByPlanId: buildPreviousPriceMap({
-				planId,
-				fromPlan,
-				variantsBefore: selectedVariantsBefore,
-			}),
+	return insertDrafts([
+		buildAllVersionsUpdateMigrationDraft({
+			targets,
+			hasBillingChanges: planDiffHasBillingChanges(baseDiff, fromPlan),
+			includeCustom,
 		}),
-	});
-	return migration.id;
+		parentDraft,
+	]);
 };

--- a/server/src/internal/products/handlers/handleUpdatePlan/handleUpdatePlanV2.ts
+++ b/server/src/internal/products/handlers/handleUpdatePlan/handleUpdatePlanV2.ts
@@ -6,12 +6,14 @@ import {
 	type UpdateProductV2Params,
 } from "@autumn/shared";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
-import { updateProduct } from "../../../product/actions/updateProduct.js";
+import { buildLicenseParentTargetCustomize } from "@/internal/licenses/actions/propagation/buildLicenseParentCustomize.js";
+import { prepareLicenseParentPropagation } from "@/internal/licenses/actions/propagation/prepareLicenseParentPropagation.js";
 import {
 	createPlanMigrationDraft,
 	getVariantMigrationSnapshots,
 	validateNoDirectVariantMigrationDrafts,
 } from "../../../product/actions/updateProduct/createPlanMigrationDraft.js";
+import { updateProduct } from "../../../product/actions/updateProduct.js";
 import { ProductService } from "../../ProductService.js";
 import { getPlanResponse } from "../../productUtils/productResponseUtils/getPlanResponse.js";
 
@@ -81,6 +83,16 @@ export const handleUpdatePlanV2 = createRoute({
 			variantsBefore,
 		});
 
+		// Snapshot parents BEFORE the write: their effective license plans are
+		// rebased by updateProduct, and the draft needs the pre-update baseline.
+		const parentsBefore = fromPlan
+			? await prepareLicenseParentPropagation({
+					ctx,
+					child: initialFullProduct,
+					targets: update_license_parents,
+				})
+			: null;
+
 		await updateProduct({
 			ctx,
 			productId: plan_id,
@@ -94,7 +106,7 @@ export const handleUpdatePlanV2 = createRoute({
 
 		const latestPlanId = new_plan_id || plan_id;
 		let responseFullProduct = null;
-		let migrationId: string | undefined;
+		let migrationIds: string[] = [];
 		if (fromPlan) {
 			const after = await ProductService.getFull({
 				db: ctx.db,
@@ -110,7 +122,20 @@ export const handleUpdatePlanV2 = createRoute({
 					product: after,
 					features: ctx.features,
 				});
-				migrationId = await createPlanMigrationDraft({
+				const licenseParents = (parentsBefore?.selectedParents ?? [])
+					.filter(({ hasCustomers }) => hasCustomers)
+					.map(({ parent, link, currentEffectivePlan }) => ({
+						planId: parent.id,
+						version: parent.version,
+						customize: buildLicenseParentTargetCustomize({
+							currentChildPlan: fromPlan,
+							editedChildPlan: toPlan,
+							currentEffectivePlan,
+							customized: link.customized,
+						}).migrationCustomize,
+					}));
+
+				migrationIds = await createPlanMigrationDraft({
 					ctx,
 					current: initialFullProduct,
 					fromPlan,
@@ -118,14 +143,15 @@ export const handleUpdatePlanV2 = createRoute({
 					mode: all_versions ? "all_versions" : "version",
 					planId: plan_id,
 					selectedVariantIds,
+					licenseParents,
 					toPlan,
 					variantsBefore,
 				});
 			}
 		}
 
-		// Fetch the latest version (no `version` pin): when a new version was
-		// created, newBase must be it — not the version that was edited.
+		// No `version` pin: when a new version was created, it must win over the
+		// version that was edited.
 		const latestFullProduct =
 			responseFullProduct ??
 			(await ProductService.getFull({
@@ -140,9 +166,14 @@ export const handleUpdatePlanV2 = createRoute({
 			features: ctx.features,
 		});
 
+		const [firstMigrationId] = migrationIds;
 		return c.json(
-			migrationId
-				? { ...latestPlan, migration: { id: migrationId } }
+			firstMigrationId
+				? {
+						...latestPlan,
+						migration: { id: firstMigrationId },
+						migrations: migrationIds.map((id) => ({ id })),
+					}
 				: latestPlan,
 		);
 	},


### PR DESCRIPTION
**Stack 2/5** — base: #2784.

A license plan's own customers move by one operation; the customers of the plans that link it move by another, over a different population. Drafting both from one update kept them in a single migration that could not be run or cancelled independently.

The parent draft is now built separately from the child's, and versioning usage can exclude license assignments so a seat is not counted as a versionable customer product of the plan that grants it.

**Known issue, not fixed here:** `insertDrafts` loops `migrationRepo.insert` with no transaction — a failed second insert leaves the first committed while the request reports failure. Flagged by review on the old stack; worth a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drafts a separate parent migration when a license plan changes and excludes license-seat assignments from versioning usage. Previously both were combined and seats were counted; now child and parent drafts are independent, and assignments are excluded.

- `createPlanMigrationDraft` accepts `licenseParents` and returns ordered `string[]` IDs; it builds the child draft and a version-scoped parent draft and inserts them sequentially. Parent billing changes flag only when the license customize includes a price.
- Adds `buildLicenseParentTargetCustomize` to derive each parent link’s target and migration customize from the pre-update baseline.
- `getVersioningUsage`/`getVersioningUsageForProduct` support `excludeLicenseAssignments` to filter rows with `customer_license_link_id IS NULL`.
- `handleUpdatePlanV2` snapshots parents before the write, computes per-parent customize, passes them to draft creation, and returns both `migration: { id }` (first) and `migrations: [{ id }]`. Callers that need to run or cancel the parent draft must read `migrations[]`.

<sup>Written for commit eac536b629aa64fa1aca5b282b06f5432d1ec7c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates license-plan updates into independently manageable child and parent migration drafts and excludes license-seat assignments from child-plan versioning usage.

- **[Improvements]** Builds parent migration customizations from the pre-update license state.
- **[Improvements, Bug fixes]** Creates separate drafts for the plan’s own customers and customers of plans that license it.
- **[Bug fixes]** Excludes license assignments from versioning-usage counts because parent migration operations handle those seats.
- **[API changes]** Returns both a legacy first migration and the complete ordered migration list.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because official SDK callers still lose the migration IDs required to run or cancel the new drafts.

The server returns both migration identifiers, but the generated update-plan response type and inbound parser still omit them, so SDK callers cannot manage either independently created migration.

**Files Needing Attention:** packages/sdk/src/models/update-plan-op.ts and the shared update-plan response contract

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/repos/getVersioningUsage.ts | Adds an optional query filter that excludes customer products representing license-seat assignments. |
| server/src/internal/licenses/actions/propagation/buildLicenseParentCustomize.ts | Derives each parent link’s target customization and migration delta from the pre-update effective plan. |
| server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts | Separates child and parent customer moves into ordered, independently runnable migration drafts. |
| server/src/internal/products/handlers/handleUpdatePlan/handleUpdatePlanV2.ts | Snapshots parent links, creates both migration drafts, and returns their IDs, but the official SDK contract still removes those response fields. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Handler as Update-plan handler
    participant Catalog as Product update
    participant Drafts as Migration repository
    Caller->>Handler: Update license plan
    Handler->>Handler: Snapshot parent license state
    Handler->>Catalog: Apply catalog update
    Handler->>Drafts: Insert child-customer draft
    Handler->>Drafts: Insert parent-customer draft
    Drafts-->>Handler: Ordered migration IDs
    Handler-->>Caller: Plan + migration + migrations[]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(migrations): draft a parent migrati..."](https://github.com/useautumn/autumn/commit/eac536b629aa64fa1aca5b282b06f5432d1ec7c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52927140)</sub>

<!-- /greptile_comment -->