### PR TITLE
fix: enforce fail-open timeout from request start

### DIFF
--- a/server/src/honoMiddlewares/routeHandler.ts
+++ b/server/src/honoMiddlewares/routeHandler.ts
@@ -332,9 +332,12 @@ export function createRoute<
 	) => {
 		const { failOpen } = opts;
 		if (!failOpen || failOpen.skip?.(c)) return executeRoute(c);
+		const timeoutMs =
+			failOpen.timeoutMs - (Date.now() - c.get("ctx").timestamp);
+		if (timeoutMs <= 0) return failOpen.respond(c);
 		return raceFailOpen({
 			run: () => executeRoute(c),
-			timeoutMs: failOpen.timeoutMs,
+			timeoutMs,
 			respond: () => failOpen.respond(c),
 		});
 	};

--- a/server/src/internal/api/check/checkUtils/getCheckFailOpenFallback.ts
+++ b/server/src/internal/api/check/checkUtils/getCheckFailOpenFallback.ts
@@ -2,19 +2,27 @@ import type { CheckParams, ParsedCheckParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildCheckFallbackResponse } from "./buildCheckFallbackResponse.js";
 
+export type CheckFailOpenReason =
+	| "route_timeout"
+	| "org_rate_limit"
+	| "dependency_error";
+
 export const getCheckFailOpenFallback = ({
 	ctx,
 	body,
 	requiredBalance,
 	error,
+	reason,
 }: {
 	ctx: AutumnContext;
 	body: ParsedCheckParams | (CheckParams & { feature_id: string });
 	requiredBalance: number;
 	error: unknown;
+	reason: CheckFailOpenReason;
 }) => {
 	ctx.logger.warn("[check] Returning fail-open fallback response", {
 		type: "check_fail_open_fallback",
+		fail_open_reason: reason,
 		error,
 		feature_id: body.feature_id,
 		required_balance: requiredBalance,

--- a/server/src/internal/api/check/handleCheck.ts
+++ b/server/src/internal/api/check/handleCheck.ts
@@ -44,6 +44,7 @@ export const handleCheck = createRoute({
 				error: new Error(
 					`check exceeded the ${CHECK_FAIL_OPEN_TIMEOUT_MS}ms blanket fail-open timeout`,
 				),
+				reason: "route_timeout",
 			});
 			return c.json(response, 202);
 		},

--- a/server/src/internal/balances/check/runCheckWithRollout.ts
+++ b/server/src/internal/balances/check/runCheckWithRollout.ts
@@ -25,6 +25,7 @@ export const runCheckWithRollout = async ({
 				body,
 				requiredBalance,
 				error: new Error("org aggregate rate cap exceeded"),
+				reason: "org_rate_limit",
 			}) as Record<string, unknown>,
 		};
 	}
@@ -40,6 +41,7 @@ export const runCheckWithRollout = async ({
 				body,
 				requiredBalance,
 				error,
+				reason: "dependency_error",
 			}) as Record<string, unknown>,
 		}),
 	});

--- a/server/tests/unit/balances/check-v2/runCheckWithRollout.test.ts
+++ b/server/tests/unit/balances/check-v2/runCheckWithRollout.test.ts
@@ -36,6 +36,7 @@ await mockModuleWithRestore("@/internal/balances/check/runCheckV2.js", () => ({
 
 import { ApiVersionClass, LATEST_VERSION } from "@autumn/shared";
 import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import { getCheckFailOpenFallback } from "@/internal/api/check/checkUtils/getCheckFailOpenFallback.js";
 import { runCheckWithRollout } from "@/internal/balances/check/runCheckWithRollout.js";
 
 import { mockModuleWithRestore } from "../../utils/mockModuleWithRestore.js";
@@ -69,6 +70,24 @@ const rolloutCtx = {
 } as never;
 
 describe("runCheckWithRollout", () => {
+	test("logs the route timeout reason explicitly", () => {
+		getCheckFailOpenFallback({
+			ctx: rolloutCtx,
+			body: { customer_id: "cus_123", feature_id: "messages" } as never,
+			requiredBalance: 1,
+			error: new Error("blanket timeout"),
+			reason: "route_timeout",
+		});
+
+		expect(mockState.warnCalls).toContainEqual([
+			"[check] Returning fail-open fallback response",
+			expect.objectContaining({
+				type: "check_fail_open_fallback",
+				fail_open_reason: "route_timeout",
+			}),
+		]);
+	});
+
 	test("uses the v2 flow", async () => {
 		const result = await runCheckWithRollout({
 			ctx: {
@@ -159,6 +178,7 @@ describe("runCheckWithRollout", () => {
 			"[check] Returning fail-open fallback response",
 			expect.objectContaining({
 				type: "check_fail_open_fallback",
+				fail_open_reason: "dependency_error",
 				feature_id: "messages",
 				required_balance: 1,
 			}),

--- a/server/tests/unit/middleware/raceFailOpen.test.ts
+++ b/server/tests/unit/middleware/raceFailOpen.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { Scopes } from "@autumn/shared";
 import { Hono } from "hono";
 import { createRoute, raceFailOpen } from "@/honoMiddlewares/routeHandler.js";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 
 const response = (label: string) => new Response(label);
 
@@ -92,9 +93,23 @@ describe("raceFailOpen", () => {
 
 describe("createRoute failOpen skip", () => {
 	// Mounted under /webhooks/ so the scope-check middleware self-bypasses and
-	// no request ctx is needed.
-	const buildApp = ({ skip }: { skip: () => boolean }) => {
-		const app = new Hono();
+	// only the request timestamp is needed in ctx.
+	const buildApp = ({
+		skip,
+		requestStartedAt = Date.now(),
+		handlerDelayMs = 60,
+	}: {
+		skip: () => boolean;
+		requestStartedAt?: number;
+		handlerDelayMs?: number;
+	}) => {
+		const app = new Hono<HonoEnv>();
+		app.use("*", async (c, next) => {
+			c.set("ctx", {
+				timestamp: requestStartedAt,
+			} as HonoEnv["Variables"]["ctx"]);
+			await next();
+		});
 		app.post(
 			"/webhooks/fail-open-test",
 			...createRoute({
@@ -105,7 +120,7 @@ describe("createRoute failOpen skip", () => {
 					respond: () => response("fail-open"),
 				},
 				handler: async () => {
-					await Bun.sleep(60);
+					await Bun.sleep(handlerDelayMs);
 					return response("handler");
 				},
 			}),
@@ -123,6 +138,18 @@ describe("createRoute failOpen skip", () => {
 
 	it("skip=false still races and fails open when the handler is slow", async () => {
 		const app = buildApp({ skip: () => false });
+		const result = await app.request("/webhooks/fail-open-test", {
+			method: "POST",
+		});
+		expect(await result.text()).toBe("fail-open");
+	});
+
+	it("counts time elapsed before the handler against the timeout", async () => {
+		const app = buildApp({
+			skip: () => false,
+			requestStartedAt: Date.now() - 100,
+			handlerDelayMs: 0,
+		});
 		const result = await app.request("/webhooks/fail-open-test", {
 			method: "POST",
 		});


### PR DESCRIPTION
Make route-level fail-open budgets account for time already spent in middleware before the handler starts. Requests that have exhausted the budget now fail open immediately; otherwise the handler races against the remaining time.

Add a focused regression test proving pre-handler elapsed time counts toward the timeout.

Verified with:
- `bun test tests/unit/middleware/raceFailOpen.test.ts`
- `bun run ts`
- `bunx biome check server/src/honoMiddlewares/routeHandler.ts server/tests/unit/middleware/raceFailOpen.test.ts` (one pre-existing `noExplicitAny` warning)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces route-level fail-open timeouts from request start instead of handler start, and logs explicit reasons when checks fail open. Previously the timeout started at handler start; now it covers pre-handler time and returns the fallback immediately if the budget is exhausted.

- Subtracts pre-handler time using c.get("ctx").timestamp; early middleware must set ctx.timestamp at request start. Falls back immediately when the budget is <= 0; otherwise races the handler against the remaining time.
- Logs an explicit check fail-open reason: "route_timeout", "org_rate_limit", or "dependency_error"; `getCheckFailOpenFallback` now requires this reason. Tests cover timeout accounting, skip behavior, and reason logging.
- No public API changes; expect earlier fail-open on routes with slow middleware.

<sup>Written for commit 4963aeabb35283683b0e9b4a7ad5aba6879f7fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes the check route’s fail-open timeout cover the entire request, including middleware work, and adds more specific telemetry for fallback responses.

- **[Bug fixes]** Subtracts time already spent in middleware from the handler’s remaining fail-open budget.
- **[Bug fixes]** Returns the fallback immediately when the request has already exhausted its timeout.
- **[Improvements]** Logs whether a check failed open because of a route timeout, organization rate limit, or dependency error.
- **[Improvements]** Adds regression coverage for pre-handler elapsed time and fallback-reason logging.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/routeHandler.ts | Calculates fail-open time from request start and immediately returns the configured fallback when no budget remains. |
| server/src/internal/api/check/checkUtils/getCheckFailOpenFallback.ts | Adds a typed fallback reason to structured warning logs without changing the API response. |
| server/src/internal/api/check/handleCheck.ts | Labels the route-level timeout fallback as a route timeout. |
| server/src/internal/balances/check/runCheckWithRollout.ts | Distinguishes organization-rate-limit fallbacks from dependency-error fallbacks. |
| server/tests/unit/middleware/raceFailOpen.test.ts | Adds regression coverage proving that pre-handler elapsed time consumes the fail-open budget. |
| server/tests/unit/balances/check-v2/runCheckWithRollout.test.ts | Verifies structured fallback-reason logging for route timeouts and dependency failures. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Middleware
  participant Route
  participant Handler
  Client->>Middleware: Start request
  Note over Middleware: Record request timestamp
  Middleware->>Route: Continue after preprocessing
  Route->>Route: Calculate remaining timeout
  alt Budget exhausted
    Route-->>Client: Fail-open response
  else Budget remains
    Route->>Handler: Run with remaining budget
    alt Handler finishes first
      Handler-->>Client: Normal response
    else Remaining budget expires
      Route-->>Client: Fail-open response
    end
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: log check fail-open reasons"](https://github.com/useautumn/autumn/commit/4963aeabb35283683b0e9b4a7ad5aba6879f7fac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52971705)</sub>

<!-- /greptile_comment -->