### PR TITLE
feat(customers): add Pooling criteria to balance sheet

### DIFF
--- a/vite/src/views/customers2/components/sheets/PooledBalanceContributions.tsx
+++ b/vite/src/views/customers2/components/sheets/PooledBalanceContributions.tsx
@@ -3,9 +3,16 @@ import {
 	type DbPooledBalance,
 	numberWithCommas,
 } from "@autumn/shared";
-import { Button, Input, Separator } from "@autumn/ui";
-import { MagnifyingGlassIcon } from "@phosphor-icons/react";
-import { useState } from "react";
+import {
+	Button,
+	Input,
+	Separator,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@autumn/ui";
+import { MagnifyingGlassIcon, QuestionIcon } from "@phosphor-icons/react";
+import { type ReactNode, useState } from "react";
 import { SheetSection } from "@/components/v2/sheets/InlineSheet";
 import { SheetPaginationControls } from "@/components/v2/sheets/SheetPaginationControls";
 import {
@@ -50,80 +57,180 @@ export function PooledBalanceContributions({
 				<Separator />
 			</div>
 			<SheetSection withSeparator={false}>
-				<h3 className="text-sub mb-2">Contributions</h3>
-				{(totalCount > CONTRIBUTIONS_PAGE_SIZE || search !== "") && (
-					<div className="relative mb-3">
-						<Input
-							placeholder="Search contributions..."
-							value={search}
-							onChange={(e) => {
-								setSearch(e.target.value);
-								setPage(0);
-							}}
-							className="w-full pr-8"
-							aria-label="Search contributions"
-						/>
-						<MagnifyingGlassIcon
-							size={14}
-							className="absolute right-2.5 top-1/2 -translate-y-1/2 text-subtle pointer-events-none z-10"
-						/>
-					</div>
-				)}
-				{contributions.length === 0 ? (
-					<p className="text-sm text-tertiary-foreground">
-						No contributions match your search
-					</p>
-				) : (
-					<div className="flex flex-col">
-						{contributions.map((contribution) => {
-							const entityId = contribution.entity_id;
-							return (
-								<div
-									key={contribution.id}
-									className="flex items-center justify-between h-9 gap-2 text-sm"
-								>
-									{entityId ? (
-										<Button
-											variant="skeleton"
-											onClick={() => goToEntity(entityId)}
-											className="font-medium hover:text-purple-600 cursor-pointer min-w-0 px-0! hover:bg-transparent active:bg-transparent active:border-none"
+				<h3 className="text-sub mb-3">Pooling</h3>
+				<div className="flex flex-col gap-4">
+					<PoolingCriteria pooledBalance={pooledBalance} />
+
+					<div className="flex flex-col gap-1.5">
+						<Subheading>Contributions</Subheading>
+						{(totalCount > CONTRIBUTIONS_PAGE_SIZE || search !== "") && (
+							<div className="relative mb-1">
+								<Input
+									placeholder="Search contributions..."
+									value={search}
+									onChange={(e) => {
+										setSearch(e.target.value);
+										setPage(0);
+									}}
+									className="w-full pr-8"
+									aria-label="Search contributions"
+								/>
+								<MagnifyingGlassIcon
+									size={14}
+									className="absolute right-2.5 top-1/2 -translate-y-1/2 text-subtle pointer-events-none z-10"
+								/>
+							</div>
+						)}
+						{contributions.length === 0 ? (
+							<p className="text-sm text-tertiary-foreground">
+								No contributions match your search
+							</p>
+						) : (
+							<div className="flex flex-col">
+								{contributions.map((contribution) => {
+									const entityId = contribution.entity_id;
+									return (
+										<div
+											key={contribution.id}
+											className="flex items-center justify-between h-9 gap-2 text-sm"
 										>
-											<span className="truncate">
-												{sourceLabel(contribution)}
-											</span>
-										</Button>
-									) : (
-										<span className="font-medium truncate">
-											{sourceLabel(contribution)}
-										</span>
-									)}
-									<div className="flex items-center gap-3 shrink-0">
-										<span className="text-tertiary-foreground truncate max-w-[140px]">
-											{planLabel(contribution)}
-										</span>
-										<span className="text-foreground font-medium tabular-nums">
-											{pooledBalance.unlimited
-												? "Unlimited"
-												: `+${numberWithCommas(contribution.current_contribution)}`}
-										</span>
-									</div>
-								</div>
-							);
-						})}
-						{pageCount > 1 && (
-							<SheetPaginationControls
-								rangeStart={pageStart + 1}
-								rangeEnd={pageStart + contributions.length}
-								total={totalFilteredCount}
-								canPrev={page > 0}
-								canNext={page < pageCount - 1}
-								onPrev={() => setPage(page - 1)}
-								onNext={() => setPage(page + 1)}
-							/>
+											{entityId ? (
+												<Button
+													variant="skeleton"
+													onClick={() => goToEntity(entityId)}
+													className="font-medium hover:text-purple-600 cursor-pointer min-w-0 px-0! hover:bg-transparent active:bg-transparent active:border-none"
+												>
+													<span className="truncate">
+														{sourceLabel(contribution)}
+													</span>
+												</Button>
+											) : (
+												<span className="font-medium truncate">
+													{sourceLabel(contribution)}
+												</span>
+											)}
+											<div className="flex items-center gap-3 shrink-0">
+												<span className="text-tertiary-foreground truncate max-w-[140px]">
+													{planLabel(contribution)}
+												</span>
+												<span className="text-foreground font-medium tabular-nums">
+													{pooledBalance.unlimited
+														? "Unlimited"
+														: `+${numberWithCommas(contribution.current_contribution)}`}
+												</span>
+											</div>
+										</div>
+									);
+								})}
+								{pageCount > 1 && (
+									<SheetPaginationControls
+										rangeStart={pageStart + 1}
+										rangeEnd={pageStart + contributions.length}
+										total={totalFilteredCount}
+										canPrev={page > 0}
+										canNext={page < pageCount - 1}
+										onPrev={() => setPage(page - 1)}
+										onNext={() => setPage(page + 1)}
+									/>
+								)}
+							</div>
 						)}
 					</div>
-				)}
+				</div>
 			</SheetSection>
 		</>
 	);
+}
+
+function Subheading({ children }: { children: ReactNode }) {
+	return (
+		<div className="flex items-center gap-1.5 text-tertiary-foreground text-sm font-medium">
+			{children}
+		</div>
+	);
+}
+
+/** A pool only merges balances that share its feature plus every property below,
+ * so surface this pool's actual values as the match criteria. */
+function PoolingCriteria({
+	pooledBalance,
+}: {
+	pooledBalance: DbPooledBalance;
+}) {
+	const criteria: { label: string; value: string }[] = [
+		{ label: "Reset", value: resetLabel(pooledBalance) },
+	];
+
+	if (!pooledBalance.unlimited) {
+		criteria.push({
+			label: "Rollover",
+			value: rolloverSignatureToLabel(pooledBalance.rollover_signature),
+		});
+	}
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<Subheading>
+				Criteria
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<QuestionIcon className="size-3.5 cursor-help text-tertiary-foreground" />
+					</TooltipTrigger>
+					<TooltipContent className="max-w-64">
+						Balances share this pool only when they match the feature and all of
+						these properties.
+					</TooltipContent>
+				</Tooltip>
+			</Subheading>
+			{criteria.map((row) => (
+				<div
+					key={row.label}
+					className="flex items-center justify-between text-sm gap-2"
+				>
+					<span className="text-tertiary-foreground">{row.label}</span>
+					<span className="text-foreground font-medium text-right truncate">
+						{row.value}
+					</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function resetLabel({
+	interval,
+	interval_count,
+}: Pick<DbPooledBalance, "interval" | "interval_count">): string {
+	if (interval === "lifetime") return "Lifetime (never resets)";
+	if (interval_count > 1) return `Every ${interval_count} ${interval}s`;
+	return `Every ${interval}`;
+}
+
+/** Reverses rolloverConfigToSignature so the card reads back the same terms the
+ * pool matched on. */
+function rolloverSignatureToLabel(signature: string): string {
+	if (signature === "none") return "None";
+
+	const parts = Object.fromEntries(
+		signature.split(";").map((part) => part.split("=") as [string, string]),
+	);
+	const toNumber = (value?: string) =>
+		value && value !== "null" ? Number(value) : null;
+
+	const max = toNumber(parts.max);
+	const maxPercentage = toNumber(parts.max_percentage);
+	const length = toNumber(parts.length);
+	const duration = parts.duration;
+
+	const cap =
+		maxPercentage !== null
+			? `Up to ${maxPercentage}%`
+			: max !== null
+				? `Up to ${numberWithCommas(max)}`
+				: "All unused";
+
+	if (length !== null && duration) {
+		return `${cap}, expires after ${length} ${duration}${length === 1 ? "" : "s"}`;
+	}
+	return cap;
 }


### PR DESCRIPTION
## What

Restructures the pooled-balance section of the customer **balance edit sheet** into a clearer hierarchy and adds a **Criteria** subsection that surfaces *why* balances pool together.

Before: a flat `Contributions` section.
Now:

```
Pooling                    ← heading
  Criteria  (?)            ← subheading + tooltip
    Reset      Every month
    Rollover   None
  Contributions            ← subheading
    symmetry-prod    Enterprise  +10,000
    ...
```

## Why

The panel showed *which* products contribute to a pooled balance but never *what makes them share one pool*. Two balances only merge when they match the same feature plus the pool's identity fields (`pooledBalanceIdentityToKey`). The new Criteria block reads those actual values off the pool row so it stays accurate per pool — e.g. the rollover terms are reversed back out of `rollover_signature`.

## Notes

- Criteria is data-driven from the `pooled_balance` row (reset interval + rollover); the Rollover row is hidden for unlimited pools since they never carry rollover.
- Explanation moved into a `?` tooltip beside the Criteria subheading, matching the existing tooltip pattern used elsewhere in the app.
- Single-file change; `tsc --noEmit` passes via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Pooling section to the customer balance edit sheet with a Criteria block that shows why balances pool together. Previously the sheet listed Contributions only; now it also shows Reset and Rollover terms per pool and nests Contributions under Pooling.

- Criteria reads directly from `pooled_balance`: Reset from `interval`/`interval_count`; Rollover from `rollover_signature`; Rollover is hidden for unlimited pools.
- The Criteria subheading includes a tooltip explaining that balances share a pool only if the feature and all criteria match; aligns with existing tooltip patterns.
- Labels handle lifetime and pluralization (e.g., “Every month”, “Every 3 months”, “Lifetime (never resets)”).
- No API or data model changes; search and pagination are unchanged. Single-file UI change in `vite/src/views/customers2/components/sheets/PooledBalanceContributions.tsx`.

<sup>Written for commit 1685e5c5bef34c960ab8a318f4c25d2c84e9caa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reorganizes the pooled-balance section and explains why balances share a pool.

- **Improvements:** Adds a Criteria subsection showing the pool's reset and rollover terms.
- **Improvements:** Groups criteria and contribution details under a clearer Pooling hierarchy.
- **Improvements:** Adds a tooltip explaining that pooling depends on matching the feature and identity properties.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The changed component preserves the contribution controls while adding criteria labels rendered from the existing pooled-balance data.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/PooledBalanceContributions.tsx | Reorganizes pooled-balance details and adds data-driven reset and rollover criteria with explanatory UI. |

<sub>Reviews (1): Last reviewed commit: ["feat(customers): add Pooling criteria to..."](https://github.com/useautumn/autumn/commit/1685e5c5bef34c960ab8a318f4c25d2c84e9caa2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53127369)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->