### PR TITLE
fix(dw): install dependencies before loading CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
 		"tw:kill": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/tw/index.ts kill",
 		"tw:kill-all": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/tw/index.ts kill-all",
 		"tw:spike": "bun scripts/tw/spike.ts",
-		"dw": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts",
+		"dw": "bun install && ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts",
 		"dw:teardown": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts teardown",
 		"dw:list": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts list",
 		"dw:cleanup": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts cleanup",


### PR DESCRIPTION
Prefix the default `bun dw` package script with `bun install` so a dependency-free worktree installs its workspace packages before Bun evaluates the TypeScript CLI import graph.

This keeps the existing in-command install as a safety check while fixing fresh-worktree startup at the package-script boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs workspace dependencies before running the `dw` CLI to fix fresh-worktree failures. Old: `bun dw` evaluated the TypeScript CLI before dependencies existed and could error. New: the `dw` script prefixes `bun install`, then runs the CLI through `infisical`; the existing in-command install remains as a fast, idempotent safety check.

<sup>Written for commit edf5431bd19f2502385cedde5945ec8a20711437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes startup of the default development-worktree command when dependencies have not yet been installed.
- **[Bug fixes]** Prefixes `bun dw` with `bun install` so workspace dependencies exist before Bun loads the TypeScript CLI import graph.
- **[Improvements]** Retains the CLI's existing internal installation check as an additional safeguard.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed script.

The dependency installation now runs before Bun evaluates the development-worktree CLI imports, directly addressing fresh-worktree startup without changing the CLI invocation that follows.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Updates the default `dw` package script to install dependencies before launching the existing Infisical-wrapped CLI. |

<sub>Reviews (1): Last reviewed commit: ["fix(dw): install dependencies before loa..."](https://github.com/useautumn/autumn/commit/edf5431bd19f2502385cedde5945ec8a20711437) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52957485)</sub>

<!-- /greptile_comment -->