### PR TITLE
fix(website): correct legal entity name to Recase, Inc.

### DIFF
--- a/apps/website/app/privacy/page.tsx
+++ b/apps/website/app/privacy/page.tsx
@@ -55,7 +55,7 @@ export default function PrivacyPolicy() {
 							<div className="hidden md:block w-1/8 lg:w-1/6 border-r border-[#292929]" />
 							<div className="flex-1 px-4 sm:px-8 py-12 md:py-16 text-white text-[16px] font-light leading-[1.6] tracking-[-2%] font-sans pb-32">
 								<p className="mb-10">
-									Autumn (Rebase, Inc.)
+									Autumn (Recase, Inc.)
 									<br />
 									Effective Date: {PRIVACY_EFFECTIVE_DATE}
 								</p>

--- a/apps/website/app/terms/page.tsx
+++ b/apps/website/app/terms/page.tsx
@@ -52,7 +52,7 @@ export default function TermsOfService() {
 							<div className="hidden md:block w-1/8 lg:w-1/6 border-r border-[#292929]" />
 							<div className="flex-1 px-4 sm:px-8 py-12 md:py-16 text-white text-[16px] font-light leading-[1.6] tracking-[-2%] font-sans pb-32">
 								<p className="mb-10">
-									Autumn (Rebase, Inc.)
+									Autumn (Recase, Inc.)
 									<br />
 									Effective Date: {TERMS_EFFECTIVE_DATE}
 								</p>

--- a/apps/website/lib/agentContent.ts
+++ b/apps/website/lib/agentContent.ts
@@ -199,7 +199,7 @@ export function buildTermsMarkdown(): string {
 	const lines: string[] = [
 		"# Terms of Service",
 		"",
-		`Autumn (Rebase, Inc.) — Effective Date: ${TERMS_EFFECTIVE_DATE}`,
+		`Autumn (Recase, Inc.) — Effective Date: ${TERMS_EFFECTIVE_DATE}`,
 		"",
 	];
 
@@ -216,7 +216,7 @@ export function buildPrivacyMarkdown(): string {
 	const lines: string[] = [
 		"# Privacy Policy",
 		"",
-		`Autumn (Rebase, Inc.) — Effective Date: ${PRIVACY_EFFECTIVE_DATE}`,
+		`Autumn (Recase, Inc.) — Effective Date: ${PRIVACY_EFFECTIVE_DATE}`,
 		"",
 	];
 

--- a/apps/website/lib/privacyPolicyContent.ts
+++ b/apps/website/lib/privacyPolicyContent.ts
@@ -6,7 +6,7 @@ export const privacyPolicySections: LegalSection[] = [
 	{
 		title: "1. Introduction",
 		content:
-			'This Privacy Policy explains how Rebase, Inc., a Delaware corporation doing business as Autumn ("Autumn," "we," "us," or "our"), collects, uses, discloses, and protects personal information when you use our platform, APIs, SDKs, website, and related services (collectively, the "Services"). By using the Services, you agree to the practices described in this Policy.',
+			'This Privacy Policy explains how Recase, Inc., a Delaware corporation doing business as Autumn ("Autumn," "we," "us," or "our"), collects, uses, discloses, and protects personal information when you use our platform, APIs, SDKs, website, and related services (collectively, the "Services"). By using the Services, you agree to the practices described in this Policy.',
 		isUppercase: false,
 	},
 	{
@@ -84,7 +84,7 @@ export const privacyPolicySections: LegalSection[] = [
 	{
 		title: "14. Contact Us",
 		content:
-			"For questions about this Privacy Policy or our data practices, contact us at security@useautumn.com or at: Rebase, Inc. (d/b/a Autumn), Email: security@useautumn.com, Website: https://useautumn.com",
+			"For questions about this Privacy Policy or our data practices, contact us at security@useautumn.com or at: Recase, Inc. (d/b/a Autumn), Email: security@useautumn.com, Website: https://useautumn.com",
 		isUppercase: false,
 	},
 ];

--- a/apps/website/lib/termsContent.ts
+++ b/apps/website/lib/termsContent.ts
@@ -10,7 +10,7 @@ export const termsSections: LegalSection[] = [
 	{
 		title: "1. Acceptance of Terms",
 		content:
-			'By accessing or using the Autumn platform, APIs, SDKs, or any related services (collectively, the "Services") provided by Rebase, Inc., a Delaware corporation ("Autumn," "we," "us," or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not use our Services.',
+			'By accessing or using the Autumn platform, APIs, SDKs, or any related services (collectively, the "Services") provided by Recase, Inc., a Delaware corporation ("Autumn," "we," "us," or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, do not use our Services.',
 		isUppercase: false,
 	},
 	{
@@ -100,7 +100,7 @@ export const termsSections: LegalSection[] = [
 	{
 		title: "16. Contact Information",
 		content:
-			"For questions about these Terms, please contact us at security@useautumn.com or at: Rebase, Inc. (d/b/a Autumn), Email: security@useautumn.com, Website: https://useautumn.com",
+			"For questions about these Terms, please contact us at security@useautumn.com or at: Recase, Inc. (d/b/a Autumn), Email: security@useautumn.com, Website: https://useautumn.com",
 		isUppercase: false,
 	},
 ];


### PR DESCRIPTION
## Summary

The website's Terms of Service, Privacy Policy, and agent-readable (`/agent.md`-style) content referred to the company as **"Rebase, Inc."** The correct Delaware corporation name is **"Recase, Inc."** — matching the `LICENSE` file and the `package.json` `author` fields across the repo.

## Changes

Corrected all six occurrences of the legal entity name:

- `apps/website/lib/termsContent.ts` — §1 Acceptance of Terms and §16 Contact Information
- `apps/website/lib/privacyPolicyContent.ts` — §1 Introduction and contact block
- `apps/website/lib/agentContent.ts` — terms & privacy markdown headers
- `apps/website/app/terms/page.tsx` — page header
- `apps/website/app/privacy/page.tsx` — page header

## Notes

- Text-only string replacements; no logic or formatting changes.
- `d/b/a Autumn` and all other content left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWxQNgL7qC11iHC5LkrRaz

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWxQNgL7qC11iHC5LkrRaz)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Eve harness, adds batch license-customize migrations, migrates dev setup to Capy v2, and corrects the website’s legal name to Recase, Inc. Old behavior: re‑homed Eve sessions stalled, some parks were misclassified, empty runs posted “Done.”, and license customize ran per-customer. New behavior: the harness adopts new session ids and recovers safely, parks classify deterministically, empty replies are reported consistently, and license customize executes via set-based batch ops with clearer events.

- Harness (apps/leaf): splits the Eve engine into small units, adopts re‑homed sessions and rewinds cursors, persists session state, and retries only when a session never ran; centralizes user messages; fixes approval flow (answer entire parked batch, keep pending rows on failed withdrawal, move cards to re‑homed runs); pairs previews with the exact request; run registry now targets the latest session id; surfaces consistent messages on Slack/web; adds focused unit tests.
- API/Server: enforces fail‑open timeouts from request start and logs a `fail_open_reason`; introduces batch license‑customize execution (add/replace/remove/repoint) over assignments with guards, queueing via `@trigger.dev/sdk/v3`, and richer webhook item changes; computes retained entitlement updates correctly; validates license links (rejects variants); extends plan/operation types to carry license transitions.
- Dev setup: removes legacy `.capy` config and migrates Setup scripts to Capy v2 VMs (Docker‑backed services, Neon branching); updates docs.
- Website: replaces “Rebase, Inc.” with “Recase, Inc.” across terms, privacy, and agent‑readable content.

**Rollout**
- No DB schema changes. Deploy server and worker together so batch license ops, webhook changes, and queue config (`batch-transition` with bounded concurrency) are available.
- Update Capy project to v2 Setup and ensure Docker services and Neon auth are configured as documented.
- Monitor check logs for new `fail_open_reason` values and verify license migration webhooks handle created/deleted item pairs for replace operations.

<sup>Written for commit c6352e53f912eac7593239fa478c90ed4baaa9a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

