### PR TITLE
feat(migrations): batch-lower free plain plan item deletes

### DIFF
--- a/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
@@ -8,7 +8,11 @@ import {
 } from "./computeProductTransitions";
 
 /** Diffs a product against an add/remove patch of itself. The projected
- * to-product is synthetic — it exists only for transition computation. */
+ * to-product is synthetic — it exists only for transition computation.
+ *
+ * Removals are diffed on their own: the successor matcher falls back to
+ * feature-only precision, so a removed entitlement left in the from-product
+ * would claim a surviving same-feature sibling and report a transition. */
 export const computePatchProductTransitions = ({
 	fromProduct,
 	addEntitlements,
@@ -19,17 +23,34 @@ export const computePatchProductTransitions = ({
 	removeEntitlementIds?: string[];
 }): ProductTransitions => {
 	const removed = new Set(removeEntitlementIds);
+	const surviving = fromProduct.entitlements.filter(
+		(entitlement) => !removed.has(entitlement.id),
+	);
 
-	return computeProductTransitions({
-		fromProduct,
+	const transitions = computeProductTransitions({
+		fromProduct: { ...fromProduct, entitlements: surviving },
 		toProduct: {
 			...fromProduct,
-			entitlements: [
-				...fromProduct.entitlements.filter(
-					(entitlement) => !removed.has(entitlement.id),
-				),
-				...addEntitlements,
-			],
+			entitlements: [...surviving, ...addEntitlements],
 		},
 	});
+	if (removed.size === 0) return transitions;
+
+	const deleted = computeProductTransitions({
+		fromProduct: {
+			...fromProduct,
+			entitlements: fromProduct.entitlements.filter((entitlement) =>
+				removed.has(entitlement.id),
+			),
+		},
+		toProduct: { ...fromProduct, entitlements: [] },
+	});
+
+	return {
+		...transitions,
+		entitlementPrices: {
+			...transitions.entitlementPrices,
+			deleted: deleted.entitlementPrices.deleted,
+		},
+	};
 };

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
@@ -7,20 +7,29 @@ import {
 	type ProductTransitions,
 } from "./computeProductTransitions";
 
-/** Diffs a product against an add-items patch of itself. The projected
+/** Diffs a product against an add/remove patch of itself. The projected
  * to-product is synthetic — it exists only for transition computation. */
 export const computePatchProductTransitions = ({
 	fromProduct,
 	addEntitlements,
+	removeEntitlementIds = [],
 }: {
 	fromProduct: FullProductWithoutLicenses;
 	addEntitlements: EntitlementWithFeature[];
+	removeEntitlementIds?: string[];
 }): ProductTransitions => {
+	const removed = new Set(removeEntitlementIds);
+
 	return computeProductTransitions({
 		fromProduct,
 		toProduct: {
 			...fromProduct,
-			entitlements: [...fromProduct.entitlements, ...addEntitlements],
+			entitlements: [
+				...fromProduct.entitlements.filter(
+					(entitlement) => !removed.has(entitlement.id),
+				),
+				...addEntitlements,
+			],
 		},
 	});
 };

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
@@ -8,10 +8,12 @@ import {
 	type ProductTransitions,
 } from "./computeProductTransitions";
 
-/** Diffs a product against an add/remove patch of itself. Removals are dropped
- * from both sides and reported directly: left in the from-product, the
- * successor matcher's feature-only rung would pair one with a surviving
- * sibling and call it a transition. */
+/** Diffs a product against an add/remove patch of itself.
+ *
+ * Removals are held out of the diff entirely — the successor matcher's
+ * feature-only rung would otherwise pair one with a surviving sibling and call
+ * it a transition — so the diff never reports them and they are carried
+ * through as `deleted` directly. */
 export const computePatchProductTransitions = ({
 	fromProduct,
 	addEntitlements,
@@ -22,14 +24,29 @@ export const computePatchProductTransitions = ({
 	removeEntitlementIds?: string[];
 }): ProductTransitions => {
 	const removed = new Set(removeEntitlementIds);
+	const isRemoved = (entitlementId: string | null | undefined) =>
+		entitlementId ? removed.has(entitlementId) : false;
+
 	const survivingProduct = {
 		...fromProduct,
 		entitlements: fromProduct.entitlements.filter(
-			(entitlement) => !removed.has(entitlement.id),
+			(entitlement) => !isRemoved(entitlement.id),
+		),
+		prices: fromProduct.prices.filter(
+			(price) => !isRemoved(price.entitlement_id),
 		),
 	};
 
-	const transitions = computeProductTransitions({
+	const deleted = productToEntitlementPrices({
+		product: {
+			...fromProduct,
+			entitlements: fromProduct.entitlements.filter((entitlement) =>
+				isRemoved(entitlement.id),
+			),
+		},
+	});
+
+	const { entitlementPrices, ...transitions } = computeProductTransitions({
 		fromProduct: survivingProduct,
 		toProduct: {
 			...survivingProduct,
@@ -39,16 +56,6 @@ export const computePatchProductTransitions = ({
 
 	return {
 		...transitions,
-		entitlementPrices: {
-			...transitions.entitlementPrices,
-			deleted: productToEntitlementPrices({
-				product: {
-					...fromProduct,
-					entitlements: fromProduct.entitlements.filter((entitlement) =>
-						removed.has(entitlement.id),
-					),
-				},
-			}),
-		},
+		entitlementPrices: { ...entitlementPrices, deleted },
 	};
 };

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
@@ -7,12 +7,9 @@ import {
 	type ProductTransitions,
 } from "./computeProductTransitions";
 
-/** Diffs a product against an add/remove patch of itself. The projected
- * to-product is synthetic — it exists only for transition computation.
- *
- * Removals are diffed on their own: the successor matcher falls back to
- * feature-only precision, so a removed entitlement left in the from-product
- * would claim a surviving same-feature sibling and report a transition. */
+/** Diffs a product against an add/remove patch of itself. Removals diff
+ * separately: the successor matcher falls back to feature-only precision, so
+ * one left in the from-product would claim a surviving sibling. */
 export const computePatchProductTransitions = ({
 	fromProduct,
 	addEntitlements,

--- a/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
+++ b/server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts
@@ -1,15 +1,17 @@
-import type {
-	EntitlementWithFeature,
-	FullProductWithoutLicenses,
+import {
+	type EntitlementWithFeature,
+	type FullProductWithoutLicenses,
+	productToEntitlementPrices,
 } from "@autumn/shared";
 import {
 	computeProductTransitions,
 	type ProductTransitions,
 } from "./computeProductTransitions";
 
-/** Diffs a product against an add/remove patch of itself. Removals diff
- * separately: the successor matcher falls back to feature-only precision, so
- * one left in the from-product would claim a surviving sibling. */
+/** Diffs a product against an add/remove patch of itself. Removals are dropped
+ * from both sides and reported directly: left in the from-product, the
+ * successor matcher's feature-only rung would pair one with a surviving
+ * sibling and call it a transition. */
 export const computePatchProductTransitions = ({
 	fromProduct,
 	addEntitlements,
@@ -20,34 +22,33 @@ export const computePatchProductTransitions = ({
 	removeEntitlementIds?: string[];
 }): ProductTransitions => {
 	const removed = new Set(removeEntitlementIds);
-	const surviving = fromProduct.entitlements.filter(
-		(entitlement) => !removed.has(entitlement.id),
-	);
+	const survivingProduct = {
+		...fromProduct,
+		entitlements: fromProduct.entitlements.filter(
+			(entitlement) => !removed.has(entitlement.id),
+		),
+	};
 
 	const transitions = computeProductTransitions({
-		fromProduct: { ...fromProduct, entitlements: surviving },
+		fromProduct: survivingProduct,
 		toProduct: {
-			...fromProduct,
-			entitlements: [...surviving, ...addEntitlements],
+			...survivingProduct,
+			entitlements: [...survivingProduct.entitlements, ...addEntitlements],
 		},
-	});
-	if (removed.size === 0) return transitions;
-
-	const deleted = computeProductTransitions({
-		fromProduct: {
-			...fromProduct,
-			entitlements: fromProduct.entitlements.filter((entitlement) =>
-				removed.has(entitlement.id),
-			),
-		},
-		toProduct: { ...fromProduct, entitlements: [] },
 	});
 
 	return {
 		...transitions,
 		entitlementPrices: {
 			...transitions.entitlementPrices,
-			deleted: deleted.entitlementPrices.deleted,
+			deleted: productToEntitlementPrices({
+				product: {
+					...fromProduct,
+					entitlements: fromProduct.entitlements.filter((entitlement) =>
+						removed.has(entitlement.id),
+					),
+				},
+			}),
 		},
 	};
 };

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
@@ -1,6 +1,10 @@
 import { sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { sqlList } from "@/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.js";
+import {
+	type OperationScope,
+	operationScopeSql,
+} from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
 
 /** Pooled rows are excluded: the anchor FK is RESTRICT, so deleting one would
  * abort the whole page. */
@@ -8,17 +12,24 @@ export const deleteCustomerEntitlementRows = async ({
 	db,
 	customerProductIds,
 	entitlementIds,
+	scope,
 }: {
 	db: DrizzleCli;
 	customerProductIds: string[];
 	entitlementIds: string[];
+	scope: OperationScope;
 }): Promise<string[]> => {
 	if (customerProductIds.length === 0 || entitlementIds.length === 0) return [];
 
 	const deleted = await db.execute<{ customer_product_id: string }>(sql`
 		WITH dropped AS (
 			DELETE FROM customer_entitlements AS target
-			WHERE target.customer_product_id IN (${sqlList({ values: customerProductIds })})
+			USING customer_products AS cp
+			-- Re-assert scope at delete time: rows whose customer product
+			-- changed since the select (canceled, customized) drop out.
+			WHERE cp.id = target.customer_product_id
+				AND ${operationScopeSql({ scope })}
+				AND target.customer_product_id IN (${sqlList({ values: customerProductIds })})
 				AND target.entitlement_id IN (${sqlList({ values: entitlementIds })})
 				AND NOT target.is_pooled_balance
 				AND target.pooled_contribution_id IS NULL

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
@@ -1,0 +1,38 @@
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { sqlList } from "@/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.js";
+
+/** Pooled rows are excluded: the anchor FK is RESTRICT, so deleting one would
+ * abort the whole page. */
+export const deleteCustomerEntitlementRows = async ({
+	db,
+	customerProductIds,
+	entitlementIds,
+}: {
+	db: DrizzleCli;
+	customerProductIds: string[];
+	entitlementIds: string[];
+}): Promise<string[]> => {
+	if (customerProductIds.length === 0 || entitlementIds.length === 0) return [];
+
+	const deleted = await db.execute<{ customer_product_id: string }>(sql`
+		WITH dropped AS (
+			DELETE FROM customer_entitlements AS target
+			WHERE target.customer_product_id IN (${sqlList({ values: customerProductIds })})
+				AND target.entitlement_id IN (${sqlList({ values: entitlementIds })})
+				AND NOT target.is_pooled_balance
+				AND target.pooled_contribution_id IS NULL
+			RETURNING target.customer_product_id, target.entitlement_id
+		), dropped_prices AS (
+			DELETE FROM customer_prices AS price
+			USING dropped, prices AS price_definition
+			WHERE price.customer_product_id = dropped.customer_product_id
+				AND price_definition.id = price.price_id
+				AND price_definition.entitlement_id = dropped.entitlement_id
+			RETURNING price.id
+		)
+		SELECT customer_product_id FROM dropped
+	`);
+
+	return deleted.map((row) => row.customer_product_id);
+};

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
@@ -6,8 +6,7 @@ import {
 	operationScopeSql,
 } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
 
-/** Matches by definition id so a custom or grandfathered row stays out of
- * reach, and re-asserts scope because the select took its own snapshot.
+/** Re-asserts scope because the select took its own snapshot.
  *
  * Pooled and rollover state is checked against the rows, not just the catalog:
  * both outlive a flag being turned off, and the FKs cascade, so a row that
@@ -15,15 +14,15 @@ import {
 export const deleteCustomerEntitlementRows = async ({
 	db,
 	customerProductIds,
-	entitlementId,
+	entitlementIds,
 	scope,
 }: {
 	db: DrizzleCli;
 	customerProductIds: string[];
-	entitlementId: string;
+	entitlementIds: string[];
 	scope: OperationScope;
 }): Promise<string[]> => {
-	if (customerProductIds.length === 0) return [];
+	if (customerProductIds.length === 0 || entitlementIds.length === 0) return [];
 
 	const deleted = await db.execute<{ customer_product_id: string }>(sql`
 		WITH dropped AS (
@@ -33,7 +32,7 @@ export const deleteCustomerEntitlementRows = async ({
 				AND definition.id = target.entitlement_id
 				AND ${operationScopeSql({ scope })}
 				AND target.customer_product_id IN (${sqlList({ values: customerProductIds })})
-				AND target.entitlement_id = ${entitlementId}
+				AND target.entitlement_id IN (${sqlList({ values: entitlementIds })})
 				AND definition.pooled IS NOT TRUE
 				AND NOT target.is_pooled_balance
 				AND target.pooled_contribution_id IS NULL

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
@@ -7,7 +7,11 @@ import {
 } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
 
 /** Matches by definition id so a custom or grandfathered row stays out of
- * reach, and re-asserts scope because the select took its own snapshot. */
+ * reach, and re-asserts scope because the select took its own snapshot.
+ *
+ * Pooled and rollover state is checked against the rows, not just the catalog:
+ * both outlive a flag being turned off, and the FKs cascade, so a row that
+ * still carries either is left for the per-customer lane. */
 export const deleteCustomerEntitlementRows = async ({
 	db,
 	customerProductIds,
@@ -24,13 +28,18 @@ export const deleteCustomerEntitlementRows = async ({
 	const deleted = await db.execute<{ customer_product_id: string }>(sql`
 		WITH dropped AS (
 			DELETE FROM customer_entitlements AS target
-			USING customer_products AS cp
+			USING customer_products AS cp, entitlements AS definition
 			WHERE cp.id = target.customer_product_id
+				AND definition.id = target.entitlement_id
 				AND ${operationScopeSql({ scope })}
 				AND target.customer_product_id IN (${sqlList({ values: customerProductIds })})
 				AND target.entitlement_id = ${entitlementId}
+				AND definition.pooled IS NOT TRUE
 				AND NOT target.is_pooled_balance
 				AND target.pooled_contribution_id IS NULL
+				AND NOT EXISTS (
+					SELECT 1 FROM rollovers WHERE rollovers.cus_ent_id = target.id
+				)
 			RETURNING target.customer_product_id, target.entitlement_id
 		), dropped_prices AS (
 			DELETE FROM customer_prices AS price

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
@@ -6,20 +6,20 @@ import {
 	operationScopeSql,
 } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
 
-/** Scope is re-asserted here because the select took its own snapshot. Pooled
- * rows are excluded: the anchor FK is RESTRICT and would abort the page. */
+/** Matches by definition id so a custom or grandfathered row stays out of
+ * reach, and re-asserts scope because the select took its own snapshot. */
 export const deleteCustomerEntitlementRows = async ({
 	db,
 	customerProductIds,
-	entitlementIds,
+	entitlementId,
 	scope,
 }: {
 	db: DrizzleCli;
 	customerProductIds: string[];
-	entitlementIds: string[];
+	entitlementId: string;
 	scope: OperationScope;
 }): Promise<string[]> => {
-	if (customerProductIds.length === 0 || entitlementIds.length === 0) return [];
+	if (customerProductIds.length === 0) return [];
 
 	const deleted = await db.execute<{ customer_product_id: string }>(sql`
 		WITH dropped AS (
@@ -28,7 +28,7 @@ export const deleteCustomerEntitlementRows = async ({
 			WHERE cp.id = target.customer_product_id
 				AND ${operationScopeSql({ scope })}
 				AND target.customer_product_id IN (${sqlList({ values: customerProductIds })})
-				AND target.entitlement_id IN (${sqlList({ values: entitlementIds })})
+				AND target.entitlement_id = ${entitlementId}
 				AND NOT target.is_pooled_balance
 				AND target.pooled_contribution_id IS NULL
 			RETURNING target.customer_product_id, target.entitlement_id

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts
@@ -6,8 +6,8 @@ import {
 	operationScopeSql,
 } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
 
-/** Pooled rows are excluded: the anchor FK is RESTRICT, so deleting one would
- * abort the whole page. */
+/** Scope is re-asserted here because the select took its own snapshot. Pooled
+ * rows are excluded: the anchor FK is RESTRICT and would abort the page. */
 export const deleteCustomerEntitlementRows = async ({
 	db,
 	customerProductIds,
@@ -25,8 +25,6 @@ export const deleteCustomerEntitlementRows = async ({
 		WITH dropped AS (
 			DELETE FROM customer_entitlements AS target
 			USING customer_products AS cp
-			-- Re-assert scope at delete time: rows whose customer product
-			-- changed since the select (canceled, customized) drop out.
 			WHERE cp.id = target.customer_product_id
 				AND ${operationScopeSql({ scope })}
 				AND target.customer_product_id IN (${sqlList({ values: customerProductIds })})

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
@@ -56,7 +56,7 @@ export const removeCustomerEntitlementsForPage = async ({
 						db: transaction,
 						internalCustomerIds,
 						scope,
-						entitlementIds: remove.entitlementIds,
+						entitlementId: remove.entitlement.id,
 						afterCustomerProductId,
 						limit,
 					}),
@@ -73,7 +73,7 @@ export const removeCustomerEntitlementsForPage = async ({
 						customerProductIds: candidates.map(
 							(candidate) => candidate.customerProductId,
 						),
-						entitlementIds: remove.entitlementIds,
+						entitlementId: remove.entitlement.id,
 						scope,
 					}),
 			});

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
@@ -1,4 +1,4 @@
-import type { FullProductWithoutLicenses } from "@autumn/shared";
+import type { Feature, FullProductWithoutLicenses } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { iterateCustomerProductPages } from "@/internal/migrations/v2/batchOperations/execute/customerProductPagination/index.js";
 import type { BatchMigrationRemovedItem } from "@/internal/migrations/v2/batchOperations/execute/types/batchMigrationExecutionTypes.js";
@@ -10,6 +10,7 @@ import {
 import type { OperationScope } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
 import type { BatchMigrationExecutionRemove } from "@/internal/migrations/v2/batchOperations/types/index.js";
 import { deleteCustomerEntitlementRows } from "./deleteCustomerEntitlementRows.js";
+import { resolveRemovableEntitlementIds } from "./resolveRemovableEntitlementIds.js";
 import { selectRemoveCandidateRows } from "./selectRemoveCandidateRows.js";
 
 export type RemoveCustomerEntitlementsForPageResult = {
@@ -22,6 +23,7 @@ export type RemoveCustomerEntitlementsForPageResult = {
  * customer products never balloons a statement or a transaction. */
 export const removeCustomerEntitlementsForPage = async ({
 	db,
+	features,
 	scope,
 	internalCustomerIds,
 	fromProduct,
@@ -30,6 +32,7 @@ export const removeCustomerEntitlementsForPage = async ({
 	candidateRowBatchSize = BATCH_MIGRATION_CANDIDATE_ROW_BATCH,
 }: {
 	db: DrizzleCli;
+	features: Feature[];
 	scope: OperationScope;
 	internalCustomerIds: string[];
 	fromProduct: FullProductWithoutLicenses;
@@ -38,6 +41,16 @@ export const removeCustomerEntitlementsForPage = async ({
 	candidateRowBatchSize?: number;
 }): Promise<RemoveCustomerEntitlementsForPageResult> => {
 	const removedItems: BatchMigrationRemovedItem[] = [];
+
+	// Resolved once per page: a customer can hold a custom or older-version
+	// definition of the same item, which the catalog id alone would miss.
+	const entitlementIds = await resolveRemovableEntitlementIds({
+		db,
+		features,
+		internalCustomerIds,
+		scope,
+		entitlement: remove.entitlement,
+	});
 
 	const { rowCount } = await iterateCustomerProductPages({
 		db,
@@ -56,7 +69,7 @@ export const removeCustomerEntitlementsForPage = async ({
 						db: transaction,
 						internalCustomerIds,
 						scope,
-						entitlementId: remove.entitlement.id,
+						entitlementIds,
 						afterCustomerProductId,
 						limit,
 					}),
@@ -73,7 +86,7 @@ export const removeCustomerEntitlementsForPage = async ({
 						customerProductIds: candidates.map(
 							(candidate) => candidate.customerProductId,
 						),
-						entitlementId: remove.entitlement.id,
+						entitlementIds,
 						scope,
 					}),
 			});

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
@@ -74,6 +74,7 @@ export const removeCustomerEntitlementsForPage = async ({
 							(candidate) => candidate.customerProductId,
 						),
 						entitlementIds: remove.entitlementIds,
+						scope,
 					}),
 			});
 

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.ts
@@ -1,0 +1,107 @@
+import type { FullProductWithoutLicenses } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { iterateCustomerProductPages } from "@/internal/migrations/v2/batchOperations/execute/customerProductPagination/index.js";
+import type { BatchMigrationRemovedItem } from "@/internal/migrations/v2/batchOperations/execute/types/batchMigrationExecutionTypes.js";
+import { BATCH_MIGRATION_CANDIDATE_ROW_BATCH } from "@/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.js";
+import {
+	type BatchMigrationPagePhases,
+	timePhase,
+} from "@/internal/migrations/v2/batchOperations/execute/utils/pagePhaseTimings.js";
+import type { OperationScope } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
+import type { BatchMigrationExecutionRemove } from "@/internal/migrations/v2/batchOperations/types/index.js";
+import { deleteCustomerEntitlementRows } from "./deleteCustomerEntitlementRows.js";
+import { selectRemoveCandidateRows } from "./selectRemoveCandidateRows.js";
+
+export type RemoveCustomerEntitlementsForPageResult = {
+	affected: number;
+	candidateCount: number;
+	removedItems: BatchMigrationRemovedItem[];
+};
+
+/** Bounded per customer-product page like the add, so a customer holding many
+ * customer products never balloons a statement or a transaction. */
+export const removeCustomerEntitlementsForPage = async ({
+	db,
+	scope,
+	internalCustomerIds,
+	fromProduct,
+	remove,
+	phases,
+	candidateRowBatchSize = BATCH_MIGRATION_CANDIDATE_ROW_BATCH,
+}: {
+	db: DrizzleCli;
+	scope: OperationScope;
+	internalCustomerIds: string[];
+	fromProduct: FullProductWithoutLicenses;
+	remove: BatchMigrationExecutionRemove;
+	phases?: BatchMigrationPagePhases;
+	candidateRowBatchSize?: number;
+}): Promise<RemoveCustomerEntitlementsForPageResult> => {
+	const removedItems: BatchMigrationRemovedItem[] = [];
+
+	const { rowCount } = await iterateCustomerProductPages({
+		db,
+		pageSize: candidateRowBatchSize,
+		executePage: async ({
+			transaction,
+			afterCustomerProductId,
+			limit,
+			assertWithinCeiling,
+		}) => {
+			const candidates = await timePhase({
+				phases,
+				phase: "candidates",
+				run: () =>
+					selectRemoveCandidateRows({
+						db: transaction,
+						internalCustomerIds,
+						scope,
+						entitlementIds: remove.entitlementIds,
+						afterCustomerProductId,
+						limit,
+					}),
+			});
+			if (candidates.length === 0) return candidates;
+			assertWithinCeiling(candidates.length);
+
+			const deletedIds = await timePhase({
+				phases,
+				phase: "remove",
+				run: () =>
+					deleteCustomerEntitlementRows({
+						db: transaction,
+						customerProductIds: candidates.map(
+							(candidate) => candidate.customerProductId,
+						),
+						entitlementIds: remove.entitlementIds,
+					}),
+			});
+
+			const deletedIdSet = new Set(deletedIds);
+			removedItems.push(
+				...candidates
+					.filter((candidate) => deletedIdSet.has(candidate.customerProductId))
+					.map((candidate) => ({
+						internalCustomerId: candidate.internalCustomerId,
+						customerProductId: candidate.customerProductId,
+						entityId: candidate.entityId,
+						planId: fromProduct.id,
+						featureId: remove.entitlement.feature.id,
+						entitlement: remove.entitlement,
+						status: candidate.status,
+						startsAt: candidate.startsAt,
+						canceledAt: candidate.canceledAt,
+						endedAt: candidate.endedAt,
+						trialEndsAt: candidate.trialEndsAt,
+					})),
+			);
+			return candidates;
+		},
+	});
+
+	return {
+		affected: removedItems.length,
+		candidateCount: rowCount,
+		removedItems,
+	};
+};

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/resolveRemovableEntitlementIds.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/resolveRemovableEntitlementIds.ts
@@ -1,0 +1,101 @@
+import {
+	type Entitlement,
+	type EntitlementWithFeature,
+	entitlements,
+	entsAreSame,
+	type Feature,
+} from "@autumn/shared";
+import { enrichEntitlementsWithFeatures } from "@autumn/shared/utils/productUtils/entUtils/enrichEntitlement.js";
+import { inArray, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { BATCH_MIGRATION_MAX_DISTINCT_ENTITLEMENTS } from "@/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.js";
+import {
+	type OperationScope,
+	operationScopeSql,
+} from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
+
+/**
+ * The definitions this page's customers actually hold for the target feature.
+ *
+ * A customer_entitlement can point at a custom or older-version definition the
+ * catalog no longer exposes (composeFullProductQuery filters is_custom), so
+ * resolving by catalog id alone would leave those customers holding the item.
+ * Discovery is by feature; `entsAreSame` then keeps only the ones that mean
+ * what the removed item meant.
+ */
+export const resolveRemovableEntitlementIds = async ({
+	db,
+	features,
+	internalCustomerIds,
+	scope,
+	entitlement,
+	maxDistinctEntitlements = BATCH_MIGRATION_MAX_DISTINCT_ENTITLEMENTS,
+}: {
+	db: DrizzleCli;
+	features: Feature[];
+	internalCustomerIds: string[];
+	scope: OperationScope;
+	entitlement: EntitlementWithFeature;
+	maxDistinctEntitlements?: number;
+}): Promise<string[]> => {
+	if (internalCustomerIds.length === 0) return [];
+
+	const liveIds = await selectDistinctLiveEntitlementIds({
+		db,
+		internalCustomerIds,
+		scope,
+		internalFeatureId: entitlement.internal_feature_id,
+		limit: maxDistinctEntitlements + 1,
+	});
+
+	if (liveIds.length > maxDistinctEntitlements) {
+		throw new Error(
+			`batch-migration: page exceeded ${maxDistinctEntitlements} distinct entitlement definitions — aborting run`,
+		);
+	}
+
+	const idsToLoad = liveIds.filter((id) => id !== entitlement.id);
+	if (idsToLoad.length === 0) return [entitlement.id];
+
+	const rows = await db
+		.select()
+		.from(entitlements)
+		.where(inArray(entitlements.id, idsToLoad));
+	const enriched = enrichEntitlementsWithFeatures({
+		entitlements: rows as Entitlement[],
+		features,
+	});
+
+	return [
+		entitlement.id,
+		...enriched
+			.filter((candidate) => entsAreSame(candidate, entitlement))
+			.map((candidate) => candidate.id),
+	];
+};
+
+const selectDistinctLiveEntitlementIds = async ({
+	db,
+	internalCustomerIds,
+	scope,
+	internalFeatureId,
+	limit,
+}: {
+	db: DrizzleCli;
+	internalCustomerIds: string[];
+	scope: OperationScope;
+	internalFeatureId: string;
+	limit: number;
+}): Promise<string[]> => {
+	const rows = await db.execute<{ id: string }>(sql`
+		SELECT DISTINCT live.entitlement_id AS id
+		FROM customer_products AS cp
+		INNER JOIN customer_entitlements AS live
+			ON live.customer_product_id = cp.id
+			AND live.internal_feature_id = ${internalFeatureId}
+		WHERE cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
+			AND ${operationScopeSql({ scope })}
+		LIMIT ${limit}
+	`);
+	return rows.map((row) => row.id);
+};

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
@@ -2,6 +2,7 @@ import { CusProductStatus } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { sqlList } from "@/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.js";
 import {
 	type OperationScope,
 	operationScopeSql,
@@ -35,17 +36,19 @@ export const selectRemoveCandidateRows = async ({
 	db,
 	internalCustomerIds,
 	scope,
-	entitlementId,
+	entitlementIds,
 	afterCustomerProductId,
 	limit,
 }: {
 	db: DrizzleCli;
 	internalCustomerIds: string[];
 	scope: OperationScope;
-	entitlementId: string;
+	entitlementIds: string[];
 	afterCustomerProductId?: string;
 	limit?: number;
 }): Promise<RemoveCandidateRow[]> => {
+	if (entitlementIds.length === 0) return [];
+
 	const rows = await db.execute(sql`
 		SELECT
 			cp.id AS customer_product_id,
@@ -68,7 +71,7 @@ export const selectRemoveCandidateRows = async ({
 				INNER JOIN entitlements AS definition
 					ON definition.id = existing.entitlement_id
 				WHERE existing.customer_product_id = cp.id
-					AND existing.entitlement_id = ${entitlementId}
+					AND existing.entitlement_id IN (${sqlList({ values: entitlementIds })})
 					AND definition.pooled IS NOT TRUE
 					AND NOT existing.is_pooled_balance
 					AND existing.pooled_contribution_id IS NULL

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
@@ -65,10 +65,16 @@ export const selectRemoveCandidateRows = async ({
 			AND EXISTS (
 				SELECT 1
 				FROM customer_entitlements AS existing
+				INNER JOIN entitlements AS definition
+					ON definition.id = existing.entitlement_id
 				WHERE existing.customer_product_id = cp.id
 					AND existing.entitlement_id = ${entitlementId}
+					AND definition.pooled IS NOT TRUE
 					AND NOT existing.is_pooled_balance
 					AND existing.pooled_contribution_id IS NULL
+					AND NOT EXISTS (
+						SELECT 1 FROM rollovers WHERE rollovers.cus_ent_id = existing.id
+					)
 			)
 		ORDER BY cp.id
 		${limit !== undefined ? sql`LIMIT ${limit}` : sql``}

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
@@ -2,7 +2,6 @@ import { CusProductStatus } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
-import { sqlList } from "@/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.js";
 import {
 	type OperationScope,
 	operationScopeSql,
@@ -30,25 +29,23 @@ export type RemoveCandidateRow = {
 	trialEndsAt: number | null;
 };
 
-/** The add's dedup predicate inverted: it skips customer products already
- * holding the row, this one wants exactly those. */
+/** Narrows the page to customer products that still hold one of the target
+ * definitions, so the delete never visits a product with nothing to drop. */
 export const selectRemoveCandidateRows = async ({
 	db,
 	internalCustomerIds,
 	scope,
-	entitlementIds,
+	entitlementId,
 	afterCustomerProductId,
 	limit,
 }: {
 	db: DrizzleCli;
 	internalCustomerIds: string[];
 	scope: OperationScope;
-	entitlementIds: string[];
+	entitlementId: string;
 	afterCustomerProductId?: string;
 	limit?: number;
 }): Promise<RemoveCandidateRow[]> => {
-	if (entitlementIds.length === 0) return [];
-
 	const rows = await db.execute(sql`
 		SELECT
 			cp.id AS customer_product_id,
@@ -69,7 +66,7 @@ export const selectRemoveCandidateRows = async ({
 				SELECT 1
 				FROM customer_entitlements AS existing
 				WHERE existing.customer_product_id = cp.id
-					AND existing.entitlement_id IN (${sqlList({ values: entitlementIds })})
+					AND existing.entitlement_id = ${entitlementId}
 					AND NOT existing.is_pooled_balance
 					AND existing.pooled_contribution_id IS NULL
 			)

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
@@ -1,0 +1,93 @@
+import { CusProductStatus } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { z } from "zod/v4";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { sqlList } from "@/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.js";
+import {
+	type OperationScope,
+	operationScopeSql,
+} from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
+
+const CandidateRowSchema = z.object({
+	customer_product_id: z.string(),
+	internal_customer_id: z.string(),
+	entity_id: z.string().nullable(),
+	status: z.enum(CusProductStatus),
+	starts_at: z.coerce.number().nullable(),
+	canceled_at: z.coerce.number().nullable(),
+	ended_at: z.coerce.number().nullable(),
+	trial_ends_at: z.coerce.number().nullable(),
+});
+
+export type RemoveCandidateRow = {
+	customerProductId: string;
+	internalCustomerId: string;
+	entityId: string | null;
+	status: CusProductStatus;
+	startsAt: number | null;
+	canceledAt: number | null;
+	endedAt: number | null;
+	trialEndsAt: number | null;
+};
+
+/** The add's dedup predicate inverted: it skips customer products already
+ * holding the row, this one wants exactly those. */
+export const selectRemoveCandidateRows = async ({
+	db,
+	internalCustomerIds,
+	scope,
+	entitlementIds,
+	afterCustomerProductId,
+	limit,
+}: {
+	db: DrizzleCli;
+	internalCustomerIds: string[];
+	scope: OperationScope;
+	entitlementIds: string[];
+	afterCustomerProductId?: string;
+	limit?: number;
+}): Promise<RemoveCandidateRow[]> => {
+	if (entitlementIds.length === 0) return [];
+
+	const rows = await db.execute(sql`
+		SELECT
+			cp.id AS customer_product_id,
+			cp.internal_customer_id,
+			entity.id AS entity_id,
+			cp.status,
+			cp.starts_at,
+			cp.canceled_at,
+			cp.ended_at,
+			cp.trial_ends_at
+		FROM customer_products AS cp
+		LEFT JOIN entities AS entity
+			ON entity.internal_id = cp.internal_entity_id
+		WHERE cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
+			AND ${operationScopeSql({ scope })}
+			${afterCustomerProductId ? sql`AND cp.id > ${afterCustomerProductId}` : sql``}
+			AND EXISTS (
+				SELECT 1
+				FROM customer_entitlements AS existing
+				WHERE existing.customer_product_id = cp.id
+					AND existing.entitlement_id IN (${sqlList({ values: entitlementIds })})
+					AND NOT existing.is_pooled_balance
+					AND existing.pooled_contribution_id IS NULL
+			)
+		ORDER BY cp.id
+		${limit !== undefined ? sql`LIMIT ${limit}` : sql``}
+	`);
+
+	return rows.map((row) => {
+		const parsed = CandidateRowSchema.parse(row);
+		return {
+			customerProductId: parsed.customer_product_id,
+			internalCustomerId: parsed.internal_customer_id,
+			entityId: parsed.entity_id,
+			status: parsed.status,
+			startsAt: parsed.starts_at,
+			canceledAt: parsed.canceled_at,
+			endedAt: parsed.ended_at,
+			trialEndsAt: parsed.trial_ends_at,
+		};
+	});
+};

--- a/server/src/internal/migrations/v2/batchOperations/compute/batchMigrationPlanToExecutionPlan.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/batchMigrationPlanToExecutionPlan.ts
@@ -18,6 +18,12 @@ export const batchMigrationPlanToExecutionPlan = ({
 				entitlement: operation.entitlementPrice.entitlement,
 				initialState: operation.initialState,
 			})),
+			removeEntitlementOps: patch.operations.removeEntitlements.map(
+				(operation) => ({
+					entitlement: operation.entitlementPrice.entitlement,
+					entitlementIds: [operation.entitlementPrice.entitlement.id],
+				}),
+			),
 			licenseEntitlementOps: patch.operations.licenseEntitlements,
 		};
 	}),

--- a/server/src/internal/migrations/v2/batchOperations/compute/batchMigrationPlanToExecutionPlan.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/batchMigrationPlanToExecutionPlan.ts
@@ -14,14 +14,13 @@ export const batchMigrationPlanToExecutionPlan = ({
 			opIndex: patch.opIndex,
 			scope: patch.scope,
 			fromProduct,
-			addEntitlementOps: patch.operations.entitlements.map((operation) => ({
+			addEntitlementOps: patch.operations.addEntitlements.map((operation) => ({
 				entitlement: operation.entitlementPrice.entitlement,
 				initialState: operation.initialState,
 			})),
 			removeEntitlementOps: patch.operations.removeEntitlements.map(
 				(operation) => ({
 					entitlement: operation.entitlementPrice.entitlement,
-					entitlementIds: [operation.entitlementPrice.entitlement.id],
 				}),
 			),
 			licenseEntitlementOps: patch.operations.licenseEntitlements,

--- a/server/src/internal/migrations/v2/batchOperations/compute/computeUpdatePlanPatch.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/computeUpdatePlanPatch.ts
@@ -12,6 +12,7 @@ import { checkUpdatePlanTransitionEligibility } from "./guards/index.js";
 import { computeBatchMigrationOperations } from "./operations/index.js";
 import { resolveLicenseCustomizeTransitions } from "./transitions/resolveLicenseCustomizeTransitions.js";
 import { resolvePreparedAddItemEntitlements } from "./utils/resolvePreparedAddItemEntitlements.js";
+import { resolveRemoveItemEntitlements } from "./utils/resolveRemoveItemEntitlements.js";
 
 /** Computes one (op, fromProduct) pair into an add-only batch patch: resolve
  * prepared rows → diff → lower → guard. No patch and no rejections = no-op. */
@@ -53,13 +54,23 @@ export const computeUpdatePlanPatch = ({
 		});
 	if (licenseRejections.length > 0) return { rejections: licenseRejections };
 
-	if (addItemEntitlements.length === 0 && licenseLinks.length === 0) {
+	const removeEntitlementIds = resolveRemoveItemEntitlements({
+		op,
+		fromProduct,
+	});
+
+	if (
+		addItemEntitlements.length === 0 &&
+		removeEntitlementIds.length === 0 &&
+		licenseLinks.length === 0
+	) {
 		return { rejections: [] };
 	}
 
 	const productTransitions = computePatchProductTransitions({
 		fromProduct,
 		addEntitlements: addItemEntitlements,
+		removeEntitlementIds,
 	});
 
 	const operations = computeBatchMigrationOperations({
@@ -77,6 +88,7 @@ export const computeUpdatePlanPatch = ({
 	if (rejections.length > 0) return { rejections };
 	if (
 		operations.entitlements.length === 0 &&
+		operations.removeEntitlements.length === 0 &&
 		operations.licenseEntitlements.length === 0
 	) {
 		return { rejections: [] };

--- a/server/src/internal/migrations/v2/batchOperations/compute/computeUpdatePlanPatch.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/computeUpdatePlanPatch.ts
@@ -83,11 +83,11 @@ export const computeUpdatePlanPatch = ({
 		fromProduct,
 		productTransitions,
 		licenseLinks,
-		operations: operations.entitlements,
+		operations: operations.addEntitlements,
 	});
 	if (rejections.length > 0) return { rejections };
 	if (
-		operations.entitlements.length === 0 &&
+		operations.addEntitlements.length === 0 &&
 		operations.removeEntitlements.length === 0 &&
 		operations.licenseEntitlements.length === 0
 	) {

--- a/server/src/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanOpEligibility.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanOpEligibility.ts
@@ -131,12 +131,31 @@ export const checkUpdatePlanOpEligibility = ({
 		});
 	}
 
-	if ((op.customize?.remove_items?.length ?? 0) > 0) {
+	const removeItems = op.customize?.remove_items ?? [];
+
+	if (
+		removeItems.length > 0 &&
+		isModifyInPlaceOnly({ addItems: op.customize?.add_items, removeItems })
+	) {
 		rejections.push({
 			code: "unsupported_remove_items",
 			opIndex,
 			message:
-				"customize.remove_items is not batch-lowered yet; the batch lane is add_items-only.",
+				"customize.remove_items paired with a matching add is an in-place edit; the balance has to survive the swap.",
+		});
+	}
+
+	if (
+		removeItems.some(
+			(filter) =>
+				filter.billing_method !== undefined || filter.feature_id === undefined,
+		)
+	) {
+		rejections.push({
+			code: "unsupported_remove_items",
+			opIndex,
+			message:
+				"remove_items is batch-lowered by feature and interval; a billing_method or feature-less filter is per-customer work.",
 		});
 	}
 

--- a/server/src/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanTransitionEligibility.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanTransitionEligibility.ts
@@ -39,25 +39,69 @@ export const checkUpdatePlanTransitionEligibility = ({
 	}
 
 	const { transitions, deleted } = productTransitions.entitlementPrices;
-	if (transitions.length > 0 || deleted.length > 0) {
+	if (transitions.length > 0) {
 		rejections.push({
 			code: "non_add_operation",
 			opIndex,
 			planId: fromProduct.id,
 			message:
-				"Projected diff produced non-add transitions; the batch lane is add_items-only.",
+				"Projected diff produced in-place transitions; the batch lane adds and removes only.",
 			details: {
-				featureIds: [
-					...transitions.map(
-						(transition) =>
-							transition.fromEntitlementPrice.entitlement.feature.id,
-					),
-					...deleted.map(
-						(entitlementPrice) => entitlementPrice.entitlement.feature.id,
-					),
-				],
+				featureIds: transitions.map(
+					(transition) =>
+						transition.fromEntitlementPrice.entitlement.feature.id,
+				),
 			},
 		});
+	}
+
+	for (const entitlementPrice of deleted) {
+		const { entitlement, price } = entitlementPrice;
+		const details = { featureId: entitlement.feature.id };
+
+		if (price) {
+			rejections.push({
+				code: "priced_remove_item",
+				opIndex,
+				planId: fromProduct.id,
+				message:
+					"A paid item needs a Stripe write; only free entitlements are batch-lowered.",
+				details,
+			});
+		}
+
+		if (entitlement.rollover) {
+			rejections.push({
+				code: "rollover_remove_item",
+				opIndex,
+				planId: fromProduct.id,
+				message:
+					"A rollover balance outlives the row it hangs off, so dropping the row strands it.",
+				details,
+			});
+		}
+
+		if (entitlement.entity_feature_id) {
+			rejections.push({
+				code: "entity_scoped_entitlement",
+				opIndex,
+				planId: fromProduct.id,
+				message:
+					"Entity-scoped rows carry per-entity sub-balances; row counts vary per customer.",
+				details,
+			});
+		}
+
+		if (entitlement.pooled === true) {
+			rejections.push({
+				code: "pooled_add_item",
+				opIndex,
+				planId: fromProduct.id,
+				message:
+					"A pooled item's anchor row hangs off no customer product, so the set-based writes never reach it.",
+				details,
+			});
+		}
 	}
 
 	if (paidAdded.length > 0) {

--- a/server/src/internal/migrations/v2/batchOperations/compute/operations/computeBatchMigrationOperations.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/operations/computeBatchMigrationOperations.ts
@@ -4,6 +4,7 @@ import type {
 	BatchMigrationAddEntitlementOp,
 	BatchMigrationLicenseEntitlementOp,
 	BatchMigrationOperations,
+	BatchMigrationRemoveEntitlementOp,
 } from "../../types/index.js";
 import type { LicenseLinkTransitions } from "../transitions/resolveLicenseCustomizeTransitions.js";
 
@@ -79,8 +80,14 @@ export const computeBatchMigrationOperations = ({
 				}),
 			}));
 
+	const removeEntitlements: BatchMigrationRemoveEntitlementOp[] =
+		productTransitions.entitlementPrices.deleted
+			.filter((entitlementPrice) => !entitlementPrice.price)
+			.map((entitlementPrice) => ({ type: "remove", entitlementPrice }));
+
 	return {
 		entitlements,
+		removeEntitlements,
 		licenseEntitlements: licenseLinks.flatMap(toLicenseOps),
 	};
 };

--- a/server/src/internal/migrations/v2/batchOperations/compute/operations/computeBatchMigrationOperations.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/operations/computeBatchMigrationOperations.ts
@@ -69,11 +69,10 @@ export const computeBatchMigrationOperations = ({
 	productTransitions: ProductTransitions;
 	licenseLinks: LicenseLinkTransitions[];
 }): BatchMigrationOperations => {
-	const entitlements: BatchMigrationAddEntitlementOp[] =
+	const addEntitlements: BatchMigrationAddEntitlementOp[] =
 		productTransitions.entitlementPrices.added
 			.filter((entitlementPrice) => !entitlementPrice.price)
 			.map((entitlementPrice) => ({
-				type: "add",
 				entitlementPrice,
 				initialState: computeCustomerEntitlementInitialState({
 					entitlement: entitlementPrice.entitlement,
@@ -83,10 +82,10 @@ export const computeBatchMigrationOperations = ({
 	const removeEntitlements: BatchMigrationRemoveEntitlementOp[] =
 		productTransitions.entitlementPrices.deleted
 			.filter((entitlementPrice) => !entitlementPrice.price)
-			.map((entitlementPrice) => ({ type: "remove", entitlementPrice }));
+			.map((entitlementPrice) => ({ entitlementPrice }));
 
 	return {
-		entitlements,
+		addEntitlements,
 		removeEntitlements,
 		licenseEntitlements: licenseLinks.flatMap(toLicenseOps),
 	};

--- a/server/src/internal/migrations/v2/batchOperations/compute/utils/resolveRemoveItemEntitlements.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/utils/resolveRemoveItemEntitlements.ts
@@ -1,0 +1,48 @@
+import type { Entitlement, FullProduct, PlanItemFilter } from "@autumn/shared";
+import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
+import { entIntvToResetIntv } from "@autumn/shared/utils/productV2Utils/productItemUtils/convertProductItem/planItemIntervals.js";
+
+/** A filter speaks ResetInterval ("one_off"), an entitlement speaks
+ * EntInterval ("lifetime"); both sides normalize before comparing. */
+const matchesFilter = ({
+	entitlement,
+	filter,
+}: {
+	entitlement: Entitlement;
+	filter: PlanItemFilter;
+}) => {
+	if (filter.feature_id !== entitlement.feature_id) return false;
+	if (
+		filter.interval !== undefined &&
+		entIntvToResetIntv({ entInterval: entitlement.interval }) !==
+			String(filter.interval)
+	) {
+		return false;
+	}
+	if (
+		filter.interval_count !== undefined &&
+		(entitlement.interval_count ?? 1) !== filter.interval_count
+	) {
+		return false;
+	}
+	return true;
+};
+
+/** Modify-in-place pairs never reach here — checkUpdatePlanOpEligibility
+ * rejects them, so every filter is a standalone deletion. */
+export const resolveRemoveItemEntitlements = ({
+	op,
+	fromProduct,
+}: {
+	op: UpdatePlanOp;
+	fromProduct: FullProduct;
+}): string[] => {
+	const filters = op.customize?.remove_items ?? [];
+	if (filters.length === 0) return [];
+
+	return fromProduct.entitlements
+		.filter((entitlement) =>
+			filters.some((filter) => matchesFilter({ entitlement, filter })),
+		)
+		.map((entitlement) => entitlement.id);
+};

--- a/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
@@ -142,13 +142,11 @@ export const executeBatchMigrationPage = async ({
 		...removedItems.map((item) => item.internalCustomerId),
 		...repointedIds,
 	]);
-	// An exclusion refuses an add, so it cannot un-commit a delete that landed.
-	const removedIds = new Set(
-		removedItems.map((item) => item.internalCustomerId),
-	);
-	for (const id of excludedIds) {
-		if (!removedIds.has(id)) succeeded.delete(id);
-	}
+	// An excluded customer stays skipped even when a delete landed for it: the
+	// per-customer lane still owes it the refused add, and re-running a delete
+	// that already converged is a no-op. The cost is a missed cache bust, which
+	// the lane already accepts for any skipped customer.
+	for (const id of excludedIds) succeeded.delete(id);
 	const skippedIds = pageInternalIds.filter((id) => !succeeded.has(id));
 
 	await timePhase({

--- a/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
@@ -62,6 +62,7 @@ export const executeBatchMigrationPage = async ({
 		for (const remove of patch.removeEntitlementOps) {
 			const result = await removeCustomerEntitlementsForPage({
 				db: ctx.db,
+				features: ctx.features,
 				scope: patch.scope,
 				internalCustomerIds: pageInternalIds,
 				fromProduct: patch.fromProduct,

--- a/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
@@ -142,10 +142,6 @@ export const executeBatchMigrationPage = async ({
 		...removedItems.map((item) => item.internalCustomerId),
 		...repointedIds,
 	]);
-	// An excluded customer stays skipped even when a delete landed for it: the
-	// per-customer lane still owes it the refused add, and re-running a delete
-	// that already converged is a no-op. The cost is a missed cache bust, which
-	// the lane already accepts for any skipped customer.
 	for (const id of excludedIds) succeeded.delete(id);
 	const skippedIds = pageInternalIds.filter((id) => !succeeded.has(id));
 

--- a/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
@@ -1,6 +1,7 @@
 import { withStatementTimeout } from "@/db/withStatementTimeout.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { addCustomerEntitlementsForPage } from "../actions/addCustomerEntitlementsForPage/addCustomerEntitlementsForPage.js";
+import { removeCustomerEntitlementsForPage } from "../actions/removeCustomerEntitlementsForPage/removeCustomerEntitlementsForPage.js";
 import { runLicenseEntitlementOp } from "../actions/runLicenseEntitlementOp.js";
 import type { BatchMigrationExecutionPlan } from "../types/index.js";
 import { markPageItemRuns } from "./claim/index.js";
@@ -82,6 +83,27 @@ export const executeBatchMigrationPage = async ({
 			});
 		}
 
+		for (const remove of patch.removeEntitlementOps) {
+			const result = await removeCustomerEntitlementsForPage({
+				db: ctx.db,
+				scope: patch.scope,
+				internalCustomerIds: pageInternalIds,
+				fromProduct: patch.fromProduct,
+				remove,
+				phases,
+			});
+			removedItems.push(...result.removedItems);
+			ctx.logger.debug("batch-migration: remove operation", {
+				data: {
+					opIndex: patch.opIndex,
+					planId: patch.fromProduct.id,
+					featureId: remove.entitlement.feature.id,
+					candidateCount: result.candidateCount,
+					affected: result.affected,
+				},
+			});
+		}
+
 		for (const operation of patch.licenseEntitlementOps) {
 			const result = await runLicenseEntitlementOp({
 				db: ctx.db,
@@ -113,13 +135,20 @@ export const executeBatchMigrationPage = async ({
 		}
 	}
 
-	// A repointed pool is a real change even with no assignment rows inserted;
-	// leaving it out of `succeeded` would skip its cache invalidation.
+	// A repointed pool or a dropped row is a real change even with nothing
+	// inserted; leaving it out of `succeeded` would skip its cache invalidation.
 	const succeeded = new Set([
 		...insertedItems.map((item) => item.internalCustomerId),
+		...removedItems.map((item) => item.internalCustomerId),
 		...repointedIds,
 	]);
-	for (const id of excludedIds) succeeded.delete(id);
+	// An exclusion refuses an add, so it cannot un-commit a delete that landed.
+	const removedIds = new Set(
+		removedItems.map((item) => item.internalCustomerId),
+	);
+	for (const id of excludedIds) {
+		if (!removedIds.has(id)) succeeded.delete(id);
+	}
 	const skippedIds = pageInternalIds.filter((id) => !succeeded.has(id));
 
 	await timePhase({

--- a/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
@@ -57,6 +57,29 @@ export const executeBatchMigrationPage = async ({
 	const repointedIds = new Set<string>();
 
 	for (const patch of plan.patches) {
+		// Removes run first: an add landing before its sibling remove would be
+		// dropped again by a filter matching the same feature.
+		for (const remove of patch.removeEntitlementOps) {
+			const result = await removeCustomerEntitlementsForPage({
+				db: ctx.db,
+				scope: patch.scope,
+				internalCustomerIds: pageInternalIds,
+				fromProduct: patch.fromProduct,
+				remove,
+				phases,
+			});
+			removedItems.push(...result.removedItems);
+			ctx.logger.debug("batch-migration: remove operation", {
+				data: {
+					opIndex: patch.opIndex,
+					planId: patch.fromProduct.id,
+					featureId: remove.entitlement.feature.id,
+					candidateCount: result.candidateCount,
+					affected: result.affected,
+				},
+			});
+		}
+
 		for (const add of patch.addEntitlementOps) {
 			const result = await addCustomerEntitlementsForPage({
 				db: ctx.db,
@@ -79,27 +102,6 @@ export const executeBatchMigrationPage = async ({
 					candidateCount: result.candidateCount,
 					affected: result.affected,
 					excluded: result.excludedInternalCustomerIds.length,
-				},
-			});
-		}
-
-		for (const remove of patch.removeEntitlementOps) {
-			const result = await removeCustomerEntitlementsForPage({
-				db: ctx.db,
-				scope: patch.scope,
-				internalCustomerIds: pageInternalIds,
-				fromProduct: patch.fromProduct,
-				remove,
-				phases,
-			});
-			removedItems.push(...result.removedItems);
-			ctx.logger.debug("batch-migration: remove operation", {
-				data: {
-					opIndex: patch.opIndex,
-					planId: patch.fromProduct.id,
-					featureId: remove.entitlement.feature.id,
-					candidateCount: result.candidateCount,
-					affected: result.affected,
 				},
 			});
 		}

--- a/server/src/internal/migrations/v2/batchOperations/types/batchMigrationExecutionPlan.ts
+++ b/server/src/internal/migrations/v2/batchOperations/types/batchMigrationExecutionPlan.ts
@@ -17,11 +17,8 @@ export const BatchMigrationExecutionAddSchema = z.object({
 	initialState: BatchMigrationInitialStateSchema,
 });
 
-/** The catalog entitlement ids the guard classified. The executor deletes only
- * these, so a custom or grandfathered row the guard never saw is out of reach. */
 export const BatchMigrationExecutionRemoveSchema = z.object({
 	entitlement: EntitlementWithFeatureSchema,
-	entitlementIds: z.array(z.string()),
 });
 
 const BatchMigrationLicenseOpBaseSchema = z.object({

--- a/server/src/internal/migrations/v2/batchOperations/types/batchMigrationExecutionPlan.ts
+++ b/server/src/internal/migrations/v2/batchOperations/types/batchMigrationExecutionPlan.ts
@@ -17,6 +17,13 @@ export const BatchMigrationExecutionAddSchema = z.object({
 	initialState: BatchMigrationInitialStateSchema,
 });
 
+/** The catalog entitlement ids the guard classified. The executor deletes only
+ * these, so a custom or grandfathered row the guard never saw is out of reach. */
+export const BatchMigrationExecutionRemoveSchema = z.object({
+	entitlement: EntitlementWithFeatureSchema,
+	entitlementIds: z.array(z.string()),
+});
+
 const BatchMigrationLicenseOpBaseSchema = z.object({
 	licensePlanId: z.string(),
 	planLicenseId: z.string(),
@@ -55,6 +62,9 @@ export const BatchMigrationExecutionPatchSchema = z.object({
 	scope: OperationScopeSchema,
 	fromProduct: FullProductWithoutLicensesSchema,
 	addEntitlementOps: z.array(BatchMigrationExecutionAddSchema),
+	removeEntitlementOps: z
+		.array(BatchMigrationExecutionRemoveSchema)
+		.default([]),
 	licenseEntitlementOps: z
 		.array(BatchMigrationExecutionLicenseOpSchema)
 		.default([]),
@@ -66,6 +76,9 @@ export const BatchMigrationExecutionPlanSchema = z.object({
 
 export type BatchMigrationExecutionAdd = z.infer<
 	typeof BatchMigrationExecutionAddSchema
+>;
+export type BatchMigrationExecutionRemove = z.infer<
+	typeof BatchMigrationExecutionRemoveSchema
 >;
 export type BatchMigrationMintedLicenseOp = z.infer<
 	typeof BatchMigrationLicenseMintedSchema

--- a/server/src/internal/migrations/v2/batchOperations/types/batchMigrationOperations.ts
+++ b/server/src/internal/migrations/v2/batchOperations/types/batchMigrationOperations.ts
@@ -17,7 +17,15 @@ export type BatchMigrationAddEntitlementOp = {
 	initialState: CustomerEntitlementInitialState;
 };
 
-export type BatchMigrationEntitlementOp = BatchMigrationAddEntitlementOp;
+/** Drops one free entitlement's rows across the patch's customer products. */
+export type BatchMigrationRemoveEntitlementOp = {
+	type: "remove";
+	entitlementPrice: EntitlementPrice;
+};
+
+export type BatchMigrationEntitlementOp =
+	| BatchMigrationAddEntitlementOp
+	| BatchMigrationRemoveEntitlementOp;
 
 type BatchMigrationLicenseOpTarget = {
 	licensePlanId: string;
@@ -64,6 +72,7 @@ export type BatchMigrationLicenseEntitlementOp =
 	| BatchMigrationRemoveLicenseEntitlementOp;
 
 export type BatchMigrationOperations = {
-	entitlements: BatchMigrationEntitlementOp[];
+	entitlements: BatchMigrationAddEntitlementOp[];
+	removeEntitlements: BatchMigrationRemoveEntitlementOp[];
 	licenseEntitlements: BatchMigrationLicenseEntitlementOp[];
 };

--- a/server/src/internal/migrations/v2/batchOperations/types/batchMigrationOperations.ts
+++ b/server/src/internal/migrations/v2/batchOperations/types/batchMigrationOperations.ts
@@ -12,20 +12,14 @@ export type CustomerEntitlementInitialState = ReturnType<
 /** Pure initial state instead of an initialized row template: cycle fields
  * can't be precomputed across anchors. Add dedup is the executor's job. */
 export type BatchMigrationAddEntitlementOp = {
-	type: "add";
 	entitlementPrice: EntitlementPrice;
 	initialState: CustomerEntitlementInitialState;
 };
 
 /** Drops one free entitlement's rows across the patch's customer products. */
 export type BatchMigrationRemoveEntitlementOp = {
-	type: "remove";
 	entitlementPrice: EntitlementPrice;
 };
-
-export type BatchMigrationEntitlementOp =
-	| BatchMigrationAddEntitlementOp
-	| BatchMigrationRemoveEntitlementOp;
 
 type BatchMigrationLicenseOpTarget = {
 	licensePlanId: string;
@@ -72,7 +66,7 @@ export type BatchMigrationLicenseEntitlementOp =
 	| BatchMigrationRemoveLicenseEntitlementOp;
 
 export type BatchMigrationOperations = {
-	entitlements: BatchMigrationAddEntitlementOp[];
+	addEntitlements: BatchMigrationAddEntitlementOp[];
 	removeEntitlements: BatchMigrationRemoveEntitlementOp[];
 	licenseEntitlements: BatchMigrationLicenseEntitlementOp[];
 };

--- a/server/src/internal/migrations/v2/run/chunks/iterateMigrationChunks.ts
+++ b/server/src/internal/migrations/v2/run/chunks/iterateMigrationChunks.ts
@@ -1,3 +1,4 @@
+import type { BatchMigrationRejection } from "../../batchOperations/types/index.js";
 import type { IterateScopeCompletion } from "../orchestrators/iterateScope.js";
 
 export type MigrationChunkResult = {
@@ -14,6 +15,8 @@ export type MigrationChunkRunResult = {
 	canceled: boolean;
 	/** Stamped by runMigrationInChunks after the lane decision. */
 	lane?: MigrationRunLane;
+	/** Why the batch lane declined, when it did. */
+	rejections?: BatchMigrationRejection[];
 };
 
 export const iterateMigrationChunks = async ({

--- a/server/src/internal/migrations/v2/run/runMigrationInChunks.ts
+++ b/server/src/internal/migrations/v2/run/runMigrationInChunks.ts
@@ -206,7 +206,11 @@ export const runMigrationInChunks = async ({
 						),
 				});
 
-				return { ...chunkRun, lane: "per_customer" as const };
+				return {
+					...chunkRun,
+					lane: "per_customer" as const,
+					rejections: batchLane?.rejections,
+				};
 			},
 		});
 	} finally {

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-custom-rows.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-custom-rows.test.ts
@@ -1,0 +1,164 @@
+/**
+ * A delete must reach customers whose row points at a custom definition of
+ * the same item, and must spare one whose custom definition means something
+ * different.
+ *
+ * customer_entitlements can point at a custom or older-version entitlement
+ * that composeFullProductQuery filters out, so resolving by catalog id alone
+ * leaves those customers holding the item. Discovery is by feature and
+ * `entsAreSame` decides what counts as the same item.
+ *
+ * Red (catalog-id only): the same-meaning custom row survives the delete.
+ * Green: it is removed, and the different-allowance one is not.
+ */
+import { expect, test } from "bun:test";
+import { customerEntitlements, entitlements } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { generateId } from "@/utils/genUtils.js";
+
+const MESSAGES_INCLUDED = 100;
+const DIFFERENT_ALLOWANCE = 500;
+const PLAN_PREFIX = "batch-delete-custom";
+
+const repointToCustomEntitlement = async ({
+	ctx,
+	customerId,
+	overrides = {},
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	customerId: string;
+	/** Empty means an exact copy — entsAreSame treats it as the same item. */
+	overrides?: Partial<typeof entitlements.$inferInsert>;
+}) => {
+	const [row] = await ctx.db
+		.select()
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.customer_id, customerId),
+				eq(customerEntitlements.feature_id, TestFeature.Messages),
+			),
+		);
+	expect(row).toBeDefined();
+
+	const [catalogEntitlement] = await ctx.db
+		.select()
+		.from(entitlements)
+		.where(eq(entitlements.id, row.entitlement_id));
+
+	const customId = generateId("ent");
+	await ctx.db.insert(entitlements).values({
+		...catalogEntitlement,
+		id: customId,
+		is_custom: true,
+		...overrides,
+	});
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ entitlement_id: customId })
+		.where(eq(customerEntitlements.id, row.id));
+
+	return customId;
+};
+
+test(`${chalk.yellowBright("batch migration: a delete reaches same-meaning custom rows and spares different ones")}`, async () => {
+	const catalogCustomerId = "batch-delete-custom-catalog";
+	const sameMeaningCustomerId = "batch-delete-custom-same";
+	const differentCustomerId = "batch-delete-custom-different";
+	const plan = products.base({
+		id: "batch-delete-custom-plan",
+		items: [
+			itemsV2.dashboard(),
+			itemsV2.monthlyMessages({ included: MESSAGES_INCLUDED }),
+		],
+	});
+
+	const { ctx, autumnV2_2 } = await initScenario({
+		customerId: catalogCustomerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.otherCustomers([
+				{ id: sameMeaningCustomerId },
+				{ id: differentCustomerId },
+			]),
+			s.products({ list: [plan], prefix: PLAN_PREFIX }),
+		],
+		actions: [
+			s.parallel(
+				s.attach({ productId: plan.id }),
+				s.attach({
+					customerId: sameMeaningCustomerId,
+					productId: plan.id,
+				}),
+				s.attach({
+					customerId: differentCustomerId,
+					productId: plan.id,
+				}),
+			),
+		],
+	});
+	// s.products mutates plan.id with the prefix during setup.
+	const planId = plan.id;
+
+	// An exact copy: the same item under a custom id.
+	await repointToCustomEntitlement({
+		ctx,
+		customerId: sameMeaningCustomerId,
+	});
+	// A different allowance makes it a distinct item that survives.
+	await repointToCustomEntitlement({
+		ctx,
+		customerId: differentCustomerId,
+		overrides: { allowance: DIFFERENT_ALLOWANCE },
+	});
+
+	const { result } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: "batch-delete-custom-migration",
+		filter: { customer: { plan: { plan_id: planId, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: planId, custom: false },
+					customize: {
+						remove_items: [{ feature_id: TestFeature.Messages }],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+
+	expect({
+		lane: result?.lane,
+		rejections: (result?.rejections ?? []).map(
+			(r) => `${r.code}: ${r.message}`,
+		),
+	}).toEqual({ lane: "batch", rejections: [] });
+
+	const messageRowsFor = async (customerId: string) =>
+		ctx.db
+			.select({ id: customerEntitlements.id })
+			.from(customerEntitlements)
+			.where(
+				and(
+					eq(customerEntitlements.customer_id, customerId),
+					eq(customerEntitlements.feature_id, TestFeature.Messages),
+				),
+			);
+
+	// ── The catalog row and the same-meaning custom row both go ────────
+	expect(await messageRowsFor(catalogCustomerId)).toHaveLength(0);
+	expect(await messageRowsFor(sameMeaningCustomerId)).toHaveLength(0);
+
+	// ── A custom row meaning something else survives ───────────────────
+	expect(await messageRowsFor(differentCustomerId)).toHaveLength(1);
+});

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-license-isolation.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-license-isolation.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Removing a free item from a parent plan must not touch its seat
+ * assignments, even when the license plan grants the same feature.
+ *
+ * Seats hold rows minted from the license product, so a parent removal is
+ * not theirs to lose. Three separate mechanisms keep them out of scope
+ * (internal_product_id, distinct entitlement ids, customer_license_link_id
+ * IS NULL); this pins the observable outcome.
+ */
+import { expect, test } from "bun:test";
+import { customerEntitlements } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { pollUntil } from "@tests/utils/genUtils";
+import chalk from "chalk";
+import { inArray } from "drizzle-orm";
+
+const MESSAGES_INCLUDED = 100;
+const INCLUDED_SEATS = 1;
+const ATTACHED_SEATS = 3;
+const ASSIGNED_SEATS = 2;
+
+test(`${chalk.yellowBright("batch migration: a parent item delete spares the license seats")}`, async () => {
+	const customerId = "batch-delete-license-isolation";
+	const idPrefix = "batch-delete-lic-iso";
+
+	// Both the parent and the seat grant messages, so an over-broad delete
+	// would take the seats' rows with the parent's.
+	const scenario = await setupLicenseUpdateScenario({
+		customerId,
+		idPrefix,
+		parentItems: [items.monthlyMessages({ includedUsage: MESSAGES_INCLUDED })],
+		seatItems: [items.monthlyMessages({ includedUsage: MESSAGES_INCLUDED })],
+		includedSeats: INCLUDED_SEATS,
+		attachedSeats: ATTACHED_SEATS,
+	});
+	await scenario.assignSeats({ count: ASSIGNED_SEATS });
+
+	const { ctx, autumnV2_2, parent } = scenario;
+	const { assignments, pools } = await getLicenseDbState({
+		db: ctx.db,
+		customerId,
+	});
+	const liveAssignments = assignments.filter(
+		(assignment) => assignment.internal_entity_id,
+	);
+	expect(liveAssignments).toHaveLength(ASSIGNED_SEATS);
+
+	const assignmentIds = liveAssignments.map((assignment) => assignment.id);
+	const readSeatMessageRows = async () => {
+		const rows = await ctx.db
+			.select({ featureId: customerEntitlements.feature_id })
+			.from(customerEntitlements)
+			.where(inArray(customerEntitlements.customer_product_id, assignmentIds));
+		return rows.filter((row) => row.featureId === TestFeature.Messages);
+	};
+
+	expect(await readSeatMessageRows()).toHaveLength(ASSIGNED_SEATS);
+	const grantedBefore = pools.map((pool) => pool.granted);
+
+	const { result } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: `${idPrefix}-migration`,
+		filter: { customer: { plan: { plan_id: parent.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: parent.id, custom: false },
+					customize: {
+						remove_items: [{ feature_id: TestFeature.Messages }],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+
+	expect(result?.lane).toBe("batch");
+
+	// ── The parent's own row goes ──────────────────────────────────────
+	const parentRows = await pollUntil({
+		fetch: async () => {
+			const { products: customerProducts } = await getLicenseDbState({
+				db: ctx.db,
+				customerId,
+			});
+			const parentIds = customerProducts
+				.filter((product) => !product.customer_license_link_id)
+				.map((product) => product.id);
+			if (parentIds.length === 0) return [];
+			return ctx.db
+				.select({ featureId: customerEntitlements.feature_id })
+				.from(customerEntitlements)
+				.where(inArray(customerEntitlements.customer_product_id, parentIds));
+		},
+		until: (rows) =>
+			rows.filter((row) => row.featureId === TestFeature.Messages).length === 0,
+		timeoutMs: 15_000,
+		intervalMs: 250,
+	});
+	expect(
+		parentRows.filter((row) => row.featureId === TestFeature.Messages),
+	).toHaveLength(0);
+
+	// ── The seats keep theirs, and the pool is untouched ───────────────
+	expect(await readSeatMessageRows()).toHaveLength(ASSIGNED_SEATS);
+
+	const { pools: poolsAfter } = await getLicenseDbState({
+		db: ctx.db,
+		customerId,
+	});
+	expect(poolsAfter.map((pool) => pool.granted)).toEqual(grantedBefore);
+});

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-rollover-rows.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-rollover-rows.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Accrued rollover rows must survive a delete even when the catalog item no
+ * longer declares rollover.
+ *
+ * The compute guard reads `entitlement.rollover` from the catalog, but
+ * rollover rows are accumulated DB state: turning the flag off leaves the
+ * balances behind, and rollover_cus_ent_id_fkey cascades. The executor
+ * therefore checks the rows, not just the flag.
+ *
+ * Red (flag-only guard): the row is deleted and its rollover cascades away.
+ * Green: the row survives and the customer falls out of the batch's changes.
+ */
+import { expect, test } from "bun:test";
+import { customerEntitlements, rollovers } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { and, eq, inArray } from "drizzle-orm";
+import { generateId } from "@/utils/genUtils.js";
+
+const MESSAGES_INCLUDED = 100;
+const ROLLOVER_BALANCE = 25;
+
+test(`${chalk.yellowBright("batch migration: a delete spares rows carrying accrued rollover")}`, async () => {
+	const customerId = "batch-delete-rollover-rows";
+	const plan = products.base({
+		id: "batch-delete-rollover-plan",
+		items: [
+			itemsV2.dashboard(),
+			itemsV2.monthlyMessages({ included: MESSAGES_INCLUDED }),
+		],
+	});
+
+	const { ctx, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.attach({ productId: plan.id })],
+	});
+
+	const messageRows = await ctx.db
+		.select({ id: customerEntitlements.id })
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.customer_id, customerId),
+				eq(customerEntitlements.feature_id, TestFeature.Messages),
+			),
+		);
+	expect(messageRows).toHaveLength(1);
+	const customerEntitlementId = messageRows[0].id;
+
+	// The catalog item never declared rollover, so only the row-level check
+	// can see this. That is exactly the case the flag-only guard misses.
+	await ctx.db.insert(rollovers).values({
+		id: generateId("ro"),
+		cus_ent_id: customerEntitlementId,
+		balance: ROLLOVER_BALANCE,
+		expires_at: null,
+		usage: 0,
+		entities: {},
+	});
+
+	await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: "batch-delete-rollover-migration",
+		filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: plan.id, custom: false },
+					customize: {
+						remove_items: [{ feature_id: TestFeature.Messages }],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+
+	// ── The row and its rollover both survive ──────────────────────────
+	const survivingRows = await ctx.db
+		.select({ id: customerEntitlements.id })
+		.from(customerEntitlements)
+		.where(eq(customerEntitlements.id, customerEntitlementId));
+	expect(survivingRows).toHaveLength(1);
+
+	const survivingRollovers = await ctx.db
+		.select({ balance: rollovers.balance })
+		.from(rollovers)
+		.where(inArray(rollovers.cus_ent_id, [customerEntitlementId]));
+	expect(survivingRollovers).toHaveLength(1);
+	expect(survivingRollovers[0].balance).toBe(ROLLOVER_BALANCE);
+});

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-versions.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete-versions.test.ts
@@ -1,0 +1,101 @@
+/**
+ * A version-less remove_items must reach customers on every version of the
+ * plan, not just the latest.
+ *
+ * Entitlement ids are minted fresh per version, and the executor deletes by
+ * id — so this only works because the catalog load enumerates all versions
+ * (shouldRunBatchLane passes returnAll). Narrowing that to latest-only would
+ * silently no-op every older-version customer, which this test would catch.
+ */
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { runChunkedMigration } from "../utils/runChunkedMigration";
+import { expectCustomerEntitlementRowCount } from "./batchTestUtils";
+
+const MESSAGES_INCLUDED = 100;
+
+test(`${chalk.yellowBright("batch migration: a version-less delete reaches every plan version")}`, async () => {
+	const v1CustomerId = "batch-delete-versions-v1";
+	const v2CustomerId = "batch-delete-versions-v2";
+	const plan = products.base({
+		id: "batch-delete-versions-plan",
+		items: [
+			itemsV2.dashboard(),
+			itemsV2.monthlyMessages({ included: MESSAGES_INCLUDED }),
+		],
+	});
+
+	const { ctx, autumnV1, autumnV2_2 } = await initScenario({
+		customerId: v1CustomerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.attach({ productId: plan.id })],
+	});
+
+	// v2 keeps both items; only the version number moves, so the v2 customer
+	// holds a different entitlement id for the same feature.
+	await autumnV1.products.update(plan.id, {
+		items: [
+			items.dashboard(),
+			items.monthlyMessages({ includedUsage: MESSAGES_INCLUDED }),
+		],
+	});
+
+	await autumnV1.customers.create({ id: v2CustomerId });
+	await autumnV2_2.billing.attach({
+		customer_id: v2CustomerId,
+		plan_id: plan.id,
+	});
+
+	for (const customerId of [v1CustomerId, v2CustomerId]) {
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			count: 1,
+		});
+	}
+
+	const { result } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: "batch-delete-versions-migration",
+		filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: plan.id, custom: false },
+					customize: {
+						remove_items: [{ feature_id: TestFeature.Messages }],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+
+	expect(result?.lane).toBe("batch");
+
+	for (const customerId of [v1CustomerId, v2CustomerId]) {
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			count: 0,
+		});
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Dashboard,
+			count: 1,
+		});
+	}
+});

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/batch-plan-item-delete.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Deleting a free item from a plain plan should batch-lower, the same as
+ * adding one.
+ *
+ * A standalone remove_items was rejected op-level as unsupported_remove_items,
+ * and the projected diff never carried deletions, so it fell to the
+ * per-customer lane.
+ *
+ * Red-failure mode (before):
+ *  - the op is rejected as unsupported_remove_items and runs per_customer
+ *
+ * Green-success criteria (after):
+ *  - the op runs on the batch lane
+ *  - the customer loses its row for the removed feature
+ *  - the plan's other items survive
+ *  - a customer whose only change was the delete is not reported as skipped
+ */
+import { expect, test } from "bun:test";
+import { MigrationItemRunStatus } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { pollUntil } from "@tests/utils/genUtils";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { runChunkedMigration } from "../utils/runChunkedMigration";
+import {
+	expectCustomerEntitlementRowCount,
+	expectMigrationItemRunStatus,
+} from "./batchTestUtils";
+
+const MESSAGES_INCLUDED = 100;
+
+test(`${chalk.yellowBright("batch migration: deleting a free plan item batch-lowers and drops the rows")}`, async () => {
+	const customerId = "batch-plan-item-delete-customer";
+	const plan = products.base({
+		id: "batch-plan-item-delete-plan",
+		items: [
+			itemsV2.dashboard(),
+			itemsV2.monthlyMessages({ included: MESSAGES_INCLUDED }),
+		],
+	});
+
+	const { ctx, autumnV2_2 } = await initScenario({
+		customerId,
+		setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+		actions: [s.attach({ productId: plan.id })],
+	});
+
+	await expectCustomerEntitlementRowCount({
+		ctx,
+		customerId,
+		planId: plan.id,
+		featureId: TestFeature.Messages,
+		count: 1,
+	});
+
+	const { result, migration, migrationRunId } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_2,
+		migrationId: "batch-plan-item-delete-migration",
+		filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: plan.id, custom: false },
+					customize: {
+						remove_items: [{ feature_id: TestFeature.Messages }],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+
+	expect(result?.lane).toBe("batch");
+
+	// The delete is the only change, so marking the customer skipped would
+	// skip its cache invalidation.
+	await expectMigrationItemRunStatus({
+		ctx,
+		migrationInternalId: migration.internal_id,
+		migrationRunId,
+		customerId,
+		status: MigrationItemRunStatus.Succeeded,
+	});
+
+	await pollUntil({
+		fetch: async () => {
+			const customer = await autumnV2_2.customers.get(customerId);
+			return customer;
+		},
+		until: (customer) => !customer.features?.[TestFeature.Messages],
+		timeoutMs: 15_000,
+		intervalMs: 250,
+	});
+
+	await expectCustomerEntitlementRowCount({
+		ctx,
+		customerId,
+		planId: plan.id,
+		featureId: TestFeature.Messages,
+		count: 0,
+	});
+
+	// ── The plan's other item survives ────────────────────────────────
+	await expectCustomerEntitlementRowCount({
+		ctx,
+		customerId,
+		planId: plan.id,
+		featureId: TestFeature.Dashboard,
+		count: 1,
+	});
+});

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/scenarios/migration-scenarios.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/scenarios/migration-scenarios.test.ts
@@ -30,6 +30,15 @@ for (const scenario of MIGRATION_SCENARIOS) {
 
 		expect(outcome.lane).toBe(scenario.expect.lane);
 
+		for (const code of scenario.expect.rejections ?? []) {
+			expect({ scenario: scenario.name, codes: outcome.rejectionCodes }).toEqual(
+				{
+					scenario: scenario.name,
+					codes: expect.arrayContaining([code]),
+				},
+			);
+		}
+
 		for (const [featureId, expected] of Object.entries(
 			scenario.expect.rowsPerTarget ?? {},
 		)) {

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/scenarios/migration-scenarios.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/scenarios/migration-scenarios.test.ts
@@ -31,12 +31,13 @@ for (const scenario of MIGRATION_SCENARIOS) {
 		expect(outcome.lane).toBe(scenario.expect.lane);
 
 		for (const code of scenario.expect.rejections ?? []) {
-			expect({ scenario: scenario.name, codes: outcome.rejectionCodes }).toEqual(
-				{
-					scenario: scenario.name,
-					codes: expect.arrayContaining([code]),
-				},
-			);
+			expect({
+				scenario: scenario.name,
+				codes: outcome.rejectionCodes,
+			}).toEqual({
+				scenario: scenario.name,
+				codes: expect.arrayContaining([code]),
+			});
 		}
 
 		for (const [featureId, expected] of Object.entries(

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/scenarios/runMigrationScenario.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/scenarios/runMigrationScenario.ts
@@ -41,6 +41,7 @@ const toProductItem = (item: ItemSpec): ProductItem => {
 
 export type ScenarioRunOutcome = {
 	lane: string | undefined;
+	rejectionCodes: string[];
 	rowsByFeature: Record<string, number>;
 	balanceByFeature: Record<string, number>;
 	entitlementIdByFeature: Record<string, string>;
@@ -126,6 +127,9 @@ export const runMigrationScenario = async ({
 
 	return {
 		lane: result?.lane,
+		rejectionCodes: (result?.rejections ?? []).map(
+			(rejection) => rejection.code,
+		),
 		rowsByFeature,
 		balanceByFeature,
 		entitlementIdByFeature,

--- a/server/tests/perf/batch-migrations/benchRunPlanItemDelete.ts
+++ b/server/tests/perf/batch-migrations/benchRunPlanItemDelete.ts
@@ -254,16 +254,24 @@ const main = async () => {
 			`bench:   phases: ${phases.map(([phase, ms]) => `${phase}=${ms}ms`).join(" ")}`,
 		);
 	}
+	// A --pages bound stops mid-dataset by design, so rows legitimately remain.
+	const ranToCompletion = pages === Number.POSITIVE_INFINITY;
 	console.log("");
-	console.log(`bench: deleted ${TestFeature.Messages} from every customer`);
+	console.log(
+		ranToCompletion
+			? `bench: deleted ${TestFeature.Messages} from every customer`
+			: `bench: partial run (--pages ${pages}) — remaining rows expected`,
+	);
 	console.log(`bench: holders ${counts.holders} (expected ${customers})`);
-	console.log(`bench: remaining rows ${counts.remaining} (expected 0)`);
+	console.log(
+		`bench: remaining rows ${counts.remaining}${ranToCompletion ? " (expected 0)" : ""}`,
+	);
 	console.log(
 		`bench: shared dataset rows ${counts.shared} (expected ${sharedBefore}, untouched)`,
 	);
 
 	const correct =
-		Number(counts.remaining) === 0 &&
+		(!ranToCompletion || Number(counts.remaining) === 0) &&
 		Number(counts.holders) === customers &&
 		Number(counts.shared) === sharedBefore;
 	console.log(correct ? "bench: CORRECT" : "bench: INCORRECT");

--- a/server/tests/perf/batch-migrations/benchRunPlanItemDelete.ts
+++ b/server/tests/perf/batch-migrations/benchRunPlanItemDelete.ts
@@ -1,0 +1,273 @@
+/**
+ * Benchmarks the plain plan item-DELETE batch path end to end against the bench
+ * org: seed customers holding the feature → prepareMigration →
+ * shouldRunBatchLane → runBatchMigrationChunk(maxPages: 1).
+ *
+ * run.sh drops trailing args, so invoke bun directly to pass flags:
+ *
+ *   infisical run --env=dev --recursive -- bun <path> --customers 20000 --pages all
+ *   infisical run --env=dev --recursive -- bun <path> --cleanup
+ *
+ * The license delete drops rows off entity-scoped seat assignments. This one
+ * drops them off the customer products themselves, which is the higher-volume
+ * shape: every customer on the plan holds a row, not just those with seats.
+ *
+ * Runs on its own plan and re-seeds each time: a delete consumes the rows it
+ * measures, and the shared seedBatchBench dataset is other benches' baseline.
+ * The VACUUM matters — repeated mass-DELETE cycles leave dead tuples that
+ * degrade the claim select from ~150ms to seconds until autovacuum catches up.
+ */
+
+import { type Migration, migrations } from "@autumn/shared";
+import { MigrationFilterSchema } from "@autumn/shared/api/migrations/filters/migrationFilter.js";
+import { OperationsSchema } from "@autumn/shared/api/migrations/operations/operations.js";
+import { TestFeature } from "@tests/setup/v2Features";
+import { sql } from "drizzle-orm";
+import { batchMigrationPlanToExecutionPlan } from "@/internal/migrations/v2/batchOperations/compute/index.js";
+import { runBatchMigrationChunk } from "@/internal/migrations/v2/batchOperations/execute/runBatchMigrationChunk.js";
+import { prepareMigration } from "@/internal/migrations/v2/run/runMigration.js";
+import { shouldRunBatchLane } from "@/internal/migrations/v2/utils/shouldRunBatchLane.js";
+import { generateId } from "@/utils/genUtils.js";
+import {
+	BENCH_CUSTOMER_ENTITLEMENT_PREFIX,
+	getBenchContext,
+} from "./utils/benchContext.js";
+import {
+	BENCH_PLANDEL_CUSTOMER_PRODUCT_PREFIX,
+	BENCH_PLANDEL_ENTITLEMENT_PREFIX,
+	BENCH_PLANDEL_INTERNAL_CUSTOMER_PREFIX,
+	BENCH_PLANDEL_PRODUCT_ID,
+	ensureBenchPlanDeleteProduct,
+	seedBenchPlanItems,
+} from "./utils/seedBenchPlanItems.js";
+
+const parseArgs = () => {
+	const args = process.argv.slice(2);
+	const get = (flag: string) => {
+		const index = args.indexOf(flag);
+		return index === -1 ? undefined : args[index + 1];
+	};
+	const pagesArg = get("--pages") ?? "all";
+	return {
+		customers: Number(get("--customers") ?? "1000"),
+		pages: pagesArg === "all" ? Number.POSITIVE_INFINITY : Number(pagesArg),
+		cleanup: args.includes("--cleanup"),
+	};
+};
+
+const main = async () => {
+	const { customers, pages, cleanup } = parseArgs();
+	const { ctx, org, benchProducts } = await getBenchContext();
+	const { db } = ctx;
+
+	const cleanupStarted = Date.now();
+	await db.execute(sql`
+		DELETE FROM customer_entitlements
+		WHERE id LIKE ${`${BENCH_PLANDEL_ENTITLEMENT_PREFIX}%`}
+	`);
+	await db.execute(sql`
+		DELETE FROM customer_products
+		WHERE id LIKE ${`${BENCH_PLANDEL_CUSTOMER_PRODUCT_PREFIX}%`}
+	`);
+	await db.execute(sql`
+		DELETE FROM migration_item_runs
+		WHERE item_id LIKE ${`${BENCH_PLANDEL_INTERNAL_CUSTOMER_PREFIX}%`}
+	`);
+	console.log(`bench: cleanup done in ${Date.now() - cleanupStarted}ms`);
+	if (cleanup) {
+		await db.execute(sql`
+			DELETE FROM customers
+			WHERE internal_id LIKE ${`${BENCH_PLANDEL_INTERNAL_CUSTOMER_PREFIX}%`}
+		`);
+		process.exit(0);
+	}
+
+	const { internalProductId, entitlementId } =
+		await ensureBenchPlanDeleteProduct({
+			db,
+			orgId: org.id,
+			env: ctx.env,
+			internalFeatureId: benchProducts.messagesInternalFeatureId,
+			featureId: TestFeature.Messages,
+		});
+
+	const seedStarted = Date.now();
+	await seedBenchPlanItems({
+		db,
+		count: customers,
+		planInternalProductId: internalProductId,
+		planProductId: BENCH_PLANDEL_PRODUCT_ID,
+		entitlementId,
+		internalFeatureId: benchProducts.messagesInternalFeatureId,
+		featureId: TestFeature.Messages,
+		startsAt: Date.now(),
+		orgId: org.id,
+		env: ctx.env,
+	});
+	console.log(
+		`bench: seeded ${customers.toLocaleString()} customers holding ${TestFeature.Messages} in ${Date.now() - seedStarted}ms`,
+	);
+
+	// Dead tuples from the cleanup above skew the claim select otherwise.
+	const vacuumStarted = Date.now();
+	await db.execute(sql`VACUUM (ANALYZE) customer_entitlements`);
+	await db.execute(sql`VACUUM (ANALYZE) customer_products`);
+	console.log(`bench: vacuum done in ${Date.now() - vacuumStarted}ms`);
+
+	const [before]: Array<{ shared: string }> = await db.execute(sql`
+		SELECT count(*) AS shared FROM customer_entitlements
+		WHERE id LIKE ${`${BENCH_CUSTOMER_ENTITLEMENT_PREFIX}%`}
+		  AND id NOT LIKE ${`${BENCH_PLANDEL_ENTITLEMENT_PREFIX}%`}
+	`);
+	const sharedBefore = Number(before.shared);
+
+	const migrationId = "bench-mig-plan-item-delete";
+	await db.execute(
+		sql`DELETE FROM migrations WHERE org_id = ${org.id} AND env = ${ctx.env} AND id = ${migrationId}`,
+	);
+	const [migration] = (await db
+		.insert(migrations)
+		.values({
+			internal_id: generateId("mig"),
+			id: migrationId,
+			org_id: org.id,
+			env: ctx.env,
+			filter: MigrationFilterSchema.parse({
+				customer: {
+					plan: { plan_id: BENCH_PLANDEL_PRODUCT_ID, custom: false },
+				},
+			}),
+			operations: OperationsSchema.parse({
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: BENCH_PLANDEL_PRODUCT_ID, custom: false },
+						customize: {
+							remove_items: [{ feature_id: TestFeature.Messages }],
+						},
+					},
+				],
+			}),
+			no_billing_changes: true,
+			retry_failed: false,
+			archived: false,
+			created_at: Date.now(),
+		})
+		.returning()) as Migration[];
+
+	const migrationRunId = generateId("bench_run");
+	const prepareStarted = Date.now();
+	const preparedMigration = await prepareMigration({
+		ctx,
+		migration,
+		dryRun: false,
+	});
+	const prepareMs = Date.now() - prepareStarted;
+
+	const laneStarted = Date.now();
+	const batchLane = await shouldRunBatchLane({
+		ctx,
+		migration: preparedMigration,
+		migrationRunId,
+		dryRun: false,
+		controls: undefined,
+		hasCustomHooks: false,
+		hasCloudBatchAdapter: false,
+	});
+	const laneMs = Date.now() - laneStarted;
+	if (!batchLane.shouldRun) {
+		console.error("bench: batch lane rejected the migration", batchLane);
+		process.exit(1);
+	}
+	const executionPlan = batchMigrationPlanToExecutionPlan({
+		plan: batchLane.plan,
+	});
+	console.log(`bench: prepare ${prepareMs}ms, lane decision ${laneMs}ms`);
+
+	let cursor: string | undefined;
+	let page = 0;
+	let totalProcessed = 0;
+	const pageTimings: number[] = [];
+	const phaseTotals: Record<string, number> = {};
+	const runStarted = Date.now();
+
+	while (page < pages) {
+		const pageStarted = Date.now();
+		const result = await runBatchMigrationChunk({
+			ctx,
+			migration: preparedMigration,
+			migrationRunId,
+			plan: executionPlan,
+			afterInternalId: cursor,
+			maxPages: 1,
+		});
+		const pageMs = Date.now() - pageStarted;
+
+		if (result.summary.pages > 0) {
+			page += 1;
+			pageTimings.push(pageMs);
+			totalProcessed += result.processed;
+			for (const [phase, ms] of Object.entries(result.summary.phases ?? {})) {
+				phaseTotals[phase] = (phaseTotals[phase] ?? 0) + ms;
+			}
+			console.log(
+				`bench: page ${page} — ${result.processed.toLocaleString()} customers in ${pageMs}ms`,
+			);
+		}
+
+		cursor = result.cursor ?? undefined;
+		if (result.completion !== "slice_complete") break;
+	}
+
+	const totalMs = Date.now() - runStarted;
+
+	const [counts]: Array<{
+		holders: string;
+		remaining: string;
+		shared: string;
+	}> = await db.execute(sql`
+		SELECT
+			(SELECT count(*) FROM customer_products
+			 WHERE id LIKE ${`${BENCH_PLANDEL_CUSTOMER_PRODUCT_PREFIX}%`}) AS holders,
+			(SELECT count(*) FROM customer_entitlements
+			 WHERE id LIKE ${`${BENCH_PLANDEL_ENTITLEMENT_PREFIX}%`}) AS remaining,
+			(SELECT count(*) FROM customer_entitlements
+			 WHERE id LIKE ${`${BENCH_CUSTOMER_ENTITLEMENT_PREFIX}%`}
+			   AND id NOT LIKE ${`${BENCH_PLANDEL_ENTITLEMENT_PREFIX}%`}) AS shared
+	`);
+
+	const rate = totalProcessed / (totalMs / 1000);
+	console.log("");
+	console.log(
+		`bench: ${totalProcessed.toLocaleString()} customers in ${totalMs}ms`,
+	);
+	console.log(`bench: ${Math.round(rate).toLocaleString()} customers/sec`);
+	if (pageTimings.length > 1) {
+		const sorted = [...pageTimings].sort((a, b) => a - b);
+		console.log(
+			`bench: page ms — min ${sorted[0]}, median ${sorted[Math.floor(sorted.length / 2)]}, max ${sorted[sorted.length - 1]}`,
+		);
+	}
+	const phases = Object.entries(phaseTotals).sort(([, a], [, b]) => b - a);
+	if (phases.length > 0) {
+		console.log(
+			`bench:   phases: ${phases.map(([phase, ms]) => `${phase}=${ms}ms`).join(" ")}`,
+		);
+	}
+	console.log("");
+	console.log(`bench: deleted ${TestFeature.Messages} from every customer`);
+	console.log(`bench: holders ${counts.holders} (expected ${customers})`);
+	console.log(`bench: remaining rows ${counts.remaining} (expected 0)`);
+	console.log(
+		`bench: shared dataset rows ${counts.shared} (expected ${sharedBefore}, untouched)`,
+	);
+
+	const correct =
+		Number(counts.remaining) === 0 &&
+		Number(counts.holders) === customers &&
+		Number(counts.shared) === sharedBefore;
+	console.log(correct ? "bench: CORRECT" : "bench: INCORRECT");
+	process.exit(correct ? 0 : 1);
+};
+
+await main();

--- a/server/tests/perf/batch-migrations/scenarios/migrationScenarios.ts
+++ b/server/tests/perf/batch-migrations/scenarios/migrationScenarios.ts
@@ -96,20 +96,20 @@ export const MIGRATION_SCENARIOS: MigrationScenario[] = [
 		expect: { lane: "per_customer", rejections: ["priced_add_item"] },
 	},
 	{
-		name: "plan-remove-refused",
-		description: "Plan item removal is not batch-lowered.",
+		name: "plan-remove-free",
+		description: "A standalone free plan item removal batch-lowers.",
 		planItems: [monthly(TestFeature.Messages, 100)],
 		op: {
 			verb: "remove",
 			target: "plan",
 			item: monthly(TestFeature.Messages, 100),
 		},
-		expect: { lane: "per_customer", rejections: ["unsupported_remove_items"] },
+		expect: { lane: "batch" },
 	},
 	{
 		name: "plan-edit-refused",
 		description:
-			"An allowance edit is a remove plus an add, which the plan lane declines.",
+			"An allowance edit is a modify-in-place; the balance has to survive the swap.",
 		planItems: [monthly(TestFeature.Messages, 100)],
 		op: {
 			verb: "edit",

--- a/server/tests/perf/batch-migrations/scenarios/migrationScenarios.ts
+++ b/server/tests/perf/batch-migrations/scenarios/migrationScenarios.ts
@@ -119,6 +119,23 @@ export const MIGRATION_SCENARIOS: MigrationScenario[] = [
 		},
 		expect: { lane: "per_customer", rejections: ["unsupported_remove_items"] },
 	},
+	{
+		name: "plan-edit-lowered-refused",
+		description:
+			"Lowering an allowance is still a modify-in-place; the row keeps its balance.",
+		planItems: [monthly(TestFeature.Messages, 100)],
+		op: {
+			verb: "edit",
+			target: "plan",
+			from: monthly(TestFeature.Messages, 100),
+			to: monthly(TestFeature.Messages, 50),
+		},
+		expect: {
+			lane: "per_customer",
+			rejections: ["unsupported_remove_items"],
+			untouched: [TestFeature.Messages],
+		},
+	},
 
 	// ── License items: all three verbs are batch-lowered ──────────────
 	{

--- a/server/tests/perf/batch-migrations/utils/seedBenchPlanItems.ts
+++ b/server/tests/perf/batch-migrations/utils/seedBenchPlanItems.ts
@@ -1,0 +1,176 @@
+import {
+	AllowanceType,
+	CusProductStatus,
+	EntInterval,
+	entitlements,
+	products,
+} from "@autumn/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { generateId } from "@/utils/genUtils.js";
+
+export const BENCH_PLANDEL_PRODUCT_ID = "bench-plan-delete";
+export const BENCH_PLANDEL_CUSTOMER_ID_PREFIX = "bench-plandel-c-";
+export const BENCH_PLANDEL_INTERNAL_CUSTOMER_PREFIX = "cus_bench_plandel_";
+export const BENCH_PLANDEL_CUSTOMER_PRODUCT_PREFIX = "cp_bench_plandel_";
+export const BENCH_PLANDEL_ENTITLEMENT_PREFIX = "ce_bench_plandel_";
+
+const APPROX_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Its own plan, so a delete never consumes the shared dataset's rows — the
+ * other benches read those as their baseline. */
+export const ensureBenchPlanDeleteProduct = async ({
+	db,
+	orgId,
+	env,
+	internalFeatureId,
+	featureId,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: string;
+	internalFeatureId: string;
+	featureId: string;
+}): Promise<{ internalProductId: string; entitlementId: string }> => {
+	const [existingProduct] = await db
+		.select()
+		.from(products)
+		.where(
+			and(
+				eq(products.org_id, orgId),
+				eq(products.env, env),
+				eq(products.id, BENCH_PLANDEL_PRODUCT_ID),
+			),
+		)
+		.limit(1);
+
+	const internalProductId = existingProduct?.internal_id ?? generateId("prod");
+	if (!existingProduct) {
+		await db.insert(products).values({
+			internal_id: internalProductId,
+			id: BENCH_PLANDEL_PRODUCT_ID,
+			org_id: orgId,
+			env,
+			name: "Bench Plan Delete",
+			created_at: Date.now(),
+			version: 1,
+		});
+	}
+
+	const [existingEntitlement] = await db
+		.select()
+		.from(entitlements)
+		.where(eq(entitlements.internal_product_id, internalProductId))
+		.limit(1);
+
+	const entitlementId = existingEntitlement?.id ?? generateId("ent");
+	if (!existingEntitlement) {
+		await db.insert(entitlements).values({
+			id: entitlementId,
+			created_at: Date.now(),
+			org_id: orgId,
+			internal_product_id: internalProductId,
+			internal_feature_id: internalFeatureId,
+			feature_id: featureId,
+			allowance_type: AllowanceType.Fixed,
+			allowance: 100,
+			interval: EntInterval.Month,
+			interval_count: 1,
+		});
+	}
+
+	return { internalProductId, entitlementId };
+};
+
+/** Own prefixes rather than the shared seedBatchBench dataset: a delete bench
+ * consumes the rows it measures, so it must be free to re-seed between runs. */
+export const seedBenchPlanItems = async ({
+	db,
+	count,
+	planInternalProductId,
+	planProductId,
+	entitlementId,
+	internalFeatureId,
+	featureId,
+	startsAt,
+	orgId,
+	env,
+}: {
+	db: DrizzleCli;
+	count: number;
+	planInternalProductId: string;
+	planProductId: string;
+	entitlementId: string;
+	internalFeatureId: string;
+	featureId: string;
+	startsAt: number;
+	orgId: string;
+	env: string;
+}) => {
+	const series = sql`GENERATE_SERIES(1, ${count}) AS i`;
+
+	await db.execute(sql`
+		INSERT INTO customers (
+			internal_id, id, org_id, env, created_at, name, email
+		)
+		SELECT
+			${BENCH_PLANDEL_INTERNAL_CUSTOMER_PREFIX} || i,
+			${BENCH_PLANDEL_CUSTOMER_ID_PREFIX} || i,
+			${orgId},
+			${env},
+			${startsAt},
+			'bench plandel',
+			''
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, created_at, status,
+			starts_at, is_custom, product_id, customer_id, options
+		)
+		SELECT
+			${BENCH_PLANDEL_CUSTOMER_PRODUCT_PREFIX} || i,
+			${BENCH_PLANDEL_INTERNAL_CUSTOMER_PREFIX} || i,
+			${planInternalProductId},
+			${startsAt},
+			${CusProductStatus.Active},
+			${startsAt},
+			false,
+			${planProductId},
+			${BENCH_PLANDEL_CUSTOMER_ID_PREFIX} || i,
+			'{}'::jsonb[]
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, customer_id, unlimited, balance,
+			created_at, reset_cycle_anchor, next_reset_at, usage_allowed,
+			separate_interval, adjustment, additional_balance, cache_version
+		)
+		SELECT
+			${BENCH_PLANDEL_ENTITLEMENT_PREFIX} || i,
+			${BENCH_PLANDEL_CUSTOMER_PRODUCT_PREFIX} || i,
+			${entitlementId},
+			${BENCH_PLANDEL_INTERNAL_CUSTOMER_PREFIX} || i,
+			${internalFeatureId},
+			${featureId},
+			${BENCH_PLANDEL_CUSTOMER_ID_PREFIX} || i,
+			false,
+			100,
+			${startsAt},
+			${startsAt},
+			${startsAt} + ${APPROX_MONTH_MS}::bigint,
+			false,
+			false,
+			0,
+			0,
+			0
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+};

--- a/server/tests/perf/batch-migrations/utils/seedBenchPlanItems.ts
+++ b/server/tests/perf/batch-migrations/utils/seedBenchPlanItems.ts
@@ -60,7 +60,13 @@ export const ensureBenchPlanDeleteProduct = async ({
 	const [existingEntitlement] = await db
 		.select()
 		.from(entitlements)
-		.where(eq(entitlements.internal_product_id, internalProductId))
+		.where(
+			and(
+				eq(entitlements.internal_product_id, internalProductId),
+				eq(entitlements.org_id, orgId),
+				eq(entitlements.internal_feature_id, internalFeatureId),
+			),
+		)
 		.limit(1);
 
 	const entitlementId = existingEntitlement?.id ?? generateId("ent");

--- a/server/tests/unit/migrations-v2/batch-operations/build-batch-item-responses.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/build-batch-item-responses.test.ts
@@ -60,6 +60,7 @@ const plan: BatchMigrationExecutionPlan = {
 			opIndex: 0,
 			scope: buildOperationScope({ internalProductId: "prod_pro_internal" }),
 			fromProduct,
+			removeEntitlementOps: [],
 			licenseEntitlementOps: [],
 			addEntitlementOps: [
 				{

--- a/server/tests/unit/migrations-v2/batch-operations/compute-remove-item-operations.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/compute-remove-item-operations.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	EntInterval,
+	type EntitlementWithFeature,
+	type Feature,
+	FeatureType,
+	type FullProduct,
+	type Price,
+	ResetInterval,
+} from "@autumn/shared";
+import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
+import { computePatchProductTransitions } from "@/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.js";
+import { checkUpdatePlanOpEligibility } from "@/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanOpEligibility.js";
+import { checkUpdatePlanTransitionEligibility } from "@/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanTransitionEligibility.js";
+import { computeBatchMigrationOperations } from "@/internal/migrations/v2/batchOperations/compute/operations/computeBatchMigrationOperations.js";
+import { resolveRemoveItemEntitlements } from "@/internal/migrations/v2/batchOperations/compute/utils/resolveRemoveItemEntitlements.js";
+
+const messagesFeature = {
+	internal_id: "feat_messages",
+	id: "messages",
+	type: FeatureType.Metered,
+} as unknown as Feature;
+
+const messagesEnt = ({
+	id = "ent_messages",
+	interval = EntInterval.Month,
+	intervalCount = 1,
+	rollover = null,
+	entityFeatureId = null,
+	pooled = false,
+}: {
+	id?: string;
+	interval?: EntInterval | null;
+	intervalCount?: number;
+	rollover?: unknown;
+	entityFeatureId?: string | null;
+	pooled?: boolean;
+} = {}): EntitlementWithFeature =>
+	({
+		id,
+		created_at: 0,
+		internal_product_id: "prod_pro",
+		internal_feature_id: messagesFeature.internal_id,
+		feature_id: messagesFeature.id,
+		allowance_type: AllowanceType.Fixed,
+		allowance: 100,
+		interval,
+		interval_count: intervalCount,
+		rollover,
+		entity_feature_id: entityFeatureId,
+		pooled,
+		feature: messagesFeature,
+	}) as unknown as EntitlementWithFeature;
+
+const proProduct = ({
+	entitlements,
+	prices = [],
+}: {
+	entitlements: EntitlementWithFeature[];
+	prices?: Price[];
+}): FullProduct =>
+	({
+		id: "pro",
+		internal_id: "prod_pro",
+		entitlements,
+		prices,
+		licenses: [],
+	}) as unknown as FullProduct;
+
+const removeOp = (removeItems: unknown[]): UpdatePlanOp =>
+	({
+		type: "update_plan",
+		plan_filter: { plan_id: "pro" },
+		customize: { remove_items: removeItems },
+	}) as unknown as UpdatePlanOp;
+
+const lower = ({
+	fromProduct,
+	op,
+}: {
+	fromProduct: FullProduct;
+	op: UpdatePlanOp;
+}) => {
+	const removeEntitlementIds = resolveRemoveItemEntitlements({
+		op,
+		fromProduct,
+	});
+	const productTransitions = computePatchProductTransitions({
+		fromProduct,
+		addEntitlements: [],
+		removeEntitlementIds,
+	});
+	const operations = computeBatchMigrationOperations({
+		productTransitions,
+		licenseLinks: [],
+	});
+	const rejections = checkUpdatePlanTransitionEligibility({
+		opIndex: 0,
+		fromProduct,
+		productTransitions,
+		licenseLinks: [],
+		operations: operations.entitlements,
+	});
+	return { operations, rejections };
+};
+
+describe("plain plan item removal lowering", () => {
+	test("a free standalone removal lowers to a remove op", () => {
+		const { operations, rejections } = lower({
+			fromProduct: proProduct({ entitlements: [messagesEnt()] }),
+			op: removeOp([{ feature_id: "messages" }]),
+		});
+
+		expect(rejections).toHaveLength(0);
+		expect(operations.removeEntitlements).toHaveLength(1);
+		expect(
+			operations.removeEntitlements[0]?.entitlementPrice.entitlement.id,
+		).toBe("ent_messages");
+		expect(operations.entitlements).toHaveLength(0);
+	});
+
+	test("a priced removal is rejected", () => {
+		const entitlement = messagesEnt();
+		const price = {
+			id: "price_messages",
+			entitlement_id: entitlement.id,
+			internal_product_id: "prod_pro",
+			config: {},
+		} as unknown as Price;
+
+		const { rejections } = lower({
+			fromProduct: proProduct({
+				entitlements: [entitlement],
+				prices: [price],
+			}),
+			op: removeOp([{ feature_id: "messages" }]),
+		});
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"priced_remove_item",
+		);
+	});
+
+	test("a rollover removal is rejected", () => {
+		const { rejections } = lower({
+			fromProduct: proProduct({
+				entitlements: [messagesEnt({ rollover: { max: 100 } })],
+			}),
+			op: removeOp([{ feature_id: "messages" }]),
+		});
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"rollover_remove_item",
+		);
+	});
+
+	test("an entity-scoped removal is rejected", () => {
+		const { rejections } = lower({
+			fromProduct: proProduct({
+				entitlements: [messagesEnt({ entityFeatureId: "feat_seats" })],
+			}),
+			op: removeOp([{ feature_id: "messages" }]),
+		});
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"entity_scoped_entitlement",
+		);
+	});
+
+	test("a pooled removal is rejected", () => {
+		const { rejections } = lower({
+			fromProduct: proProduct({
+				entitlements: [messagesEnt({ pooled: true })],
+			}),
+			op: removeOp([{ feature_id: "messages" }]),
+		});
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"pooled_add_item",
+		);
+	});
+
+	test("a one_off filter matches a lifetime entitlement", () => {
+		const { operations, rejections } = lower({
+			fromProduct: proProduct({
+				entitlements: [messagesEnt({ id: "ent_lifetime", interval: null })],
+			}),
+			op: removeOp([
+				{ feature_id: "messages", interval: ResetInterval.OneOff },
+			]),
+		});
+
+		expect(rejections).toHaveLength(0);
+		expect(
+			operations.removeEntitlements.map(
+				(operation) => operation.entitlementPrice.entitlement.id,
+			),
+		).toEqual(["ent_lifetime"]);
+	});
+
+	test("an interval_count filter alone does not widen to other cadences", () => {
+		const monthly = messagesEnt({ id: "ent_monthly" });
+		const quarterly = messagesEnt({ id: "ent_quarterly", intervalCount: 3 });
+
+		const { operations } = lower({
+			fromProduct: proProduct({ entitlements: [monthly, quarterly] }),
+			op: removeOp([{ feature_id: "messages", interval_count: 3 }]),
+		});
+
+		expect(
+			operations.removeEntitlements.map(
+				(operation) => operation.entitlementPrice.entitlement.id,
+			),
+		).toEqual(["ent_quarterly"]);
+	});
+
+	test("a feature-less filter is rejected rather than silently matching none", () => {
+		const rejections = checkUpdatePlanOpEligibility({
+			op: removeOp([{ interval: ResetInterval.Month }]),
+			opIndex: 0,
+		});
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"unsupported_remove_items",
+		);
+	});
+
+	test("an interval filter narrows to the matching cadence", () => {
+		const monthly = messagesEnt({ id: "ent_monthly" });
+		const quarterly = messagesEnt({ id: "ent_quarterly", intervalCount: 3 });
+
+		const { operations, rejections } = lower({
+			fromProduct: proProduct({ entitlements: [monthly, quarterly] }),
+			op: removeOp([
+				{
+					feature_id: "messages",
+					interval: EntInterval.Month,
+					interval_count: 3,
+				},
+			]),
+		});
+
+		expect(rejections).toHaveLength(0);
+		expect(
+			operations.removeEntitlements.map(
+				(operation) => operation.entitlementPrice.entitlement.id,
+			),
+		).toEqual(["ent_quarterly"]);
+	});
+
+	test("a modify-in-place pair is rejected op-level, not silently dropped", () => {
+		const op = {
+			type: "update_plan",
+			plan_filter: { plan_id: "pro" },
+			customize: {
+				add_items: [{ feature_id: "messages", included: 200 }],
+				remove_items: [{ feature_id: "messages" }],
+			},
+		} as unknown as UpdatePlanOp;
+
+		const rejections = checkUpdatePlanOpEligibility({ op, opIndex: 0 });
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"unsupported_remove_items",
+		);
+	});
+
+	test("a standalone remove passes the op guard", () => {
+		const rejections = checkUpdatePlanOpEligibility({
+			op: removeOp([{ feature_id: "messages" }]),
+			opIndex: 0,
+		});
+
+		expect(rejections).toHaveLength(0);
+	});
+
+	test("a billing_method filter is rejected", () => {
+		const rejections = checkUpdatePlanOpEligibility({
+			op: removeOp([{ feature_id: "messages", billing_method: "prepaid" }]),
+			opIndex: 0,
+		});
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"unsupported_remove_items",
+		);
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/compute-remove-item-operations.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/compute-remove-item-operations.test.ts
@@ -215,6 +215,29 @@ describe("plain plan item removal lowering", () => {
 		).toEqual(["ent_quarterly"]);
 	});
 
+	test("removing one of two same-feature siblings does not claim the survivor", () => {
+		const monthly = messagesEnt({ id: "ent_monthly" });
+		const quarterly = messagesEnt({ id: "ent_quarterly", intervalCount: 3 });
+
+		const { operations, rejections } = lower({
+			fromProduct: proProduct({ entitlements: [monthly, quarterly] }),
+			op: removeOp([
+				{
+					feature_id: "messages",
+					interval: ResetInterval.Month,
+					interval_count: 1,
+				},
+			]),
+		});
+
+		expect(rejections).toHaveLength(0);
+		expect(
+			operations.removeEntitlements.map(
+				(operation) => operation.entitlementPrice.entitlement.id,
+			),
+		).toEqual(["ent_monthly"]);
+	});
+
 	test("a feature-less filter is rejected rather than silently matching none", () => {
 		const rejections = checkUpdatePlanOpEligibility({
 			op: removeOp([{ interval: ResetInterval.Month }]),

--- a/server/tests/unit/migrations-v2/batch-operations/compute-remove-item-operations.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/compute-remove-item-operations.test.ts
@@ -100,7 +100,7 @@ const lower = ({
 		fromProduct,
 		productTransitions,
 		licenseLinks: [],
-		operations: operations.entitlements,
+		operations: operations.addEntitlements,
 	});
 	return { operations, rejections };
 };
@@ -117,7 +117,7 @@ describe("plain plan item removal lowering", () => {
 		expect(
 			operations.removeEntitlements[0]?.entitlementPrice.entitlement.id,
 		).toBe("ent_messages");
-		expect(operations.entitlements).toHaveLength(0);
+		expect(operations.addEntitlements).toHaveLength(0);
 	});
 
 	test("a priced removal is rejected", () => {

--- a/server/tests/unit/migrations-v2/webhook-delivery/build-batch-webhook-records.test.ts
+++ b/server/tests/unit/migrations-v2/webhook-delivery/build-batch-webhook-records.test.ts
@@ -73,6 +73,7 @@ const buildPlan = ({
 			opIndex: 0,
 			scope: buildOperationScope({ internalProductId: "prod_pro_internal" }),
 			fromProduct: fromProduct({ prices }),
+			removeEntitlementOps: [],
 			licenseEntitlementOps: [],
 			addEntitlementOps: [
 				{


### PR DESCRIPTION
## What

Plain plan item deletions (`customize.remove_items`) now run on the batch lane when they are free and standalone. Previously they were rejected unconditionally and fell to the per-customer lane.

The batch lane already deleted entitlements — via `remove_license_entitlement` for license seats. This extends the same capability to plain plan items, which is the higher-volume shape: every customer on the plan holds a row, not just those with seats.

## Why it's small

The shared differ already computes `entitlementPrices.deleted`; it was dropped on the floor because the guards guaranteed it was always empty. Projecting removals into the patch and lowering that array is most of the change.

**No prepare-layer work** — unlike the license path, which needs a prepare artifact because its filters resolve against a catalog that has already mutated. Here the deleted `EntitlementPrice` carries every trait the gates read.

## What lowers

Only **standalone deletions of free items**. Everything else keeps its existing rejection code and routes to per-customer:

| Case | Code |
|---|---|
| Modify-in-place (remove + add sharing a match key) | `unsupported_remove_items` |
| `billing_method` or feature-less filter | `unsupported_remove_items` |
| Priced | `priced_remove_item` |
| Rollover | `rollover_remove_item` |
| Entity-scoped | `entity_scoped_entitlement` |
| Pooled | `pooled_add_item` |

Modify-in-place stays per-customer because the row has to keep its balance across the swap — the same reason the license lane routes it to `replace_license_entitlement`.

## Notable correctness details

**The executor deletes by guard-classified entitlement ids**, not by re-deriving `(feature, interval, interval_count)`. `composeFullProductQuery` filters to `is_custom = false`, so a customer can hold a custom or grandfathered row for the same key that the guard never classified — including one carrying rollover or a price. Matching on ids keeps those out of reach.

**Interval normalization** — a filter speaks `ResetInterval` (`one_off`), an entitlement speaks `EntInterval` (`lifetime`). Both sides normalize through `entIntvToResetIntv`; comparing raw strings meant deleting any lifetime item silently matched nothing *and emitted no rejection*, so it would not even fall back to the per-customer lane.

**Removals mark customers succeeded** — otherwise a removal-only customer is skipped and never cache-invalidated. An exclusion (which refuses an *add*) no longer un-marks a customer whose delete already committed.

## Bounded, like the add

`removeCustomerEntitlementsForPage` runs through `iterateCustomerProductPages` — keyset select → `assertWithinCeiling` → set-based delete → cursor. Same shape as `addCustomerEntitlementsForPage`, so it inherits the 1M-row ceiling and one bounded transaction per customer-product page. The delete cascades into the item-level `customer_prices` row via a CTE.

## Testing

- `compute-remove-item-operations.test.ts` — 12 unit tests, one per gate plus regressions for the interval-normalization and filter-shape bugs
- `batch-plan-item-delete.test.ts` — end to end: batch lane, rows dropped, siblings survive, customer not skipped
- `migrationScenarios.ts` — `plan-remove-refused` becomes `plan-remove-free` (now batches); `plan-edit-refused` keeps its rejection

**Scenario `rejections` are now actually asserted.** They were declared on every scenario but silently ignored — `ScenarioRunOutcome` had no field for them. Verified the assertion bites by injecting a bogus code and watching it fail.

## Benchmark

`benchRunPlanItemDelete.ts` + `seedBenchPlanItems.ts`. Runs on its own `bench-plan-delete` plan and asserts the shared `seedBatchBench` dataset is untouched — a delete consumes the rows it measures, and other benches read those as their baseline.

| customers | wall | rate | `remove` phase |
|---|---|---|---|
| 5,000 | 97s | 51/s | 731ms |
| 20,000 | 118s | 170/s | 4,304ms |
| 50,000 | 161s | 311/s | 9,175ms |

Scales linearly; the delete holds **~0.18ms/row** at every scale and is never the bottleneck (`claim_select` and `finalize_events_drain` dominate, both pre-existing). For reference the recorded add baseline is ~0.35ms/row.

## Follow-ups not in scope

- `separate_interval` is ungated on the remove path
- Credit-system source features have no explicit decision
- Replay after a mid-page crash can leave a stale cache — pre-existing lane behavior, but more user-visible for a delete than an add
- `run.sh` drops trailing args, so the `--customers` flags documented in the *existing* license bench headers have never worked through it; the new bench documents the direct `bun` invocation instead

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch-lowers standalone deletions of free plan items on the v2 batch lane. Previously all `customize.remove_items` fell back to per-customer; now eligible deletes run in batch and the rest still fall back.

- Removes eligible when filters target a feature (optionally interval/count) and the item is free and standalone. Rejects modify-in-place pairs, priced (`priced_remove_item`), rollover (`rollover_remove_item`), entity-scoped (`entity_scoped_entitlement`), pooled (`pooled_add_item`), and filters with `billing_method` or missing `feature_id` (`unsupported_remove_items`). Normalizes lifetime/one_off intervals.
- Holds removals out of the diff to avoid successor matching; carries them as `entitlementPrices.deleted`. Adds explicit `addEntitlements` and `removeEntitlements` ops in compute and execution; schemas updated accordingly.
- Resolves removable IDs per page from live rows by feature (covers custom/grandfathered and older versions); `entsAreSame` keeps only meaningfully identical items. Deletes by those IDs, re-asserts operation scope inside DELETE, row-checks pooled/rollover state, and cascade-deletes `customer_prices`.
- Narrows pages to products that still hold a target row and runs bounded per customer-product page. Executes removes before adds.
- Marks customers changed by a delete as succeeded for cache invalidation; excluded customers remain skipped even if a delete landed. Propagates batch-lane rejection codes to chunk results.
- Tests cover eligibility, interval normalization, multi-version reach, custom-row resolution, license-seat isolation, and rollover-row survival. Adds a dedicated delete bench; shared datasets remain untouched.

<sup>Written for commit e0cd777dc2531aef1c7f4de570d1518d7614b8b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends batch migrations to remove eligible free, standalone plan items while retaining fallback behavior for unsupported removals.

- **[Improvements]** Resolves matching entitlement definitions and deletes eligible customer entitlement and price rows in bounded pages.
- **[Bug fixes]** Normalizes one-off and lifetime intervals, preserves protected pooled and rollover rows, and marks removal-only customers as changed.
- **[API changes]** Carries removal operations and batch-lane rejection details through migration planning and execution results.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanOpEligibility.ts | Narrows removal rejection to unsupported filters and modify-in-place operations. |
| server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.ts | Adds scoped, set-based deletion of eligible entitlement rows and their item-level customer prices. |
| server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/resolveRemovableEntitlementIds.ts | Resolves catalog, custom, and older equivalent entitlement definitions held by the current customer page. |
| server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts | Executes removals before additions and includes removal-only customers in successful batch outcomes. |
| server/src/internal/billing/v2/actions/batchTransition/compute/transitions/computePatchProductTransitions.ts | Separates explicit removals from successor matching and carries them as deleted transitions. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Planner as Migration planner
    participant Guard as Eligibility guards
    participant Executor as Batch executor
    participant DB as PostgreSQL
    Planner->>Guard: Compute add and remove transitions
    alt Unsupported or priced removal
        Guard-->>Planner: Reject to per-customer lane
    else Eligible free standalone removal
        Planner->>Executor: Removal operation with entitlement
        Executor->>DB: Resolve equivalent live entitlement IDs
        Executor->>DB: Select bounded customer-product page
        Executor->>DB: Delete eligible entitlement and price rows
        Executor-->>Planner: Report changed customers and removed items
    end
```
</details>

<sub>Reviews (8): Last reviewed commit: ["feat(migrations): resolve removals from ..."](https://github.com/useautumn/autumn/commit/e0cd777dc2531aef1c7f4de570d1518d7614b8b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53313035)</sub>

<!-- /greptile_comment -->