### PR TITLE
feat: 🎸 UTC usage windows

### DIFF
--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -145,7 +145,10 @@ export const prepareFeatureDeductionV2 = ({
 	// bounds with no provenance, not an unenforceable cap.
 	for (const windowLimit of usageWindowLimits) {
 		windowLimit.new_window_id = generateId("uw");
-		if (windowLimit.anchor_customer_entitlement_id === null) {
+		if (
+			windowLimit.anchor_mode === "billing_cycle" &&
+			windowLimit.anchor_customer_entitlement_id === null
+		) {
 			ctx.logger.warn(
 				`usage window for feature ${windowLimit.feature_id} has no anchor entitlement; using calendar-aligned bounds with no provenance.`,
 			);

--- a/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
+++ b/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
@@ -112,8 +112,12 @@ export const flushSubjectBalancesToDb = async ({
 	);
 
 	if (!error) {
+		const usageWindowRowCount = usageWindowUpdates.reduce(
+			(total, update) => total + update.usage_windows.length,
+			0,
+		);
 		logger.info(
-			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, ${usageWindowUpdates.length} usage windows, source: ${source}`,
+			`[flushSubjectBalancesToDb] ${customerId}: flushed ${entries.length} balances, ${usageWindowUpdates.length} usage window groups (${usageWindowRowCount} rows), source: ${source}`,
 		);
 		return;
 	}

--- a/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
+++ b/server/src/internal/customers/cache/fullSubject/actions/invalidate/invalidateSharedBalanceFields.ts
@@ -181,8 +181,12 @@ async function getDelFieldsFromManifest({
 	if (!parsed) return;
 	const { subjectBalances, usageWindowUpdates } = parsed;
 
+	const usageWindowRowCount = usageWindowUpdates.reduce(
+		(total, update) => total + update.usage_windows.length,
+		0,
+	);
 	logger.info(
-		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances, ${usageWindowUpdates.length} usage windows`,
+		`[invalidateSharedBalanceFields] ${customerId}: GETDEL ${balanceKeys.length} balance keys, flushing ${subjectBalances.length} balances, ${usageWindowUpdates.length} usage window groups (${usageWindowRowCount} rows)`,
 	);
 
 	await flushSubjectBalancesToDb({

--- a/server/tests/integration/balances/usage-windows/plan-changes/plan-change-anchor-utc.test.ts
+++ b/server/tests/integration/balances/usage-windows/plan-changes/plan-change-anchor-utc.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Usage-window bounds under `anchor: 'utc'`, the mirror of plan-change-anchor.
+ *
+ * Contract under test:
+ *   - a utc cap ignores an available billing cycle and uses calendar bounds,
+ *     with no anchor provenance stamped on the counter
+ *   - because those bounds can't move, a plan change does NOT refill the
+ *     counter (the billing_cycle equivalent zeroes it)
+ */
+
+import { expect, test } from "bun:test";
+import {
+	ApiVersion,
+	EntInterval,
+	getUsageWindowBounds,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import {
+	expectCustomerUsageLimit,
+	setCustomerUsageLimit,
+} from "../../utils/usage-limit-utils/customerUsageLimitUtils.js";
+import {
+	fetchActivePlanCusEnt,
+	fetchUsageWindowRows,
+} from "../../utils/usage-limit-utils/usageWindowDbTestUtils.js";
+
+const autumnV2_3 = new AutumnInt({ version: ApiVersion.V2_3 });
+
+// ── Contract: utc ignores the billing cycle, keeps calendar bounds ──
+test.concurrent(
+	`${chalk.yellowBright("uw-anchor-utc1: a utc cap uses calendar bounds despite an active plan cycle")}`,
+	async () => {
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyCredits({ includedUsage: 100 })],
+		});
+
+		const customerId = "uw-anchor-utc-1";
+		const { ctx, autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		await setCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.Credits,
+			limit: 5,
+			interval: ResetInterval.Day,
+			anchor: "utc",
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			value: 2,
+		});
+		await expectCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.Credits,
+			usage: 2,
+			limit: 5,
+		});
+
+		// Counters mirror to Postgres only on a flushing cache invalidation, never
+		// on track; re-setting the same cap is the cheapest way to trigger one.
+		await setCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.Credits,
+			limit: 5,
+			interval: ResetInterval.Day,
+			anchor: "utc",
+		});
+
+		await timeout(4000);
+		const planEnt = await fetchActivePlanCusEnt({
+			ctx,
+			customerId,
+			featureId: TestFeature.Credits,
+		});
+		expect(planEnt?.next_reset_at).toBeTruthy();
+
+		const windowRows = await fetchUsageWindowRows({
+			ctx,
+			customerId,
+			featureId: TestFeature.Credits,
+		});
+		expect(windowRows).toHaveLength(1);
+
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: Date.now(),
+		});
+		expect(Number(windowRows[0].window_start_at)).toBe(calendar.windowStartAt);
+		expect(Number(windowRows[0].window_end_at)).toBe(calendar.windowEndAt);
+		// utc resolves no anchor at all, so provenance is intentionally absent.
+		expect(windowRows[0].anchor_customer_entitlement_id).toBeNull();
+
+		// Sanity: the plan's cycle WAS usable and would have produced different
+		// bounds, so the assertions above cannot pass by the two modes coinciding.
+		const cycleAligned = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: Date.now(),
+			anchor: Number(planEnt.next_reset_at),
+		});
+		expect(cycleAligned.windowStartAt).not.toBe(calendar.windowStartAt);
+	},
+);
+
+// ── Contract: immovable bounds mean a plan change can't refill ──────
+test.concurrent(
+	`${chalk.yellowBright("uw-anchor-utc2: a plan change does not refill a utc-anchored counter")}`,
+	async () => {
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyCredits({ includedUsage: 100 })],
+		});
+
+		const customerId = "uw-anchor-utc-2";
+		const { ctx, autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.post("/balances.create", {
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			included_grant: 100,
+		});
+		await setCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.Credits,
+			limit: 5,
+			interval: ResetInterval.Day,
+			anchor: "utc",
+		});
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			value: 2,
+		});
+
+		// The attach re-seeds counters from Postgres, so the counter must be
+		// mirrored there first — which only a flushing cache invalidation does.
+		await setCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.Credits,
+			limit: 5,
+			interval: ResetInterval.Day,
+			anchor: "utc",
+		});
+		await timeout(4000);
+
+		// The billing_cycle equivalent (uw-plan-change-anchor2) re-keys here and
+		// zeroes the counter; utc bounds don't move, so the 2 must survive.
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		await expectCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.Credits,
+			usage: 2,
+			limit: 5,
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Credits,
+			value: 3,
+		});
+		await expectCustomerUsageLimit({
+			autumn: autumnV2_3,
+			customerId,
+			featureId: TestFeature.Credits,
+			usage: 5,
+			limit: 5,
+		});
+
+		await timeout(4000);
+		const windowRows = await fetchUsageWindowRows({
+			ctx,
+			customerId,
+			featureId: TestFeature.Credits,
+		});
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: Date.now(),
+		});
+		// One row, still on the calendar window: the attach neither re-keyed nor
+		// opened a second counter.
+		expect(windowRows).toHaveLength(1);
+		expect(Number(windowRows[0].window_start_at)).toBe(calendar.windowStartAt);
+		expect(windowRows[0].anchor_customer_entitlement_id).toBeNull();
+	},
+);

--- a/server/tests/integration/balances/utils/usage-limit-utils/customerUsageLimitUtils.ts
+++ b/server/tests/integration/balances/utils/usage-limit-utils/customerUsageLimitUtils.ts
@@ -19,12 +19,14 @@ export const setCustomerUsageLimit = async ({
 	featureId,
 	limit,
 	interval = ResetInterval.Month,
+	anchor,
 }: {
 	autumn: AutumnInt;
 	customerId: string;
 	featureId: string;
 	limit: number;
 	interval?: DbUsageLimit["interval"];
+	anchor?: DbUsageLimit["anchor"];
 }) => {
 	const billingControls: CustomerBillingControls = {
 		usage_limits: [
@@ -33,12 +35,13 @@ export const setCustomerUsageLimit = async ({
 				enabled: true,
 				limit,
 				interval,
+				...(anchor && { anchor }),
 			},
 		],
 	};
 
 	await timeout(2000);
-	await autumn.customers.update(customerId, {
+	await autumn.customers.updateRpc(customerId, {
 		billing_controls: billingControls,
 	});
 	await timeout(3000);

--- a/server/tests/integration/balances/utils/usage-limit-utils/usageWindowDbTestUtils.ts
+++ b/server/tests/integration/balances/utils/usage-limit-utils/usageWindowDbTestUtils.ts
@@ -1,6 +1,6 @@
 import { expect } from "bun:test";
-import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { pollUntilAsserted } from "@tests/utils/genUtils.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
 import { sql } from "drizzle-orm";
 
 // biome-ignore lint/suspicious/noExplicitAny: raw SQL rows are untyped

--- a/server/tests/unit/billing/pick-stricter-usage-limit.test.ts
+++ b/server/tests/unit/billing/pick-stricter-usage-limit.test.ts
@@ -16,11 +16,13 @@ const limit = (
 	value: number,
 	interval: DbUsageLimit["interval"] = ResetInterval.Month,
 	enabled = true,
+	anchor: DbUsageLimit["anchor"] = "billing_cycle",
 ): DbUsageLimit => ({
 	feature_id: "messages",
 	enabled,
 	limit: value,
 	interval,
+	anchor,
 });
 
 describe("pickStricterUsageLimit", () => {
@@ -63,5 +65,50 @@ describe("pickStricterUsageLimit", () => {
 		const perWeek = limit(70, ResetInterval.Week);
 		const perYear = limit(100, ResetInterval.Year);
 		expect(pickStricterUsageLimit(perWeek, perYear)).toBe(perYear);
+	});
+
+	test("equal rate: utc wins over billing_cycle (order-independent)", () => {
+		const utc = limit(200, ResetInterval.Day, true, "utc");
+		const cycle = limit(200, ResetInterval.Day, true, "billing_cycle");
+		expect(pickStricterUsageLimit(utc, cycle)).toBe(utc);
+		expect(pickStricterUsageLimit(cycle, utc)).toBe(utc);
+	});
+
+	test("equal rate across DIFFERENT intervals: utc still wins", () => {
+		// 100/day and 700/week are both 100/day, so the rate comparison ties and
+		// the anchor tiebreak decides.
+		const utcWeekly = limit(700, ResetInterval.Week, true, "utc");
+		const cycleDaily = limit(100, ResetInterval.Day, true, "billing_cycle");
+		expect(pickStricterUsageLimit(utcWeekly, cycleDaily)).toBe(utcWeekly);
+		expect(pickStricterUsageLimit(cycleDaily, utcWeekly)).toBe(utcWeekly);
+	});
+
+	test("a stricter rate beats a utc anchor", () => {
+		// The anchor is only a tiebreak: it must never override a lower rate.
+		const utcLoose = limit(1000, ResetInterval.Day, true, "utc");
+		const cycleTight = limit(5, ResetInterval.Day, true, "billing_cycle");
+		expect(pickStricterUsageLimit(utcLoose, cycleTight)).toBe(cycleTight);
+		expect(pickStricterUsageLimit(cycleTight, utcLoose)).toBe(cycleTight);
+	});
+
+	test("disabled still loses to a utc anchor", () => {
+		const utcDisabled = limit(5, ResetInterval.Day, false, "utc");
+		const cycleEnabled = limit(1000, ResetInterval.Day, true, "billing_cycle");
+		expect(pickStricterUsageLimit(utcDisabled, cycleEnabled)).toBe(
+			cycleEnabled,
+		);
+		expect(pickStricterUsageLimit(cycleEnabled, utcDisabled)).toBe(
+			cycleEnabled,
+		);
+	});
+
+	test("legacy rows without an anchor read as billing_cycle", () => {
+		// Stored rows are jsonb cast with drizzle's $type; nothing parses them on
+		// read, so pre-field rows arrive with `anchor` absent.
+		const legacy = { ...limit(200, ResetInterval.Day) } as DbUsageLimit;
+		delete (legacy as Partial<DbUsageLimit>).anchor;
+		const utc = limit(200, ResetInterval.Day, true, "utc");
+		expect(pickStricterUsageLimit(legacy, utc)).toBe(utc);
+		expect(pickStricterUsageLimit(utc, legacy)).toBe(utc);
 	});
 });

--- a/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
+++ b/server/tests/unit/usage-windows/fullSubjectToUsageWindowLimits.test.ts
@@ -511,6 +511,119 @@ describe("fullSubjectToUsageWindowLimits", () => {
 		expect(limits[0].anchor_customer_entitlement_id).toBeNull();
 	});
 
+	test("anchor 'utc' uses calendar bounds even when a billing cycle exists", () => {
+		const cycleAnchor = Date.UTC(2026, 0, 9, 15, 30, 0);
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				usageLimits: [
+					{
+						feature_id: "credits",
+						limit: 3,
+						interval: ResetInterval.Day,
+						anchor: "utc",
+					},
+				],
+				customerProducts: [
+					customerProductWithEntitlement({
+						id: "ce_credits",
+						featureId: "credits",
+						cycleAnchor,
+					}),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+		});
+		const anchored = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+			anchor: cycleAnchor,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			anchor_mode: "utc",
+			window_start_at: calendar.windowStartAt,
+			window_end_at: calendar.windowEndAt,
+		});
+		// Sanity: a usable anchor WAS present and would have moved the bounds, so
+		// the assertion above cannot pass vacuously.
+		expect(anchored.windowStartAt).not.toBe(calendar.windowStartAt);
+	});
+
+	test("anchor 'utc' drops provenance even when an anchor ent exists", () => {
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				usageLimits: [
+					{
+						feature_id: "credits",
+						limit: 3,
+						interval: ResetInterval.Day,
+						anchor: "utc",
+					},
+				],
+				looseEntitlements: [
+					looseEntitlement({ id: "ce_credits", featureId: "credits" }),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		// Same fixture anchors to ce_credits under billing_cycle; utc must not.
+		expect(limits).toHaveLength(1);
+		expect(limits[0].anchor_customer_entitlement_id).toBeNull();
+		expect(limits[0].anchor_mode).toBe("utc");
+	});
+
+	test("an entry with no anchor field falls back to billing-cycle alignment", () => {
+		// Stored entries are jsonb cast with drizzle's $type and never parsed on
+		// read, so pre-field rows arrive with `anchor` absent.
+		const cycleAnchor = Date.UTC(2026, 0, 9, 15, 30, 0);
+		const limits = fullSubjectToUsageWindowLimits({
+			fullSubject: buildSubject({
+				usageLimits: [
+					{ feature_id: "credits", limit: 3, interval: ResetInterval.Day },
+				],
+				customerProducts: [
+					customerProductWithEntitlement({
+						id: "ce_credits",
+						featureId: "credits",
+						cycleAnchor,
+					}),
+				],
+			}),
+			featureIds: ["credits"],
+			features: [creditsFeature],
+			now: NOW,
+		});
+
+		const calendar = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+		});
+		const anchored = getUsageWindowBounds({
+			interval: EntInterval.Day,
+			now: NOW,
+			anchor: cycleAnchor,
+		});
+
+		expect(limits).toHaveLength(1);
+		expect(limits[0]).toMatchObject({
+			anchor_mode: "billing_cycle",
+			window_start_at: anchored.windowStartAt,
+			window_end_at: anchored.windowEndAt,
+		});
+		expect(anchored.windowStartAt).not.toBe(calendar.windowStartAt);
+	});
+
 	test("metered cap contained by two credit systems anchors deterministically", () => {
 		const limits = fullSubjectToUsageWindowLimits({
 			fullSubject: buildSubject({

--- a/shared/models/cusModels/billingControls/usageLimit.ts
+++ b/shared/models/cusModels/billingControls/usageLimit.ts
@@ -15,6 +15,10 @@ export const USAGE_LIMIT_INTERVALS = [
 	ResetInterval.Year,
 ] as const;
 
+export const USAGE_LIMIT_ANCHORS = ["billing_cycle", "utc"] as const;
+export const UsageLimitAnchorSchema = z.enum(USAGE_LIMIT_ANCHORS);
+export type UsageLimitAnchor = z.infer<typeof UsageLimitAnchorSchema>;
+
 export const USAGE_LIMIT_FILTER_MAX_KEYS = 4;
 export const USAGE_LIMIT_FILTER_MAX_KEY_LENGTH = 64;
 export const USAGE_LIMIT_FILTER_MAX_VALUE_LENGTH = 128;
@@ -68,6 +72,10 @@ export const DbUsageLimitSchema = z.object({
 	interval: z.enum(USAGE_LIMIT_INTERVALS).meta({
 		description:
 			"Interval for the cap, aligned to the customer's billing cycle.",
+	}),
+	anchor: UsageLimitAnchorSchema.optional().meta({
+		description:
+			"Window alignment. 'billing_cycle' phases the interval to the customer's renewal time; 'utc' aligns to the UTC calendar.",
 	}),
 	filter: UsageLimitFilterSchema.optional().meta({
 		description:
@@ -129,6 +137,7 @@ const usageLimitPerDay = (usageLimit: DbUsageLimit) =>
 
 // Enabled beats disabled. Same interval: lower limit wins. Different intervals:
 // lower per-day rate wins (the resolver enforces a single window per feature).
+// Equal rates: utc beats billing_cycle, whose bounds a plan change can refill.
 export const pickStricterUsageLimit = (
 	left: DbUsageLimit,
 	right: DbUsageLimit,
@@ -137,8 +146,21 @@ export const pickStricterUsageLimit = (
 	const leftEnabled = left.enabled ?? true;
 	const rightEnabled = right.enabled ?? true;
 	if (leftEnabled !== rightEnabled) return leftEnabled ? left : right;
+
 	if (left.interval === right.interval) {
-		return right.limit < left.limit ? right : left;
+		if (left.limit !== right.limit) {
+			return right.limit < left.limit ? right : left;
+		}
+	} else {
+		const leftPerDay = usageLimitPerDay(left);
+		const rightPerDay = usageLimitPerDay(right);
+		if (leftPerDay !== rightPerDay) {
+			return rightPerDay < leftPerDay ? right : left;
+		}
 	}
-	return usageLimitPerDay(right) < usageLimitPerDay(left) ? right : left;
+
+	const leftAnchor = left.anchor ?? "billing_cycle";
+	const rightAnchor = right.anchor ?? "billing_cycle";
+	if (leftAnchor !== rightAnchor) return leftAnchor === "utc" ? left : right;
+	return left;
 };

--- a/shared/models/cusProductModels/cusEntModels/usageWindowModels.ts
+++ b/shared/models/cusProductModels/cusEntModels/usageWindowModels.ts
@@ -1,4 +1,5 @@
 import { z } from "zod/v4";
+import { UsageLimitAnchorSchema } from "../../cusModels/billingControls/usageLimit.js";
 import { EntInterval } from "../../productModels/intervals/entitlementInterval.js";
 
 /**
@@ -50,6 +51,7 @@ export const UsageWindowLimitSchema = z.object({
 	// creation; storage no longer depends on it, so null just means calendar
 	// bounds with no provenance.
 	anchor_customer_entitlement_id: z.string().nullable(),
+	anchor_mode: UsageLimitAnchorSchema.default("billing_cycle"),
 	// Candidate row id (ksuid) minted server-side per request. Lua uses it ONLY
 	// when this request creates the counter row; lookups match the logical key
 	// (window_start_at + entity), never the id.

--- a/shared/utils/usageWindowUtils/convertUsageWindow/usageLimitToUsageWindowLimit.ts
+++ b/shared/utils/usageWindowUtils/convertUsageWindow/usageLimitToUsageWindowLimit.ts
@@ -1,10 +1,10 @@
 import type { DbUsageLimit } from "../../../models/cusModels/billingControls/usageLimit.js";
+import { usageLimitFilterKey } from "../../../models/cusModels/billingControls/usageLimit.js";
 import type { FullSubject } from "../../../models/cusModels/fullSubject/fullSubjectModel.js";
 import type { UsageWindowLimit } from "../../../models/cusProductModels/cusEntModels/usageWindowModels.js";
 import type { CusProductStatus } from "../../../models/cusProductModels/cusProductEnums.js";
 import type { Feature } from "../../../models/featureModels/featureModels.js";
 import { resetIntvToEntIntv } from "../../productV2Utils/productItemUtils/convertProductItem/planItemIntervals.js";
-import { usageLimitFilterKey } from "../../../models/cusModels/billingControls/usageLimit.js";
 import { buildUsageWindowKey } from "../buildUsageWindowKey.js";
 import { findUsageWindowAnchor } from "../findUsageWindowAnchor/findUsageWindowAnchor.js";
 import { getUsageWindowAnchorTimestamp } from "../getUsageWindowAnchorTimestamp.js";
@@ -21,8 +21,9 @@ export type UsageWindowEntityScope = {
  * Resolves one stored usage-limit entry into the enforceable UsageWindowLimit
  * handed to the deduction script. The entry's ResetInterval converts to the
  * internal EntInterval here -- the single edge between the API/storage
- * vocabulary and the window internals. Window bounds align to the customer's
- * billing cycle via the anchor entitlement when one exists, else UTC calendar.
+ * vocabulary and the window internals. Under `anchor: 'billing_cycle'` bounds
+ * align to the anchor entitlement's cycle when one exists, else UTC calendar;
+ * `anchor: 'utc'` skips the lookup and always uses the UTC calendar.
  */
 export const usageLimitToUsageWindowLimit = ({
 	fullSubject,
@@ -53,15 +54,21 @@ export const usageLimitToUsageWindowLimit = ({
 	});
 
 	const scopeType = entityScope ? "entity" : "customer";
+	const anchorMode = usageLimit.anchor ?? "billing_cycle";
 	const { anchorCustomerEntitlementId, anchorCustomerEntitlement } =
-		findUsageWindowAnchor({
-			fullSubject,
-			featureId: feature.id,
-			features,
-			isCreditSystem: dimensionType === "balance",
-			inStatuses,
-			scopeType,
-		});
+		anchorMode === "utc"
+			? {
+					anchorCustomerEntitlementId: null,
+					anchorCustomerEntitlement: undefined,
+				}
+			: findUsageWindowAnchor({
+					fullSubject,
+					featureId: feature.id,
+					features,
+					isCreditSystem: dimensionType === "balance",
+					inStatuses,
+					scopeType,
+				});
 
 	const { windowStartAt, windowEndAt } = getUsageWindowBounds({
 		interval,
@@ -96,5 +103,6 @@ export const usageLimitToUsageWindowLimit = ({
 		window_end_at: windowEndAt,
 		limit: usageLimit.limit,
 		anchor_customer_entitlement_id: anchorCustomerEntitlementId,
+		anchor_mode: anchorMode,
 	};
 };

--- a/vite/src/components/billing-controls/UsageAnchorTooltip.tsx
+++ b/vite/src/components/billing-controls/UsageAnchorTooltip.tsx
@@ -1,0 +1,16 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@autumn/ui";
+import { QuestionIcon } from "@phosphor-icons/react";
+
+export function UsageAnchorTooltip() {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<QuestionIcon className="size-3.5 cursor-help text-tertiary-foreground" />
+			</TooltipTrigger>
+			<TooltipContent className="max-w-64">
+				By default the window follows the customer's billing cycle, so a daily
+				cap resets at their renewal time. Anchor to UTC to reset at midnight UTC.
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx
@@ -22,6 +22,7 @@ import {
 } from "@autumn/ui";
 import { useState } from "react";
 import { toast } from "sonner";
+import { UsageAnchorTooltip } from "@/components/billing-controls/UsageAnchorTooltip";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import {
 	LayoutGroup,
@@ -56,18 +57,21 @@ export const buildUsageLimitItem = ({
 	enabled,
 	limit,
 	interval,
+	anchorUtc,
 	filter,
 }: {
 	featureId: string;
 	enabled: boolean;
 	limit: number;
 	interval: string;
+	anchorUtc?: boolean;
 	filter?: DbUsageLimit["filter"];
 }): DbUsageLimit => ({
 	feature_id: featureId,
 	enabled,
 	limit,
 	interval: interval as ResetInterval,
+	anchor: anchorUtc ? "utc" : "billing_cycle",
 	...(filter && { filter }),
 });
 
@@ -158,6 +162,7 @@ export function BillingUsageLimitSheet() {
 	const [selectedInterval, setSelectedInterval] = useState<string>(
 		existingItem?.interval ?? ResetInterval.Month,
 	);
+	const [anchorUtc, setAnchorUtc] = useState(existingItem?.anchor === "utc");
 	const [conditions, setConditions] = useState<UsageLimitCondition[]>(
 		conditionsFromFilter(existingItem?.filter),
 	);
@@ -217,6 +222,7 @@ export function BillingUsageLimitSheet() {
 			enabled,
 			limit: parsedLimit,
 			interval: selectedInterval,
+			anchorUtc,
 			filter,
 		});
 
@@ -333,6 +339,14 @@ export function BillingUsageLimitSheet() {
 									))}
 								</SelectContent>
 							</Select>
+						</div>
+
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-1.5">
+								<FormLabel className="mb-0">Anchor to UTC time</FormLabel>
+								<UsageAnchorTooltip />
+							</div>
+							<Switch checked={anchorUtc} onCheckedChange={setAnchorUtc} />
 						</div>
 
 						<div>

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanBillingControlsSection.tsx
@@ -32,6 +32,7 @@ import {
 	hasBillingControls,
 } from "@/components/billing-controls/BillingControlsDisplay";
 import { OVERAGE_BILLING_OPTIONS } from "@/components/billing-controls/overageBillingOptions";
+import { UsageAnchorTooltip } from "@/components/billing-controls/UsageAnchorTooltip";
 import { FieldInfo } from "@/components/general/form/field-info";
 import { FeatureSearchDropdown } from "@/components/v2/dropdowns/FeatureSearchDropdown";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
@@ -400,21 +401,37 @@ function SpendLimitFields({ form }: { form: UsePlanBillingControlForm }) {
 
 function UsageLimitFields({ form }: { form: UsePlanBillingControlForm }) {
 	return (
-		<div className="grid grid-cols-2 gap-2.5">
-			<NumberFieldRow
-				form={form}
-				name="usage_limit"
-				label="Limit"
-				placeholder="eg. 1000"
-				parse="float"
-			/>
-			<SelectFieldRow
-				form={form}
-				name="usage_interval"
-				label="Interval"
-				placeholder="Interval"
-				options={USAGE_INTERVAL_OPTIONS}
-			/>
+		<div className="flex flex-col gap-2.5">
+			<div className="grid grid-cols-2 gap-2.5">
+				<NumberFieldRow
+					form={form}
+					name="usage_limit"
+					label="Limit"
+					placeholder="eg. 1000"
+					parse="float"
+				/>
+				<SelectFieldRow
+					form={form}
+					name="usage_interval"
+					label="Interval"
+					placeholder="Interval"
+					options={USAGE_INTERVAL_OPTIONS}
+				/>
+			</div>
+			<form.Field name="usage_anchor_utc">
+				{(field) => (
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-1.5">
+							<FormLabel className="mb-0">Anchor to UTC time</FormLabel>
+							<UsageAnchorTooltip />
+						</div>
+						<Switch
+							checked={field.state.value}
+							onCheckedChange={field.handleChange}
+						/>
+					</div>
+				)}
+			</form.Field>
 		</div>
 	);
 }

--- a/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
+++ b/vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts
@@ -40,6 +40,7 @@ export type PlanBillingControlFormValues = {
 	overage_billing: OverageBillingOption;
 	usage_limit: number | null;
 	usage_interval: ResetInterval;
+	usage_anchor_utc: boolean;
 	alert_name: string;
 	alert_threshold: number | null;
 	threshold_type: DbUsageAlert["threshold_type"];
@@ -176,6 +177,7 @@ export function buildControlItem(
 			enabled: values.enabled,
 			limit: values.usage_limit ?? 0,
 			interval: values.usage_interval,
+			anchor: values.usage_anchor_utc ? "utc" : "billing_cycle",
 		} satisfies DbUsageLimit;
 	}
 
@@ -240,6 +242,7 @@ function toDefaultValues(
 		),
 		usage_limit: usageLimit?.limit ?? null,
 		usage_interval: usageLimit?.interval ?? ResetInterval.Month,
+		usage_anchor_utc: usageLimit?.anchor === "utc",
 		alert_name: usageAlert?.name ?? "",
 		alert_threshold: usageAlert?.threshold ?? null,
 		threshold_type: usageAlert?.threshold_type ?? "usage",


### PR DESCRIPTION
- **test: 💍 red tests for UTC usage limits**
- **refactor: 💡 make logs clearer for invalidateSharedBalanceFields**
- **feat: 🎸 UTC usage windows**
- **feat: 🎸 UI for UTC usage windows**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UTC anchoring mode for usage limits so windows can reset on the UTC calendar. Previously all caps aligned to the customer’s billing cycle; with `anchor: 'utc'` they use calendar bounds, drop anchor provenance, and do not refill on plan change.

- Schema/model: adds `anchor?: 'billing_cycle' | 'utc'` to `DbUsageLimit` (defaults to `'billing_cycle'` for legacy rows) and `anchor_mode` to `UsageWindowLimit`.
- Window resolution: `'utc'` skips entitlement lookup and uses calendar bounds; `'billing_cycle'` retains cycle alignment and only warns if the anchor is missing in that mode.
- Enforcement: `pickStricterUsageLimit` now breaks ties by anchor and prefers `'utc'` when rates are equal; stricter rates still win.
- UI: adds an “Anchor to UTC time” toggle with help tooltip in the customer usage limit sheet and plan editor; form values write `anchor`.
- Observability: logs in balance flush/invalidate now report window groups and row counts.

Migration/rollout
- No data migration required; limits without `anchor` behave as `'billing_cycle'`.
- Review any customers with duplicate equal-rate caps: selection may change due to the new tie-breaker preferring `'utc'`.

<sup>Written for commit 22cb664920f44c3384b72155bc165b46e2523656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds configurable UTC-aligned usage windows while retaining billing-cycle alignment as the default.
- **API changes, Improvements:** Adds an optional `anchor` setting to usage-limit models and propagates the selected mode into enforceable usage windows.
- **Improvements:** Adds dashboard controls and explanatory tooltips for selecting UTC alignment on customer and plan usage limits.
- **Bug fixes, Improvements:** Restricts missing-anchor warnings to billing-cycle windows and clarifies usage-window flush logging.
- **Improvements:** Adds unit and integration coverage for UTC bounds, plan changes, legacy limits, and stricter-limit selection.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The new anchor mode is preserved through billing-control schemas and forms, defaults legacy limits to billing-cycle behavior, and reaches deduction and reconciliation using calendar bounds without introducing a conflicting counter identity.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/models/cusModels/billingControls/usageLimit.ts | Adds the public anchor model and deterministic UTC preference when otherwise-equivalent limits are resolved. |
| shared/utils/usageWindowUtils/convertUsageWindow/usageLimitToUsageWindowLimit.ts | Converts UTC limits to calendar bounds without billing-entitlement provenance while preserving legacy billing-cycle defaults. |
| server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts | Avoids emitting the missing billing-cycle anchor warning for intentionally unanchored UTC windows. |
| vite/src/views/customers2/components/sheets/BillingUsageLimitSheet.tsx | Adds customer-level UTC anchor state, serialization, and a switch to the usage-limit editor. |
| vite/src/views/products/plan/components/edit-plan-details/usePlanBillingControlForm.ts | Round-trips the UTC anchor option through plan billing-control form defaults and submission. |
| server/tests/integration/balances/usage-windows/plan-changes/plan-change-anchor-utc.test.ts | Verifies UTC calendar bounds and retention of usage across plan changes. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  UI[Customer or plan usage-limit form] --> API[Billing controls API]
  API --> Model[Usage limit with anchor mode]
  Model --> Resolve[Resolve strictest applicable limit]
  Resolve --> Convert[Build usage-window bounds]
  Convert -->|billing_cycle| Cycle[Billing-cycle-aligned window]
  Convert -->|utc| UTC[UTC calendar-aligned window]
  Cycle --> Deduct[Usage deduction and persistence]
  UTC --> Deduct
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 UI for UTC usage windows"](https://github.com/useautumn/autumn/commit/22cb664920f44c3384b72155bc165b46e2523656) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52943949)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->