### PR TITLE
copy: keep "for" attached in hero H1 on mobile

### DIFF
--- a/apps/website/components/hero.tsx
+++ b/apps/website/components/hero.tsx
@@ -148,7 +148,7 @@ export default function Hero() {
 						<div className="flex flex-col gap-6 w-full px-0 lg:px-0">
 							<h1 className="hero-reveal lg:opacity-0 text-[44px] md:text-[56px] w-full max-w-sm sm:max-w-[480px] md:max-w-xl leading-[44px] tracking-[-4%] md:leading-14 font-sans">
 								<span className="text-[#FFFFFF99] font-normal">
-									The control plane for
+									The control plane&nbsp;for
 								</span>{" "}
 								<span className="text-white block md:inline">
 									usage-based pricing


### PR DESCRIPTION
Follow-up to #2811. On mobile the H1 grey text wrapped with "for" alone on its own line. Binds "plane for" with a non-breaking space so it wraps as "The control / plane for".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents “for” from wrapping alone in the hero H1 on mobile by replacing the space between “plane” and “for” with a non-breaking space. Previously, “for” could appear on its own line; now “plane for” stays together without changing copy or styles.

**Review notes**
- Verify on small/mobile breakpoints that the H1 wraps as “The control / plane for / usage-based pricing” and never isolates “for”.
- Confirm `&nbsp;` renders as expected in SSR and does not affect desktop layout.

<sup>Written for commit dfef29dfadd1c69fd55d4c000b657053ef6ea884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adjusts the homepage hero heading so “plane for” stays together when wrapping on mobile.

- **[Bug fixes]** Replaces the normal space between “plane” and “for” with a non-breaking space, preventing “for” from appearing alone on a line.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change only adjusts a wrapping boundary in static hero text, and the responsive heading retains other valid wrapping points without an established layout failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/components/hero.tsx | Keeps two words together in the hero heading to improve mobile line wrapping; no actionable issue was identified. |

<sub>Reviews (1): Last reviewed commit: ["copy: keep &quot;for&quot; attached in hero H1 on ..."](https://github.com/useautumn/autumn/commit/dfef29dfadd1c69fd55d4c000b657053ef6ea884) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53135320)</sub>

<!-- /greptile_comment -->