### PR TITLE
fix(migrations): mint Stripe prices once during live prepare

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -35,11 +35,14 @@ export const initStripeResourcesForProducts = async ({
 	products,
 	candidateProducts = [],
 	internalEntityId,
+	allowLiveCreate = false,
 }: {
 	ctx: AutumnContext;
 	products: FullProduct[];
 	candidateProducts?: FullProduct[];
 	internalEntityId?: string;
+	/** Live is reuse-only unless set — catalog edits must not mint Stripe prices. */
+	allowLiveCreate?: boolean;
 }) => {
 	const { db, org, env, logger } = ctx;
 
@@ -50,7 +53,7 @@ export const initStripeResourcesForProducts = async ({
 	);
 	await applyStripeReuseFromVariantFamilies({ ctx, products });
 
-	if (env === AppEnv.Live) return;
+	if (env === AppEnv.Live && !allowLiveCreate) return;
 	if (orgDisableStripeWrites({ ctx, includeSandbox: true })) return;
 	// No Stripe account (e.g. fresh sandbox sub-orgs) — resources are
 	// created lazily once one is connected.

--- a/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts
+++ b/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts
@@ -442,7 +442,11 @@ export const ensurePricesAndEntitlements: PrepareModule<
 							candidateProducts: resolved,
 							reuseProcessor: false,
 						});
-						await initStripeResourcesForProducts({ ctx, products: [product] });
+						await initStripeResourcesForProducts({
+							ctx,
+							products: [product],
+							allowLiveCreate: true,
+						});
 						resolved.push(product);
 					}
 				}),


### PR DESCRIPTION
## Summary
- Live `initStripeResourcesForProducts` is reuse-only, so migration prepare left custom prices without a `stripe_price_id`. Each customer then minted a new Stripe price at evaluate (Resend `plan-migrate-1-qw9`: 6 customers, 6 Stripe prices for one Autumn price).
- Opt the `ensurePricesAndEntitlements` path into live create via `allowLiveCreate`. Catalog/versioning callers stay reuse-only.

## Test plan
- [ ] Confirm catalog live init still skips Stripe minting (existing `init-stripe-resources-live-reuse` coverage).
- [ ] After merge, re-run a live `update_plan` migration and confirm one Stripe price is minted at prepare and reused across customers.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mints a shared Stripe price during live migration prepare to prevent per-customer price duplication. Previously, live prepare was reuse-only and left prices without a stripe_price_id; now the prepare path creates the price once so all customers reuse it.

- Adds allowLiveCreate to initStripeResourcesForProducts; live remains reuse-only unless set. Catalog/versioning callers stay reuse-only.
- enable allowLiveCreate in ensurePricesAndEntitlements during live prepare to mint and persist one Stripe price before evaluate.
- Continues to respect environment checks and orgDisableStripeWrites; no Stripe writes in sandbox or when disabled.

<sup>Written for commit b60a8594167d22b796794c4a7a2097f52b140757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows migration preparation to create a live Stripe price once, while leaving ordinary live catalog initialization reuse-only.

- **Bug fixes:** Adds an `allowLiveCreate` option to selectively bypass the initializer's live reuse-only return.
- **Bug fixes, Improvements:** Enables that option while preparing migration prices and continues processing versions of each plan sequentially so later versions can reuse the first Stripe price.
- **Bug fixes:** The new side effect still needs serialization because overlapping prepares can both mint the same price.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until live migration preparation is serialized or made idempotent so overlapping prepares cannot mint duplicate Stripe prices.

The intended single-create behavior works within one preparation execution, but no lock coordinates separate prepare executions and both can reach Stripe creation with independently planned prices lacking IDs.

**Files Needing Attention:** server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Adds an opt-in that permits the existing resource initializer to create Stripe resources in live mode while preserving reuse-only behavior by default. |
| server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts | Enables live creation for prepared migration prices, but the unguarded prepare path can invoke this side effect concurrently and mint duplicates. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Prepare request A
  participant B as Prepare request B
  participant DB as Database
  participant Stripe
  A->>DB: Upsert planned price without Stripe ID
  B->>DB: Upsert same planned price without Stripe ID
  A->>Stripe: Create price
  B->>Stripe: Create duplicate price
  A->>DB: Save Stripe price A ID
  B->>DB: Save Stripe price B ID
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts:445-449
**Concurrent prepares duplicate prices**

If two requests prepare the same live migration concurrently, both reach this live-create call with independently planned prices that lack Stripe IDs, causing duplicate Stripe prices and leaving only the last persisted ID referenced in the database.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): mint Stripe prices once..."](https://github.com/useautumn/autumn/commit/b60a8594167d22b796794c4a7a2097f52b140757) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53046374)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->