### PR TITLE
fix(migrations): match plan item filters in plan-item interval space

### DIFF
--- a/server/src/internal/migrations/v2/operations/updatePlan/setup/itemAlreadyExists.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/setup/itemAlreadyExists.ts
@@ -1,23 +1,31 @@
 import {
-	EntInterval,
 	type FullCusProduct,
+	type ProductItemInterval,
+	billingToItemInterval,
+	entToItemInterval,
 	findCustomerEntitlementByFeature,
 	findFeatureById,
 	isBooleanFeature,
+	resetIntvToItemIntv,
 } from "@autumn/shared";
 import type { CreatePlanItemParamsV1 } from "@autumn/shared/api/products/items/crud/createPlanItemParamsV1.js";
 import type { PlanItemFilter } from "@autumn/shared/api/products/items/filter/planItemFilter.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { handleCustomizeDeleteItems } from "@/internal/billing/v2/setup/patch/handleCustomizeDeleteItems.js";
 
-const getAddItemEntitlementInterval = ({
+const addItemToPlanItemInterval = ({
 	item,
 }: {
 	item: CreatePlanItemParamsV1;
-}): EntInterval =>
-	(item.reset?.interval ??
-		item.price?.interval ??
-		EntInterval.Lifetime) as EntInterval;
+}): ProductItemInterval | null => {
+	if (item.reset?.interval !== undefined)
+		return resetIntvToItemIntv(item.reset.interval);
+	if (item.price?.interval !== undefined)
+		return billingToItemInterval({
+			billingInterval: item.price.interval,
+		});
+	return null;
+};
 
 export const itemAlreadyExists = ({
 	ctx,
@@ -59,13 +67,13 @@ export const itemAlreadyExists = ({
 		);
 	}
 
-	const itemInterval = getAddItemEntitlementInterval({ item });
+	const itemInterval = addItemToPlanItemInterval({ item });
 
 	return remainingCustomerProduct.customer_entitlements.some(
 		(customerEntitlement) =>
 			customerEntitlement.feature_id === item.feature_id &&
-			String(
-				customerEntitlement.entitlement.interval ?? EntInterval.Lifetime,
-			) === String(itemInterval),
+			entToItemInterval({
+				entInterval: customerEntitlement.entitlement.interval,
+			}) === itemInterval,
 	);
 };

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-replace-one-off-included.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-replace-one-off-included.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Upsolve: bumping a one-off included grant (100 → 2000) via remove+add.
+ * The auto-draft filter uses reset interval `one_off`; the entitlement is stored as `lifetime`.
+ *
+ * Red (current):  "two items for the same feature" / customer stays at 100
+ * Green (after):  grant becomes 2000 and usage carries
+ */
+
+import { test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { ResetInterval } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { runUpdatePlanMigration } from "../../utils/runUpdatePlanMigration";
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: replace one-off included grant keeps usage")}`,
+	async () => {
+		const customerId = "mig-replace-oneoff-included";
+		const free = products.base({
+			id: "mig-replace-oneoff-free",
+			items: [items.lifetimeMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer(), s.products({ list: [free] })],
+			actions: [
+				s.billing.attach({ productId: free.id }),
+				s.track({ featureId: TestFeature.Messages, value: 20, timeout: 2000 }),
+			],
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: free.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: free.id },
+						customize: {
+							remove_items: [
+								{
+									feature_id: TestFeature.Messages,
+									interval: ResetInterval.OneOff,
+									interval_count: 1,
+								},
+							],
+							add_items: [
+								{
+									feature_id: TestFeature.Messages,
+									included: 2000,
+									reset: { interval: ResetInterval.OneOff },
+								},
+							],
+						},
+					},
+				],
+			},
+			runOnServer: false,
+			noBillingChanges: true,
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: 2000,
+			remaining: 1980,
+			usage: 20,
+			nextResetAt: null,
+			planId: free.id,
+			breakdown: {
+				[ResetInterval.OneOff]: {
+					included_grant: 2000,
+					remaining: 1980,
+					usage: 20,
+				},
+			},
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-same-item-carry.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-same-item-carry.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Same-item remove+add (production draft shape: interval + interval_count)
+ * must update the grant, carry usage, and leave sibling intervals alone.
+ *
+ * Red (current):  grant resets / usage drops / sibling bucket is rewritten
+ * Green (after):  remaining = newGrant - carriedUsage; other intervals unchanged
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5 } from "@autumn/shared";
+import { ResetInterval } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { runUpdatePlanMigration } from "../../utils/runUpdatePlanMigration";
+
+const replaceSameItem = ({
+	planId,
+	interval,
+	included,
+}: {
+	planId: string;
+	interval: ResetInterval;
+	included: number;
+}) => ({
+	type: "update_plan" as const,
+	plan_filter: { plan_id: planId },
+	customize: {
+		remove_items: [
+			{
+				feature_id: TestFeature.Messages,
+				interval,
+				interval_count: 1,
+			},
+		],
+		add_items: [
+			{
+				feature_id: TestFeature.Messages,
+				included,
+				reset: { interval },
+			},
+		],
+	},
+});
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: replace lifetime item carries usage")}`,
+	async () => {
+		const customerId = "mig-same-item-lifetime";
+		const free = products.base({
+			id: "mig-same-item-lifetime-plan",
+			items: [items.lifetimeMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer(), s.products({ list: [free] })],
+			actions: [
+				s.billing.attach({ productId: free.id }),
+				s.track({ featureId: TestFeature.Messages, value: 40, timeout: 2000 }),
+			],
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: free.id } } },
+			operations: {
+				customer: [
+					replaceSameItem({
+						planId: free.id,
+						interval: ResetInterval.OneOff,
+						included: 250,
+					}),
+				],
+			},
+			runOnServer: false,
+			noBillingChanges: true,
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: 250,
+			remaining: 210,
+			usage: 40,
+			nextResetAt: null,
+			planId: free.id,
+			breakdown: {
+				[ResetInterval.OneOff]: {
+					included_grant: 250,
+					remaining: 210,
+					usage: 40,
+				},
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: replace monthly item carries usage and reset")}`,
+	async () => {
+		const customerId = "mig-same-item-monthly";
+		const free = products.base({
+			id: "mig-same-item-monthly-plan",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer(), s.products({ list: [free] })],
+			actions: [
+				s.billing.attach({ productId: free.id }),
+				s.track({ featureId: TestFeature.Messages, value: 30, timeout: 2000 }),
+			],
+		});
+
+		const before = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		const nextResetAt = before.balances[TestFeature.Messages]?.next_reset_at;
+		expect(nextResetAt).not.toBeNull();
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: free.id } } },
+			operations: {
+				customer: [
+					replaceSameItem({
+						planId: free.id,
+						interval: ResetInterval.Month,
+						included: 200,
+					}),
+				],
+			},
+			runOnServer: false,
+			noBillingChanges: true,
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: 200,
+			remaining: 170,
+			usage: 30,
+			nextResetAt: nextResetAt!,
+			planId: free.id,
+			breakdown: {
+				[ResetInterval.Month]: {
+					included_grant: 200,
+					remaining: 170,
+					usage: 30,
+				},
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: replace lifetime leaves monthly sibling usage")}`,
+	async () => {
+		const customerId = "mig-same-item-lifetime-sibling";
+		const free = products.base({
+			id: "mig-same-item-lifetime-sibling-plan",
+			items: [
+				items.monthlyMessages({ includedUsage: 100 }),
+				items.lifetimeMessages({ includedUsage: 500 }),
+			],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer(), s.products({ list: [free] })],
+			actions: [s.billing.attach({ productId: free.id })],
+		});
+
+		await autumnV2_3.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			current_balance: 50,
+			interval: ResetInterval.Month,
+		});
+		await autumnV2_3.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.Messages,
+			current_balance: 400,
+			interval: ResetInterval.OneOff,
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: free.id } } },
+			operations: {
+				customer: [
+					replaceSameItem({
+						planId: free.id,
+						interval: ResetInterval.OneOff,
+						included: 800,
+					}),
+				],
+			},
+			runOnServer: false,
+			noBillingChanges: true,
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: 900,
+			remaining: 750,
+			usage: 150,
+			planId: free.id,
+			breakdownCount: 2,
+			breakdown: {
+				[ResetInterval.Month]: {
+					included_grant: 100,
+					remaining: 50,
+					usage: 50,
+				},
+				[ResetInterval.OneOff]: {
+					included_grant: 800,
+					remaining: 700,
+					usage: 100,
+				},
+			},
+		});
+	},
+);

--- a/server/tests/unit/shared/planItemFilterMatchesCustomerPair.test.ts
+++ b/server/tests/unit/shared/planItemFilterMatchesCustomerPair.test.ts
@@ -1,0 +1,503 @@
+/**
+ * PlanItemFilter matching must compare PlanItemInterval | null, never raw
+ * EntInterval / ResetInterval / BillingInterval strings.
+ *
+ * one_off (filter/price) and lifetime (entitlement) both convert to null.
+ * month on either side converts to ProductItemInterval.Month.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	BillWhen,
+	BillingInterval,
+	BillingMethod,
+	EntInterval,
+	type FullCustomerEntitlement,
+	type FullCustomerPrice,
+	Infinite,
+	PriceType,
+	type ProductItem,
+	ProductItemInterval,
+	ResetInterval,
+} from "@autumn/shared";
+import { planItemFilterMatchesCustomerPair } from "@shared/api/products/items/utils/match/planItemFilterMatchesCustomerPair";
+import { matchesPlanItemFilter } from "@shared/utils/productV2Utils/productItemUtils/matchPlanItem";
+
+const FEATURE_ID = "messages";
+const OTHER_FEATURE_ID = "words";
+
+const customerEntitlement = ({
+	featureId = FEATURE_ID,
+	interval = EntInterval.Lifetime,
+	intervalCount = 1,
+}: {
+	featureId?: string;
+	interval?: EntInterval | null;
+	intervalCount?: number | null;
+} = {}) =>
+	({
+		feature_id: featureId,
+		entitlement: {
+			interval,
+			interval_count: intervalCount,
+			feature: { id: featureId },
+		},
+	}) as FullCustomerEntitlement;
+
+const customerPrice = ({
+	featureId = FEATURE_ID,
+	interval = BillingInterval.Month,
+	intervalCount = 1,
+	billWhen = BillWhen.EndOfPeriod,
+}: {
+	featureId?: string;
+	interval?: BillingInterval;
+	intervalCount?: number | null;
+	billWhen?: BillWhen;
+} = {}) =>
+	({
+		price: {
+			config: {
+				type: PriceType.Usage,
+				bill_when: billWhen,
+				billing_units: 1,
+				usage_tiers: [{ to: Infinite, amount: 1 }],
+				interval,
+				interval_count: intervalCount,
+				feature_id: featureId,
+				internal_feature_id: `internal_${featureId}`,
+			},
+		},
+	}) as FullCustomerPrice;
+
+const match = ({
+	filter,
+	entitlement,
+	price,
+}: {
+	filter: Parameters<typeof planItemFilterMatchesCustomerPair>[0]["filter"];
+	entitlement?: ReturnType<typeof customerEntitlement>;
+	price?: ReturnType<typeof customerPrice>;
+}) =>
+	planItemFilterMatchesCustomerPair({
+		filter,
+		customerEntitlement: entitlement,
+		customerPrice: price,
+	});
+
+describe("planItemFilterMatchesCustomerPair — entitlement reset interval", () => {
+	const cases: {
+		name: string;
+		filter: ResetInterval | BillingInterval;
+		ent: EntInterval | null;
+		expected: boolean;
+	}[] = [
+		{
+			name: "one_off filter matches lifetime entitlement",
+			filter: ResetInterval.OneOff,
+			ent: EntInterval.Lifetime,
+			expected: true,
+		},
+		{
+			name: "BillingInterval.OneOff filter matches lifetime entitlement",
+			filter: BillingInterval.OneOff,
+			ent: EntInterval.Lifetime,
+			expected: true,
+		},
+		{
+			name: "one_off filter matches null entitlement interval",
+			filter: ResetInterval.OneOff,
+			ent: null,
+			expected: true,
+		},
+		{
+			name: "one_off filter does not match monthly entitlement",
+			filter: ResetInterval.OneOff,
+			ent: EntInterval.Month,
+			expected: false,
+		},
+		{
+			name: "month filter matches monthly entitlement",
+			filter: ResetInterval.Month,
+			ent: EntInterval.Month,
+			expected: true,
+		},
+		{
+			name: "month filter does not match lifetime entitlement",
+			filter: ResetInterval.Month,
+			ent: EntInterval.Lifetime,
+			expected: false,
+		},
+		{
+			name: "month filter does not match yearly entitlement",
+			filter: ResetInterval.Month,
+			ent: EntInterval.Year,
+			expected: false,
+		},
+		{
+			name: "year filter matches yearly entitlement",
+			filter: ResetInterval.Year,
+			ent: EntInterval.Year,
+			expected: true,
+		},
+		{
+			name: "week filter matches weekly entitlement",
+			filter: ResetInterval.Week,
+			ent: EntInterval.Week,
+			expected: true,
+		},
+		{
+			name: "quarter filter matches quarterly entitlement",
+			filter: ResetInterval.Quarter,
+			ent: EntInterval.Quarter,
+			expected: true,
+		},
+		{
+			name: "semi_annual filter matches semi-annual entitlement",
+			filter: ResetInterval.SemiAnnual,
+			ent: EntInterval.SemiAnnual,
+			expected: true,
+		},
+		{
+			name: "minute filter matches minute entitlement",
+			filter: ResetInterval.Minute,
+			ent: EntInterval.Minute,
+			expected: true,
+		},
+		{
+			name: "hour filter matches hourly entitlement",
+			filter: ResetInterval.Hour,
+			ent: EntInterval.Hour,
+			expected: true,
+		},
+		{
+			name: "day filter matches daily entitlement",
+			filter: ResetInterval.Day,
+			ent: EntInterval.Day,
+			expected: true,
+		},
+		{
+			name: "day filter does not match monthly entitlement",
+			filter: ResetInterval.Day,
+			ent: EntInterval.Month,
+			expected: false,
+		},
+	];
+
+	for (const { name, filter, ent, expected } of cases) {
+		test(name, () => {
+			expect(
+				match({
+					filter: { interval: filter },
+					entitlement: customerEntitlement({ interval: ent }),
+				}),
+			).toBe(expected);
+		});
+	}
+});
+
+describe("planItemFilterMatchesCustomerPair — price billing interval", () => {
+	const cases: {
+		name: string;
+		filter: ResetInterval | BillingInterval;
+		price: BillingInterval;
+		expected: boolean;
+	}[] = [
+		{
+			name: "one_off filter matches one_off price",
+			filter: ResetInterval.OneOff,
+			price: BillingInterval.OneOff,
+			expected: true,
+		},
+		{
+			name: "one_off filter does not match monthly price",
+			filter: ResetInterval.OneOff,
+			price: BillingInterval.Month,
+			expected: false,
+		},
+		{
+			name: "month filter matches monthly price",
+			filter: BillingInterval.Month,
+			price: BillingInterval.Month,
+			expected: true,
+		},
+		{
+			name: "month filter does not match one_off price",
+			filter: BillingInterval.Month,
+			price: BillingInterval.OneOff,
+			expected: false,
+		},
+		{
+			name: "year filter matches yearly price",
+			filter: BillingInterval.Year,
+			price: BillingInterval.Year,
+			expected: true,
+		},
+		{
+			name: "week filter matches weekly price",
+			filter: BillingInterval.Week,
+			price: BillingInterval.Week,
+			expected: true,
+		},
+		{
+			name: "quarter filter matches quarterly price",
+			filter: BillingInterval.Quarter,
+			price: BillingInterval.Quarter,
+			expected: true,
+		},
+		{
+			name: "semi_annual filter matches semi-annual price",
+			filter: BillingInterval.SemiAnnual,
+			price: BillingInterval.SemiAnnual,
+			expected: true,
+		},
+	];
+
+	for (const { name, filter, price, expected } of cases) {
+		test(name, () => {
+			expect(
+				match({
+					filter: { interval: filter },
+					price: customerPrice({ interval: price }),
+				}),
+			).toBe(expected);
+		});
+	}
+});
+
+describe("planItemFilterMatchesCustomerPair — price OR reset", () => {
+	test("one_off filter matches monthly-priced lifetime entitlement (continuous-use)", () => {
+		expect(
+			match({
+				filter: { interval: ResetInterval.OneOff },
+				price: customerPrice({ interval: BillingInterval.Month }),
+				entitlement: customerEntitlement({ interval: EntInterval.Lifetime }),
+			}),
+		).toBe(true);
+	});
+
+	test("month filter matches monthly-priced lifetime entitlement on the price side", () => {
+		expect(
+			match({
+				filter: { interval: BillingInterval.Month },
+				price: customerPrice({ interval: BillingInterval.Month }),
+				entitlement: customerEntitlement({ interval: EntInterval.Lifetime }),
+			}),
+		).toBe(true);
+	});
+
+	test("year filter matches neither monthly price nor lifetime entitlement", () => {
+		expect(
+			match({
+				filter: { interval: BillingInterval.Year },
+				price: customerPrice({ interval: BillingInterval.Month }),
+				entitlement: customerEntitlement({ interval: EntInterval.Lifetime }),
+			}),
+		).toBe(false);
+	});
+
+	test("one_off filter matches one_off price even when entitlement is monthly", () => {
+		expect(
+			match({
+				filter: { interval: ResetInterval.OneOff },
+				price: customerPrice({ interval: BillingInterval.OneOff }),
+				entitlement: customerEntitlement({ interval: EntInterval.Month }),
+			}),
+		).toBe(true);
+	});
+});
+
+describe("planItemFilterMatchesCustomerPair — interval_count", () => {
+	test("count 1 matches missing entitlement interval_count", () => {
+		expect(
+			match({
+				filter: { interval_count: 1 },
+				entitlement: customerEntitlement({ intervalCount: null }),
+			}),
+		).toBe(true);
+	});
+
+	test("count 1 matches explicit 1", () => {
+		expect(
+			match({
+				filter: { interval_count: 1 },
+				entitlement: customerEntitlement({ intervalCount: 1 }),
+			}),
+		).toBe(true);
+	});
+
+	test("count 2 matches 2", () => {
+		expect(
+			match({
+				filter: { interval_count: 2 },
+				entitlement: customerEntitlement({ intervalCount: 2 }),
+			}),
+		).toBe(true);
+	});
+
+	test("count 2 does not match 1", () => {
+		expect(
+			match({
+				filter: { interval_count: 2 },
+				entitlement: customerEntitlement({ intervalCount: 1 }),
+			}),
+		).toBe(false);
+	});
+
+	test("one_off + count 1 matches lifetime entitlement", () => {
+		expect(
+			match({
+				filter: { interval: ResetInterval.OneOff, interval_count: 1 },
+				entitlement: customerEntitlement({
+					interval: EntInterval.Lifetime,
+					intervalCount: 1,
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("one_off + count 2 does not match lifetime count 1", () => {
+		expect(
+			match({
+				filter: { interval: ResetInterval.OneOff, interval_count: 2 },
+				entitlement: customerEntitlement({
+					interval: EntInterval.Lifetime,
+					intervalCount: 1,
+				}),
+			}),
+		).toBe(false);
+	});
+});
+
+describe("planItemFilterMatchesCustomerPair — feature_id and billing_method", () => {
+	test("feature_id matches entitlement feature", () => {
+		expect(
+			match({
+				filter: { feature_id: FEATURE_ID },
+				entitlement: customerEntitlement({ featureId: FEATURE_ID }),
+			}),
+		).toBe(true);
+	});
+
+	test("feature_id does not match a different entitlement feature", () => {
+		expect(
+			match({
+				filter: { feature_id: FEATURE_ID },
+				entitlement: customerEntitlement({ featureId: OTHER_FEATURE_ID }),
+			}),
+		).toBe(false);
+	});
+
+	test("feature_id matches price feature when there is no entitlement", () => {
+		expect(
+			match({
+				filter: { feature_id: FEATURE_ID },
+				price: customerPrice({ featureId: FEATURE_ID }),
+			}),
+		).toBe(true);
+	});
+
+	test("prepaid filter matches in-advance price", () => {
+		expect(
+			match({
+				filter: { billing_method: BillingMethod.Prepaid },
+				price: customerPrice({ billWhen: BillWhen.InAdvance }),
+			}),
+		).toBe(true);
+	});
+
+	test("prepaid filter does not match entitlement-only pair", () => {
+		expect(
+			match({
+				filter: { billing_method: BillingMethod.Prepaid },
+				entitlement: customerEntitlement(),
+			}),
+		).toBe(false);
+	});
+
+	test("usage_based filter matches end-of-period price", () => {
+		expect(
+			match({
+				filter: { billing_method: BillingMethod.UsageBased },
+				price: customerPrice({ billWhen: BillWhen.EndOfPeriod }),
+			}),
+		).toBe(true);
+	});
+
+	test("feature_id AND one_off does not match the right interval on the wrong feature", () => {
+		expect(
+			match({
+				filter: { feature_id: FEATURE_ID, interval: ResetInterval.OneOff },
+				entitlement: customerEntitlement({
+					featureId: OTHER_FEATURE_ID,
+					interval: EntInterval.Lifetime,
+				}),
+			}),
+		).toBe(false);
+	});
+
+	test("feature_id AND month does not match lifetime entitlement on that feature", () => {
+		expect(
+			match({
+				filter: { feature_id: FEATURE_ID, interval: ResetInterval.Month },
+				entitlement: customerEntitlement({
+					featureId: FEATURE_ID,
+					interval: EntInterval.Lifetime,
+				}),
+			}),
+		).toBe(false);
+	});
+});
+
+describe("matchesPlanItemFilter — convert to planItemInterval", () => {
+	const featureItem = ({
+		interval = null,
+		intervalCount = 1,
+		featureId = FEATURE_ID,
+	}: {
+		interval?: ProductItem["interval"];
+		intervalCount?: number;
+		featureId?: string;
+	} = {}) =>
+		({
+			feature_id: featureId,
+			interval,
+			interval_count: intervalCount,
+		}) as ProductItem;
+
+	test("one_off filter matches a lifetime feature item (interval null)", () => {
+		expect(
+			matchesPlanItemFilter({
+				item: featureItem({ interval: null }),
+				filter: { interval: ResetInterval.OneOff },
+			}),
+		).toBe(true);
+	});
+
+	test("one_off filter does not match a monthly feature item", () => {
+		expect(
+			matchesPlanItemFilter({
+				item: featureItem({ interval: ProductItemInterval.Month }),
+				filter: { interval: ResetInterval.OneOff },
+			}),
+		).toBe(false);
+	});
+
+	test("month filter matches a monthly feature item", () => {
+		expect(
+			matchesPlanItemFilter({
+				item: featureItem({ interval: ProductItemInterval.Month }),
+				filter: { interval: ResetInterval.Month },
+			}),
+		).toBe(true);
+	});
+
+	test("month filter does not match a lifetime feature item", () => {
+		expect(
+			matchesPlanItemFilter({
+				item: featureItem({ interval: null }),
+				filter: { interval: ResetInterval.Month },
+			}),
+		).toBe(false);
+	});
+});

--- a/shared/api/products/items/utils/match/planItemFilterMatchesCustomerPair.ts
+++ b/shared/api/products/items/utils/match/planItemFilterMatchesCustomerPair.ts
@@ -2,8 +2,20 @@ import { BillingMethod } from "@api/products/components/billingMethod";
 import type { PlanItemFilter } from "@api/products/items/filter/planItemFilter";
 import type { FullCustomerEntitlement } from "@models/cusProductModels/cusEntModels/cusEntModels";
 import type { FullCustomerPrice } from "@models/cusProductModels/cusPriceModels/cusPriceModels";
+import { BillingInterval } from "@models/productModels/intervals/billingInterval";
+import type { ProductItemInterval } from "@models/productModels/intervals/productItemInterval";
+import { ResetInterval } from "@models/productModels/intervals/resetInterval";
 import { BillingType } from "@models/productModels/priceModels/priceEnums";
+import { resetIntvToItemIntv } from "@utils/productV2Utils/productItemUtils/convertProductItem/planItemIntervals";
+import {
+	billingToItemInterval,
+	entToItemInterval,
+} from "@utils/productV2Utils/productItemUtils/itemIntervalUtils";
 import { getBillingType } from "@utils/productUtils/priceUtils";
+
+const filterToItemInterval = (
+	interval: NonNullable<PlanItemFilter["interval"]>,
+): ProductItemInterval | null => resetIntvToItemIntv(interval as ResetInterval);
 
 const customerPriceToBillingMethod = ({
 	customerPrice,
@@ -24,17 +36,17 @@ const customerPriceToBillingMethod = ({
 };
 
 const intervalSideMatchesFilter = ({
-	interval,
+	itemInterval,
 	intervalCount,
 	filter,
 }: {
-	interval?: string | null;
+	itemInterval: ProductItemInterval | null;
 	intervalCount?: number | null;
 	filter: PlanItemFilter;
 }) => {
 	if (
 		filter.interval !== undefined &&
-		String(interval) !== String(filter.interval)
+		itemInterval !== filterToItemInterval(filter.interval)
 	)
 		return false;
 
@@ -73,14 +85,19 @@ export const planItemFilterMatchesCustomerPair = ({
 		const priceMatches =
 			!!customerPrice &&
 			intervalSideMatchesFilter({
-				interval: customerPrice.price.config.interval,
+				itemInterval: billingToItemInterval({
+					billingInterval:
+						customerPrice.price.config.interval ?? BillingInterval.OneOff,
+				}),
 				intervalCount: customerPrice.price.config.interval_count,
 				filter,
 			});
 		const resetMatches =
 			!!customerEntitlement &&
 			intervalSideMatchesFilter({
-				interval: customerEntitlement.entitlement.interval,
+				itemInterval: entToItemInterval({
+					entInterval: customerEntitlement.entitlement.interval,
+				}),
 				intervalCount: customerEntitlement.entitlement.interval_count,
 				filter,
 			});

--- a/shared/utils/productV2Utils/productItemUtils/matchPlanItem.ts
+++ b/shared/utils/productV2Utils/productItemUtils/matchPlanItem.ts
@@ -1,10 +1,13 @@
 import { BillingMethod } from "../../../api/products/components/billingMethod.js";
 import type { PlanItemFilter } from "../../../api/products/items/filter/planItemFilter.js";
+import { ResetInterval } from "../../../models/productModels/intervals/resetInterval.js";
 import {
 	type ProductItem,
 	UsageModel,
 } from "../../../models/productV2Models/productItemModels/productItemModels.js";
+import { resetIntvToItemIntv } from "./convertProductItem/planItemIntervals.js";
 import {
+	billingToItemInterval,
 	itemToBillingInterval,
 	itemToBillingIntervalCount,
 } from "./itemIntervalUtils.js";
@@ -37,8 +40,9 @@ export const matchesPlanItemFilter = ({
 
 	if (
 		filter.interval !== undefined &&
-		String(itemToBillingInterval({ item })) !== String(filter.interval)
-		// String(itemToEntInterval({ item })) !== String(filter.interval)
+		billingToItemInterval({
+			billingInterval: itemToBillingInterval({ item }),
+		}) !== resetIntvToItemIntv(filter.interval as ResetInterval)
 	)
 		return false;
 


### PR DESCRIPTION
## Summary
- Plan-item filters compared raw interval strings (`one_off` vs `lifetime`), so auto-draft remove+add missed the existing grant and stacked a second item for the same feature.
- Convert filter, price, and entitlement intervals to `ProductItemInterval | null` before compare (`one_off` and `lifetime` both become `null`).
- Unit coverage for the matcher matrix, plus integration tests that same-item lifetime/monthly replace carries usage and leaves sibling intervals alone.

## Test plan
- [x] `bun test tests/unit/shared/planItemFilterMatchesCustomerPair.test.ts` (from `server/`)
- [x] `bun t tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-replace-one-off-included.test.ts`
- [x] `bun t tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-same-item-carry.test.ts`
- [ ] After deploy, re-run Upsolve `plan-migrate-1-usb` (or a new draft) so customers still on 100 credits get the 2000 grant


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plan-item matching in migrations by comparing intervals in the unified plan-item interval space. Previously, `one_off` remove+add filters failed to match `lifetime` entitlements and created duplicate items; now replacements match, carry usage, and leave sibling intervals untouched.

- Review notes
  - Normalizes filter `ResetInterval`, price `BillingInterval`, and entitlement `EntInterval` to `ProductItemInterval | null` in `planItemFilterMatchesCustomerPair` and `matchesPlanItemFilter`; `itemAlreadyExists` applies `remove_items` to the in-memory customer product before checking for an existing item.
  - Adds unit and integration coverage for one-off included replacements, continuous-use monthly → included, and lifetime/monthly carry-over scenarios.
  - `initStripeResourcesForProducts` adds `allowLiveCreate`; `ensurePricesAndEntitlements` opts in so live prepare mints shared Stripe prices once instead of per customer.
  - Migration scheduling honors `MIGRATION_RUN_CUSTOMER_CONCURRENCY=25` with slice-based yielding in `iterateScope`.

- Rollout
  - Action: re-run Upsolve `plan-migrate-1-usb` so customers still on 100 credits receive the 2000 grant.

<sup>Written for commit dcad60465ba288247e12d15fa48c8e64806dc20c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR normalizes migration item filters into plan-item interval space and expands migration execution and UI/content updates.
- **Bug fixes:** Treats one-off prices and lifetime entitlements as the same plan-item interval, improving remove-and-replace matching and usage carry-over.
- **Improvements:** Adds concurrent scheduled migration processing and broader unit/integration coverage.
- **Improvements:** Refreshes pooled-balance contribution details, the marketing blog, homepage copy, imagery, and changelog content.
- **Bug fixes:** Enables creation and reuse of required Stripe resources while preparing live plan migrations.
</details>


<h3>Confidence Score: 4/5</h3>

The live migration path should not be merged until Stripe product and price creation is made retry-safe.

A transient database failure after Stripe accepts a resource creation can cause migration preparation retries to create duplicate live products or prices.

**Files Needing Attention:** server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts; server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/products/items/utils/match/planItemFilterMatchesCustomerPair.ts | Normalizes filter, price, and entitlement intervals before matching while preserving intentional price-or-reset semantics. |
| server/src/internal/migrations/v2/operations/updatePlan/setup/itemAlreadyExists.ts | Applies removal filters to a cloned customer product before checking whether an added item already remains. |
| server/src/internal/migrations/v2/run/orchestrators/iterateScope.ts | Allows scheduled work to run concurrently, drains in-flight work at slice boundaries, and relies on item checkpoints during cursor resumption. |
| server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts | Coordinates Stripe-resource reuse across plan versions but enables non-idempotent live creation during migration preparation. |
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Adds an override for live Stripe creation, exposing create-before-persist failure gaps to migration retries. |
| vite/src/views/customers2/components/sheets/PooledBalanceContributions.tsx | Expands pooled-balance contribution presentation with clearer labels, explanatory tooltips, and richer row details. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant M as Migration preparation
  participant DB as Autumn database
  participant S as Stripe
  M->>DB: Upsert synthesized plan rows
  M->>S: Create product or price
  S-->>M: Return Stripe ID
  M->>DB: Persist Stripe ID
  alt Database write fails
    M-->>M: Preparation fails and is retried
    M->>S: Create the same resource again
  end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts`, line 449-453 ([link](https://github.com/useautumn/autumn/blob/dcad60465ba288247e12d15fa48c8e64806dc20c/server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts#L449-L453)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Live Stripe creation is not retry-safe**

   When Stripe creates a product or price but the subsequent database write fails, retrying live migration preparation creates the resource again because these calls have no idempotency key or lookup-based recovery. This leaves duplicate live Stripe catalog resources and can cause customers to use different prices for the same plan item.

   **Knowledge Base Used:** [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts
   Line: 449-453
   
   Comment:
   **Live Stripe creation is not retry-safe**
   
   When Stripe creates a product or price but the subsequent database write fails, retrying live migration preparation creates the resource again because these calls have no idempotency key or lookup-based recovery. This leaves duplicate live Stripe catalog resources and can cause customers to use different prices for the same plan item.
   
   **Knowledge Base Used:** [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/ensurePricesAndEntitlements.ts:449-453
**Live Stripe creation is not retry-safe**

When Stripe creates a product or price but the subsequent database write fails, retrying live migration preparation creates the resource again because these calls have no idempotency key or lookup-based recovery. This leaves duplicate live Stripe catalog resources and can cause customers to use different prices for the same plan item.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): match plan item filters..."](https://github.com/useautumn/autumn/commit/dcad60465ba288247e12d15fa48c8e64806dc20c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53370690)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)

<!-- /greptile_comment -->