### PR TITLE
refactor(revenuecat): fire the renewal webhooks from one lifecycle action

### DIFF
--- a/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
@@ -1,5 +1,5 @@
 import type { WebhookRenewal } from "@puzzmo/revenue-cat-webhook-types";
-import { AttachScenario, CusProductStatus } from "@shared/index";
+import { CusProductStatus } from "@shared/index";
 import {
 	getRevenueCatCustomerEmail,
 	getRevenueCatCustomerFingerprint,
@@ -9,9 +9,7 @@ import { provisionRevenueCatCusProduct } from "@/external/revenueCat/misc/provis
 import { resolveRevenuecatResources } from "@/external/revenueCat/misc/resolveRevenuecatResources";
 import { recordRevenueCatInvoice } from "@/external/revenueCat/utils/recordRevenueCatInvoice";
 import type { RevenueCatWebhookContext } from "@/external/revenueCat/webhookMiddlewares/revenuecatWebhookContext";
-import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
 import { customerProductActions } from "@/internal/customers/cusProducts/actions";
-import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
 import { getExistingCusProducts } from "@/internal/customers/cusProducts/cusProductUtils/getExistingCusProducts";
 
 export const handleRenewal = async ({
@@ -21,7 +19,7 @@ export const handleRenewal = async ({
 	event: WebhookRenewal;
 	ctx: RevenueCatWebhookContext;
 }) => {
-	const { org, env, logger } = ctx;
+	const { logger } = ctx;
 	const { product_id, app_user_id, original_app_user_id } = event;
 
 	const {
@@ -52,24 +50,10 @@ export const handleRenewal = async ({
 			`Renewal for existing active product ${product.id}, sending webhook`,
 		);
 
-		await addProductsUpdatedWebhookTask({
+		await customerProductActions.renew({
 			ctx: customerCtx,
-			internalCustomerId: curSameProduct.internal_customer_id,
-			org,
-			env,
-			customerId: customer.id || "",
-			scenario: AttachScenario.Renew,
-			cusProduct: curSameProduct,
-		});
-
-		// No cusProduct mutation on renewal — empty updates still surface an
-		// "updated" plan change so billing.updated mirrors the legacy webhook.
-		emitCustomerProductBillingUpdated({
-			ctx: customerCtx,
-			originalFullCustomer: structuredClone(customer),
-			updateCustomerProducts: [
-				{ customerProduct: curSameProduct, updates: {} },
-			],
+			customerProduct: curSameProduct,
+			fullCustomer: customer,
 		});
 
 		await recordRevenueCatInvoice({

--- a/server/src/internal/customers/cusProducts/actions/cancelCustomerProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/cancelCustomerProduct.ts
@@ -5,8 +5,7 @@ import {
 	type InsertCustomerProduct,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
-import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
+import { dispatchCustomerProductUpdatedWebhooks } from "@/internal/customers/cusProducts/actions/dispatchCustomerProductUpdatedWebhooks";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 
 /**
@@ -30,8 +29,6 @@ export const cancelCustomerProduct = async ({
 	fullCustomer: FullCustomer;
 	endedAt?: number | null;
 }): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
-	const { org, env } = ctx;
-
 	const originalFullCustomer = structuredClone(fullCustomer);
 
 	// 1. Cancel the product
@@ -59,20 +56,13 @@ export const cancelCustomerProduct = async ({
 	);
 
 	// 3. Send webhooks
-	await addProductsUpdatedWebhookTask({
+	await dispatchCustomerProductUpdatedWebhooks({
 		ctx,
-		internalCustomerId: customerProduct.internal_customer_id,
-		org,
-		env,
-		customerId: fullCustomer.id || "",
-		scenario: AttachScenario.Cancel,
-		cusProduct: customerProduct,
-	});
-
-	emitCustomerProductBillingUpdated({
-		ctx,
+		customerProduct,
+		fullCustomer,
 		originalFullCustomer,
-		updateCustomerProducts: [{ customerProduct, updates }],
+		scenario: AttachScenario.Cancel,
+		updates,
 	});
 
 	return { updates };

--- a/server/src/internal/customers/cusProducts/actions/dispatchCustomerProductUpdatedWebhooks.ts
+++ b/server/src/internal/customers/cusProducts/actions/dispatchCustomerProductUpdatedWebhooks.ts
@@ -1,0 +1,48 @@
+import type {
+	AttachScenario,
+	FullCusProduct,
+	FullCustomer,
+	InsertCustomerProduct,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
+import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
+
+/**
+ * Fires the products_updated + billing.updated pair lifecycle actions owe on
+ * every customer product change, so an action cannot send one and skip the other.
+ */
+export const dispatchCustomerProductUpdatedWebhooks = async ({
+	ctx,
+	customerProduct,
+	fullCustomer,
+	originalFullCustomer,
+	scenario,
+	updates,
+}: {
+	ctx: AutumnContext;
+	customerProduct: FullCusProduct;
+	fullCustomer: FullCustomer;
+	/** Snapshot taken by the action before it mutated anything. */
+	originalFullCustomer: FullCustomer;
+	scenario: AttachScenario;
+	updates: Partial<InsertCustomerProduct>;
+}): Promise<void> => {
+	const { org, env } = ctx;
+
+	await addProductsUpdatedWebhookTask({
+		ctx,
+		internalCustomerId: customerProduct.internal_customer_id,
+		org,
+		env,
+		customerId: fullCustomer.id || "",
+		scenario,
+		cusProduct: customerProduct,
+	});
+
+	emitCustomerProductBillingUpdated({
+		ctx,
+		originalFullCustomer,
+		updateCustomerProducts: [{ customerProduct, updates }],
+	});
+};

--- a/server/src/internal/customers/cusProducts/actions/index.ts
+++ b/server/src/internal/customers/cusProducts/actions/index.ts
@@ -11,6 +11,7 @@ import {
 import { markCustomerProductActive } from "./markCustomerProductActive";
 import { markCustomerProductPastDue } from "./markCustomerProductPastDue";
 import { preserveOneOffPrepaidCarryOvers } from "./preserveOneOffPrepaidCarryOvers";
+import { renewCustomerProduct } from "./renewCustomerProduct";
 import { uncancelCustomerProduct } from "./uncancelCustomerProduct";
 import { updateCustomerProductDbAndCache } from "./updateDbAndCache";
 
@@ -29,6 +30,9 @@ export const customerProductActions = {
 
 	/** Uncancels a customer product and sends a Renew webhook */
 	uncancel: uncancelCustomerProduct,
+
+	/** Sends the Renew webhooks for an already-active customer product (no DB write) */
+	renew: renewCustomerProduct,
 
 	/** Marks a customer product as past due and sends a PastDue webhook */
 	markPastDue: markCustomerProductPastDue,

--- a/server/src/internal/customers/cusProducts/actions/markCustomerProductActive.ts
+++ b/server/src/internal/customers/cusProducts/actions/markCustomerProductActive.ts
@@ -6,8 +6,7 @@ import {
 	type InsertCustomerProduct,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
-import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
+import { dispatchCustomerProductUpdatedWebhooks } from "@/internal/customers/cusProducts/actions/dispatchCustomerProductUpdatedWebhooks";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 
 /**
@@ -30,8 +29,6 @@ export const markCustomerProductActive = async ({
 	customerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
 }): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
-	const { org, env } = ctx;
-
 	const originalFullCustomer = structuredClone(fullCustomer);
 
 	const updates: Partial<InsertCustomerProduct> = {
@@ -54,20 +51,13 @@ export const markCustomerProductActive = async ({
 			: cp,
 	);
 
-	await addProductsUpdatedWebhookTask({
+	await dispatchCustomerProductUpdatedWebhooks({
 		ctx,
-		internalCustomerId: customerProduct.internal_customer_id,
-		org,
-		env,
-		customerId: fullCustomer.id || "",
-		scenario: AttachScenario.Renew,
-		cusProduct: customerProduct,
-	});
-
-	emitCustomerProductBillingUpdated({
-		ctx,
+		customerProduct,
+		fullCustomer,
 		originalFullCustomer,
-		updateCustomerProducts: [{ customerProduct, updates }],
+		scenario: AttachScenario.Renew,
+		updates,
 	});
 
 	return { updates };

--- a/server/src/internal/customers/cusProducts/actions/markCustomerProductPastDue.ts
+++ b/server/src/internal/customers/cusProducts/actions/markCustomerProductPastDue.ts
@@ -6,8 +6,7 @@ import {
 	type InsertCustomerProduct,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
-import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
+import { dispatchCustomerProductUpdatedWebhooks } from "@/internal/customers/cusProducts/actions/dispatchCustomerProductUpdatedWebhooks";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 
 /**
@@ -29,8 +28,6 @@ export const markCustomerProductPastDue = async ({
 	customerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
 }): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
-	const { org, env } = ctx;
-
 	const originalFullCustomer = structuredClone(fullCustomer);
 
 	// 1. Mark as past due
@@ -56,20 +53,13 @@ export const markCustomerProductPastDue = async ({
 	);
 
 	// 3. Send webhooks
-	await addProductsUpdatedWebhookTask({
+	await dispatchCustomerProductUpdatedWebhooks({
 		ctx,
-		internalCustomerId: customerProduct.internal_customer_id,
-		org,
-		env,
-		customerId: fullCustomer.id || "",
-		scenario: AttachScenario.PastDue,
-		cusProduct: customerProduct,
-	});
-
-	emitCustomerProductBillingUpdated({
-		ctx,
+		customerProduct,
+		fullCustomer,
 		originalFullCustomer,
-		updateCustomerProducts: [{ customerProduct, updates }],
+		scenario: AttachScenario.PastDue,
+		updates,
 	});
 
 	return { updates };

--- a/server/src/internal/customers/cusProducts/actions/renewCustomerProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/renewCustomerProduct.ts
@@ -1,0 +1,44 @@
+import {
+	AttachScenario,
+	type FullCusProduct,
+	type FullCustomer,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
+import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
+
+/**
+ * Sends products_updated + billing.updated for a renewal of an already-active
+ * customer product. Pure side-effect: the cycle anchor is owned by the store.
+ */
+export const renewCustomerProduct = async ({
+	ctx,
+	customerProduct,
+	fullCustomer,
+}: {
+	ctx: AutumnContext;
+	customerProduct: FullCusProduct;
+	fullCustomer: FullCustomer;
+}): Promise<void> => {
+	const { org, env } = ctx;
+
+	const originalFullCustomer = structuredClone(fullCustomer);
+
+	await addProductsUpdatedWebhookTask({
+		ctx,
+		internalCustomerId: customerProduct.internal_customer_id,
+		org,
+		env,
+		customerId: fullCustomer.id || "",
+		scenario: AttachScenario.Renew,
+		cusProduct: customerProduct,
+	});
+
+	// No cusProduct mutation on renewal — empty updates still surface an
+	// "updated" plan change so billing.updated mirrors the legacy webhook.
+	emitCustomerProductBillingUpdated({
+		ctx,
+		originalFullCustomer,
+		updateCustomerProducts: [{ customerProduct, updates: {} }],
+	});
+};

--- a/server/src/internal/customers/cusProducts/actions/renewCustomerProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/renewCustomerProduct.ts
@@ -4,8 +4,7 @@ import {
 	type FullCustomer,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
-import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
+import { dispatchCustomerProductUpdatedWebhooks } from "@/internal/customers/cusProducts/actions/dispatchCustomerProductUpdatedWebhooks";
 
 /**
  * Sends products_updated + billing.updated for a renewal of an already-active
@@ -20,25 +19,16 @@ export const renewCustomerProduct = async ({
 	customerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
 }): Promise<void> => {
-	const { org, env } = ctx;
-
 	const originalFullCustomer = structuredClone(fullCustomer);
-
-	await addProductsUpdatedWebhookTask({
-		ctx,
-		internalCustomerId: customerProduct.internal_customer_id,
-		org,
-		env,
-		customerId: fullCustomer.id || "",
-		scenario: AttachScenario.Renew,
-		cusProduct: customerProduct,
-	});
 
 	// No cusProduct mutation on renewal — empty updates still surface an
 	// "updated" plan change so billing.updated mirrors the legacy webhook.
-	emitCustomerProductBillingUpdated({
+	await dispatchCustomerProductUpdatedWebhooks({
 		ctx,
+		customerProduct,
+		fullCustomer,
 		originalFullCustomer,
-		updateCustomerProducts: [{ customerProduct, updates: {} }],
+		scenario: AttachScenario.Renew,
+		updates: {},
 	});
 };

--- a/server/src/internal/customers/cusProducts/actions/uncancelCustomerProduct.ts
+++ b/server/src/internal/customers/cusProducts/actions/uncancelCustomerProduct.ts
@@ -6,8 +6,7 @@ import {
 	type InsertCustomerProduct,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { addProductsUpdatedWebhookTask } from "@/internal/analytics/handlers/handleProductsUpdated";
-import { emitCustomerProductBillingUpdated } from "@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated";
+import { dispatchCustomerProductUpdatedWebhooks } from "@/internal/customers/cusProducts/actions/dispatchCustomerProductUpdatedWebhooks";
 import { CusProductService } from "@/internal/customers/cusProducts/CusProductService";
 
 /**
@@ -29,8 +28,6 @@ export const uncancelCustomerProduct = async ({
 	customerProduct: FullCusProduct;
 	fullCustomer: FullCustomer;
 }): Promise<{ updates: Partial<InsertCustomerProduct> }> => {
-	const { org, env } = ctx;
-
 	const originalFullCustomer = structuredClone(fullCustomer);
 
 	// 1. Uncancel the product
@@ -59,20 +56,13 @@ export const uncancelCustomerProduct = async ({
 	);
 
 	// 3. Send webhooks
-	await addProductsUpdatedWebhookTask({
+	await dispatchCustomerProductUpdatedWebhooks({
 		ctx,
-		internalCustomerId: customerProduct.internal_customer_id,
-		org,
-		env,
-		customerId: fullCustomer.id || "",
-		scenario: AttachScenario.Renew,
-		cusProduct: customerProduct,
-	});
-
-	emitCustomerProductBillingUpdated({
-		ctx,
+		customerProduct,
+		fullCustomer,
 		originalFullCustomer,
-		updateCustomerProducts: [{ customerProduct, updates }],
+		scenario: AttachScenario.Renew,
+		updates,
 	});
 
 	return { updates };

--- a/server/tests/unit/customers/cus-products/renew-customer-product-emission.test.ts
+++ b/server/tests/unit/customers/cus-products/renew-customer-product-emission.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+	AttachScenario,
+	type FullCusProduct,
+	type FullCustomer,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+import { mockModuleWithRestore } from "../../utils/mockModuleWithRestore.js";
+
+type ProductsUpdatedArgs = {
+	internalCustomerId: string;
+	org: { id: string };
+	customerId: string;
+	scenario: AttachScenario;
+	cusProduct: FullCusProduct;
+};
+
+type BillingUpdatedArgs = {
+	originalFullCustomer: FullCustomer;
+	updateCustomerProducts: {
+		customerProduct: FullCusProduct;
+		updates: Record<string, unknown>;
+	}[];
+};
+
+type Emission =
+	| { name: "products_updated"; args: ProductsUpdatedArgs }
+	| { name: "billing.updated"; args: BillingUpdatedArgs };
+
+const emissions: Emission[] = [];
+
+await mockModuleWithRestore(
+	"@/internal/analytics/handlers/handleProductsUpdated.js",
+	() => ({
+		addProductsUpdatedWebhookTask: (args: ProductsUpdatedArgs) => {
+			emissions.push({ name: "products_updated", args });
+			return Promise.resolve();
+		},
+	}),
+);
+
+await mockModuleWithRestore(
+	"@/internal/customers/cusProducts/actions/emitCustomerProductBillingUpdated.js",
+	() => ({
+		emitCustomerProductBillingUpdated: (args: BillingUpdatedArgs) => {
+			emissions.push({ name: "billing.updated", args });
+		},
+	}),
+);
+
+const { renewCustomerProduct } = await import(
+	"@/internal/customers/cusProducts/actions/renewCustomerProduct.js"
+);
+
+const customerProduct = {
+	id: "cus_prod_renew_1",
+	internal_customer_id: "internal_cus_1",
+	product: { id: "pro", name: "Pro" },
+} as unknown as FullCusProduct;
+
+const buildContext = () =>
+	({
+		org: { id: "org_1", slug: "acme" },
+		env: "production",
+		logger: { debug: () => {}, info: () => {}, error: () => {} },
+	}) as unknown as AutumnContext;
+
+const buildFullCustomer = () =>
+	({
+		id: "customer_1",
+		internal_id: "internal_cus_1",
+		customer_products: [customerProduct],
+	}) as unknown as FullCustomer;
+
+const findEmission = <TName extends Emission["name"]>(name: TName) =>
+	emissions.find(
+		(emission): emission is Extract<Emission, { name: TName }> =>
+			emission.name === name,
+	);
+
+describe("renewCustomerProduct", () => {
+	beforeEach(() => {
+		emissions.length = 0;
+	});
+
+	test("enqueues the products_updated task with the Renew scenario", async () => {
+		await renewCustomerProduct({
+			ctx: buildContext(),
+			customerProduct,
+			fullCustomer: buildFullCustomer(),
+		});
+
+		const productsUpdated = findEmission("products_updated");
+
+		expect(productsUpdated).toBeDefined();
+		expect(productsUpdated?.args.scenario).toBe(AttachScenario.Renew);
+		expect(productsUpdated?.args.cusProduct.id).toBe("cus_prod_renew_1");
+		expect(productsUpdated?.args.internalCustomerId).toBe("internal_cus_1");
+		expect(productsUpdated?.args.customerId).toBe("customer_1");
+		expect(productsUpdated?.args.org.id).toBe("org_1");
+	});
+
+	test("emits billing.updated for the customer product with empty updates", async () => {
+		await renewCustomerProduct({
+			ctx: buildContext(),
+			customerProduct,
+			fullCustomer: buildFullCustomer(),
+		});
+
+		const billingUpdated = findEmission("billing.updated");
+
+		expect(billingUpdated).toBeDefined();
+		expect(billingUpdated?.args.originalFullCustomer.id).toBe("customer_1");
+		expect(billingUpdated?.args.updateCustomerProducts).toHaveLength(1);
+		expect(
+			billingUpdated?.args.updateCustomerProducts[0].customerProduct.id,
+		).toBe("cus_prod_renew_1");
+		expect(billingUpdated?.args.updateCustomerProducts[0].updates).toEqual({});
+	});
+
+	test("enqueues products_updated before emitting billing.updated", async () => {
+		await renewCustomerProduct({
+			ctx: buildContext(),
+			customerProduct,
+			fullCustomer: buildFullCustomer(),
+		});
+
+		expect(emissions.map((emission) => emission.name)).toEqual([
+			"products_updated",
+			"billing.updated",
+		]);
+	});
+});


### PR DESCRIPTION
The active-renewal branch fired products_updated and billing.updated as two inline calls, unlike every other RevenueCat lifecycle path.

Adds customerProductActions.renew, a webhook-only action (no DB write, since the renewal cycle anchor is owned by the app store), and routes the branch through it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies RevenueCat renewal webhooks behind one lifecycle action to match other lifecycle paths and prevent partial emissions. Previously the renewal path fired `products_updated` and `billing.updated` inline; now it calls `customerProductActions.renew`, which emits both in order and does not write to the DB.

- Sends renewal webhooks via `renewCustomerProduct` (no DB mutation; store owns the cycle anchor) and guarantees `products_updated` precedes `billing.updated`.
- Extracts `dispatchCustomerProductUpdatedWebhooks` and refactors cancel/uncancel/mark-active/mark-past-due to use it, so actions cannot emit only one of the pair.
- Adds `renew-customer-product-emission.test.ts` to verify scenario, payloads, and ordering.
- Migration: call `customerProductActions.renew` for RevenueCat active renewal paths; do not call `addProductsUpdatedWebhookTask` and `emitCustomerProductBillingUpdated` directly.

<sup>Written for commit cfc80bc0a332d2678d9946632dc09a1e474cea42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

