### PR TITLE
fix(migrations): run 25 customers in parallel per chunk

### DIFF
--- a/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
+++ b/server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts
@@ -16,8 +16,8 @@ export type IterateScopeSummary<T> = {
 	cursor: string | null;
 };
 
-/** Iterates scope items; a scheduler forces sequential execution and ends between items.
- * Errors are collected by default or rethrown when `onError` is `throw`. */
+/** Iterates scope items up to `concurrency` in flight. A scheduler ends the
+ * slice between items after the time budget. Errors continue or rethrow. */
 export const iterateScope = async <T>({
 	iterate,
 	perItem,
@@ -36,7 +36,7 @@ export const iterateScope = async <T>({
 	const results: IterateScopeItemResult<T>[] = [];
 	let succeeded = 0;
 	let failed = 0;
-	const maxParallel = scheduler ? 1 : Math.max(1, Math.floor(concurrency));
+	const maxParallel = Math.max(1, Math.floor(concurrency));
 	const sliceStartedAtMs = scheduler?.now();
 	let hasProcessedScheduledItem = false;
 	const summarize = (
@@ -60,6 +60,8 @@ export const iterateScope = async <T>({
 			results.push({ status: "failed", item, error });
 			failed++;
 			if (onError === "throw") throw error;
+		} finally {
+			hasProcessedScheduledItem = true;
 		}
 	};
 
@@ -75,7 +77,6 @@ export const iterateScope = async <T>({
 				if (shouldStop?.()) return summarize("stopped");
 				if (scheduledSliceIsComplete()) return summarize("slice_complete");
 				await runItem(item);
-				hasProcessedScheduledItem = true;
 				if (shouldStop?.()) return summarize("stopped");
 			}
 		}
@@ -90,19 +91,20 @@ export const iterateScope = async <T>({
 		inflight.add(p);
 	};
 
+	const drain = async (completion: IterateScopeCompletion) => {
+		await Promise.all(inflight);
+		return summarize(completion);
+	};
+
 	for await (const batch of iterate()) {
 		for (const item of batch) {
-			if (shouldStop?.()) {
-				await Promise.all(inflight);
-				return summarize("stopped");
-			}
+			if (shouldStop?.()) return drain("stopped");
+			if (scheduledSliceIsComplete()) return drain("slice_complete");
 			schedule(item);
 			if (inflight.size >= maxParallel) {
 				await Promise.race(inflight);
-				if (shouldStop?.()) {
-					await Promise.all(inflight);
-					return summarize("stopped");
-				}
+				if (shouldStop?.()) return drain("stopped");
+				if (scheduledSliceIsComplete()) return drain("slice_complete");
 			}
 		}
 	}

--- a/server/src/internal/migrations/v2/run/utils/migrationRunConstants.ts
+++ b/server/src/internal/migrations/v2/run/utils/migrationRunConstants.ts
@@ -4,7 +4,7 @@ import type { MigrationRunScheduler } from "../types/migrationRunScheduler.js";
  * and the per-customer lazy task). Flip to re-enable. */
 export const LAZY_MIGRATION_RUNS_DISABLED = true;
 
-export const MIGRATION_RUN_CUSTOMER_CONCURRENCY = 1;
+export const MIGRATION_RUN_CUSTOMER_CONCURRENCY = 25;
 export const MIGRATION_CHUNK_FETCH_SIZE = 100;
 export const MIGRATION_SLICE_DURATION_MS = 10_000;
 

--- a/server/tests/unit/migrations-v2/scheduling/iterate-scope-scheduling.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/iterate-scope-scheduling.test.ts
@@ -1,4 +1,4 @@
-// Contract: scheduled scopes run one customer at a time and finish the task only between customers.
+// Contract: scheduled scopes honor concurrency and finish the task only between items.
 // Exhausting the source on the final customer must not request an unnecessary continuation.
 import { describe, expect, test } from "bun:test";
 import { iterateScope } from "@/internal/migrations/v2/run/orchestrators/iterateScope.js";
@@ -17,7 +17,7 @@ const iterateItems = (items: RunScopeItem[]) =>
 	};
 
 describe("iterateScope migration scheduling", () => {
-	test("forces sequential customer execution when a scheduler is present", async () => {
+	test("honors concurrency when a scheduler is present", async () => {
 		let active = 0;
 		let maxActive = 0;
 		const scheduler: MigrationRunScheduler = {
@@ -43,7 +43,44 @@ describe("iterateScope migration scheduling", () => {
 			},
 		});
 
-		expect(maxActive).toBe(1);
+		expect(maxActive).toBe(3);
+	});
+
+	test("ends a parallel slice after the time budget without exceeding concurrency", async () => {
+		let nowMs = 0;
+		let active = 0;
+		let maxActive = 0;
+		const scheduler: MigrationRunScheduler = {
+			batchSize: 100,
+			sliceDurationMs: 10,
+			now: () => nowMs,
+		};
+
+		const summary = await iterateScope({
+			iterate: iterateItems([
+				customerItem("customer_1"),
+				customerItem("customer_2"),
+				customerItem("customer_3"),
+				customerItem("customer_4"),
+				customerItem("customer_5"),
+				customerItem("customer_6"),
+			]),
+			concurrency: 3,
+			scheduler,
+			perItem: async () => {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				await Promise.resolve();
+				nowMs += 6;
+				active--;
+				return undefined;
+			},
+		});
+
+		expect(maxActive).toBe(3);
+		expect(summary.completion).toBe("slice_complete");
+		expect(summary.processed).toBeGreaterThanOrEqual(3);
+		expect(summary.processed).toBeLessThan(6);
 	});
 
 	test("ends a slice between customers after the time budget", async () => {

--- a/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
+++ b/server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts
@@ -26,7 +26,7 @@ describe("migration task scheduler", () => {
 
 	test("keeps fleet and per-run concurrency independently tunable", () => {
 		expect(MIGRATION_TASK_QUEUE_CONCURRENCY).toBe(1);
-		expect(MIGRATION_RUN_CUSTOMER_CONCURRENCY).toBe(1);
+		expect(MIGRATION_RUN_CUSTOMER_CONCURRENCY).toBe(25);
 	});
 
 	test("uses a bounded customer-work slice", () => {


### PR DESCRIPTION
## Summary
- Per-customer migration chunks forced `maxParallel = 1` whenever a scheduler was present, so `concurrency` was ignored. Live Resend `plan-migrate-8-5jg` ran ~50 customers/min.
- Honor `MIGRATION_RUN_CUSTOMER_CONCURRENCY = 25` and still `slice_complete` after 10s so the fleet queue keeps yielding.

## Test plan
- [x] `iterate-scope-scheduling` + `migration-task-scheduler` unit tests
- [ ] After deploy, restart the live per-customer run (in-flight chunk tasks will not pick this up)
- [ ] Confirm ~25 in-flight customers per chunk and rate well above 50/min

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs up to 25 customers in parallel per migration chunk and still ends the slice after 10s. Previously, scheduled runs forced serial execution (maxParallel=1) and ignored concurrency, capping throughput at ~50 customers/min.

- Honors `MIGRATION_RUN_CUSTOMER_CONCURRENCY` during scheduled runs and adds stop/slice checks while draining in‑flight work; sets `MIGRATION_RUN_CUSTOMER_CONCURRENCY` to 25.
- Keeps fleet queue behavior unchanged; slice still yields at 10s.
- Updates tests to assert parallel slices respect concurrency and time budget.

**Rollout**
- Deploy and restart any live per-customer migrations to pick up the new concurrency; in-flight chunk tasks will not update.

<sup>Written for commit 965ee3e6e0390aea7547bc53acd66bc7b0c309d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows scheduled customer migrations to honor the configured concurrency of 25 while retaining time-sliced queue yielding.
- **Bug fixes, Improvements:** Removes the scheduler’s forced single-customer execution limit.
- **Improvements:** Raises per-customer migration concurrency from 1 to 25.
- **Bug fixes:** Updates scheduling tests to cover concurrent execution and time-budget completion.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until continuation cursors remain source-ordered during parallel migrations, because disabling checkpoints can migrate a customer more than once.

Parallel completion order now determines the next chunk cursor, so a supported checkpoint-disabled run can revisit customers whose IDs fall below an out-of-order cursor and execute their migration side effects again.

**Files Needing Attention:** server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts | Enables scheduler-backed parallelism, but derives continuation state from nondeterministic completion order. |
| server/src/internal/migrations/v2/run/utils/migrationRunConstants.ts | Raises the customer concurrency limit from 1 to 25 as intended. |
| server/tests/unit/migrations-v2/scheduling/iterate-scope-scheduling.test.ts | Adds parallel scheduling coverage but does not verify cursor correctness when checkpoints are disabled and completions are out of order. |
| server/tests/unit/migrations-v2/scheduling/migration-task-scheduler.test.ts | Updates the expected configured customer concurrency to 25. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Fetch customers in descending ID order] --> B[Run up to 25 customers concurrently]
  B --> C[Append results as customers finish]
  C --> D[Use last completed customer as cursor]
  D --> E[Drain active customers after slice budget]
  E --> F[Start next chunk below cursor]
  F --> A
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts:39
**Completion order breaks cursor progression**

When a scheduled migration runs concurrently with checkpointing disabled, `results` records customers in completion order and uses the last result as the next descending-ID cursor. For example, if customers 500, 400, and 300 finish as 300, 500, 400, the next query starts below 400 and executes customer 300's migration side effects again.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): run 25 customers in par..."](https://github.com/useautumn/autumn/commit/965ee3e6e0390aea7547bc53acd66bc7b0c309d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53064916)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->