### PR TITLE
fix: allow atmn reward scopes during OAuth login

### DIFF
--- a/server/src/internal/auth/oauth/atmnOAuthClients.ts
+++ b/server/src/internal/auth/oauth/atmnOAuthClients.ts
@@ -3,9 +3,9 @@ import { oauthClientRepo } from "../repos/index.js";
 
 const ATMN_OAUTH_CLIENT_NAMES = new Set(["atmn", "autumn cli"]);
 
-// Fixed scope set the pinned legacy atmn CLI requests. Self-heal is limited to
-// these so an unauthenticated /authorize can never widen the reserved client.
-const ATMN_LEGACY_OAUTH_SCOPES = new Set<string>([
+// Fixed scope set for first-party atmn CLI releases. Self-heal is limited so
+// unauthenticated /authorize requests cannot widen the reserved client.
+const ATMN_OAUTH_SCOPES = new Set<string>([
 	"organisation:read",
 	"customers:create",
 	"customers:read",
@@ -24,6 +24,8 @@ const ATMN_LEGACY_OAUTH_SCOPES = new Set<string>([
 	"plans:delete",
 	"apiKeys:create",
 	"apiKeys:read",
+	"rewards:read",
+	"rewards:write",
 ]);
 
 const configuredAtmnClientIds = () =>
@@ -116,9 +118,7 @@ export const ensureAtmnAuthorizeScopes = async ({
 }) => {
 	if (!scope) return;
 
-	const requested = scope
-		.split(/\s+/)
-		.filter((s) => ATMN_LEGACY_OAUTH_SCOPES.has(s));
+	const requested = scope.split(/\s+/).filter((s) => ATMN_OAUTH_SCOPES.has(s));
 	if (requested.length === 0) return;
 
 	const client = await oauthClientRepo.getByClientId({ db, clientId });

--- a/server/tests/unit/auth/atmnOAuthClients.test.ts
+++ b/server/tests/unit/auth/atmnOAuthClients.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from "bun:test";
-import { isAtmnOAuthClientRecord } from "@/internal/auth/oauth/atmnOAuthClients.js";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	ensureAtmnAuthorizeScopes,
+	isAtmnOAuthClientRecord,
+} from "@/internal/auth/oauth/atmnOAuthClients.js";
+import { oauthClientRepo } from "@/internal/auth/repos/index.js";
+
+afterEach(() => {
+	mock.restore();
+});
 
 describe("isAtmnOAuthClientRecord", () => {
 	test("does not classify arbitrary metadata values as atmn", () => {
@@ -27,5 +36,37 @@ describe("isAtmnOAuthClientRecord", () => {
 				name: "atmn",
 			}),
 		).toBe(true);
+	});
+});
+
+// Previously, reward scopes were filtered out and Better Auth returned invalid_scope.
+test("self-heals only allowed reward scopes requested by atmn", async () => {
+	const db = {} as DrizzleCli;
+	const clientId = "atmn_client";
+	const client = {
+		id: "oauth_client",
+		clientId,
+		name: "atmn",
+		redirectUris: ["http://localhost:31448/"],
+		scopes: [] as string[],
+		metadata: null,
+		createdAt: new Date(),
+	};
+	spyOn(oauthClientRepo, "getByClientId").mockResolvedValue(client);
+	const addScopes = spyOn(
+		oauthClientRepo,
+		"addScopesByClientId",
+	).mockResolvedValue(client);
+
+	await ensureAtmnAuthorizeScopes({
+		db,
+		clientId,
+		scope: "rewards:read billing:write rewards:write",
+	});
+
+	expect(addScopes).toHaveBeenCalledWith({
+		db,
+		clientId,
+		scopes: ["rewards:read", "rewards:write"],
 	});
 });


### PR DESCRIPTION
## Root cause

atmn 1.1.20 correctly began requesting rewards:read and rewards:write, but the reserved CLI OAuth client self-heal only allowed the older scope set. Better Auth therefore rejected login before consent and redirected invalid_scope to the normal localhost callback.

## Fix

- Allow the two reward scopes in the fixed first-party atmn scope set.
- Keep all other requested scopes filtered so unauthenticated authorize requests cannot widen the reserved client.
- Cover both the self-heal boundary and the complete HTTP authorize flow.

Once deployed, the existing 1.1.20 package should work without republishing because the server updates the persisted reserved client before authorization validation.

## Red / green verification

The HTTP integration test inserts an old-style atmn OAuth client without reward scopes, sends the complete scope set produced by the current CLI, and follows the real authorize route.

- Red against the pre-fix local server: redirected to localhost with error=invalid_scope for rewards:read and rewards:write.
- Green against the fixed worktree server: 302 to the Autumn /sign-in flow with no invalid_scope.
- Server auth unit suite: 75 passed, 0 failed.
- atmn auth and login-scope tests: 7 passed, 0 failed.
- Biome: clean.
- Server typecheck reaches two pre-existing origin/dev errors in shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts concerning additional_currencies; no errors in changed files.