### PR TITLE
fix: emit webhooks for entity default plans

### DIFF
--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -39,6 +39,7 @@ export const attachDefaultProductsToEntities = async ({
 	for (const entity of entities) {
 		const entityFullCustomer = {
 			...fullCustomer,
+			customer_products: [...fullCustomer.customer_products],
 			entity,
 		};
 		const insertCustomerProducts = freeDefaultProducts.map((product) =>
@@ -72,5 +73,10 @@ export const attachDefaultProductsToEntities = async ({
 			autumnBillingPlan,
 			originalFullCustomer: entityFullCustomer,
 		});
+
+		fullCustomer.customer_products = [
+			...fullCustomer.customer_products,
+			...insertCustomerProducts,
+		];
 	}
 };

--- a/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
+++ b/server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts
@@ -8,6 +8,8 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { executeAutumnBillingPlan } from "@/internal/billing/v2/execute/executeAutumnBillingPlan";
 import { initFullCustomerProductFromProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromProduct";
+import { sendBillingUpdatedWebhook } from "@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
+import { billingPlanToSendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
 import { setupDefaultProductsContext } from "@/internal/customers/actions/createWithDefaults/setup/setupDefaultProductsContext";
 
 export const attachDefaultProductsToEntities = async ({
@@ -35,26 +37,40 @@ export const attachDefaultProductsToEntities = async ({
 
 	const currentEpochMs = Date.now();
 	for (const entity of entities) {
+		const entityFullCustomer = {
+			...fullCustomer,
+			entity,
+		};
 		const insertCustomerProducts = freeDefaultProducts.map((product) =>
 			initFullCustomerProductFromProduct({
 				ctx,
 				initContext: {
-					fullCustomer: {
-						...fullCustomer,
-						entity: entity,
-					},
+					fullCustomer: entityFullCustomer,
 					fullProduct: product,
 					currentEpochMs,
 				},
 			}),
 		);
+		const autumnBillingPlan = {
+			customerId: fullCustomer.id ?? "",
+			insertCustomerProducts,
+		};
 
 		await executeAutumnBillingPlan({
 			ctx,
-			autumnBillingPlan: {
-				customerId: fullCustomer.id ?? "",
-				insertCustomerProducts,
-			},
+			autumnBillingPlan,
+		});
+
+		await billingPlanToSendProductsUpdated({
+			ctx,
+			autumnBillingPlan,
+			billingContext: { fullCustomer: entityFullCustomer },
+		});
+
+		void sendBillingUpdatedWebhook({
+			ctx,
+			autumnBillingPlan,
+			originalFullCustomer: entityFullCustomer,
 		});
 	}
 };

--- a/server/tests/unit/entities/entity-default-webhooks.test.ts
+++ b/server/tests/unit/entities/entity-default-webhooks.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+const executeModulePath =
+	"@/internal/billing/v2/execute/executeAutumnBillingPlan";
+const initProductModulePath =
+	"@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProductFromProduct";
+const billingWebhookModulePath =
+	"@/internal/billing/v2/workflows/sendBillingUpdatedWebhook/sendBillingUpdatedWebhook";
+const productsWebhookModulePath =
+	"@/internal/billing/v2/workflows/sendProductsUpdated/billingPlanToSendProductsUpdated";
+const defaultsModulePath =
+	"@/internal/customers/actions/createWithDefaults/setup/setupDefaultProductsContext";
+
+const realExecute = { ...(await import(executeModulePath)) };
+const realInitProduct = { ...(await import(initProductModulePath)) };
+const realBillingWebhook = { ...(await import(billingWebhookModulePath)) };
+const realProductsWebhook = { ...(await import(productsWebhookModulePath)) };
+const realDefaults = { ...(await import(defaultsModulePath)) };
+
+const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+const hobby = { id: "hobby", name: "Hobby", prices: [] };
+const customerProduct = {
+	id: "cus_prod_hobby",
+	product: hobby,
+};
+
+mock.module(executeModulePath, () => ({
+	executeAutumnBillingPlan: async (args: Record<string, unknown>) => {
+		calls.push({ name: "execute", args });
+	},
+}));
+mock.module(initProductModulePath, () => ({
+	initFullCustomerProductFromProduct: () => customerProduct,
+}));
+mock.module(billingWebhookModulePath, () => ({
+	sendBillingUpdatedWebhook: async (args: Record<string, unknown>) => {
+		calls.push({ name: "billing.updated", args });
+	},
+}));
+mock.module(productsWebhookModulePath, () => ({
+	billingPlanToSendProductsUpdated: async (args: Record<string, unknown>) => {
+		calls.push({ name: "customer.products.updated", args });
+	},
+}));
+mock.module(defaultsModulePath, () => ({
+	setupDefaultProductsContext: async () => ({
+		fullProducts: [hobby],
+		paidProducts: [],
+		hasPaidProducts: false,
+	}),
+}));
+
+const { attachDefaultProductsToEntities } = await import(
+	"@/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities"
+);
+
+afterAll(() => {
+	mock.module(executeModulePath, () => realExecute);
+	mock.module(initProductModulePath, () => realInitProduct);
+	mock.module(billingWebhookModulePath, () => realBillingWebhook);
+	mock.module(productsWebhookModulePath, () => realProductsWebhook);
+	mock.module(defaultsModulePath, () => realDefaults);
+});
+
+beforeEach(() => {
+	calls.length = 0;
+});
+
+describe("entity default product webhooks", () => {
+	test("emits both webhooks after attaching the default product", async () => {
+		const entity = { id: "entity_1" };
+		const fullCustomer = {
+			id: "customer_1",
+			internal_id: "internal_customer_1",
+		};
+		const ctx = {
+			org: { config: { default_applies_to_entities: true } },
+		} as AutumnContext;
+
+		await attachDefaultProductsToEntities({
+			ctx,
+			fullCustomer: fullCustomer as never,
+			entities: [entity as never],
+		});
+
+		expect(calls.map(({ name }) => name)).toEqual([
+			"execute",
+			"customer.products.updated",
+			"billing.updated",
+		]);
+
+		const autumnBillingPlan = {
+			customerId: "customer_1",
+			insertCustomerProducts: [customerProduct],
+		};
+		expect(calls[0]?.args.autumnBillingPlan).toEqual(autumnBillingPlan);
+		expect(calls[1]?.args).toMatchObject({
+			autumnBillingPlan,
+			billingContext: { fullCustomer: { ...fullCustomer, entity } },
+		});
+		expect(calls[2]?.args).toMatchObject({
+			autumnBillingPlan,
+			originalFullCustomer: { ...fullCustomer, entity },
+		});
+	});
+});

--- a/server/tests/unit/entities/entity-default-webhooks.test.ts
+++ b/server/tests/unit/entities/entity-default-webhooks.test.ts
@@ -67,12 +67,13 @@ beforeEach(() => {
 	calls.length = 0;
 });
 
-describe("entity default product webhooks", () => {
-	test("emits both webhooks after attaching the default product", async () => {
+describe("entity default products", () => {
+	test("emits both webhooks and updates the create response state", async () => {
 		const entity = { id: "entity_1" };
 		const fullCustomer = {
 			id: "customer_1",
 			internal_id: "internal_customer_1",
+			customer_products: [] as (typeof customerProduct)[],
 		};
 		const ctx = {
 			org: { config: { default_applies_to_entities: true } },
@@ -94,14 +95,28 @@ describe("entity default product webhooks", () => {
 			customerId: "customer_1",
 			insertCustomerProducts: [customerProduct],
 		};
+		const webhookCustomer = {
+			id: "customer_1",
+			internal_id: "internal_customer_1",
+			customer_products: [],
+			entity,
+		};
 		expect(calls[0]?.args.autumnBillingPlan).toEqual(autumnBillingPlan);
 		expect(calls[1]?.args).toMatchObject({
 			autumnBillingPlan,
-			billingContext: { fullCustomer: { ...fullCustomer, entity } },
+			billingContext: { fullCustomer: webhookCustomer },
 		});
 		expect(calls[2]?.args).toMatchObject({
 			autumnBillingPlan,
-			originalFullCustomer: { ...fullCustomer, entity },
+			originalFullCustomer: webhookCustomer,
 		});
+		expect(
+			(
+				calls[2]?.args.originalFullCustomer as {
+					customer_products: unknown[];
+				}
+			).customer_products,
+		).toEqual([]);
+		expect(fullCustomer.customer_products).toEqual([customerProduct]);
 	});
 });


### PR DESCRIPTION
Entity default product attachment now queues `customer.products.updated` and emits `billing.updated` after the default billing plan is persisted. Both emissions use an entity-enriched pre-attach customer snapshot so the payload is scoped to the newly created entity and reports the correct transition.

The attached products are then added to the in-memory customer state, making the immediate `entities.create` response include the default subscription, flags, and balances consistently with customer creation.

Adds focused regression coverage for execution order, both webhook inputs, snapshot isolation, and response state.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Entity default-plan attachment now emits the same product and billing notifications as other billing flows, after plan persistence and with entity-specific context.

- **[Bug fixes]** Queues `customer.products.updated` after each entity’s default plan is executed.
- **[Bug fixes]** Emits `billing.updated` with the newly created entity’s identifier and billing-plan changes.
- **[Improvements]** Preserves newly attached products in the shared customer state returned by entity creation.
- **[Improvements]** Adds focused unit coverage for notification order, entity-scoped inputs, and response-state updates.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts | Executes each entity’s default plan before dispatching entity-scoped product and billing notifications, then updates the shared customer state. |
| server/tests/unit/entities/entity-default-webhooks.test.ts | Covers notification ordering, billing-plan arguments, entity-enriched customer context, and returned product state. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant EntityFlow as Entity creation
    participant Billing as Billing plan executor
    participant Products as customer.products.updated
    participant BillingHook as billing.updated
    EntityFlow->>Billing: Persist entity default plan
    Billing-->>EntityFlow: Plan persisted
    EntityFlow->>Products: Queue product update with entity context
    EntityFlow->>BillingHook: Emit billing update with entity context
    EntityFlow->>EntityFlow: Add inserted products to response state
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: include entity defaults in create r..."](https://github.com/useautumn/autumn/commit/44947d2d1db5f7f0c501f8e61c48cd595443a02f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53591956)</sub>

<!-- /greptile_comment -->