### PR TITLE
fix: include currencies in feature price items

### DIFF
--- a/shared/models/productV2Models/productItemModels/featurePriceItem.ts
+++ b/shared/models/productV2Models/productItemModels/featurePriceItem.ts
@@ -12,6 +12,7 @@ export const FeaturePriceItemSchema = ProductItemSchema.pick({
 	usage_model: true,
 
 	price: true,
+	additional_currencies: true,
 	tiers: true,
 	tier_behavior: true,
 	billing_units: true,


### PR DESCRIPTION
## Root cause

The flat feature-price currency comparator reads additional_currencies, which is defined on ProductItemSchema, but FeaturePriceItemSchema omitted that field from its pick. The runtime capability and comparator were correct while the narrower inferred type was stale.

## Fix

Include the existing additional_currencies field in FeaturePriceItemSchema. This is a one-line schema correction with no casts or comparator changes.

## Verification

- Full server typecheck: clean.
- Currency comparator and product-item currency tests: 8 passed, 0 failed.
- Biome: clean.
- Knip pre-commit check: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `additional_currencies` to `FeaturePriceItemSchema` so feature price items expose all configured currencies in types. Previously the schema omitted this field, hiding currencies in the inferred type even though runtime objects and the comparator supported them.

- One-line schema update in `shared/models/productV2Models/productItemModels/featurePriceItem.ts`; no comparator or runtime logic changes.
- Type-only correction; no behavior change expected.
- No migration required; consumers can now access `additional_currencies` on feature price items.

<sup>Written for commit e4e5c283169319c269ec2e60113ab2a6c00fb22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects the feature-price item schema so its inferred type includes the existing additional-currency field.

- **[Bug fixes]** Adds `additional_currencies` to `FeaturePriceItemSchema`, aligning the narrower feature-price type with `ProductItemSchema` and existing currency comparison and conversion logic.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The schema now exposes an existing optional ProductItem field that feature-price comparison and conversion code already consumes, without making the field required or altering its runtime validation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/models/productV2Models/productItemModels/featurePriceItem.ts | Safely adds the existing optional `additional_currencies` field to the feature-price schema pick, resolving stale type inference without changing validation semantics. |

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 include currencies in feature pr..."](https://github.com/useautumn/autumn/commit/e4e5c283169319c269ec2e60113ab2a6c00fb22a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52966704)</sub>

<!-- /greptile_comment -->