### PR TITLE
Fix one-off migration item display

### DIFF
--- a/vite/src/views/migrations/migration/shared/migrationItemUtils.ts
+++ b/vite/src/views/migrations/migration/shared/migrationItemUtils.ts
@@ -93,10 +93,8 @@ export function migrationItemToProductItem(
 			price.max_purchase == null ? null : included + price.max_purchase;
 	} else {
 		const reset = migItem.reset as Record<string, unknown> | undefined;
-		if (reset?.interval) {
-			base.interval = reset.interval as ProductItemInterval;
-			base.interval_count = reset.interval_count as number | undefined;
-		}
+		base.interval = (reset?.interval as ProductItemInterval) ?? null;
+		base.interval_count = reset?.interval_count as number | undefined;
 	}
 	return base;
 }

--- a/vite/tests/views/migrations/migration/shared/migration-item-utils.test.ts
+++ b/vite/tests/views/migrations/migration/shared/migration-item-utils.test.ts
@@ -4,6 +4,7 @@ import {
 	BillingMethod,
 	FeatureType,
 	FeatureUsageType,
+	getProductItemDisplay,
 	ProductItemInterval,
 	TierBehavior,
 	UsageModel,
@@ -32,6 +33,49 @@ const features: Feature[] = [
 ];
 
 describe("migrationItemUtils", () => {
+	test("displays items without a reset interval as one-off", () => {
+		const productItem = migrationItemToProductItem(
+			{ feature_id: "credits", included: 2000 },
+			features,
+		);
+
+		expect(
+			getProductItemDisplay({ item: productItem, features, fullDisplay: true })
+				.secondary_text,
+		).toBe("one-off");
+	});
+
+	test("preserves explicit reset intervals", () => {
+		const migrationItem = {
+			feature_id: "credits",
+			included: 2000,
+			reset: { interval: ProductItemInterval.Month },
+		};
+		const productItem = migrationItemToProductItem(migrationItem, features);
+
+		expect(productItem.interval).toBe(ProductItemInterval.Month);
+		expect(productItemToMigrationItem(productItem)).toMatchObject(migrationItem);
+	});
+
+	test("round-trips one-off price intervals", () => {
+		const productItem = migrationItemToProductItem(
+			{
+				feature_id: "credits",
+				price: {
+					amount: 25,
+					interval: "one_off",
+					billing_method: BillingMethod.Prepaid,
+				},
+			},
+			features,
+		);
+
+		expect(productItem.interval).toBeNull();
+		expect(productItemToMigrationItem(productItem).price).toMatchObject({
+			interval: "one_off",
+		});
+	});
+
 	test("round-trips tiered usage prices", () => {
 		const migrationItem = {
 			feature_id: "credits",


### PR DESCRIPTION
## Summary

- stop migration items without reset configuration from inheriting the editor default monthly interval
- preserve explicit reset and price intervals when mapping migration items for display
- cover omitted resets, explicit recurring resets, and one-off and recurring price intervals

## Test plan

- bun test tests/views/migrations (39 passed)
- bun run ts
- targeted ESLint
- React Doctor changed-file scan (100/100)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes display of migration items without a reset by treating them as one-off instead of monthly. This prevents accidental defaulting to a monthly interval and preserves explicit reset and price intervals.

- Updates migrationItemToProductItem to set interval to null when no reset is provided; preserves reset.interval and reset.interval_count when present.
- Ensures UI shows “one-off” for items with no reset via `getProductItemDisplay`; one-off price intervals now round-trip correctly.
- Adds targeted tests for omitted resets, explicit resets, and one-off prices. No API or schema changes; no migration required.

<sup>Written for commit 5d4b56891d960551a20a51eeb2b3a5310d4c884e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes how one-off migration items are mapped for display while preserving explicitly configured intervals.

- **Bug fixes:** Treat migration items without a price or reset interval as one-off instead of inheriting the editor’s monthly default.
- **Improvements:** Preserve explicit reset intervals and distinguish one-off from recurring price intervals during display mapping.
- **Improvements:** Add focused coverage for omitted resets, explicit resets, and one-off and recurring prices.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable changed-code issues identified.

The mapper now reflects the migration payload’s explicit interval configuration rather than retaining an unrelated editor default, and the added tests cover the corrected one-off and recurring cases.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/migrations/migration/shared/migrationItemUtils.ts | Explicitly clears the default interval for reset-less items while retaining configured reset and price intervals; no changed-code defect identified. |
| vite/tests/views/migrations/migration/shared/migration-item-utils.test.ts | Adds focused regression tests for one-off display and interval preservation without introducing test-quality issues. |

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 display one-off migration items ..."](https://github.com/useautumn/autumn/commit/5d4b56891d960551a20a51eeb2b3a5310d4c884e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53390245)</sub>

<!-- /greptile_comment -->