### PR TITLE
Fix replacement grants in plan migrations

### DIFF
--- a/server/src/internal/migrations/v2/operations/updatePlan/setup/itemAlreadyExists.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/setup/itemAlreadyExists.ts
@@ -8,6 +8,7 @@ import {
 import type { CreatePlanItemParamsV1 } from "@autumn/shared/api/products/items/crud/createPlanItemParamsV1.js";
 import type { PlanItemFilter } from "@autumn/shared/api/products/items/filter/planItemFilter.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { handleCustomizeDeleteItems } from "@/internal/billing/v2/setup/patch/handleCustomizeDeleteItems.js";
 
 const getAddItemEntitlementInterval = ({
 	item,
@@ -17,36 +18,6 @@ const getAddItemEntitlementInterval = ({
 	(item.reset?.interval ??
 		item.price?.interval ??
 		EntInterval.Lifetime) as EntInterval;
-
-const itemWillReplaceRemovedItem = ({
-	item,
-	removeItems,
-}: {
-	item: CreatePlanItemParamsV1;
-	removeItems?: PlanItemFilter[];
-}) => {
-	if (!removeItems?.length) return false;
-
-	const itemInterval = getAddItemEntitlementInterval({ item });
-
-	return removeItems.some((removeItem) => {
-		if (
-			removeItem.feature_id !== undefined &&
-			removeItem.feature_id !== item.feature_id
-		) {
-			return false;
-		}
-
-		if (
-			removeItem.interval !== undefined &&
-			String(removeItem.interval) !== String(itemInterval)
-		) {
-			return false;
-		}
-
-		return true;
-	});
-};
 
 export const itemAlreadyExists = ({
 	ctx,
@@ -59,7 +30,19 @@ export const itemAlreadyExists = ({
 	item: CreatePlanItemParamsV1;
 	removeItems?: PlanItemFilter[];
 }): boolean => {
-	if (itemWillReplaceRemovedItem({ item, removeItems })) return false;
+	const remainingCustomerProduct = removeItems?.length
+		? {
+				...customerProduct,
+				customer_prices: [...customerProduct.customer_prices],
+				customer_entitlements: [...customerProduct.customer_entitlements],
+			}
+		: customerProduct;
+	if (removeItems?.length) {
+		handleCustomizeDeleteItems({
+			customize: { remove_items: removeItems },
+			targetCustomerProduct: remainingCustomerProduct,
+		});
+	}
 
 	const feature = findFeatureById({
 		features: ctx.features,
@@ -70,7 +53,7 @@ export const itemAlreadyExists = ({
 	if (isBooleanFeature({ feature })) {
 		return Boolean(
 			findCustomerEntitlementByFeature({
-				cusEnts: customerProduct.customer_entitlements,
+				cusEnts: remainingCustomerProduct.customer_entitlements,
 				featureId: item.feature_id,
 			}),
 		);
@@ -78,7 +61,7 @@ export const itemAlreadyExists = ({
 
 	const itemInterval = getAddItemEntitlementInterval({ item });
 
-	return customerProduct.customer_entitlements.some(
+	return remainingCustomerProduct.customer_entitlements.some(
 		(customerEntitlement) =>
 			customerEntitlement.feature_id === item.feature_id &&
 			String(

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-replace-continuous-item.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-replace-continuous-item.test.ts
@@ -1,0 +1,89 @@
+/** Red: replacing a monthly paid continuous-use item drops its grant.
+ * Green: the replacement free item grants 100 units and keeps the $20 charge. */
+import { test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	type ApiCustomerV5,
+	BillingInterval,
+} from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { runUpdatePlanMigration } from "../../utils/runUpdatePlanMigration";
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: replace paid continuous-use item with included grant")}`,
+	async () => {
+		const customerId = "migration-update-replace-continuous-item";
+		const domains = products.base({
+			id: "migration-domains-addon",
+			isAddOn: true,
+			items: [
+				items.prepaid({
+					featureId: TestFeature.Users,
+					price: 20,
+					billingUnits: 100,
+				}),
+			],
+		});
+		const { autumnV1, autumnV2_2, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [domains] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: domains.id,
+					options: [{ feature_id: TestFeature.Users, quantity: 100 }],
+				}),
+			],
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_2,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: domains.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: domains.id },
+						customize: {
+							price: itemsV2.monthlyPrice({ amount: 20 }),
+							remove_items: [
+								{
+									feature_id: TestFeature.Users,
+									interval: BillingInterval.Month,
+								},
+							],
+							add_items: [{ feature_id: TestFeature.Users, included: 100 }],
+						},
+					},
+				],
+			},
+			runOnServer: false,
+		});
+
+		const customer = await autumnV2_2.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Users,
+			granted: 100,
+			remaining: 100,
+			planId: domains.id,
+		});
+		await expectCustomerInvoiceCorrect({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			count: 1,
+			latestTotal: 20,
+		});
+	},
+);


### PR DESCRIPTION
## Summary

- evaluate migration add-item deduplication after applying remove_items
- reuse billing patch deletion semantics instead of comparing price and entitlement intervals
- add a regression test for replacing a monthly paid continuous-use item with an included grant

## Root cause

Continuous-use entitlements are lifetime while their paid Stripe price can be monthly. The migration compared the removal filter with the entitlement interval, treated the replacement grant as a duplicate, then removed the existing entitlement.

## Test plan

- [x] bunx tsgo --build --noEmit
- [x] Biome check on changed files
- [x] update-plan-op-replace-continuous-item integration test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves replacement grants in update_plan migrations by applying remove_items semantics before add-item duplicate checks. Previously, replacing a monthly paid continuous-use item with an included grant dropped the grant; now the grant remains and the monthly charge persists.

- `itemAlreadyExists` clones the customer product, runs `handleCustomizeDeleteItems` for `remove_items`, then checks duplicates against remaining entitlements (no interval comparison).
- Adds regression test `update-plan-op-replace-continuous-item.test.ts` confirming 100 units are granted and a $20 monthly charge persists.

<sup>Written for commit 7ab1fd51f1d030fc04e45853a22a3dd30188fc34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes update-plan migrations so replacement grants are deduplicated only after the requested removals are applied.

- **[Bug fixes]** Reuses billing patch deletion semantics when deciding whether an added plan item already exists.
- **[Bug fixes]** Preserves an included grant when replacing a monthly paid continuous-use item.
- **[Improvements]** Adds an integration regression test covering the replacement grant and retained monthly charge.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/operations/updatePlan/setup/itemAlreadyExists.ts | Simulates requested item deletions on copied plan arrays before checking whether each replacement item already exists. |
| server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-replace-continuous-item.test.ts | Verifies that replacing a paid continuous-use item grants 100 included units while retaining the expected $20 monthly invoice. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Existing customer plan] --> B[Apply remove_items to copied plan]
  B --> C{Does add_item still exist?}
  C -->|Yes| D[Skip duplicate item]
  C -->|No| E[Keep replacement item]
  E --> F[Execute updated plan migration]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 preserve replacement grants in m..."](https://github.com/useautumn/autumn/commit/7ab1fd51f1d030fc04e45853a22a3dd30188fc34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53043220)</sub>

<!-- /greptile_comment -->