### PR TITLE
fix: reset future start date on early activation

### DIFF
--- a/server/src/external/stripe/webhookHandlers/common/expireAndActivateWithTracking.ts
+++ b/server/src/external/stripe/webhookHandlers/common/expireAndActivateWithTracking.ts
@@ -36,14 +36,12 @@ export const expireAndActivateWithTracking = async ({
 			activatedAt: eventContext.nowMs,
 		});
 
-	// Track expired product (UPDATE)
 	const expiredCustomerProduct = trackCustomerProductUpdate({
 		eventContext,
 		customerProduct,
 		updates,
 	});
 
-	// Track activated scheduled product (UPDATE: scheduled → active)
 	if (activatedCustomerProduct) {
 		trackCustomerProductUpdate({
 			eventContext,
@@ -52,7 +50,6 @@ export const expireAndActivateWithTracking = async ({
 		});
 	}
 
-	// Track inserted default product (INSERT)
 	if (insertedCustomerProduct) {
 		trackCustomerProductInsertion({
 			eventContext,

--- a/server/src/external/stripe/webhookHandlers/common/expireAndActivateWithTracking.ts
+++ b/server/src/external/stripe/webhookHandlers/common/expireAndActivateWithTracking.ts
@@ -33,6 +33,7 @@ export const expireAndActivateWithTracking = async ({
 			ctx,
 			customerProduct,
 			fullCustomer,
+			activatedAt: eventContext.nowMs,
 		});
 
 	// Track expired product (UPDATE)

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/linkScheduledCustomerProductsToSubscription.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/linkScheduledCustomerProductsToSubscription.ts
@@ -51,6 +51,7 @@ const executeLinkScheduledCustomerProductsToSubscription = async ({
 				scheduledIds: cusProduct.scheduled_ids?.length
 					? cusProduct.scheduled_ids
 					: [scheduleId],
+				activatedAt: subscriptionStartMs,
 			});
 			linkedCount++;
 			continue;

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/activateScheduledCustomerProducts.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/activateScheduledCustomerProducts.ts
@@ -33,7 +33,6 @@ export const activateScheduledCustomerProducts = async ({
 	const stripeSubscriptionSchedule = stripeSubscription.schedule;
 
 	for (const customerProduct of fullCustomer.customer_products) {
-		// Check if can activate: free OR on this subscription OR on this schedule
 		const hasStarted = hasCustomerProductStarted(customerProduct, { nowMs });
 		const canActivate = cp(customerProduct)
 			.free()
@@ -61,7 +60,6 @@ export const activateScheduledCustomerProducts = async ({
 			`Activating scheduled product: ${customerProduct.product.name}${customerProduct.entity_id ? `@${customerProduct.entity_id}` : ""}`,
 		);
 
-		// Free products get empty IDs, paid products get IDs from stripe subscription
 		const subscriptionIds = isFree ? [] : [stripeSubscription.id];
 		const scheduledIds = isFree
 			? []

--- a/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/activateScheduledCustomerProducts.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/activateScheduledCustomerProducts.ts
@@ -79,6 +79,7 @@ export const activateScheduledCustomerProducts = async ({
 			fullCustomer,
 			subscriptionIds,
 			scheduledIds,
+			activatedAt: nowMs,
 		});
 
 		trackCustomerProductUpdate({

--- a/server/src/internal/customers/cusProducts/actions/activateFreeSuccessorProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/activateFreeSuccessorProduct.ts
@@ -89,7 +89,6 @@ export const activateFreeSuccessorProduct = async ({
 			...updates,
 		} as FullCusProduct;
 
-		// Update fullCustomer in memory
 		fullCustomer.customer_products = fullCustomer.customer_products.map((cp) =>
 			cp.id === scheduledCustomerProduct.id ? activatedCustomerProduct : cp,
 		);

--- a/server/src/internal/customers/cusProducts/actions/activateFreeSuccessorProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/activateFreeSuccessorProduct.ts
@@ -1,5 +1,4 @@
 import {
-	CusProductStatus,
 	cp,
 	type FullCusProduct,
 	type FullCustomer,
@@ -29,10 +28,12 @@ export const activateFreeSuccessorProduct = async ({
 	ctx,
 	fromCustomerProduct,
 	fullCustomer,
+	activatedAt,
 }: {
 	ctx: AutumnContext;
 	fromCustomerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
+	activatedAt: number;
 }): Promise<{
 	activatedCustomerProduct?: FullCusProduct;
 	insertedCustomerProduct?: FullCusProduct;
@@ -76,21 +77,24 @@ export const activateFreeSuccessorProduct = async ({
 		scheduledCustomerProduct &&
 		isCustomerProductFree(scheduledCustomerProduct)
 	) {
-		await activateScheduledCustomerProduct({
+		const { updates } = await activateScheduledCustomerProduct({
 			ctx,
 			fromCustomerProduct,
 			customerProduct: scheduledCustomerProduct,
 			fullCustomer,
+			activatedAt,
 		});
+		const activatedCustomerProduct = {
+			...scheduledCustomerProduct,
+			...updates,
+		} as FullCusProduct;
 
 		// Update fullCustomer in memory
 		fullCustomer.customer_products = fullCustomer.customer_products.map((cp) =>
-			cp.id === scheduledCustomerProduct.id
-				? { ...cp, status: CusProductStatus.Active }
-				: cp,
+			cp.id === scheduledCustomerProduct.id ? activatedCustomerProduct : cp,
 		);
 
-		return { activatedCustomerProduct: scheduledCustomerProduct };
+		return { activatedCustomerProduct };
 	}
 
 	// 2. Fall back to default product (creates a new customer product)

--- a/server/src/internal/customers/cusProducts/actions/activateScheduled.ts
+++ b/server/src/internal/customers/cusProducts/actions/activateScheduled.ts
@@ -68,8 +68,6 @@ export const activateScheduledCustomerProduct = async ({
 			})
 		: [];
 
-	// Executing through the shared plan runs the license lifecycle for
-	// activations that bring license-bearing parents live.
 	await executeAutumnBillingPlan({
 		ctx,
 		autumnBillingPlan: {

--- a/server/src/internal/customers/cusProducts/actions/activateScheduled.ts
+++ b/server/src/internal/customers/cusProducts/actions/activateScheduled.ts
@@ -22,6 +22,7 @@ export const activateScheduledCustomerProduct = async ({
 	fullCustomer,
 	subscriptionIds,
 	scheduledIds,
+	activatedAt,
 }: {
 	ctx: AutumnContext;
 	fromCustomerProduct?: FullCusProduct; // for cases where expiry happens before activation (eg. expireAndActivateDefault)
@@ -29,6 +30,7 @@ export const activateScheduledCustomerProduct = async ({
 	fullCustomer: FullCustomer;
 	subscriptionIds?: string[];
 	scheduledIds?: string[];
+	activatedAt: number;
 }): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
 	const { org, env, logger } = ctx;
 
@@ -53,11 +55,11 @@ export const activateScheduledCustomerProduct = async ({
 		fullCustomer,
 	});
 
-	// 1. Update status and subscription/schedule IDs
 	const updates: Partial<InsertCustomerProduct> = {
 		status: CusProductStatus.Active,
 		subscription_ids: subscriptionIds,
 		scheduled_ids: scheduledIds,
+		starts_at: Math.min(customerProduct.starts_at, activatedAt),
 	};
 	const customerLicenseTransitions = transitionSource
 		? computeCustomerLicenseTransitions({

--- a/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
+++ b/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
@@ -55,8 +55,6 @@ export const expireCustomerProductAndActivateDefault = async ({
 		...extraUpdates,
 	};
 
-	// Executing through the shared plan runs the license lifecycle when the
-	// expiring product carried license state.
 	await executeAutumnBillingPlan({
 		ctx,
 		autumnBillingPlan: {
@@ -75,7 +73,6 @@ export const expireCustomerProductAndActivateDefault = async ({
 		`[expireCustomerProduct]: expiring ${customerProduct.product.name}`,
 	);
 
-	// Update full customer
 	fullCustomer.customer_products = fullCustomer.customer_products.map((cp) =>
 		cp.id === customerProduct.id
 			? ({ ...cp, ...updates } as FullCusProduct)

--- a/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
+++ b/server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts
@@ -32,12 +32,14 @@ export const expireCustomerProductAndActivateDefault = async ({
 	fullCustomer,
 	updates: extraUpdates,
 	emitBillingUpdated = false,
+	activatedAt = Date.now(),
 }: {
 	ctx: AutumnContext;
 	customerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
 	updates?: Partial<InsertCustomerProduct>;
 	emitBillingUpdated?: boolean;
+	activatedAt?: number;
 }): Promise<{
 	updates: Partial<InsertCustomerProduct>;
 	activatedCustomerProduct?: FullCusProduct;
@@ -98,6 +100,7 @@ export const expireCustomerProductAndActivateDefault = async ({
 			ctx,
 			fromCustomerProduct: customerProduct,
 			fullCustomer,
+			activatedAt,
 		});
 
 	// 4. Emit billing.updated (payload needs the activated/inserted products)

--- a/server/tests/integration/customers/cus-products/activate-scheduled.test.ts
+++ b/server/tests/integration/customers/cus-products/activate-scheduled.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Red: early activation keeps a future starts_at. Green: starts_at becomes the activation time.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	customerProducts,
+	customers,
+	ms,
+	products,
+} from "@autumn/shared";
+import ctx from "@tests/utils/testInitUtils/createTestContext";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { CusService } from "@/internal/customers/CusService";
+import { customerProductActions } from "@/internal/customers/cusProducts/actions";
+import { generateId } from "@/utils/genUtils";
+
+test(`${chalk.yellowBright("activate scheduled: early activation replaces future starts_at")}`, async () => {
+	const now = Date.now();
+	const customerId = generateId("early_activation_customer");
+	const internalCustomerId = generateId("cus");
+	const productId = generateId("early_activation_plan");
+	const internalProductId = generateId("prod");
+	const customerProductId = generateId("cus_prod");
+	const futureStartsAt = now + ms.days(30);
+
+	await ctx.db.insert(customers).values({
+		id: customerId,
+		internal_id: internalCustomerId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: now,
+		processor: null,
+	});
+	await ctx.db.insert(products).values({
+		id: productId,
+		internal_id: internalProductId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		name: "Early Activation Plan",
+		created_at: now,
+		is_default: true,
+	});
+	await ctx.db.insert(customerProducts).values({
+		id: customerProductId,
+		customer_id: customerId,
+		internal_customer_id: internalCustomerId,
+		product_id: productId,
+		internal_product_id: internalProductId,
+		created_at: now,
+		updated_at: now,
+		status: CusProductStatus.Scheduled,
+		starts_at: futureStartsAt,
+	});
+
+	try {
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+			expand: [],
+		});
+		const customerProduct = fullCustomer.customer_products[0]!;
+		const activatedAt = Date.now();
+
+		await customerProductActions.activateScheduled({
+			ctx: { ...ctx, testOptions: { skipWebhooks: true } },
+			customerProduct,
+			fullCustomer,
+			activatedAt,
+		});
+
+		const [activated] = await ctx.db
+			.select({
+				status: customerProducts.status,
+				startsAt: customerProducts.starts_at,
+			})
+			.from(customerProducts)
+			.where(eq(customerProducts.id, customerProductId));
+		expect(activated?.status).toBe(CusProductStatus.Active);
+		expect(activated?.startsAt).toBe(activatedAt);
+	} finally {
+		await ctx.db
+			.delete(customers)
+			.where(eq(customers.internal_id, internalCustomerId));
+		await ctx.db
+			.delete(products)
+			.where(eq(products.internal_id, internalProductId));
+	}
+});


### PR DESCRIPTION
## Summary
- reset `starts_at` when a scheduled customer product activates early
- preserve the original scheduled timestamp for on-time or late activation
- pass clock-aware activation times through Stripe subscription handlers

## Red / green
- red: an active product retained a `starts_at` 30 days in the future
- green: the persisted `starts_at` equals the actual early activation time

## Test plan
- `bunx tsgo --build --noEmit`
- `./run.sh /Users/charlielamb/code/atmn/autumn-fix-early-scheduled-start-pr/server/tests/integration/customers/cus-products/activate-scheduled.test.ts`
- targeted Biome check for all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset starts_at when a scheduled customer product activates early so entitlements reflect the real start. Before: early activations kept a future starts_at; now: starts_at equals the activation time. On-time or late activations keep their scheduled starts_at.

- activateScheduledCustomerProduct: sets starts_at = min(existing starts_at, activatedAt); activates the product; keeps subscription/schedule IDs otherwise.
- Thread clock-aware activatedAt through Stripe flows: creation link uses subscriptionStartMs; schedule-phase updates use nowMs; expire/activate uses event clock and defaults to Date.now().
- activateFreeSuccessorProduct: merges DB activation updates into in-memory state and returns the updated product.
- Adds integration test server/tests/integration/customers/cus-products/activate-scheduled.test.ts; no migrations or external API changes.

<sup>Written for commit b3a43671d50b5aa0b7e311d97c54c22f7140e50b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR corrects the start timestamp of products activated before their scheduled date while preserving the original timestamp for on-time or late activation.
- **[Bug fixes]** Persist the earlier of the scheduled start and actual activation time.
- **[Improvements]** Pass clock-aware activation timestamps through Stripe subscription handlers.
- **[Improvements]** Keep activated successor-product state synchronized in memory and add an integration test for early activation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/actions/activateScheduled.ts | Updates scheduled activation to persist the actual timestamp when activation occurs early. |
| server/src/internal/customers/cusProducts/actions/activateFreeSuccessorProduct.ts | Returns and stores an in-memory successor product containing the persisted activation updates. |
| server/src/internal/customers/cusProducts/actions/expireAndActivateDefault.ts | Propagates an explicit activation timestamp while retaining a current-time default for existing callers. |
| server/src/external/stripe/webhookHandlers/common/expireAndActivateWithTracking.ts | Uses the Stripe event context clock when activating a successor after expiration. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionCreated/tasks/linkScheduledCustomerProductsToSubscription.ts | Uses the Stripe subscription start when linking and activating a scheduled product. |
| server/src/external/stripe/webhookHandlers/handleStripeSubscriptionUpdated/tasks/handleSchedulePhaseChanges/activateScheduledCustomerProducts.ts | Passes the clock-aware current time into schedule-phase activation. |
| server/tests/integration/customers/cus-products/activate-scheduled.test.ts | Verifies that early activation replaces a future scheduled start with the supplied activation time. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Stripe
    participant Handler as Subscription handler
    participant Activation as Scheduled-product activation
    participant DB as Customer-product storage
    Stripe->>Handler: Subscription event
    Handler->>Activation: Activate with clock-aware activatedAt
    Activation->>Activation: "starts_at = min(scheduled start, activatedAt)"
    Activation->>DB: Persist active status and starts_at
```
</details>

<sub>Reviews (2): Last reviewed commit: ["style: 💄 remove redundant activation co..."](https://github.com/useautumn/autumn/commit/b3a43671d50b5aa0b7e311d97c54c22f7140e50b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53284843)</sub>

<!-- /greptile_comment -->