### PR TITLE
copy: rewrite homepage hero to control plane messaging

### DIFF
--- a/apps/website/components/hero.tsx
+++ b/apps/website/components/hero.tsx
@@ -148,19 +148,20 @@ export default function Hero() {
 						<div className="flex flex-col gap-6 w-full px-0 lg:px-0">
 							<h1 className="hero-reveal lg:opacity-0 text-[44px] md:text-[56px] w-full max-w-sm sm:max-w-[480px] md:max-w-xl leading-[44px] tracking-[-4%] md:leading-14 font-sans">
 								<span className="text-[#FFFFFF99] font-normal">
-									The API for
+									The control plane for
 								</span>{" "}
 								<span className="text-white block md:inline">
-									plans, usage and AI credits
+									usage-based pricing
 								</span>
 							</h1>
 							<p className="hero-reveal lg:opacity-0 tracking-[-2%] w-full max-w-xs sm:max-w-[480px] md:max-w-xl text-[#FFFFFF99] md:text-[16px] text-[14px] font-light leading-5 font-sans">
-								Replace your in-house usage tracking, gating and asynchronous
-								billing logic. Autumn gives you a{" "}
+								One layer for billing, ledgering and entitlements. Autumn
+								moves pricing{" "}
 								<span className="text-white font-light">
-									flexible source of truth
-								</span>{" "}
-								across self-serve payments and enterprise deals.
+									from code into config
+								</span>
+								, so you can change your plans and sell custom contracts 10x
+								faster.
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
Rewrites the homepage hero H1 and subhead.

**Before**
- H1: The API for plans, usage and AI credits
- Sub: Replace your in-house usage tracking, gating and asynchronous billing logic. Autumn gives you a flexible source of truth across self-serve payments and enterprise deals.

**After**
- H1: The control plane for usage-based pricing
- Sub: One layer for billing, ledgering and entitlements. Autumn moves pricing from code into config, so you can change your plans and sell custom contracts 10x faster.

Grey/white span styling preserved; "from code into config" emphasized in white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the homepage hero to position Autumn as “the control plane for usage-based pricing,” replacing the prior “API for plans, usage and AI credits.” This updates product messaging only; layout and styling remain unchanged.

- Updates H1 and subhead in apps/website/components/hero.tsx; grey/white span styling is preserved.
- New subhead emphasizes “from code into config” and faster plan changes/custom contracts.
- No functional, layout, or dependency changes; verify responsive breakpoints and line wrapping only.

<sup>Written for commit 53370d2350816d56523d68a4ba82c7f0e7798ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Rewrites the homepage hero to position Autumn as the control plane for usage-based pricing.

- **Improvements:** Updates the hero heading and supporting copy.
- **Improvements:** Preserves the existing grey/white styling while emphasizing “from code into config.”
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change only updates static homepage copy, and the revised JSX renders with the intended spacing, punctuation, and emphasis.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/components/hero.tsx | Replaces static hero copy while preserving valid JSX structure, styling, spacing, and punctuation. |

<sub>Reviews (1): Last reviewed commit: ["copy: rewrite homepage hero to control p..."](https://github.com/useautumn/autumn/commit/53370d2350816d56523d68a4ba82c7f0e7798ec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53130886)</sub>

<!-- /greptile_comment -->