### PR TITLE
test: cover atmn OAuth reward scope login

### DIFF
--- a/server/tests/integration/auth/atmn-oauth-reward-scopes.test.ts
+++ b/server/tests/integration/auth/atmn-oauth-reward-scopes.test.ts
@@ -1,0 +1,57 @@
+/** Regression: atmn reward scopes must self-heal before Better Auth validates the full authorize request. */
+
+import { expect, test } from "bun:test";
+import { oauthClient } from "@autumn/shared";
+import { eq } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { generateId } from "@/utils/genUtils.js";
+import { buildCliOAuthScopes } from "../../../../packages/atmn/src/commands/auth/oauth.js";
+
+const { db } = initDrizzle();
+const baseUrl =
+	process.env.AUTUMN_TEST_BASE_URL?.replace(/\/$/, "") ??
+	`http://localhost:${process.env.SERVER_PORT ?? "8080"}`;
+
+test("atmn authorize accepts the complete CLI scope set", async () => {
+	const clientId = generateId("oauth_client");
+	const redirectUri = "http://localhost:31448/";
+	const scopes = buildCliOAuthScopes();
+
+	try {
+		await db.insert(oauthClient).values({
+			id: generateId("oauth_client"),
+			clientId,
+			name: "atmn",
+			redirectUris: [redirectUri],
+			scopes: scopes.filter((scope) => !scope.startsWith("rewards:")),
+			tokenEndpointAuthMethod: "none",
+			grantTypes: ["authorization_code"],
+			responseTypes: ["code"],
+			public: true,
+			type: "native",
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		});
+
+		const authorizeUrl = new URL(`${baseUrl}/api/auth/oauth2/authorize`);
+		authorizeUrl.search = new URLSearchParams({
+			client_id: clientId,
+			redirect_uri: redirectUri,
+			response_type: "code",
+			scope: scopes.join(" "),
+			state: "atmn-reward-scope-test",
+			code_challenge: "A".repeat(43),
+			code_challenge_method: "S256",
+			prompt: "consent",
+		}).toString();
+
+		const response = await fetch(authorizeUrl, { redirect: "manual" });
+		const location = response.headers.get("location") ?? "";
+
+		expect(response.status).toBe(302);
+		expect(location).not.toContain("error=invalid_scope");
+		expect(new URL(location).pathname).toBe("/sign-in");
+	} finally {
+		await db.delete(oauthClient).where(eq(oauthClient.clientId, clientId));
+	}
+});


### PR DESCRIPTION
## Coverage

Adds an HTTP integration test for the atmn 1.1.20 login regression fixed by #2796.

The test inserts an old-style reserved atmn OAuth client without reward scopes, sends the complete scope set produced by the current CLI through /api/auth/oauth2/authorize, and verifies authorization continues to the Autumn sign-in page instead of returning invalid_scope to localhost.

## Local red / green

- Red against the pre-fix local server: the response redirected to localhost with error=invalid_scope for rewards:read and rewards:write.
- Green against the fixed worktree server: the same unchanged test returned 302 to /sign-in without invalid_scope.
- The temporary OAuth client is deleted in finally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integration test to prevent regressions where atmn OAuth authorize rejects reward scopes. Previously, authorize returned invalid_scope and redirected to localhost; now it accepts the full CLI scope set and redirects 302 to /sign-in.

**Review notes**
- Adds `server/tests/integration/auth/atmn-oauth-reward-scopes.test.ts` that seeds an atmn OAuth client missing `rewards:*` scopes, then calls `/api/auth/oauth2/authorize` with the full CLI scope set.
- Asserts a 302 response, no `invalid_scope`, and a redirect to `/sign-in`; deletes the temporary OAuth client in `finally`.
- Fails on a pre-fix server; passes on the fixed branch.

<sup>Written for commit 3931a998275834ee1732850998a0f7d3f9f958ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds regression coverage for legacy atmn OAuth clients that lack newer reward scopes, verifying that authorization proceeds to sign-in instead of returning `invalid_scope`.

- **[Bug fixes]** Creates an old-style atmn OAuth client, requests the current CLI scope set, and confirms reward scopes are repaired before validation.
- **[Improvements]** Cleans up the temporary OAuth client after the test, including when the request or assertion fails.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete defects identified in the added regression test.

The test uses the repository’s established HTTP integration pattern, inserts a uniquely identified OAuth client, verifies the corrected authorization redirect, and reliably removes its fixture.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/tests/integration/auth/atmn-oauth-reward-scopes.test.ts | Adds focused HTTP integration coverage for the atmn reward-scope login regression with isolated fixture setup and cleanup. |

<sub>Reviews (1): Last reviewed commit: ["test: 💍 cover atmn oauth reward scope l..."](https://github.com/useautumn/autumn/commit/3931a998275834ee1732850998a0f7d3f9f958ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52964378)</sub>

<!-- /greptile_comment -->