### PR TITLE
fix: 🐛 reset retained entitlement billing state

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.ts
@@ -15,6 +15,7 @@ import { computeManualTopUpPlan } from "@/internal/billing/v2/actions/updateSubs
 import { computeUpdateLicenseQuantityPlan } from "@/internal/billing/v2/actions/updateSubscription/compute/updateLicenseQuantity/computeUpdateLicenseQuantityPlan";
 import { computeUpdateQuantityPlan } from "@/internal/billing/v2/actions/updateSubscription/compute/updateQuantity/computeUpdateQuantityPlan";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
+import { computeRetainedCustomerEntitlementUpdates } from "@/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates";
 import { addStripeSubscriptionIdToBillingPlan } from "@/internal/billing/v2/execute/addStripeSubscriptionIdToBillingPlan";
 import { computeFieldUpdates } from "./computeFieldUpdates";
 
@@ -70,7 +71,10 @@ export const computeUpdateSubscriptionPlan = async ({
 				customEntitlements: [],
 				customFreeTrial: undefined,
 				lineItems: computeAnchorResetLineItems({ ctx, billingContext }),
-				updateCustomerEntitlements: undefined,
+				updateCustomerEntitlements: computeRetainedCustomerEntitlementUpdates({
+					updateSubscriptionContext: billingContext,
+					finalCustomerProduct: billingContext.customerProduct,
+				}),
 			};
 
 			break;

--- a/server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts
+++ b/server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts
@@ -1,0 +1,93 @@
+import {
+	addCusProductToCusEnt,
+	type AutumnBillingPlan,
+	EntInterval,
+	featureUtils,
+	getCycleEnd,
+	isBooleanEntitlement,
+	isOneOffPrepaidConsumableCustomerEntitlement,
+	isUnlimitedEntitlement,
+	type UpdateSubscriptionBillingContext,
+} from "@autumn/shared";
+import { entitlementToResetCycleAnchor } from "@/internal/billing/v2/utils/initFullCustomerProduct/cycleAnchorUtils";
+import { initCustomerEntitlementBalance } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementBalance";
+
+export const computeRetainedCustomerEntitlementUpdates = ({
+	updateSubscriptionContext,
+	finalCustomerProduct,
+}: {
+	updateSubscriptionContext: UpdateSubscriptionBillingContext;
+	finalCustomerProduct: UpdateSubscriptionBillingContext["customerProduct"];
+}): AutumnBillingPlan["updateCustomerEntitlements"] => {
+	const resetsBillingCycle =
+		updateSubscriptionContext.requestedBillingCycleAnchor === "now";
+	const resetsUsage =
+		updateSubscriptionContext.carryOverUsages?.enabled === false;
+	if (!resetsBillingCycle && !resetsUsage) return [];
+
+	return finalCustomerProduct.customer_entitlements
+		.map((customerEntitlement) => {
+			const { entitlement } = customerEntitlement;
+			const resetsEntitlementBillingCycle =
+				resetsBillingCycle &&
+				!isBooleanEntitlement({ entitlement }) &&
+				entitlement.allowance !== null;
+			const resetsCustomerEntitlementUsage =
+				resetsUsage &&
+				!isBooleanEntitlement({ entitlement }) &&
+				!isUnlimitedEntitlement({ entitlement }) &&
+				!featureUtils.isAllocated(entitlement.feature) &&
+				!isOneOffPrepaidConsumableCustomerEntitlement(
+					addCusProductToCusEnt({
+						cusEnt: customerEntitlement,
+						cusProduct: finalCustomerProduct,
+					}),
+				);
+			if (!resetsEntitlementBillingCycle && !resetsCustomerEntitlementUsage)
+				return undefined;
+
+			const resetBalance = resetsCustomerEntitlementUsage
+				? initCustomerEntitlementBalance({
+						initContext: {
+							fullCustomer: updateSubscriptionContext.fullCustomer,
+							fullProduct: updateSubscriptionContext.fullProducts[0],
+							featureQuantities: updateSubscriptionContext.featureQuantities,
+						},
+						entitlement: customerEntitlement.entitlement,
+					})
+				: undefined;
+
+			return {
+				customerEntitlement,
+				updates: {
+					...(resetBalance
+						? {
+								balance: resetBalance.balance,
+								adjustment: 0,
+								entities: resetBalance.entities ?? undefined,
+							}
+						: {}),
+					...(resetsEntitlementBillingCycle
+						? {
+								reset_cycle_anchor: entitlementToResetCycleAnchor({
+									entitlement: customerEntitlement.entitlement,
+									resetCycleAnchor:
+										updateSubscriptionContext.resetCycleAnchorMs,
+									now: updateSubscriptionContext.currentEpochMs,
+								}),
+								next_reset_at: getCycleEnd({
+									anchor: updateSubscriptionContext.resetCycleAnchorMs,
+									interval:
+										customerEntitlement.entitlement.interval ??
+										EntInterval.Month,
+									intervalCount:
+										customerEntitlement.entitlement.interval_count,
+									now: updateSubscriptionContext.currentEpochMs,
+								}),
+							}
+						: {}),
+				},
+			};
+		})
+		.filter((update) => update !== undefined);
+};

--- a/server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts
+++ b/server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts
@@ -1,13 +1,15 @@
 import {
 	addCusProductToCusEnt,
 	type AutumnBillingPlan,
-	EntInterval,
+	cusProductToProduct,
 	featureUtils,
 	getCycleEnd,
 	isBooleanEntitlement,
 	isOneOffPrepaidConsumableCustomerEntitlement,
+	isResettingEntitlement,
 	isUnlimitedEntitlement,
 	type UpdateSubscriptionBillingContext,
+	UpdateSubscriptionIntent,
 } from "@autumn/shared";
 import { entitlementToResetCycleAnchor } from "@/internal/billing/v2/utils/initFullCustomerProduct/cycleAnchorUtils";
 import { initCustomerEntitlementBalance } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlementBalance";
@@ -22,16 +24,19 @@ export const computeRetainedCustomerEntitlementUpdates = ({
 	const resetsBillingCycle =
 		updateSubscriptionContext.requestedBillingCycleAnchor === "now";
 	const resetsUsage =
+		updateSubscriptionContext.intent === UpdateSubscriptionIntent.UpdatePlan &&
 		updateSubscriptionContext.carryOverUsages?.enabled === false;
 	if (!resetsBillingCycle && !resetsUsage) return [];
+
+	const finalFullProduct = resetsUsage
+		? cusProductToProduct({ cusProduct: finalCustomerProduct })
+		: undefined;
 
 	return finalCustomerProduct.customer_entitlements
 		.map((customerEntitlement) => {
 			const { entitlement } = customerEntitlement;
 			const resetsEntitlementBillingCycle =
-				resetsBillingCycle &&
-				!isBooleanEntitlement({ entitlement }) &&
-				entitlement.allowance !== null;
+				resetsBillingCycle && isResettingEntitlement({ entitlement });
 			const resetsCustomerEntitlementUsage =
 				resetsUsage &&
 				!isBooleanEntitlement({ entitlement }) &&
@@ -50,7 +55,7 @@ export const computeRetainedCustomerEntitlementUpdates = ({
 				? initCustomerEntitlementBalance({
 						initContext: {
 							fullCustomer: updateSubscriptionContext.fullCustomer,
-							fullProduct: updateSubscriptionContext.fullProducts[0],
+							fullProduct: finalFullProduct!,
 							featureQuantities: updateSubscriptionContext.featureQuantities,
 						},
 						entitlement: customerEntitlement.entitlement,
@@ -77,9 +82,7 @@ export const computeRetainedCustomerEntitlementUpdates = ({
 								}),
 								next_reset_at: getCycleEnd({
 									anchor: updateSubscriptionContext.resetCycleAnchorMs,
-									interval:
-										customerEntitlement.entitlement.interval ??
-										EntInterval.Month,
+									interval: customerEntitlement.entitlement.interval!,
 									intervalCount:
 										customerEntitlement.entitlement.interval_count,
 									now: updateSubscriptionContext.currentEpochMs,

--- a/server/src/internal/billing/v2/compute/computePatchPlan/computePatchCustomerProductPlan.ts
+++ b/server/src/internal/billing/v2/compute/computePatchPlan/computePatchCustomerProductPlan.ts
@@ -1,15 +1,12 @@
 import {
 	type AutumnBillingPlan,
 	CusProductStatus,
-	EntInterval,
-	getCycleEnd,
-	isBooleanEntitlement,
 	type UpdateSubscriptionBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems";
+import { computeRetainedCustomerEntitlementUpdates } from "@/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates";
 import { computeCustomerLicenseTransitions } from "@/internal/billing/v2/compute/customerLicenseTransitions/computeCustomerLicenseTransitions";
-import { entitlementToResetCycleAnchor } from "@/internal/billing/v2/utils/initFullCustomerProduct/cycleAnchorUtils";
 import { initPatchCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initPatchedCustomerProduct";
 
 export const computePatchCustomerProductPlan = ({
@@ -70,7 +67,7 @@ export const computePatchCustomerProductPlan = ({
 		customerLicenseTransitions,
 		lineItems: allLineItems,
 		insertCustomerEntitlements: oneOffPrepaidCarryOverCustomerEntitlements,
-		updateCustomerEntitlements: computeAnchorResetEntitlementUpdates({
+		updateCustomerEntitlements: computeRetainedCustomerEntitlementUpdates({
 			updateSubscriptionContext,
 			finalCustomerProduct,
 		}),
@@ -119,40 +116,4 @@ export const computePatchCustomerProductPlan = ({
 			},
 		],
 	} satisfies AutumnBillingPlan;
-};
-
-const computeAnchorResetEntitlementUpdates = ({
-	updateSubscriptionContext,
-	finalCustomerProduct,
-}: {
-	updateSubscriptionContext: UpdateSubscriptionBillingContext;
-	finalCustomerProduct: UpdateSubscriptionBillingContext["customerProduct"];
-}): AutumnBillingPlan["updateCustomerEntitlements"] => {
-	if (updateSubscriptionContext.requestedBillingCycleAnchor !== "now")
-		return [];
-
-	return finalCustomerProduct.customer_entitlements
-		.filter((customerEntitlement) => {
-			const { entitlement } = customerEntitlement;
-			return (
-				!isBooleanEntitlement({ entitlement }) && entitlement.allowance !== null
-			);
-		})
-		.map((customerEntitlement) => ({
-			customerEntitlement,
-			updates: {
-				reset_cycle_anchor: entitlementToResetCycleAnchor({
-					entitlement: customerEntitlement.entitlement,
-					resetCycleAnchor: updateSubscriptionContext.resetCycleAnchorMs,
-					now: updateSubscriptionContext.currentEpochMs,
-				}),
-				next_reset_at: getCycleEnd({
-					anchor: updateSubscriptionContext.resetCycleAnchorMs,
-					interval:
-						customerEntitlement.entitlement.interval ?? EntInterval.Month,
-					intervalCount: customerEntitlement.entitlement.interval_count,
-					now: updateSubscriptionContext.currentEpochMs,
-				}),
-			},
-		}));
 };

--- a/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-transition-rules.test.ts
+++ b/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-transition-rules.test.ts
@@ -278,3 +278,50 @@ test(`${chalk.yellowBright("transition-rules 4: updateSubscription inherits rest
 		await clearTransitionRule({ secretKey: ctx.orgSecretKey });
 	}
 });
+
+test(`${chalk.yellowBright("transition-rules 5: inherited usage reset does not reset cancellation")}`, async () => {
+	const pro = products.pro({
+		id: "tr-cancel-pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { customerId, autumnV1, autumnV2_3, ctx } = await initScenario({
+		customerId: "transition-rules-cancel",
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [s.billing.attach({ productId: pro.id })],
+	});
+
+	try {
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: 40,
+			},
+			{ timeout: 2000 },
+		);
+		await setTransitionRule({
+			secretKey: ctx.orgSecretKey,
+			carryOverUsages: { enabled: false },
+		});
+
+		await autumnV2_3.billing.update({
+			customer_id: customerId,
+			plan_id: pro.id,
+			cancel_action: "cancel_end_of_cycle",
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expectCustomerFeatureCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			balance: 60,
+			usage: 40,
+		});
+	} finally {
+		await clearTransitionRule({ secretKey: ctx.orgSecretKey });
+	}
+});

--- a/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-and-usage-reset.test.ts
+++ b/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-and-usage-reset.test.ts
@@ -146,6 +146,15 @@ test.concurrent(
 			actions: [s.billing.attach({ productId: pro.id })],
 		});
 
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: 40,
+			},
+			{ timeout: 2000 },
+		);
+
 		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
 			customer_id: customerId,
 			plan_id: pro.id,
@@ -158,8 +167,8 @@ test.concurrent(
 			autumn: autumnV2_3,
 			featureId: TestFeature.Messages,
 			planId: pro.id,
-			remaining: 100,
-			usage: 0,
+			remaining: 60,
+			usage: 40,
 			nextResetAt: null,
 		});
 	},

--- a/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-and-usage-reset.test.ts
+++ b/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-and-usage-reset.test.ts
@@ -1,0 +1,70 @@
+import { test } from "bun:test";
+import type { UpdateSubscriptionV1ParamsInput } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { addMonths } from "date-fns";
+
+/** Both reset flags must restart the entitlement cycle and discard prior usage
+ * during a same-plan customization. */
+test.concurrent(
+	`${chalk.yellowBright("update-sub combined reset: same-plan customization resets cycle and usage")}`,
+	async () => {
+		const customerId = "update-sub-combined-custom";
+		const pro = products.base({
+			id: "pro",
+			items: [
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.monthlyPrice({ price: 20 }),
+			],
+		});
+
+		const { autumnV2_3, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.advanceTestClock({ days: 14 }),
+			],
+		});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: 40,
+			},
+			{ timeout: 2000 },
+		);
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 30 }) },
+			billing_cycle_anchor: "now",
+			carry_over_usages: { enabled: false },
+		});
+
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			planId: pro.id,
+			nextResetAt: addMonths(advancedTo, 1).getTime(),
+		});
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			remaining: 100,
+			usage: 0,
+		});
+	},
+);

--- a/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-and-usage-reset.test.ts
+++ b/server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-and-usage-reset.test.ts
@@ -9,8 +9,8 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import { addMonths } from "date-fns";
 
-/** Both reset flags must restart the entitlement cycle and discard prior usage
- * during a same-plan customization. */
+/** Same-plan resets update retained billing state without changing entitlement
+ * lifecycle semantics or using stale patch inputs. */
 test.concurrent(
 	`${chalk.yellowBright("update-sub combined reset: same-plan customization resets cycle and usage")}`,
 	async () => {
@@ -65,6 +65,102 @@ test.concurrent(
 			featureId: TestFeature.Messages,
 			remaining: 100,
 			usage: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("update-sub usage reset: uses final patched item grant")}`,
+	async () => {
+		const customerId = "update-sub-reset-patched-grant";
+		const pro = products.base({
+			id: "pro",
+			items: [
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.monthlyPrice({ price: 20 }),
+			],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		await autumnV2_3.track(
+			{
+				customer_id: customerId,
+				feature_id: TestFeature.Messages,
+				value: 40,
+			},
+			{ timeout: 2000 },
+		);
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			feature_quantities: [
+				{ feature_id: TestFeature.Messages, quantity: 300 },
+			],
+			customize: {
+				remove_items: [{ feature_id: TestFeature.Messages }],
+				add_items: [
+					itemsV2.prepaidMessages({ amount: 10, billingUnits: 100 }),
+				],
+			},
+			carry_over_usages: { enabled: false },
+		});
+
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			planId: pro.id,
+			remaining: 300,
+			usage: 0,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("update-sub anchor reset: lifetime entitlement stays lifetime")}`,
+	async () => {
+		const customerId = "update-sub-anchor-lifetime";
+		const pro = products.base({
+			id: "pro",
+			items: [
+				items.lifetimeMessages({ includedUsage: 100 }),
+				items.monthlyPrice({ price: 20 }),
+			],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 30 }) },
+			billing_cycle_anchor: "now",
+		});
+
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			planId: pro.id,
+			remaining: 100,
+			usage: 0,
+			nextResetAt: null,
 		});
 	},
 );


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets retained-entitlement billing state when a subscription update or patch resets the billing cycle or disables usage carry-over. Previously patches only advanced anchors and updates ignored entitlements; now both paths reset cycle anchors and, when carry-over is off, reinitialize usage.

- Adds shared `computeRetainedCustomerEntitlementUpdates` and uses it in patch and update flows.
- On `billing_cycle_anchor: "now"`, sets `reset_cycle_anchor` and `next_reset_at` for resetting entitlements; lifetime entitlements remain lifetime.
- When `carry_over_usages.enabled: false` on `UpdatePlan`, reinitializes eligible balances from the final customized plan and `feature_quantities` (sets `balance`, `adjustment: 0`, and `entities`).
- Skips boolean, unlimited, allocated features, and one-off prepaid consumables; does nothing when neither flag is set.
- Preserves scheduled cancellation; inherited usage resets from transition rules do not change `cancel_action`.
- Tests cover combined cycle/usage resets, using the final grant in update-sub, lifetime anchor behavior, and cancellation preservation.

<sup>Written for commit 46697e97a625cf4e036b1313f9ba42d930618077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR resets retained entitlement billing state when a subscription's billing cycle restarts or usage carry-over is disabled.

- **[Bug fixes]** Shares retained-entitlement reset computation between same-plan patch and subscription-update flows.
- **[Bug fixes]** Reinitializes eligible usage balances from the final patched plan and updates recurring reset anchors.
- **[Improvements]** Adds integration coverage for customized grants, lifetime entitlements, combined resets, and cancellation preservation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/compute/computeAutumnUtils/computeRetainedCustomerEntitlementUpdates.ts | Introduces shared filtering and state computation for retained entitlement cycle and usage resets; no eligible blocking follow-up issue was established. |
| server/src/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.ts | Applies retained-entitlement updates to anchor-only and cancellation-preserving subscription updates. |
| server/src/internal/billing/v2/compute/computePatchPlan/computePatchCustomerProductPlan.ts | Replaces the local anchor-only calculation with the shared retained-entitlement reset helper. |
| server/tests/integration/billing/update-subscription/params/billing-cycle-anchor/update-sub-anchor-and-usage-reset.test.ts | Covers combined cycle and usage resets, final customized grants, and lifetime entitlement preservation. |
| server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-transition-rules.test.ts | Verifies that inherited usage-reset rules do not override scheduled cancellation behavior. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Subscription update] --> B{Reset billing cycle or disable carry-over?}
  B -- No --> C[Leave retained entitlements unchanged]
  B -- Yes --> D[Inspect retained entitlements]
  D --> E{Recurring resettable entitlement?}
  E -- Yes --> F[Update reset anchor and next reset time]
  E -- No --> G[Preserve lifecycle timing]
  D --> H{Usage reset eligible?}
  H -- Yes --> I[Reinitialize balance, adjustment, and entity balances]
  H -- No --> J[Preserve usage balance]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test: 💍 strengthen lifetime anchor rese..."](https://github.com/useautumn/autumn/commit/46697e97a625cf4e036b1313f9ba42d930618077) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53010447)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->