### PR TITLE
feat(migrations): apply license customize on the per-customer lane

### DIFF
--- a/server/src/internal/licenses/actions/customize/computeLicenseCustomize.ts
+++ b/server/src/internal/licenses/actions/customize/computeLicenseCustomize.ts
@@ -24,14 +24,26 @@ export const derivePlanLicenseItemRefs = (effectiveProduct: FullProduct) => {
 			.map((price) => price.entitlement_id)
 			.filter((id): id is string => Boolean(id)),
 	);
+	const featureByEntitlementId = new Map(
+		effectiveProduct.entitlements.map((ent) => [
+			ent.id,
+			ent.internal_feature_id,
+		]),
+	);
 	return [
 		...effectiveProduct.prices.map((price) => ({
 			entitlementId: price.entitlement_id ?? undefined,
 			priceId: price.id,
+			internalFeatureId: price.entitlement_id
+				? featureByEntitlementId.get(price.entitlement_id)
+				: undefined,
 		})),
 		...effectiveProduct.entitlements
 			.filter((ent) => !priceReferencedEntitlementIds.has(ent.id))
-			.map((ent) => ({ entitlementId: ent.id })),
+			.map((ent) => ({
+				entitlementId: ent.id,
+				internalFeatureId: ent.internal_feature_id,
+			})),
 	];
 };
 

--- a/server/src/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.ts
+++ b/server/src/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.ts
@@ -32,6 +32,49 @@ type PreparedLinkRebase = {
 
 export type PreparedCatalogPlanLicenseRebases = PreparedLinkRebase[];
 
+/** A customized link keeps its own item set, but the rows it inherited from the
+ * catalog are only spared from deletion while some link still references them. */
+const pinCatalogRefsForCustomizedLink = async ({
+	db,
+	planLicenseId,
+	catalogItems,
+	existingRows,
+}: {
+	db: DrizzleCli;
+	planLicenseId: string;
+	catalogItems: ReturnType<typeof derivePlanLicenseItemRefs>;
+	existingRows: Awaited<
+		ReturnType<typeof licenseItemRepo.listByPlanLicenseIds>
+	>;
+}) => {
+	const held = existingRows.entitlements
+		.filter((row) => row.plan_license_id === planLicenseId)
+		.map((row) => row.id);
+	const heldPrices = existingRows.prices
+		.filter((row) => row.plan_license_id === planLicenseId)
+		.map((row) => row.id);
+	const missing = catalogItems.filter(
+		(item) =>
+			(item.entitlementId !== undefined &&
+				!held.includes(item.entitlementId)) ||
+			("priceId" in item &&
+				item.priceId !== undefined &&
+				!heldPrices.includes(item.priceId)),
+	);
+	if (missing.length === 0) return;
+
+	const retained = [
+		...held.map((entitlementId) => ({ entitlementId })),
+		...heldPrices.map((priceId) => ({ priceId })),
+	];
+	await licenseItemRepo.replaceItems({
+		db,
+		planLicenseId,
+		items: [...retained, ...missing],
+		customized: true,
+	});
+};
+
 export const materializeCustomerPlanLicenseSnapshots = async ({
 	db,
 	baseProduct,
@@ -45,9 +88,21 @@ export const materializeCustomerPlanLicenseSnapshots = async ({
 			licenseInternalProductIds: [baseProduct.internal_id],
 		});
 	const items = derivePlanLicenseItemRefs(baseProduct);
+	const existingRows = await licenseItemRepo.listByPlanLicenseIds({
+		db,
+		planLicenseIds: referenced.map((planLicense) => planLicense.id),
+	});
 	let materialized = false;
 	for (const planLicense of referenced) {
-		if (planLicense.customized) continue;
+		if (planLicense.customized) {
+			await pinCatalogRefsForCustomizedLink({
+				db,
+				planLicenseId: planLicense.id,
+				catalogItems: items,
+				existingRows,
+			});
+			continue;
+		}
 		await licenseItemRepo.replaceItems({
 			db,
 			planLicenseId: planLicense.id,
@@ -190,19 +245,26 @@ const hasLicenseCustomize = (customize: DiffedCustomizePlanV1) =>
 	customize.add_items !== undefined ||
 	customize.remove_items !== undefined;
 
+/** A customize names the shape it wants, not the rows behind it, so ids come
+ * from the saved plan first — the previous snapshot's rows may have just been
+ * replaced by the same save. */
 const resolveTargetItemRefs = ({
 	targetPlan,
+	newBasePlan,
 	previousEffectivePlan,
 }: {
 	targetPlan: ApiPlanV1;
+	newBasePlan: ApiPlanV1;
 	previousEffectivePlan: ApiPlanV1;
 }) => {
 	const refs: { entitlementId?: string; priceId?: string }[] = [];
-	const previousItems = [...previousEffectivePlan.items];
+	const candidateItems = [...newBasePlan.items, ...previousEffectivePlan.items];
 
 	if (targetPlan.price) {
 		const priceId =
-			targetPlan.price.price_id ?? previousEffectivePlan.price?.price_id;
+			targetPlan.price.price_id ??
+			newBasePlan.price?.price_id ??
+			previousEffectivePlan.price?.price_id;
 		if (!priceId) {
 			throw new InternalError({
 				message: "Failed to resolve license base price",
@@ -215,14 +277,11 @@ const resolveTargetItemRefs = ({
 		let entitlementId = item.entitlement_id;
 		let priceId = item.price_id;
 		if (!entitlementId || (item.price && !priceId)) {
-			const previousIndex = previousItems.findIndex((candidate) =>
+			const match = candidateItems.find((candidate) =>
 				itemsEqual(item, candidate),
 			);
-			if (previousIndex >= 0) {
-				const [previousItem] = previousItems.splice(previousIndex, 1);
-				entitlementId ??= previousItem.entitlement_id;
-				priceId ??= previousItem.price_id;
-			}
+			entitlementId ??= match?.entitlement_id;
+			priceId ??= match?.price_id;
 		}
 
 		if (!entitlementId || (item.price && !priceId)) {
@@ -283,6 +342,7 @@ export const applyCatalogPlanLicenseRebases = async ({
 					planLicenseId: link.id,
 					items: resolveTargetItemRefs({
 						targetPlan: canonicalTargetPlan,
+						newBasePlan,
 						previousEffectivePlan,
 					}),
 					customized: true,

--- a/server/src/internal/licenses/actions/links/validateLicenseLink.ts
+++ b/server/src/internal/licenses/actions/links/validateLicenseLink.ts
@@ -36,6 +36,22 @@ export const validateLicenseLink = ({
 			statusCode: 400,
 		});
 	}
+	// Variants never inherit their base's links and never draft a parent
+	// migration, so a link either side of one silently diverges.
+	if (licenseProduct.base_internal_product_id) {
+		throw new RecaseError({
+			message: `A variant cannot be used as a plan license (${licensePlanId ?? licenseProduct.id}).`,
+			code: ErrCode.InvalidRequest,
+		});
+	}
+
+	if (parentProduct?.base_internal_product_id) {
+		throw new RecaseError({
+			message: `A variant cannot link a plan license (${parentProduct.id}).`,
+			code: ErrCode.InvalidRequest,
+		});
+	}
+
 	if (parentProduct && licenseProduct.id === parentProduct.id) {
 		throw new RecaseError({
 			message: `A plan cannot be linked as a license to itself (${licensePlanId ?? licenseProduct.id}).`,

--- a/server/src/internal/migrations/v2/operations/operationRegistry.ts
+++ b/server/src/internal/migrations/v2/operations/operationRegistry.ts
@@ -19,7 +19,9 @@ const processors: Record<
 
 export function getProcessor({
 	type,
-}: { type: string }): OperationProcessor<CustomerOperation> {
+}: {
+	type: string;
+}): OperationProcessor<CustomerOperation> {
 	const processor = processors[type as CustomerOperation["type"]];
 	if (!processor)
 		throw new Error(`No processor registered for operation type "${type}"`);

--- a/server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts
@@ -77,7 +77,9 @@ export const setupUpdatePlanProductContext = async ({
 		(customize.add_items === undefined || customize.add_items.length === 0) &&
 		customize.remove_items === undefined &&
 		(customize.update_items === undefined ||
-			customize.update_items.length === 0)
+			customize.update_items.length === 0) &&
+		(customize.upsert_licenses === undefined ||
+			customize.upsert_licenses.length === 0)
 	) {
 		return undefined;
 	}
@@ -128,6 +130,7 @@ export const setupUpdatePlanProductContext = async ({
 		patchContext,
 		customPrices,
 		customEnts,
+		insertPlanLicenses,
 	} = await setupUpdateSubscriptionProductContext({
 		ctx,
 		fullCustomer: productFullCustomer,
@@ -202,6 +205,7 @@ export const setupUpdatePlanProductContext = async ({
 		adjustableFeatureQuantities: setupAdjustableQuantities({ params }),
 		customPrices,
 		customEnts,
+		insertPlanLicenses,
 		trialContext: operationBillingContext.trialContext,
 		isCustom: targetCustomerProduct.is_custom,
 		billingVersion: BillingVersion.V2,

--- a/server/src/internal/product/actions/previewUpdatePlan/previewAffectedLicenseParents.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewAffectedLicenseParents.ts
@@ -12,11 +12,8 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { customerProductRepo } from "@/internal/customers/cusProducts/repos/index.js";
-import { applyLicenseCustomizeToBasePlan } from "@/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.js";
-import {
-	diffLicensePlanCustomize,
-	toApiPlanLicenseWithCustomize,
-} from "@/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.js";
+import { toApiPlanLicenseWithCustomize } from "@/internal/licenses/actions/customize/toApiPlanLicenseWithCustomize.js";
+import { buildLicenseParentTargetCustomize } from "@/internal/licenses/actions/propagation/buildLicenseParentCustomize.js";
 import { listLicenseParentContexts } from "@/internal/licenses/actions/propagation/listLicenseParentContexts.js";
 import {
 	licenseParentTargetKey,
@@ -121,20 +118,13 @@ export const previewAffectedLicenseParents = async ({
 							}),
 					}),
 				]);
-			const currentCustomize = getApiPlanDiff({
-				from: currentChildPlan,
-				to: currentEffectivePlan,
-			});
-			const targetEffectivePlan = currentLink.customized
-				? applyLicenseCustomizeToBasePlan({
-						basePlan: editedChildPlan,
-						customize: currentCustomize,
-					})
-				: editedChildPlan;
-			const targetCustomize = diffLicensePlanCustomize({
-				basePlan: editedChildPlan,
-				effectivePlan: targetEffectivePlan,
-			});
+			const { targetEffectivePlan, targetCustomize } =
+				buildLicenseParentTargetCustomize({
+					currentChildPlan,
+					editedChildPlan,
+					currentEffectivePlan,
+					customized: currentLink.customized,
+				});
 			const targetLicense: ApiPlanLicenseV1 = {
 				license_plan_id: child.id,
 				version: childWillVersion ? child.version + 1 : child.version,

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/all-versions-parent-ops.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/all-versions-parent-ops.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Contract: in all_versions mode, license-parent ops stay version-scoped.
+ *
+ * The base plan's own targets drop `version` so every version is swept, but a
+ * license link pins a version, and two versions of one parent can carry
+ * different customizes. A bare plan_id would let each op match the other
+ * version's customers, applying the wrong delta and then resetting it.
+ */
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+
+test(`${chalk.yellowBright("plans.update: all_versions keeps parent ops version-scoped")}`, async () => {
+	const proCustomerId = "lic-allver-pro-cus";
+	const scaleCustomerId = "lic-allver-scale-cus";
+
+	// Free seat plan: price is outside this contract, and keeping it out avoids
+	// the child edit having to restate it.
+	const devSeat = products.base({
+		id: "dev-seat",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+		group: "lic-allver-seat-licenses",
+	});
+	const pro = products.base({ id: "pro", items: [items.dashboard()] });
+	const scale = products.base({
+		id: "scale",
+		items: [items.monthlyWords({ includedUsage: 100 })],
+	});
+
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId: proCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.otherCustomers([{ id: scaleCustomerId, paymentMethod: "success" }]),
+			s.products({ list: [pro, scale, devSeat], prefix: "lic-allver" }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: pro.id,
+				licenseProductId: devSeat.id,
+				included: 1,
+			}),
+			s.licenses.link({
+				parentProductId: scale.id,
+				licenseProductId: devSeat.id,
+				included: 2,
+			}),
+			s.billing.attach({
+				productId: pro.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+			s.billing.attach({
+				customerId: scaleCustomerId,
+				productId: scale.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 3 }],
+			}),
+		],
+	});
+
+	const response = await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		items: [itemsV2.monthlyMessages({ included: 1000 })],
+		all_versions: true,
+		update_license_parents: [
+			{ plan_id: pro.id, version: 1 },
+			{ plan_id: scale.id, version: 1 },
+		],
+		migration: { draft: true },
+	});
+
+	// ── Side effect: a draft exists ────────────────────────────────────
+	expect(response.migration?.id).toBeDefined();
+
+	const [migration] = await migrationRepo.get({
+		ctx,
+		id: response.migration.id,
+	});
+	const customerOps = migration?.operations?.customer ?? [];
+
+	// ── Behavior: one op, since the child itself has no customers ──────
+	// The child is only ever held via parent seat assignments here, so there is
+	// no child population to migrate — just the collapsed parent op.
+	expect(customerOps).toHaveLength(1);
+
+	const planIdsOf = (filter: unknown): string[] => {
+		const matcher = (filter as { plan_id?: unknown })?.plan_id;
+		if (typeof matcher === "string") return [matcher];
+		const inList = (matcher as { $in?: string[] })?.$in;
+		return inList ?? [];
+	};
+
+	const parentOp = customerOps.find(
+		(op) =>
+			op.type === "update_plan" && planIdsOf(op.plan_filter).includes(pro.id),
+	);
+	expect(parentOp).toBeDefined();
+	if (parentOp?.type !== "update_plan") {
+		throw new Error("expected an update_plan op");
+	}
+
+	// ── Both parents collapse into ONE op via $in ──────────────────────
+	expect(planIdsOf(parentOp.plan_filter).sort()).toEqual(
+		[pro.id, scale.id].sort(),
+	);
+
+	// ── The parent op keeps its version, unlike the base plan's targets ─
+	expect((parentOp.plan_filter as { version?: number }).version).toBe(1);
+
+	// ── The change rides on upsert_licenses only ───────────────────────
+	const upserts = parentOp.customize?.upsert_licenses ?? [];
+	expect(upserts).toHaveLength(1);
+	expect(upserts[0]).toMatchObject({ license_plan_id: devSeat.id });
+	expect(JSON.stringify(upserts[0]?.customize ?? {})).toContain(
+		TestFeature.Messages,
+	);
+
+	// The parent's own plan items are untouched — applying the child's diff
+	// to the parent would edit the wrong plan.
+	expect(parentOp.customize?.add_items).toBeUndefined();
+	expect(parentOp.customize?.remove_items).toBeUndefined();
+	expect(parentOp.customize?.price).toBeUndefined();
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/base-price-propagation.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/base-price-propagation.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Contract: raising a license plan's base seat price propagates to parents
+ * without charging anyone at migration time.
+ *
+ * A seat price change touches a Stripe subscription item, so it must run on the
+ * per-customer lane — the batch lane rejects a priced `upsert_licenses`
+ * (checkUpdatePlanOpEligibility.ts). It must also stay charge-free:
+ * `assertNoChargeArtifacts` (processUpdatePlan.ts) throws if the computed plan
+ * emits line items without `proration: true`. Customers pay the new rate at
+ * their next cycle, matching how a plain base-price update behaves
+ * (migrate.ts sets proration_behavior "none").
+ *
+ * A parent whose link overrides the price is excluded: the override pins its
+ * own amount, so the base change never reaches it.
+ */
+import { expect, test } from "bun:test";
+import { type ApiCustomerV3, BillingInterval } from "@autumn/shared";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { runMigrationInChunks } from "@/internal/migrations/v2/run/runMigrationInChunks.js";
+import { generateId } from "@/utils/genUtils.js";
+
+const ATTACHED_SEATS = 3;
+const INCLUDED_SEATS = 1;
+const SEAT_PRICE = 10;
+const NEW_SEAT_PRICE = 20;
+const OVERRIDE_SEAT_PRICE = 15;
+
+const planIdsOf = (filter: unknown): string[] => {
+	const matcher = (filter as { plan_id?: unknown })?.plan_id;
+	if (typeof matcher === "string") return [matcher];
+	return (matcher as { $in?: string[] })?.$in ?? [];
+};
+
+test(`${chalk.yellowBright("plans.update: a base seat price rise propagates per-customer without charging")}`, async () => {
+	const idPrefix = "base-price-prop";
+	const parentCustomerId = `${idPrefix}-parent-cus`;
+	const overrideCustomerId = `${idPrefix}-override-cus`;
+
+	const devSeat = products.base({
+		id: "dev-seat",
+		items: [
+			items.monthlyPrice({ price: SEAT_PRICE }),
+			items.monthlyMessages({ includedUsage: 100 }),
+		],
+		group: `${idPrefix}-licenses`,
+	});
+	const pro = products.base({ id: "pro", items: [items.dashboard()] });
+	const ent = products.base({ id: "ent", items: [items.dashboard()] });
+
+	const { autumnV1, autumnV2_3, ctx } = await initScenario({
+		customerId: parentCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.otherCustomers([{ id: overrideCustomerId, paymentMethod: "success" }]),
+			s.products({ list: [pro, ent, devSeat], prefix: idPrefix }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: pro.id,
+				licenseProductId: devSeat.id,
+				included: INCLUDED_SEATS,
+			}),
+			// This parent pins its own seat price, so the base rise must skip it.
+			s.licenses.link({
+				parentProductId: ent.id,
+				licenseProductId: devSeat.id,
+				included: 1,
+				customize: {
+					price: {
+						amount: OVERRIDE_SEAT_PRICE,
+						interval: BillingInterval.Month,
+					},
+				},
+			}),
+			s.billing.attach({
+				productId: pro.id,
+				licenseQuantities: [
+					{ licenseProductId: devSeat.id, quantity: ATTACHED_SEATS },
+				],
+			}),
+			s.billing.attach({
+				customerId: overrideCustomerId,
+				productId: ent.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+		],
+	});
+
+	const before = await autumnV1.customers.get<ApiCustomerV3>(parentCustomerId);
+	const invoicesBefore = before.invoices?.length ?? 0;
+
+	const response = await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		price: { amount: NEW_SEAT_PRICE, interval: BillingInterval.Month },
+		items: [itemsV2.monthlyMessages({ included: 100 })],
+		disable_version: true,
+		update_license_parents: [
+			{ plan_id: pro.id, version: 1 },
+			{ plan_id: ent.id, version: 1 },
+		],
+		migration: { draft: true },
+	});
+
+	// ── The draft carries the price, and admits it bills ───────────────
+	const migrationId = response.migrations?.[0]?.id;
+	expect(migrationId).toBeDefined();
+
+	const [migration] = await migrationRepo.get({ ctx, id: migrationId });
+	expect(migration?.no_billing_changes).toBe(false);
+
+	const customerOps = migration?.operations?.customer ?? [];
+	expect(customerOps).toHaveLength(1);
+	const op = customerOps[0];
+	if (op?.type !== "update_plan") throw new Error("expected update_plan");
+
+	expect(op.customize?.upsert_licenses?.[0]?.customize?.price).toMatchObject({
+		amount: NEW_SEAT_PRICE,
+	});
+
+	// ── The overriding parent is not in the migration ──────────────────
+	expect(planIdsOf(op.plan_filter)).toEqual([pro.id]);
+	expect(planIdsOf(op.plan_filter)).not.toContain(ent.id);
+
+	// ── It runs per-customer, since it touches Stripe ──────────────────
+	const result = await runMigrationInChunks({
+		ctx,
+		migration,
+		migrationRunId: generateId("mrun"),
+		dryRun: false,
+	});
+	expect(result.lane).toBe("per_customer");
+
+	// ── Charge-free: the new rate lands next cycle, not now ────────────
+	const after = await autumnV1.customers.get<ApiCustomerV3>(parentCustomerId);
+	expect(after.invoices?.length ?? 0).toBe(invoicesBefore);
+
+	// ── The customer's effective seat price really is the new one ──────
+	const { pools } = await getLicenseDbState({
+		db: ctx.db,
+		customerId: parentCustomerId,
+	});
+	const planLicenseId = pools[0]?.plan_license_id;
+	expect(planLicenseId).toBeTruthy();
+
+	const link = await ctx.db.query.planLicenses.findFirst({
+		where: (planLicense, { eq }) => eq(planLicense.id, planLicenseId as string),
+	});
+	expect(link?.is_custom).toBe(true);
+
+	// Seat quantity survives the price swap.
+	expect(pools[0]?.granted).toBe(ATTACHED_SEATS);
+
+	// ── The PAID seats reprice on Stripe, so next cycle bills the new
+	// rate. Included seats are free and must not add anything. ─────────
+	const customerRow = await ctx.db.query.customers.findFirst({
+		where: (customer, { eq }) => eq(customer.id, parentCustomerId),
+	});
+	const customerProducts = await ctx.db.query.customerProducts.findMany({
+		where: (customerProduct, { eq }) =>
+			eq(customerProduct.internal_customer_id, customerRow?.internal_id ?? ""),
+	});
+	const subscriptionIds = [
+		...new Set(
+			customerProducts.flatMap(
+				(customerProduct) => customerProduct.subscription_ids ?? [],
+			),
+		),
+	];
+	expect(subscriptionIds.length).toBeGreaterThan(0);
+
+	const seatLineTotals: number[] = [];
+	for (const subscriptionId of subscriptionIds) {
+		const subscription =
+			await ctx.stripeCli.subscriptions.retrieve(subscriptionId);
+		for (const item of subscription.items.data) {
+			const unitAmount = item.price.unit_amount ?? 0;
+			if (unitAmount === 0) continue;
+			seatLineTotals.push((unitAmount / 100) * (item.quantity ?? 0));
+		}
+	}
+
+	const paidSeats = ATTACHED_SEATS - INCLUDED_SEATS;
+	expect(seatLineTotals).toContain(paidSeats * NEW_SEAT_PRICE);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/child-and-parent-separate-migrations.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/child-and-parent-separate-migrations.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Contract: the child plan and its parents get SEPARATE migrations.
+ *
+ * They move different customer populations by different operations — the child
+ * by its own item diff, parents by a license customize — so each is drafted,
+ * run and cancelled on its own rather than sharing one row.
+ *
+ * The response carries `migrations` for every draft, and keeps `migration`
+ * pointing at the first so single-draft consumers are unaffected.
+ */
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+
+const planIdsOf = (filter: unknown): string[] => {
+	const matcher = (filter as { plan_id?: unknown })?.plan_id;
+	if (typeof matcher === "string") return [matcher];
+	return (matcher as { $in?: string[] })?.$in ?? [];
+};
+
+test(`${chalk.yellowBright("plans.update: child and parent are drafted as separate migrations")}`, async () => {
+	const idPrefix = "split-mig";
+	const parentCustomerId = `${idPrefix}-parent-cus`;
+	const directCustomerId = `${idPrefix}-direct-cus`;
+
+	const devSeat = products.base({
+		id: "dev-seat",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+		group: `${idPrefix}-licenses`,
+	});
+	const pro = products.base({ id: "pro", items: [items.dashboard()] });
+
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId: parentCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.otherCustomers([{ id: directCustomerId, paymentMethod: "success" }]),
+			s.products({ list: [pro, devSeat], prefix: idPrefix }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: pro.id,
+				licenseProductId: devSeat.id,
+				included: 1,
+			}),
+			s.billing.attach({
+				productId: pro.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+			// A customer on the child plan directly, so BOTH populations exist.
+			s.billing.attach({
+				customerId: directCustomerId,
+				productId: devSeat.id,
+			}),
+		],
+	});
+
+	const response = await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		items: [itemsV2.monthlyMessages({ included: 1000 })],
+		disable_version: true,
+		update_license_parents: [{ plan_id: pro.id, version: 1 }],
+		migration: { draft: true },
+	});
+
+	// ── Two drafts, and `migration` still points at the first ──────────
+	expect(response.migrations).toHaveLength(2);
+	expect(response.migration?.id).toBe(response.migrations[0].id);
+
+	const ids: string[] = response.migrations.map(({ id }: { id: string }) => id);
+	expect(new Set(ids).size).toBe(2);
+
+	const opsById = new Map<string, unknown[]>();
+	for (const id of ids) {
+		const [row] = await migrationRepo.get({ ctx, id });
+		opsById.set(id, row?.operations?.customer ?? []);
+	}
+
+	// ── Each migration carries exactly one op, for one population ──────
+	const childOps = [...opsById.values()].find((ops) =>
+		ops.some((op) =>
+			planIdsOf((op as { plan_filter: unknown }).plan_filter).includes(
+				devSeat.id,
+			),
+		),
+	);
+	const parentOps = [...opsById.values()].find((ops) =>
+		ops.some((op) =>
+			planIdsOf((op as { plan_filter: unknown }).plan_filter).includes(pro.id),
+		),
+	);
+	expect(childOps).toHaveLength(1);
+	expect(parentOps).toHaveLength(1);
+
+	// The child migration never touches the parent, and vice versa.
+	const childOp = childOps?.[0] as { customize?: Record<string, unknown> };
+	const parentOp = parentOps?.[0] as { customize?: Record<string, unknown> };
+	expect(childOp.customize?.upsert_licenses).toBeUndefined();
+	expect(parentOp.customize?.add_items).toBeUndefined();
+	expect(parentOp.customize?.upsert_licenses).toBeDefined();
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/customized-parent-excluded-from-migration.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/customized-parent-excluded-from-migration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Contract: a parent whose license link overrides the edited feature is left
+ * out of the migration entirely.
+ *
+ * The override pins its own value, so the child's edit never reaches it — the
+ * rebase re-applies the override onto the edited child and the delta comes out
+ * empty. This mirrors the catalog write path, which skips customized links
+ * (rebaseCatalogPlanLicenses.ts:50), so preview, draft and write agree.
+ *
+ * The plain parents still collapse into one `$in` op. Emitting an op for the
+ * customized parent would be worse than useless: an upsert_licenses entry with
+ * no add_items resets the link to catalog inheritance, silently discarding the
+ * override.
+ */
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+
+const ENT_SEAT_MESSAGES = 900;
+
+const planIdsOf = (filter: unknown): string[] => {
+	const matcher = (filter as { plan_id?: unknown })?.plan_id;
+	if (typeof matcher === "string") return [matcher];
+	return (matcher as { $in?: string[] })?.$in ?? [];
+};
+
+test(`${chalk.yellowBright("plans.update: a customized parent link gets its own op instead of collapsing")}`, async () => {
+	const proCustomerId = "cust-split-pro-customer";
+	const scaleCustomerId = "cust-split-scale-customer";
+	const entCustomerId = "cust-split-ent-customer";
+	const idPrefix = "cust-split";
+
+	const devSeat = products.base({
+		id: "dev-seat",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+		group: `${idPrefix}-seat-licenses`,
+	});
+	const pro = products.base({ id: "pro", items: [items.dashboard()] });
+	const scale = products.base({
+		id: "scale",
+		items: [items.monthlyWords({ includedUsage: 100 })],
+	});
+	const ent = products.base({ id: "ent", items: [items.dashboard()] });
+
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId: proCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.otherCustomers([
+				{ id: scaleCustomerId, paymentMethod: "success" },
+				{ id: entCustomerId, paymentMethod: "success" },
+			]),
+			s.products({ list: [pro, scale, ent, devSeat], prefix: idPrefix }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: pro.id,
+				licenseProductId: devSeat.id,
+				included: 1,
+			}),
+			s.licenses.link({
+				parentProductId: scale.id,
+				licenseProductId: devSeat.id,
+				included: 2,
+			}),
+			s.licenses.link({
+				parentProductId: ent.id,
+				licenseProductId: devSeat.id,
+				included: 3,
+				customize: {
+					remove_items: [{ feature_id: TestFeature.Messages }],
+					add_items: [itemsV2.monthlyMessages({ included: ENT_SEAT_MESSAGES })],
+				},
+			}),
+			s.billing.attach({
+				productId: pro.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+			s.billing.attach({
+				customerId: scaleCustomerId,
+				productId: scale.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+			s.billing.attach({
+				customerId: entCustomerId,
+				productId: ent.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+		],
+	});
+
+	const response = await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		items: [itemsV2.monthlyMessages({ included: 1000 })],
+		disable_version: true,
+		update_license_parents: [
+			{ plan_id: pro.id, version: 1 },
+			{ plan_id: scale.id, version: 1 },
+			{ plan_id: ent.id, version: 1 },
+		],
+		migration: { draft: true },
+	});
+
+	expect(response.migration?.id).toBeDefined();
+	const [migration] = await migrationRepo.get({
+		ctx,
+		id: response.migration.id,
+	});
+	const customerOps = migration?.operations?.customer ?? [];
+
+	// Only the plain parents are migrated; the override has nothing to apply.
+	expect(customerOps).toHaveLength(1);
+
+	const plainOp = customerOps[0];
+	if (plainOp?.type !== "update_plan") {
+		throw new Error("expected an update_plan op");
+	}
+
+	expect(planIdsOf(plainOp.plan_filter).sort()).toEqual(
+		[pro.id, scale.id].sort(),
+	);
+
+	// The customized parent is absent — not swept in, and not reset.
+	expect(planIdsOf(plainOp.plan_filter)).not.toContain(ent.id);
+
+	// The plain parents move to the child's new allowance.
+	expect(
+		plainOp.customize?.upsert_licenses?.[0]?.customize?.add_items,
+	).toContainEqual(
+		expect.objectContaining({
+			feature_id: TestFeature.Messages,
+			included: 1000,
+		}),
+	);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/license-plan-draft-excludes-seats.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/license-plan-draft-excludes-seats.test.ts
@@ -1,0 +1,124 @@
+/**
+ * A license plan's own migration must not target seat assignments.
+ *
+ * Seats live on the license plan as customer products, so the versioning usage
+ * query counts them as its customers and a draft is built scoped directly at
+ * the plan. But operationScopeSql excludes any row carrying a
+ * customer_license_link_id — seats are reached through the parent's
+ * upsert_licenses instead — so that op matches nothing and the run reports
+ * "No changes".
+ *
+ * Red-failure mode (current behavior):
+ *  - two drafts are created; the license-plan one runs and skips every customer
+ *
+ * Green-success criteria (after fix):
+ *  - only the parent draft is created, and running it moves the assignments
+ */
+import { expect, test } from "bun:test";
+import { customerEntitlements, migrationItemRuns } from "@autumn/shared";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import chalk from "chalk";
+import { eq, inArray } from "drizzle-orm";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { runMigrationInChunks } from "@/internal/migrations/v2/run/runMigrationInChunks.js";
+import { generateId } from "@/utils/genUtils.js";
+
+const SEAT_MESSAGES = 100;
+const SEAT_WORDS = 50;
+const NEW_WORDS = 30;
+
+test(`${chalk.yellowBright("plans.update: a license plan drafts no migration for its own seat assignments")}`, async () => {
+	const customerId = "lic-seat-draft-customer";
+	const idPrefix = "lic-seat-draft";
+
+	const scenario = await setupLicenseUpdateScenario({
+		customerId,
+		idPrefix,
+		seatItems: [
+			items.monthlyMessages({ includedUsage: SEAT_MESSAGES }),
+			items.monthlyWords({ includedUsage: SEAT_WORDS }),
+		],
+		includedSeats: 1,
+		attachedSeats: 3,
+	});
+	await scenario.assignSeats({ count: 2 });
+
+	const { ctx, autumnV2_3, parent, devSeat } = scenario;
+	const { assignments } = await getLicenseDbState({ db: ctx.db, customerId });
+	const liveAssignments = assignments.filter(
+		(assignment) => assignment.internal_entity_id,
+	);
+	expect(liveAssignments).toHaveLength(2);
+
+	// Drop messages and shrink words in one edit — the shape that produced both
+	// a delete and an update on the same migration.
+	const response = await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		items: [itemsV2.monthlyWords({ included: NEW_WORDS })],
+		disable_version: true,
+		update_license_parents: [{ plan_id: parent.id, version: 1 }],
+		migration: { draft: true },
+	});
+
+	// ── Only the parent is worth migrating ─────────────────────────────
+	const drafts = response.migrations ?? [];
+	const planIdsOf = (filter: unknown): string[] => {
+		const matcher = (filter as { plan_id?: unknown })?.plan_id;
+		if (typeof matcher === "string") return [matcher];
+		return (matcher as { $in?: string[] })?.$in ?? [];
+	};
+
+	const targeted: string[] = [];
+	for (const entry of drafts as { id: string }[]) {
+		const [row] = await migrationRepo.get({ ctx, id: entry.id });
+		for (const op of row?.operations?.customer ?? []) {
+			if (op.type !== "update_plan") continue;
+			targeted.push(...planIdsOf(op.plan_filter));
+		}
+	}
+	expect(targeted).not.toContain(devSeat.id);
+	expect(targeted).toContain(parent.id);
+
+	// ── Running every draft actually moves the assignments ─────────────
+	for (const entry of drafts as { id: string }[]) {
+		const [row] = await migrationRepo.get({ ctx, id: entry.id });
+		if (!row) continue;
+		await runMigrationInChunks({
+			ctx,
+			migration: row,
+			migrationRunId: generateId("mrun"),
+			dryRun: false,
+		});
+
+		const runs = await ctx.db
+			.select({ status: migrationItemRuns.status })
+			.from(migrationItemRuns)
+			.where(eq(migrationItemRuns.migration_internal_id, row.internal_id));
+		expect(runs.every((run) => run.status !== "skipped")).toBe(true);
+	}
+
+	const rows = await ctx.db
+		.select({
+			featureId: customerEntitlements.feature_id,
+			balance: customerEntitlements.balance,
+		})
+		.from(customerEntitlements)
+		.where(
+			inArray(
+				customerEntitlements.customer_product_id,
+				liveAssignments.map((assignment) => assignment.id),
+			),
+		);
+
+	// messages was dropped; words shrank to the new allowance.
+	expect(
+		rows.filter((row) => row.featureId === TestFeature.Messages),
+	).toHaveLength(0);
+	expect(
+		rows.filter((row) => row.featureId === TestFeature.Words),
+	).toHaveLength(2);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/migration-license-price-change.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/migration-license-price-change.test.ts
@@ -1,0 +1,89 @@
+/**
+ * A per-customer migration whose license customize carries a base price change.
+ *
+ * setupCustomPlanLicenses mints a plan_license row for the customized link and
+ * returns it as insertPlanLicenses for execute to persist. The migration's
+ * product context dropped that field, so the row was never inserted while the
+ * customer's pool was still repointed onto its id.
+ *
+ * Red: the run fails on customer_licenses_plan_license_fkey.
+ * Green: the run completes and the pool resolves to a live link.
+ */
+import { expect, test } from "bun:test";
+import { BillingInterval, planLicenses } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import chalk from "chalk";
+import { inArray } from "drizzle-orm";
+
+const SEAT_PRICE = 10;
+const NEW_SEAT_PRICE = 50;
+const INCLUDED_SEATS = 1;
+const ATTACHED_SEATS = 3;
+const ASSIGNED_SEATS = 2;
+
+test(`${chalk.yellowBright("migration: a license base price change persists its customized link")}`, async () => {
+	const customerId = "mig-lic-price-customer";
+	const idPrefix = "mig-lic-price";
+
+	const scenario = await setupLicenseUpdateScenario({
+		customerId,
+		idPrefix,
+		seatPrice: SEAT_PRICE,
+		seatItems: [items.oneOffMessages({ includedUsage: 100 })],
+		includedSeats: INCLUDED_SEATS,
+		attachedSeats: ATTACHED_SEATS,
+	});
+	await scenario.assignSeats({ count: ASSIGNED_SEATS });
+
+	const { ctx, autumnV2_2, parent, devSeat } = scenario;
+
+	const { result } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: `${idPrefix}-mig`,
+		filter: { customer: { plan: { plan_id: parent.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: parent.id, custom: false },
+					customize: {
+						upsert_licenses: [
+							{
+								license_plan_id: devSeat.id,
+								customize: {
+									price: {
+										amount: NEW_SEAT_PRICE,
+										interval: BillingInterval.Month,
+									},
+									remove_items: [{ feature_id: TestFeature.Messages }],
+								},
+							},
+						],
+					},
+				},
+			],
+		},
+	});
+
+	expect(result).toBeDefined();
+
+	// Every pool must resolve to a link that exists.
+	const { pools } = await getLicenseDbState({ db: ctx.db, customerId });
+
+	const linkIds = pools
+		.map((pool) => pool.plan_license_id)
+		.filter((id): id is string => Boolean(id));
+	if (linkIds.length === 0) return;
+
+	const alive = await ctx.db
+		.select({ id: planLicenses.id })
+		.from(planLicenses)
+		.where(inArray(planLicenses.id, linkIds));
+
+	expect(alive.length).toBe(linkIds.length);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/parent-migration-draft-ops.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/parent-migration-draft-ops.test.ts
@@ -1,0 +1,143 @@
+/**
+ * TDD test for wiring license parents into the migration draft.
+ *
+ * A child-plan edit that propagates to parent plans must produce ONE draft with
+ * TWO ops: the child's own item diff, and a single upsert_licenses op covering
+ * every parent. Today `update_license_parents` reaches updateProduct but never
+ * createPlanMigrationDraft, so the parents' customers are stranded.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - edit child + update_license_parents + migration:{draft:true}
+ *         -> a draft carrying a parent op
+ *     - the op targets plan_filter.plan_id === { $in: [parentA, parentB] } with
+ *       customize = { upsert_licenses: [{ license_plan_id: child, customize }] }
+ *     - N parents sharing one license update collapse into ONE op, not N
+ *     - the parent op carries no add_items/remove_items/price of its own
+ *     - the upsert customize is the delta from the customers' CURRENT
+ *       definition, not from the edited catalog plan (which diffs to nothing
+ *       for an uncustomized link, yielding a no-op migration)
+ *     - no child op here: the child has no customers of its own
+ *   Side effects:
+ *     - one row in `migrations`; response.migration.id defined
+ *
+ * Pre-impl red: response.migration.id is undefined — no draft at all.
+ * Post-impl green: the parent op exists, collapsed via $in, carrying a
+ * non-empty upsert customize.
+ */
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+
+test(`${chalk.yellowBright("plans.update: child edit drafts one migration with a child op and a collapsed parent op")}`, async () => {
+	const proCustomerId = "lic-parent-ops-pro-customer";
+	const scaleCustomerId = "lic-parent-ops-scale-customer";
+
+	// Free seat plan: price is outside this contract, and keeping it out avoids
+	// the child edit having to restate it.
+	const devSeat = products.base({
+		id: "dev-seat",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+		group: "lic-parent-ops-seat-licenses",
+	});
+	const pro = products.base({ id: "pro", items: [items.dashboard()] });
+	const scale = products.base({
+		id: "scale",
+		items: [items.monthlyWords({ includedUsage: 100 })],
+	});
+
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId: proCustomerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.otherCustomers([{ id: scaleCustomerId, paymentMethod: "success" }]),
+			s.products({ list: [pro, scale, devSeat], prefix: "lic-parent-ops" }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: pro.id,
+				licenseProductId: devSeat.id,
+				included: 1,
+			}),
+			s.licenses.link({
+				parentProductId: scale.id,
+				licenseProductId: devSeat.id,
+				included: 2,
+			}),
+			s.billing.attach({
+				productId: pro.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+			s.billing.attach({
+				customerId: scaleCustomerId,
+				productId: scale.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 3 }],
+			}),
+		],
+	});
+
+	const response = await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		items: [itemsV2.monthlyMessages({ included: 1000 })],
+		disable_version: true,
+		update_license_parents: [
+			{ plan_id: pro.id, version: 1 },
+			{ plan_id: scale.id, version: 1 },
+		],
+		migration: { draft: true },
+	});
+
+	// ── Side effect: a draft exists ────────────────────────────────────
+	expect(response.migration?.id).toBeDefined();
+
+	const [migration] = await migrationRepo.get({
+		ctx,
+		id: response.migration.id,
+	});
+	const customerOps = migration?.operations?.customer ?? [];
+
+	// ── Behavior: one op, since the child itself has no customers ──────
+	// The child is only ever held via parent seat assignments here, so there is
+	// no child population to migrate — just the collapsed parent op.
+	expect(customerOps).toHaveLength(1);
+
+	const planIdsOf = (filter: unknown): string[] => {
+		const matcher = (filter as { plan_id?: unknown })?.plan_id;
+		if (typeof matcher === "string") return [matcher];
+		const inList = (matcher as { $in?: string[] })?.$in;
+		return inList ?? [];
+	};
+
+	const parentOp = customerOps.find(
+		(op) =>
+			op.type === "update_plan" && planIdsOf(op.plan_filter).includes(pro.id),
+	);
+	expect(parentOp).toBeDefined();
+	if (parentOp?.type !== "update_plan") {
+		throw new Error("expected an update_plan op");
+	}
+
+	// ── Both parents collapse into ONE op via $in ──────────────────────
+	expect(planIdsOf(parentOp.plan_filter).sort()).toEqual(
+		[pro.id, scale.id].sort(),
+	);
+
+	// ── The change rides on upsert_licenses only ───────────────────────
+	const upserts = parentOp.customize?.upsert_licenses ?? [];
+	expect(upserts).toHaveLength(1);
+	expect(upserts[0]).toMatchObject({ license_plan_id: devSeat.id });
+	expect(JSON.stringify(upserts[0]?.customize ?? {})).toContain(
+		TestFeature.Messages,
+	);
+
+	// The parent's own plan items are untouched — applying the child's diff
+	// to the parent would edit the wrong plan.
+	expect(parentOp.customize?.add_items).toBeUndefined();
+	expect(parentOp.customize?.remove_items).toBeUndefined();
+	expect(parentOp.customize?.price).toBeUndefined();
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/parent-without-customers-excluded.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/parent-without-customers-excluded.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Contract: a parent with no customers contributes no migration target, and a
+ * single op patches each matched customer exactly once.
+ *
+ * Both parents offer the same license, but only one has customers. Emitting a
+ * target for the empty parent would widen the filter for no reason; emitting
+ * two ops for one license would let the second write clobber the first for any
+ * customer reachable through both.
+ */
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+
+const planIdsOf = (filter: unknown): string[] => {
+	const matcher = (filter as { plan_id?: unknown })?.plan_id;
+	if (typeof matcher === "string") return [matcher];
+	return (matcher as { $in?: string[] })?.$in ?? [];
+};
+
+test(`${chalk.yellowBright("plans.update: a parent with no customers contributes no migration target")}`, async () => {
+	const customerId = "shared-cus-both-parents";
+	const idPrefix = "shared-cus";
+
+	const devSeat = products.base({
+		id: "dev-seat",
+		items: [items.monthlyMessages({ includedUsage: 500 })],
+		group: `${idPrefix}-seat-licenses`,
+	});
+	const pro = products.base({ id: "pro", items: [items.dashboard()] });
+	const scale = products.base({
+		id: "scale",
+		items: [items.monthlyWords({ includedUsage: 100 })],
+	});
+
+	// One customer, BOTH parent plans, each carrying the same seat license.
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.products({ list: [pro, scale, devSeat], prefix: idPrefix }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: pro.id,
+				licenseProductId: devSeat.id,
+				included: 1,
+			}),
+			s.licenses.link({
+				parentProductId: scale.id,
+				licenseProductId: devSeat.id,
+				included: 2,
+			}),
+			// Only `pro` is attached. Attaching BOTH parents to one customer
+			// currently 500s with a license_entitlements FK violation — a
+			// pre-existing bug in the attach path, unrelated to migrations.
+			s.billing.attach({
+				productId: pro.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+		],
+	});
+
+	const response = await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		items: [itemsV2.monthlyMessages({ included: 1000 })],
+		disable_version: true,
+		update_license_parents: [
+			{ plan_id: pro.id, version: 1 },
+			{ plan_id: scale.id, version: 1 },
+		],
+		migration: { draft: true },
+	});
+
+	expect(response.migration?.id).toBeDefined();
+	const [migration] = await migrationRepo.get({
+		ctx,
+		id: response.migration.id,
+	});
+	const customerOps = migration?.operations?.customer ?? [];
+
+	// A single op, so any customer matched through it is patched exactly once.
+	// `scale` is absent: it has no customers, and a parent with nobody to
+	// migrate must not contribute a target.
+	expect(customerOps).toHaveLength(1);
+
+	const op = customerOps[0];
+	if (op?.type !== "update_plan") throw new Error("expected update_plan");
+	expect(planIdsOf(op.plan_filter)).toEqual([pro.id]);
+	expect(planIdsOf(op.plan_filter)).not.toContain(scale.id);
+
+	// One upsert entry for the license, not one per parent.
+	const upserts = op.customize?.upsert_licenses ?? [];
+	expect(upserts).toHaveLength(1);
+	expect(upserts[0]).toMatchObject({ license_plan_id: devSeat.id });
+	expect(upserts[0]?.customize?.add_items).toContainEqual(
+		expect.objectContaining({
+			feature_id: TestFeature.Messages,
+			included: 1000,
+		}),
+	);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/plan-save-after-migration.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/plan-save-after-migration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Editing a license plan after a batch migration has customized its link.
+ *
+ * The migration mints its own link and replaces that link's item set, moving the
+ * catalog entitlement's only license reference off the catalog link. The next
+ * plan save therefore deletes and re-creates that entitlement, while the link
+ * rebase still resolves the target item against the pre-save plan and re-inserts
+ * the id that was just dropped.
+ *
+ * Red: plans.update fails with license_entitlements_entitlement_fkey.
+ * Green: the save succeeds and the link resolves to the live entitlement.
+ */
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	entitlements,
+	licenseEntitlements,
+	planLicenses,
+	products,
+} from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import chalk from "chalk";
+import { eq, inArray } from "drizzle-orm";
+
+const NEW_MESSAGES = 123;
+const NEW_SEAT_PRICE = 20;
+const INCLUDED_SEATS = 1;
+const ATTACHED_SEATS = 3;
+const ASSIGNED_SEATS = 2;
+
+test(`${chalk.yellowBright("plans.update: saving a license plan after a migration keeps its links resolvable")}`, async () => {
+	const customerId = "plan-save-after-mig-customer";
+	const idPrefix = "plan-save-after-mig";
+
+	const scenario = await setupLicenseUpdateScenario({
+		customerId,
+		idPrefix,
+		seatPrice: 10,
+		seatItems: [items.dashboard()],
+		includedSeats: INCLUDED_SEATS,
+		attachedSeats: ATTACHED_SEATS,
+	});
+	await scenario.assignSeats({ count: ASSIGNED_SEATS });
+
+	const { ctx, autumnV2_2, autumnV2_3, parent, devSeat } = scenario;
+
+	const { result } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: `${idPrefix}-mig`,
+		filter: { customer: { plan: { plan_id: parent.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: parent.id, custom: false },
+					customize: {
+						upsert_licenses: [
+							{
+								license_plan_id: devSeat.id,
+								customize: {
+									add_items: [{ feature_id: TestFeature.Dashboard }],
+									remove_items: [{ feature_id: TestFeature.Dashboard }],
+								},
+							},
+						],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+	expect(result?.lane).toBe("batch");
+
+	await autumnV2_3.post("/plans.update", {
+		plan_id: devSeat.id,
+		price: { amount: NEW_SEAT_PRICE, interval: BillingInterval.Month },
+		items: [itemsV2.monthlyMessages({ included: NEW_MESSAGES })],
+		disable_version: true,
+		update_license_parents: [{ plan_id: parent.id, version: 1 }],
+	});
+
+	// Every link the seat plan is referenced by must resolve to a live row.
+	const [seatProduct] = await ctx.db
+		.select({ internalId: products.internal_id })
+		.from(products)
+		.where(eq(products.id, devSeat.id));
+
+	const links = await ctx.db
+		.select({ id: planLicenses.id })
+		.from(planLicenses)
+		.where(
+			eq(planLicenses.license_internal_product_id, seatProduct.internalId),
+		);
+	expect(links.length).toBeGreaterThan(0);
+
+	const junctionRows = await ctx.db
+		.select({ entitlementId: licenseEntitlements.entitlement_id })
+		.from(licenseEntitlements)
+		.where(
+			inArray(
+				licenseEntitlements.plan_license_id,
+				links.map((link) => link.id),
+			),
+		);
+
+	const referencedIds = junctionRows
+		.map((row) => row.entitlementId)
+		.filter((id): id is string => Boolean(id));
+	if (referencedIds.length === 0) return;
+
+	const alive = await ctx.db
+		.select({ id: entitlements.id })
+		.from(entitlements)
+		.where(inArray(entitlements.id, referencedIds));
+
+	expect(alive.length).toBe(referencedIds.length);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-item-ops-playground.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-item-ops-playground.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Seeds a license plan with live seat assignments and LEAVES IT IN THE DB for
+ * manual testing of the three batch verbs. Runs no migration and asserts
+ * nothing.
+ *
+ * Run:
+ *   cd server
+ *   ./run.sh <abs path to this file>
+ *
+ * What it builds, for customer `lic-ops-customer`:
+ *   - plan `pro_lic-ops`       parent, 1 included seat, 3 attached
+ *   - plan `dev-seat_lic-ops`  the license plan, granting:
+ *       messages  100/month   ← edit or delete this one
+ *       words     50/month    ← the control: must survive either way
+ *   - 2 seats assigned to entities, each holding both features
+ *
+ * One of the assignments has its messages balance spent down to 40, so an edit
+ * has to credit the delta rather than reset it.
+ */
+import { test } from "bun:test";
+import { customerEntitlements } from "@autumn/shared";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import chalk from "chalk";
+import { and, eq, inArray } from "drizzle-orm";
+
+const CUSTOMER_ID = "lic-ops-customer";
+const ID_PREFIX = "lic-ops";
+const SEAT_MESSAGES = 100;
+const SEAT_WORDS = 50;
+const CONSUMED_TO = 40;
+const INCLUDED_SEATS = 1;
+const ATTACHED_SEATS = 3;
+const ASSIGNED_SEATS = 2;
+
+const heading = (label: string) =>
+	console.log(
+		`\n${chalk.cyanBright(`── ${label} ${"─".repeat(Math.max(0, 58 - label.length))}`)}`,
+	);
+
+test(`${chalk.yellowBright("SEED: license item add/edit/delete playground")}`, async () => {
+	const scenario = await setupLicenseUpdateScenario({
+		customerId: CUSTOMER_ID,
+		idPrefix: ID_PREFIX,
+		seatItems: [
+			items.monthlyMessages({ includedUsage: SEAT_MESSAGES }),
+			items.monthlyWords({ includedUsage: SEAT_WORDS }),
+		],
+		includedSeats: INCLUDED_SEATS,
+		attachedSeats: ATTACHED_SEATS,
+	});
+	await scenario.assignSeats({ count: ASSIGNED_SEATS });
+
+	const { ctx, parent, devSeat } = scenario;
+	const { pools, assignments } = await getLicenseDbState({
+		db: ctx.db,
+		customerId: CUSTOMER_ID,
+	});
+	const live = assignments.filter(
+		(assignment) => assignment.internal_entity_id,
+	);
+
+	// Spend one assignment's messages down, so an edit must preserve
+	// consumption. Words is left alone as the control.
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ balance: CONSUMED_TO })
+		.where(
+			and(
+				eq(customerEntitlements.customer_product_id, live[0]?.id ?? ""),
+				eq(customerEntitlements.feature_id, TestFeature.Messages),
+			),
+		);
+
+	const rows = await ctx.db
+		.select({
+			customerProductId: customerEntitlements.customer_product_id,
+			featureId: customerEntitlements.feature_id,
+			balance: customerEntitlements.balance,
+		})
+		.from(customerEntitlements)
+		.where(
+			inArray(
+				customerEntitlements.customer_product_id,
+				live.map((assignment) => assignment.id),
+			),
+		);
+
+	heading("SEEDED");
+	console.log(`customer         ${CUSTOMER_ID}`);
+	console.log(`parent plan      ${parent.id}`);
+	console.log(`license plan     ${devSeat.id}   (edit THIS one)`);
+	console.log(
+		`pool granted     ${pools[0]?.granted} (${INCLUDED_SEATS} included)`,
+	);
+	console.log(`live assignments ${live.length}`);
+	for (const row of rows) {
+		console.log(
+			`   ${row.customerProductId}  ${row.featureId} = ${row.balance}`,
+		);
+	}
+
+	heading("MIGRATION OPS TO TRY");
+	const opFor = (customize: Record<string, unknown>) =>
+		JSON.stringify(
+			{
+				filter: { customer: { plan: { plan_id: parent.id, custom: false } } },
+				operations: {
+					customer: [
+						{
+							type: "update_plan",
+							plan_filter: { plan_id: parent.id, custom: false },
+							customize: {
+								upsert_licenses: [{ license_plan_id: devSeat.id, customize }],
+							},
+						},
+					],
+				},
+				no_billing_changes: true,
+			},
+			null,
+			2,
+		);
+
+	console.log(chalk.bold("\nADD — a feature the seat does not grant:"));
+	console.log(opFor({ add_items: [{ feature_id: TestFeature.Dashboard }] }));
+
+	console.log(
+		chalk.bold(`\nEDIT — ${TestFeature.Messages} ${SEAT_MESSAGES} -> 200:`),
+	);
+	console.log(
+		opFor({
+			add_items: [
+				{
+					feature_id: TestFeature.Messages,
+					included: 200,
+					reset: { interval: "month" },
+				},
+			],
+			remove_items: [
+				{
+					feature_id: TestFeature.Messages,
+					interval: "month",
+					interval_count: 1,
+				},
+			],
+		}),
+	);
+
+	console.log(chalk.bold(`\nDELETE — drop ${TestFeature.Messages}:`));
+	console.log(opFor({ remove_items: [{ feature_id: TestFeature.Messages }] }));
+
+	heading("EXPECTED AFTER EACH");
+	console.log("ADD      every assignment gains one dashboard row; lane batch");
+	console.log(
+		`EDIT     messages becomes 200 and ${CONSUMED_TO} -> 140 on the spent one;`,
+	);
+	console.log("         consumption preserved, not reset; lane batch");
+	console.log("DELETE   messages rows gone, words rows untouched; lane batch");
+	console.log("");
+	console.log(`words stays ${SEAT_WORDS} throughout — it is the control.`);
+
+	heading("RE-SEED");
+	console.log(
+		`./run.sh $(pwd)/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-item-ops-playground.test.ts`,
+	);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-parent-propagation-playground.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-parent-propagation-playground.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Seeds a license plan shared by THREE parent plans, each with live customers,
+ * and LEAVES IT IN THE DB for manual testing. Runs no update and asserts nothing.
+ *
+ * Run:
+ *   cd server
+ *   ./run.sh <abs path to this file>
+ *
+ * What it builds:
+ *   - plan `dev-seat_lic-prop`  the shared license plan, $20/mo + 500 messages
+ *   - `pro_lic-prop`     1 seat included, link NOT customized, 1 customer
+ *   - `scale_lic-prop`   2 seats included, link NOT customized, 1 customer
+ *   - `ent_lic-prop`     3 seats included, link CUSTOMIZED to 900 messages,
+ *                        1 customer with 2 seats assigned to entities
+ *
+ * The customized parent is the interesting one: its link overrides messages, so
+ * editing the child rebases that override rather than overwriting it. It
+ * therefore yields a DIFFERENT customize from the two plain parents — which is
+ * exactly what splits it into its own migration op while pro + scale collapse
+ * into one via $in.
+ */
+import { test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const ID_PREFIX = "lic-prop";
+const PRO_CUSTOMER_ID = `${ID_PREFIX}-pro-customer`;
+const SCALE_CUSTOMER_ID = `${ID_PREFIX}-scale-customer`;
+const ENT_CUSTOMER_ID = `${ID_PREFIX}-ent-customer`;
+const DIRECT_CUSTOMER_ID = `${ID_PREFIX}-direct-customer`;
+const SEAT_PRICE = 20;
+const SEAT_MESSAGES = 500;
+const ENT_SEAT_MESSAGES = 900;
+
+const heading = (label: string) =>
+	console.log(
+		`\n${chalk.cyanBright(`── ${label} ${"─".repeat(Math.max(0, 58 - label.length))}`)}`,
+	);
+
+test(`${chalk.yellowBright("SEED: license parent propagation playground (3 parents)")}`, async () => {
+	// Bare names — s.products stamps ID_PREFIX onto them.
+	const devSeat = products.base({
+		id: "dev-seat",
+		items: [
+			items.monthlyPrice({ price: SEAT_PRICE }),
+			items.monthlyMessages({ includedUsage: SEAT_MESSAGES }),
+		],
+		group: `${ID_PREFIX}-dev-seat-licenses`,
+	});
+	const pro = products.base({ id: "pro", items: [items.dashboard()] });
+	const scale = products.base({
+		id: "scale",
+		items: [items.monthlyWords({ includedUsage: 100 })],
+	});
+	const ent = products.base({
+		id: "ent",
+		items: [items.dashboard(), items.monthlyWords({ includedUsage: 500 })],
+	});
+
+	const { ctx } = await initScenario({
+		customerId: PRO_CUSTOMER_ID,
+		setup: [
+			s.customer({ paymentMethod: "success", testClock: false }),
+			s.otherCustomers([
+				{ id: SCALE_CUSTOMER_ID, paymentMethod: "success" },
+				{ id: ENT_CUSTOMER_ID, paymentMethod: "success" },
+				{ id: DIRECT_CUSTOMER_ID, paymentMethod: "success" },
+			]),
+			// Pinned so the seeded plan ids stay short and predictable in the
+			// dashboard; the default prefix is the customer id.
+			s.products({ list: [pro, scale, ent, devSeat], prefix: ID_PREFIX }),
+		],
+		actions: [
+			s.licenses.link({
+				parentProductId: pro.id,
+				licenseProductId: devSeat.id,
+				included: 1,
+			}),
+			s.licenses.link({
+				parentProductId: scale.id,
+				licenseProductId: devSeat.id,
+				included: 2,
+			}),
+			// Customized link: overrides the seat's message grant.
+			s.licenses.link({
+				parentProductId: ent.id,
+				licenseProductId: devSeat.id,
+				included: 3,
+				customize: {
+					remove_items: [{ feature_id: TestFeature.Messages }],
+					add_items: [itemsV2.monthlyMessages({ included: ENT_SEAT_MESSAGES })],
+				},
+			}),
+			s.billing.attach({
+				productId: pro.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 2 }],
+			}),
+			s.billing.attach({
+				customerId: SCALE_CUSTOMER_ID,
+				productId: scale.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 3 }],
+			}),
+			// Straight onto the license plan, so the child has its OWN customers
+			// and the update drafts a child migration as well as a parent one.
+			s.billing.attach({
+				customerId: DIRECT_CUSTOMER_ID,
+				productId: devSeat.id,
+			}),
+			s.billing.attach({
+				customerId: ENT_CUSTOMER_ID,
+				productId: ent.id,
+				licenseQuantities: [{ licenseProductId: devSeat.id, quantity: 4 }],
+			}),
+		],
+	});
+
+	// initScenario prefixes the ids in place, so these are the real ones.
+	heading("SEEDED");
+	console.log(`license plan   ${devSeat.id}   (edit THIS one)`);
+	console.log(`parent A       ${pro.id}   customer ${PRO_CUSTOMER_ID}`);
+	console.log(`parent B       ${scale.id}   customer ${SCALE_CUSTOMER_ID}`);
+	console.log(
+		`parent C       ${ent.id}   customer ${ENT_CUSTOMER_ID}   (CUSTOMIZED: ${ENT_SEAT_MESSAGES} messages)`,
+	);
+	console.log(
+		`direct cus     ${DIRECT_CUSTOMER_ID}   (on the license plan itself)`,
+	);
+	console.log(`org            ${ctx.org.id}`);
+
+	heading("WHAT TO DO");
+	console.log(`1. Open plan '${devSeat.id}' in the dashboard`);
+	console.log(
+		`2. Change included ${TestFeature.Messages} from ${SEAT_MESSAGES} to 1000`,
+	);
+	console.log("3. Save — the change dialog should open");
+
+	heading("EXPECTED IN THE DIALOG");
+	console.log("Parents step        lists all THREE parents, 1 customer each");
+	console.log(
+		`                    '${ent.id}' may flag a conflict (its link overrides messages)`,
+	);
+	console.log("Review step         parent cards badged 'Parent plan'");
+	console.log(
+		"Confirm button      reads 'Apply & migrate' (NOT 'Update version')",
+	);
+
+	heading("EXPECTED: TWO SEPARATE MIGRATIONS");
+	console.log("You should land on /migrations with TWO new rows:");
+	console.log("");
+	console.log(`  1. child   plan_id ${devSeat.id}`);
+	console.log(
+		`             moves ${DIRECT_CUSTOMER_ID} (add_items/remove_items)`,
+	);
+	console.log(`  2. parents plan_id $in [${pro.id}, ${scale.id}]`);
+	console.log("             moves their customers (upsert_licenses)");
+	console.log("");
+	console.log("Each runs and cancels on its own.");
+	console.log(
+		`'${ent.id}' is in NEITHER: its link overrides messages to ${ENT_SEAT_MESSAGES},`,
+	);
+	console.log(
+		"so the child's edit never reaches it and there is nothing to migrate.",
+	);
+
+	heading("MORE SCENARIOS TO TRY");
+	console.log(
+		"- Deselect a parent in the Parents step: it keeps the old terms",
+	);
+	console.log("- Select ONLY the customized parent: expect a single op");
+	console.log("- Add a free boolean item instead: expect no_billing_changes");
+	console.log("- Change the seat PRICE: expect billing changes on all parents");
+
+	heading("RE-READ STATE LATER");
+	console.log(
+		`./run.sh $(pwd)/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-parent-propagation-playground.test.ts`,
+	);
+	console.log("(re-running resets the playground to this clean state)");
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-two-migration-playground.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-two-migration-playground.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Seeds a license plan held BOTH ways and LEAVES IT IN THE DB for manual
+ * testing. Runs no migration and asserts nothing.
+ *
+ * Run:
+ *   cd server
+ *   ./run.sh <abs path to this file>
+ *
+ * Editing the license plan here must produce TWO migrations, because two
+ * distinct populations hold it:
+ *   - seat assignments under the parent, reached via upsert_licenses
+ *   - a customer holding the license plan directly, reached by plan id
+ *
+ * The seat-only playground produces one migration on purpose: a license-scoped
+ * op cannot reach a seat assignment, so drafting one would only ever report
+ * "no changes".
+ */
+import { test } from "bun:test";
+import { customerEntitlements } from "@autumn/shared";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import chalk from "chalk";
+import { and, eq, inArray } from "drizzle-orm";
+
+const ID_PREFIX = "two-mig";
+const SEAT_CUSTOMER_ID = `${ID_PREFIX}-seat-customer`;
+const DIRECT_CUSTOMER_ID = `${ID_PREFIX}-direct-customer`;
+const SEAT_MESSAGES = 100;
+const SEAT_WORDS = 50;
+const CONSUMED_TO = 40;
+
+const heading = (label: string) =>
+	console.log(
+		`\n${chalk.cyanBright(`── ${label} ${"─".repeat(Math.max(0, 58 - label.length))}`)}`,
+	);
+
+test(`${chalk.yellowBright("SEED: license held by seats AND directly (two migrations)")}`, async () => {
+	const scenario = await setupLicenseUpdateScenario({
+		customerId: SEAT_CUSTOMER_ID,
+		idPrefix: ID_PREFIX,
+		seatItems: [
+			items.monthlyMessages({ includedUsage: SEAT_MESSAGES }),
+			items.monthlyWords({ includedUsage: SEAT_WORDS }),
+		],
+		includedSeats: 1,
+		attachedSeats: 3,
+	});
+	await scenario.assignSeats({ count: 2 });
+
+	const { ctx, autumnV2_3, parent, devSeat } = scenario;
+
+	// The second population: a customer holding the license plan in its own
+	// right, which only a plan-scoped migration can reach.
+	await autumnV2_3.post("/customers", {
+		id: DIRECT_CUSTOMER_ID,
+		name: "Two Mig Direct",
+	});
+	await autumnV2_3.billing.attach({
+		customer_id: DIRECT_CUSTOMER_ID,
+		plan_id: devSeat.id,
+	});
+
+	const { assignments } = await getLicenseDbState({
+		db: ctx.db,
+		customerId: SEAT_CUSTOMER_ID,
+	});
+	const live = assignments.filter(
+		(assignment) => assignment.internal_entity_id,
+	);
+
+	// Spend one seat's messages down so an edit must credit the delta.
+	if (live[0]) {
+		await ctx.db
+			.update(customerEntitlements)
+			.set({ balance: CONSUMED_TO })
+			.where(
+				and(
+					eq(customerEntitlements.customer_product_id, live[0].id),
+					eq(customerEntitlements.feature_id, TestFeature.Messages),
+				),
+			);
+	}
+
+	const seatRows = await ctx.db
+		.select({
+			featureId: customerEntitlements.feature_id,
+			balance: customerEntitlements.balance,
+		})
+		.from(customerEntitlements)
+		.where(
+			inArray(
+				customerEntitlements.customer_product_id,
+				live.map((assignment) => assignment.id),
+			),
+		);
+
+	heading("SEEDED");
+	console.log(`license plan     ${devSeat.id}   (edit THIS one)`);
+	console.log(`parent plan      ${parent.id}`);
+	console.log("");
+	console.log(
+		`seat customer    ${SEAT_CUSTOMER_ID}   ${live.length} assignments`,
+	);
+	for (const row of seatRows) {
+		console.log(`   ${row.featureId} = ${row.balance}`);
+	}
+	console.log(
+		`direct customer  ${DIRECT_CUSTOMER_ID}   holds ${devSeat.id} itself`,
+	);
+
+	heading("WHAT TO DO");
+	console.log(`1. Open plan '${devSeat.id}' in the dashboard`);
+	console.log(
+		`2. Delete ${TestFeature.Messages} and change ${TestFeature.Words} to 30`,
+	);
+	console.log(`3. Save, tick '${parent.id}' in the Parents step, and migrate`);
+
+	heading("EXPECTED: TWO MIGRATIONS");
+	console.log(`1. plan_id ${devSeat.id}`);
+	console.log(`   moves ${DIRECT_CUSTOMER_ID} — its own item diff`);
+	console.log(`2. plan_id ${parent.id}`);
+	console.log("   moves the seat assignments — upsert_licenses");
+	console.log("");
+	console.log("Both should report lane batch. After running both:");
+	console.log(
+		`   ${TestFeature.Messages} gone from the seats AND the direct customer`,
+	);
+	console.log(`   ${TestFeature.Words} = 30, with the spent seat credited`);
+
+	heading("RE-SEED");
+	console.log(
+		"./run.sh $(pwd)/tests/integration/licenses/catalog-update/child-plan/propagate/seeds/seed-license-two-migration-playground.test.ts",
+	);
+});

--- a/server/tests/integration/licenses/catalog-update/child-plan/propagate/variant-license-link-rejected.test.ts
+++ b/server/tests/integration/licenses/catalog-update/child-plan/propagate/variant-license-link-rejected.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Variants and license links are not reconciled: a variant never inherits its
+ * base's links, a variant linked as a seat plan creates no pools so the seats it
+ * sells can never be assigned, and a variant parent leaves the seat plan
+ * un-editable. Until propagation handles them, linking either side is refused.
+ *
+ * Red: both links are accepted.
+ * Green: both are rejected at link time.
+ */
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+const INCLUDED_SEATS = 1;
+
+test(`${chalk.yellowBright("licenses: a variant cannot take part in a license link")}`, async () => {
+	const idPrefix = `variant-link-rejected-${Date.now().toString(36)}`;
+
+	const parent = products.base({
+		id: `${idPrefix}-pro`,
+		items: [items.dashboard()],
+	});
+	const devSeat = products.base({
+		id: `${idPrefix}-dev-seat`,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+		group: `${idPrefix}-dev-seat-licenses`,
+	});
+
+	const scenario = await initScenario({
+		customerId: `${idPrefix}-customer`,
+		setup: [s.customer(), s.products({ list: [parent, devSeat] })],
+		actions: [],
+	});
+
+	const { autumnV2_3 } = scenario;
+
+	const parentVariant = await autumnV2_3.post("/plans.create_variant", {
+		base_plan_id: parent.id,
+		variant_plan_id: `${idPrefix}-pro-annual`,
+		name: "Pro Annual",
+	});
+	const seatVariant = await autumnV2_3.post("/plans.create_variant", {
+		base_plan_id: devSeat.id,
+		variant_plan_id: `${idPrefix}-dev-seat-annual`,
+		name: "Dev Seat Annual",
+	});
+	expect(parentVariant).toBeDefined();
+	expect(seatVariant).toBeDefined();
+
+	// A variant as the seat plan mints no pools, so its seats can never be assigned.
+	const linkVariantSeat = autumnV2_3.post("/plans.update", {
+		plan_id: parent.id,
+		licenses: [
+			{
+				license_plan_id: `${idPrefix}-dev-seat-annual`,
+				included: INCLUDED_SEATS,
+			},
+		],
+	});
+	await expect(linkVariantSeat).rejects.toThrow(/variant/i);
+
+	// A variant parent leaves the seat plan un-editable.
+	const linkVariantParent = autumnV2_3.post("/plans.update", {
+		plan_id: `${idPrefix}-pro-annual`,
+		licenses: [{ license_plan_id: devSeat.id, included: INCLUDED_SEATS }],
+	});
+	await expect(linkVariantParent).rejects.toThrow(/variant/i);
+});

--- a/server/tests/setup/v2Features.ts
+++ b/server/tests/setup/v2Features.ts
@@ -34,8 +34,6 @@ export enum TestFeature {
 	AiCreditsTiered = "ai_credits_tiered", // AI credit system with global + provider markup tiers
 
 	Orbs = "orbs", // credit system that wraps an AI credit system (1000 orbs per $1)
-
-	PoolCredits = "pool_credits", // credit system fed by five metered features
 }
 
 export const getFeatures = ({ orgId }: { orgId: string }) => ({
@@ -105,20 +103,6 @@ export const getFeatures = ({ orgId }: { orgId: string }) => ({
 		env: AppEnv.Sandbox,
 		usageType: FeatureUsageType.Single,
 		eventNames: ["action-event"],
-	}),
-	[TestFeature.PoolCredits]: constructCreditSystem({
-		featureId: TestFeature.PoolCredits,
-		orgId,
-		env: AppEnv.Sandbox,
-		// Five sources at deliberately different rates, so a breakdown of what
-		// drew on the pool has enough slices to be worth drawing.
-		schema: [
-			{ metered_feature_id: TestFeature.Action1, credit_cost: 0.2 },
-			{ metered_feature_id: TestFeature.Action2, credit_cost: 0.6 },
-			{ metered_feature_id: TestFeature.Action3, credit_cost: 1.4 },
-			{ metered_feature_id: TestFeature.Words, credit_cost: 0.01 },
-			{ metered_feature_id: TestFeature.Messages, credit_cost: 2 },
-		],
 	}),
 	[TestFeature.Credits]: constructCreditSystem({
 		featureId: TestFeature.Credits,


### PR DESCRIPTION
**Stack 3/6** — base: #2785.

An `update_plan` op carrying `customize.upsert_licenses` was accepted by the schema but dropped before execution: the setup guard returned early when the only change was a license, so the customize never reached the products it matched.

A customized link now pins its catalog refs when the plan saves, so the rows a migration mints survive the rebase that follows. Variants are refused at link time — they never inherit their base's links, so a link either side of one sells seats that cannot be assigned.

Includes integration coverage for parent propagation: separate child and parent migrations, base price propagation, customized parents excluded from the draft, and seats excluded from the license plan's own versioning population.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Executes per-customer `update_plan` license customizes and preserves customized license links across plan saves; previously license-only edits were dropped by setup, now they apply and persist. Rejects variant links that would create unassignable seats.

- Runs `customize.upsert_licenses` in per-customer migrations; setup admits license-only edits and forwards `insertPlanLicenses` so customized links persist and pools resolve.
- Pins catalog item refs for customized links and resolves target items against the newly saved base plan first; migration-minted rows survive rebases and post-migration saves.
- Draft behavior: emits separate migrations for child vs. parents, collapses multiple parents into one `$in` op, keeps parent ops version-scoped in `all_versions`, excludes parents with no customers and parents that override the edited feature, and ensures a license plan’s draft does not target seats.
- Propagates seat base-price changes to parents without mid-cycle charges; still runs per-customer for Stripe-touching changes.
- Validation: rejects variants on either side of a license link.

**Migration/rollout notes**
- No API changes. Linking a variant as a license plan or as a parent now fails validation; remove or replace such links before attempting new links.

<sup>Written for commit 6d35ba72410ce7c910fd40f9be08679754b09987. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR enables per-customer migrations to apply license-only customizations and preserves customized license links when catalog plans are saved.

- **[Bug fixes]** Allows migrations containing only `upsert_licenses` changes to reach execution and passes the generated license rows through the billing context.
- **[Bug fixes]** Pins and re-resolves customized license item references during catalog rebases so migration-created rows remain valid.
- **[Improvements]** Rejects license links involving plan variants, which are unsupported by license propagation.
- **[Improvements]** Aligns parent-plan previews with the shared license propagation logic and adds broad integration coverage for migration drafting, pricing, versioning, and link validation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/licenses/actions/customize/rebaseCatalogPlanLicenses.ts | Preserves customized link references during catalog saves and resolves rebased items against the newly saved base plan. |
| server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts | Allows license-only update operations to proceed and carries generated license inserts into billing execution. |
| server/src/internal/licenses/actions/links/validateLicenseLink.ts | Rejects unsupported links when either the parent or license plan is a variant. |
| server/src/internal/product/actions/previewUpdatePlan/previewAffectedLicenseParents.ts | Reuses shared parent-customization logic so previews reflect the propagation path. |
| server/tests/setup/v2Features.ts | Removes the unused pooled-credit test fixture while retaining the features required by the new integration scenarios. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Draft as Migration Draft
    participant Runner as Per-customer Runner
    participant Setup as Update-plan Setup
    participant Billing as Billing Pipeline
    participant DB as License State
    Draft->>Runner: update_plan with upsert_licenses
    Runner->>Setup: Build customer product context
    Setup->>Setup: Admit license-only customization
    Setup->>Billing: Pass insertPlanLicenses
    Billing->>DB: Persist customized license links
    DB->>DB: Pin catalog references before rebase
    DB->>DB: Resolve references against saved base plan
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(licenses): cover parent propagation..."](https://github.com/useautumn/autumn/commit/6d35ba72410ce7c910fd40f9be08679754b09987) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52928353)</sub>

<!-- /greptile_comment -->