### PR TITLE
feat(catalog-v2): draft and apply license parent migrations

### DIFF
--- a/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
+++ b/server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts
@@ -63,6 +63,22 @@ export const mergeAutumnBillingPlans = ({
 		getKey: (transition) => transition.incomingCustomerLicense.id,
 	}),
 	customFreeTrial: incoming.customFreeTrial ?? base.customFreeTrial,
+	insertPlanLicenses: mergeByKey({
+		base: base.insertPlanLicenses,
+		incoming: incoming.insertPlanLicenses,
+		getKey: (spec) => spec.row.id,
+	}),
+	customerLicenseUpdates: mergeByKey({
+		base: base.customerLicenseUpdates,
+		incoming: incoming.customerLicenseUpdates,
+		getKey: (update) =>
+			update.customerLicenseId ?? update.customerLicenseLinkId ?? "",
+	}),
+	customerLicenseTransitions: mergeByKey({
+		base: base.customerLicenseTransitions,
+		incoming: incoming.customerLicenseTransitions,
+		getKey: (transition) => transition.incomingCustomerLicense.id,
+	}),
 	lineItems: mergeById({
 		base: base.lineItems,
 		incoming: incoming.lineItems,

--- a/server/src/internal/catalogV2/actions/buildMigrationDraft/buildMigrationDraftUtils.ts
+++ b/server/src/internal/catalogV2/actions/buildMigrationDraft/buildMigrationDraftUtils.ts
@@ -1,7 +1,8 @@
-import type {
-	DiffedCustomizePlanV1,
-	MigrationUpdatePlanCustomize,
-	PlanFilter,
+import {
+	basePriceToKey,
+	type DiffedCustomizePlanV1,
+	type MigrationUpdatePlanCustomize,
+	type PlanFilter,
 } from "@autumn/shared";
 import type { MigrationTarget } from "./types";
 
@@ -34,7 +35,10 @@ const previousPriceKey = ({
 	previousPrice,
 }: {
 	previousPrice: MigrationTarget["previousPrice"];
-}) => JSON.stringify(previousPrice);
+}) =>
+	previousPrice === null
+		? "null"
+		: basePriceToKey({ price: previousPrice });
 
 /** Stamp previous_price only when every target shares one base price — one op can't carry mixed previous prices. */
 export const stampPreviousPrice = ({

--- a/server/src/internal/catalogV2/actions/buildMigrationDraft/groupTargetsByCustomize.ts
+++ b/server/src/internal/catalogV2/actions/buildMigrationDraft/groupTargetsByCustomize.ts
@@ -1,4 +1,4 @@
-import { type DiffedCustomizePlanV1, customizeToKey } from "@autumn/shared";
+import { customizeToKey, type DiffedCustomizePlanV1 } from "@autumn/shared";
 import { toMigratableCustomize } from "./toMigratableCustomize";
 import type { MigrationTarget } from "./types";
 

--- a/server/src/internal/catalogV2/actions/buildMigrationDraft/toMigratableCustomize.ts
+++ b/server/src/internal/catalogV2/actions/buildMigrationDraft/toMigratableCustomize.ts
@@ -1,6 +1,6 @@
 import type { DiffedCustomizePlanV1 } from "@autumn/shared";
 
-/** Drop non-migratable lanes (free trial, metadata) from a plan diff. */
+/** Drop non-migratable lanes (free trial, remove_licenses) from a plan diff. */
 export const toMigratableCustomize = ({
 	customize,
 }: {
@@ -12,5 +12,8 @@ export const toMigratableCustomize = ({
 		: {}),
 	...(customize.remove_items !== undefined
 		? { remove_items: customize.remove_items }
+		: {}),
+	...(customize.upsert_licenses !== undefined
+		? { upsert_licenses: customize.upsert_licenses }
 		: {}),
 });

--- a/server/src/internal/catalogV2/actions/buildMigrationDraft/types.ts
+++ b/server/src/internal/catalogV2/actions/buildMigrationDraft/types.ts
@@ -6,7 +6,7 @@ type PreviousPrice = ReturnType<typeof toBasePriceParams> | null;
 export type MigrationTarget = {
 	planId: string;
 	version: number;
-	/** Migratable keys only (`price` / `add_items` / `remove_items`). */
+	/** Migratable keys only (`price` / `add_items` / `remove_items` / `upsert_licenses`). */
 	customize: DiffedCustomizePlanV1;
 	previousPrice: PreviousPrice;
 	hasBillingChanges: boolean;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/computeMigrationDraftPlans.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/computeMigrationDraftPlans.ts
@@ -1,44 +1,15 @@
-import {
-	type CatalogMigration,
-	productToProductKey,
-	type UpdateCatalogParams,
-} from "@autumn/shared";
+import type { CatalogMigration, UpdateCatalogParams } from "@autumn/shared";
 import { buildMigrationDraft } from "@/internal/catalogV2/actions/buildMigrationDraft/buildMigrationDraft";
 import type { MigrationTarget } from "@/internal/catalogV2/actions/buildMigrationDraft/types";
-import {
-	includeCustomForMigrationDraft,
-	isEligibleForMigrationDraft,
-} from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/isEligibleForMigrationDraft";
-import { resolveMigrationTarget } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveMigrationTarget";
+import { resolveLicenseMigrationTarget } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/resolveLicenseMigrationTarget";
+import { resolveOwnMigrationTarget } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveOwnMigrationTarget";
+import { versionsWithCustomersByPlanId } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/versionsWithCustomersByPlanId";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
-
-const versionsWithCustomersByPlanId = ({
-	productStatesContext,
-}: {
-	productStatesContext: ProductStatesContext;
-}): Record<string, number[]> => {
-	const result: Record<string, number[]> = {};
-	for (const [planId, versions] of Object.entries(
-		productStatesContext.versionsByPlanId,
-	)) {
-		result[planId] = versions
-			.filter(
-				(product) =>
-					productKeyToState({
-						productKey: productToProductKey({ product }),
-						productStatesContext,
-					}).customerUsage.hasVersionableCustomerProducts,
-			)
-			.map((product) => product.version);
-	}
-	return result;
-};
 
 /**
- * One draft covering every requesting (planId, version) row that has
- * versionable customers. Empty diffs / mints never become targets.
+ * One draft covering this row's own plan diff plus its license-link diffs.
+ * Empty diffs / mints never become targets.
  */
 export const computeMigrationDraftPlans = ({
 	upsertProductPlans,
@@ -52,17 +23,20 @@ export const computeMigrationDraftPlans = ({
 	const targets: MigrationTarget[] = [];
 
 	for (const upsertProductPlan of upsertProductPlans) {
-		if (!isEligibleForMigrationDraft({ upsertProductPlan, params })) continue;
-
-		const target = resolveMigrationTarget({
+		const own = resolveOwnMigrationTarget({
 			upsertProductPlan,
+			params,
 			productStatesContext,
-			includeCustom: includeCustomForMigrationDraft({
-				upsertProductPlan,
-				params,
-			}),
 		});
-		if (target) targets.push(target);
+		if (own) targets.push(own);
+
+		const license = resolveLicenseMigrationTarget({
+			upsertProductPlan,
+			upsertProductPlans,
+			params,
+			productStatesContext,
+		});
+		if (license) targets.push(license);
 	}
 
 	const draft = buildMigrationDraft({

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams.ts
@@ -4,19 +4,6 @@ import type {
 } from "@autumn/shared";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 
-const matchingDraftPlanParams = ({
-	upsertProductPlan,
-	params,
-}: {
-	upsertProductPlan: UpsertProductPlan;
-	params: UpdateCatalogParams;
-}): UpdateCatalogPlanParams | undefined =>
-	params.plans.find(
-		(planParams) =>
-			planParams.migration?.draft &&
-			upsertMatchesDraftEntry({ upsertProductPlan, planParams }),
-	);
-
 const upsertMatchesDraftEntry = ({
 	upsertProductPlan,
 	planParams,
@@ -34,16 +21,27 @@ const upsertMatchesDraftEntry = ({
 	return upsertProductPlan.row.source === "direct";
 };
 
-/** This `(planId, version)` row asked for a draft and has versionable customers. */
-export const isEligibleForMigrationDraft = ({
+/** The params entry whose `migration.draft` claims this upsert row. */
+export const matchingDraftPlanParams = ({
 	upsertProductPlan,
 	params,
 }: {
 	upsertProductPlan: UpsertProductPlan;
 	params: UpdateCatalogParams;
-}): boolean =>
-	matchingDraftPlanParams({ upsertProductPlan, params }) != null &&
-	upsertProductPlan.state.hasCustomers;
+}): UpdateCatalogPlanParams | undefined =>
+	params.plans.find(
+		(planParams) =>
+			planParams.migration?.draft &&
+			upsertMatchesDraftEntry({ upsertProductPlan, planParams }),
+	);
+
+export const upsertClaimsMigrationDraft = ({
+	upsertProductPlan,
+	params,
+}: {
+	upsertProductPlan: UpsertProductPlan;
+	params: UpdateCatalogParams;
+}): boolean => matchingDraftPlanParams({ upsertProductPlan, params }) != null;
 
 export const includeCustomForMigrationDraft = ({
 	upsertProductPlan,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/declaredLicenseDraftUpserts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/declaredLicenseDraftUpserts.ts
@@ -1,0 +1,65 @@
+import type { UpdateCatalogParams } from "@autumn/shared";
+import {
+	includeCustomForMigrationDraft,
+	upsertClaimsMigrationDraft,
+} from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams";
+import {
+	type LicenseDraftUpserts,
+	licenseUpsertFromPlanLicense,
+	sortLicenseDraftUpserts,
+} from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseUpsertFromPlanLicense";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+
+const declaredParentIsClaimed = ({
+	parent,
+	upsertProductPlans,
+	params,
+}: {
+	parent: UpsertProductPlan;
+	upsertProductPlans: UpsertProductPlan[];
+	params: UpdateCatalogParams;
+}): boolean => {
+	if (upsertClaimsMigrationDraft({ upsertProductPlan: parent, params })) {
+		return true;
+	}
+	return upsertProductPlans.some(
+		(child) =>
+			upsertClaimsMigrationDraft({ upsertProductPlan: child, params }) &&
+			parent.planLicenses?.some(
+				(link) => link.licensePlanId === child.row.planId,
+			),
+	);
+};
+
+/** Final composed link deltas when this parent declared `licenses[]`. */
+export const declaredLicenseDraftUpserts = ({
+	parent,
+	upsertProductPlans,
+	params,
+}: {
+	parent: UpsertProductPlan;
+	upsertProductPlans: UpsertProductPlan[];
+	params: UpdateCatalogParams;
+}): LicenseDraftUpserts => {
+	const includeCustom =
+		includeCustomForMigrationDraft({ upsertProductPlan: parent, params }) ||
+		upsertProductPlans.some(
+			(child) =>
+				upsertClaimsMigrationDraft({ upsertProductPlan: child, params }) &&
+				includeCustomForMigrationDraft({ upsertProductPlan: child, params }),
+		);
+
+	if (!declaredParentIsClaimed({ parent, upsertProductPlans, params })) {
+		return { upserts: [], hasBillingChanges: false, includeCustom };
+	}
+
+	const resolved = (parent.planLicenses ?? [])
+		.map((planLicense) => licenseUpsertFromPlanLicense({ planLicense }))
+		.filter((entry) => entry != null);
+
+	return {
+		upserts: sortLicenseDraftUpserts(resolved.map((entry) => entry.upsert)),
+		hasBillingChanges: resolved.some((entry) => entry.hasBillingChanges),
+		includeCustom,
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseEffectiveMigratableCustomize.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseEffectiveMigratableCustomize.ts
@@ -1,0 +1,31 @@
+import {
+	diffPlanV1,
+	type FullProductWithoutLicenses,
+	type LicenseCustomize,
+} from "@autumn/shared";
+import { toMigratableCustomize } from "@/internal/catalogV2/actions/buildMigrationDraft/toMigratableCustomize";
+import { fullProductToApiPlanV1Sync } from "@/internal/catalogV2/actions/buildPlanChange";
+
+/** Effective content delta of one license link, or null when the overlay is unchanged. */
+export const licenseEffectiveMigratableCustomize = ({
+	fromProduct,
+	toProduct,
+}: {
+	fromProduct: FullProductWithoutLicenses;
+	toProduct: FullProductWithoutLicenses;
+}): LicenseCustomize | null => {
+	const customize = toMigratableCustomize({
+		customize: diffPlanV1({
+			from: fullProductToApiPlanV1Sync({ product: fromProduct }),
+			to: fullProductToApiPlanV1Sync({ product: toProduct }),
+		}),
+	});
+	const { price, add_items, remove_items } = customize;
+	const nested = {
+		...(price !== undefined ? { price } : {}),
+		...(add_items !== undefined ? { add_items } : {}),
+		...(remove_items !== undefined ? { remove_items } : {}),
+	};
+	if (Object.keys(nested).length === 0) return null;
+	return nested;
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseUpsertFromPlanLicense.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseUpsertFromPlanLicense.ts
@@ -1,0 +1,55 @@
+import {
+	type CustomizePlanLicense,
+	planDiffHasBillingChanges,
+} from "@autumn/shared";
+import { fullProductToApiPlanV1Sync } from "@/internal/catalogV2/actions/buildPlanChange";
+import { licenseEffectiveMigratableCustomize } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseEffectiveMigratableCustomize";
+import type { PlanLicensePlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+
+export type LicenseDraftUpsert = {
+	upsert: CustomizePlanLicense;
+	hasBillingChanges: boolean;
+};
+
+export type LicenseDraftUpserts = {
+	upserts: CustomizePlanLicense[];
+	hasBillingChanges: boolean;
+	includeCustom: boolean;
+};
+
+/** One link's current → effective content, wrapped as an `upsert_licenses` entry. */
+export const licenseUpsertFromPlanLicense = ({
+	planLicense,
+}: {
+	planLicense: PlanLicensePlan;
+}): LicenseDraftUpsert | null => {
+	if (!planLicense.currentPlanLicense || !planLicense.effectiveLicenseProduct) {
+		return null;
+	}
+
+	const customize = licenseEffectiveMigratableCustomize({
+		fromProduct: planLicense.currentPlanLicense.product,
+		toProduct: planLicense.effectiveLicenseProduct,
+	});
+	if (!customize) return null;
+
+	return {
+		upsert: {
+			license_plan_id: planLicense.licensePlanId,
+			customize,
+		},
+		hasBillingChanges: planDiffHasBillingChanges(
+			customize,
+			fullProductToApiPlanV1Sync({
+				product: planLicense.currentPlanLicense.product,
+			}),
+		),
+	};
+};
+
+export const sortLicenseDraftUpserts = (
+	upserts: CustomizePlanLicense[],
+): CustomizePlanLicense[] =>
+	[...upserts].sort((left, right) =>
+		left.license_plan_id.localeCompare(right.license_plan_id),
+	);

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
@@ -1,0 +1,58 @@
+import type { UpdateCatalogParams } from "@autumn/shared";
+import {
+	includeCustomForMigrationDraft,
+	upsertClaimsMigrationDraft,
+} from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams";
+import {
+	type LicenseDraftUpsert,
+	type LicenseDraftUpserts,
+	licenseUpsertFromPlanLicense,
+	sortLicenseDraftUpserts,
+} from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseUpsertFromPlanLicense";
+import { shouldPropagate } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+
+/** Link deltas for children that follow this parent. */
+export const propagateLicenseDraftUpserts = ({
+	parent,
+	upsertProductPlans,
+	params,
+}: {
+	parent: UpsertProductPlan;
+	upsertProductPlans: UpsertProductPlan[];
+	params: UpdateCatalogParams;
+}): LicenseDraftUpserts => {
+	let includeCustom = includeCustomForMigrationDraft({
+		upsertProductPlan: parent,
+		params,
+	});
+	const resolved: LicenseDraftUpsert[] = [];
+
+	for (const child of upsertProductPlans) {
+		if (!upsertClaimsMigrationDraft({ upsertProductPlan: child, params })) {
+			continue;
+		}
+		if (!shouldPropagate({ parent, child, upsertProducts: upsertProductPlans })) {
+			continue;
+		}
+
+		const planLicense = parent.planLicenses?.find(
+			(link) => link.licensePlanId === child.row.planId,
+		);
+		if (!planLicense) continue;
+
+		const entry = licenseUpsertFromPlanLicense({ planLicense });
+		if (!entry) continue;
+
+		resolved.push(entry);
+		if (includeCustomForMigrationDraft({ upsertProductPlan: child, params })) {
+			includeCustom = true;
+		}
+	}
+
+	return {
+		upserts: sortLicenseDraftUpserts(resolved.map((entry) => entry.upsert)),
+		hasBillingChanges: resolved.some((entry) => entry.hasBillingChanges),
+		includeCustom,
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/resolveLicenseMigrationTarget.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/resolveLicenseMigrationTarget.ts
@@ -1,0 +1,53 @@
+import type { UpdateCatalogParams } from "@autumn/shared";
+import type { MigrationTarget } from "@/internal/catalogV2/actions/buildMigrationDraft/types";
+import { declaredLicenseDraftUpserts } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/declaredLicenseDraftUpserts";
+import { propagateLicenseDraftUpserts } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts";
+import { rowCanReceiveMigrationDraft } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/rowCanReceiveMigrationDraft";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+
+/** This parent's link diffs, or null when nothing claimed this row. */
+export const resolveLicenseMigrationTarget = ({
+	upsertProductPlan,
+	upsertProductPlans,
+	params,
+	productStatesContext,
+}: {
+	upsertProductPlan: UpsertProductPlan;
+	upsertProductPlans: UpsertProductPlan[];
+	params: UpdateCatalogParams;
+	productStatesContext: ProductStatesContext;
+}): MigrationTarget | null => {
+	if (
+		!rowCanReceiveMigrationDraft({
+			upsertProductPlan,
+			productStatesContext,
+		})
+	) {
+		return null;
+	}
+
+	const { upserts, hasBillingChanges, includeCustom } =
+		upsertProductPlan.declaredLicenses !== undefined
+			? declaredLicenseDraftUpserts({
+					parent: upsertProductPlan,
+					upsertProductPlans,
+					params,
+				})
+			: propagateLicenseDraftUpserts({
+					parent: upsertProductPlan,
+					upsertProductPlans,
+					params,
+				});
+
+	if (upserts.length === 0) return null;
+
+	return {
+		planId: upsertProductPlan.row.planId,
+		version: upsertProductPlan.row.version,
+		customize: { upsert_licenses: upserts },
+		previousPrice: null,
+		hasBillingChanges,
+		includeCustom,
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveOwnMigrationTarget.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveOwnMigrationTarget.ts
@@ -1,55 +1,55 @@
 import {
 	diffPlanV1,
 	planDiffHasBillingChanges,
-	productToProductKey,
 	toBasePriceParams,
+	type UpdateCatalogParams,
 } from "@autumn/shared";
 import { toMigratableCustomize } from "@/internal/catalogV2/actions/buildMigrationDraft/toMigratableCustomize";
 import type { MigrationTarget } from "@/internal/catalogV2/actions/buildMigrationDraft/types";
 import { fullProductToApiPlanV1Sync } from "@/internal/catalogV2/actions/buildPlanChange";
+import {
+	includeCustomForMigrationDraft,
+	upsertClaimsMigrationDraft,
+} from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/matchingDraftPlanParams";
+import { rowCanReceiveMigrationDraft } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/rowCanReceiveMigrationDraft";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
 
-/** One upsert row → a draft target, or null when it shouldn't migrate. */
-export const resolveMigrationTarget = ({
+/** This row's own plan diff, or null when it did not ask / has nothing to migrate. */
+export const resolveOwnMigrationTarget = ({
 	upsertProductPlan,
+	params,
 	productStatesContext,
-	includeCustom,
 }: {
 	upsertProductPlan: UpsertProductPlan;
+	params: UpdateCatalogParams;
 	productStatesContext: ProductStatesContext;
-	includeCustom: boolean;
 }): MigrationTarget | null => {
-	const { row } = upsertProductPlan;
-	if (row.versioning === "new_version") return null;
-	if (!row.currentFullProduct) return null;
+	if (!upsertClaimsMigrationDraft({ upsertProductPlan, params })) return null;
+	if (!rowCanReceiveMigrationDraft({ upsertProductPlan, productStatesContext })) {
+		return null;
+	}
 
-	const { customerUsage } = productKeyToState({
-		productKey: productToProductKey({ product: row.currentFullProduct }),
-		productStatesContext,
-	});
-	if (!customerUsage.hasVersionableCustomerProducts) return null;
+	const { currentFullProduct, nextFullProduct, planId, version } =
+		upsertProductPlan.row;
+	if (!currentFullProduct) return null;
 
-	// Each FullProduct already carries the feature objects for its item ids
-	// (current = pre-rename join, next = post-rename projection).
-	const fromPlan = fullProductToApiPlanV1Sync({
-		product: row.currentFullProduct,
-	});
-	const toPlan = fullProductToApiPlanV1Sync({
-		product: row.nextFullProduct,
-	});
+	const fromPlan = fullProductToApiPlanV1Sync({ product: currentFullProduct });
+	const toPlan = fullProductToApiPlanV1Sync({ product: nextFullProduct });
 	const customize = toMigratableCustomize({
 		customize: diffPlanV1({ from: fromPlan, to: toPlan }),
 	});
 	if (Object.keys(customize).length === 0) return null;
 
 	return {
-		planId: row.planId,
-		version: row.version,
+		planId,
+		version,
 		customize,
 		previousPrice: fromPlan.price ? toBasePriceParams(fromPlan.price) : null,
 		hasBillingChanges: planDiffHasBillingChanges(customize, fromPlan),
-		includeCustom,
+		includeCustom: includeCustomForMigrationDraft({
+			upsertProductPlan,
+			params,
+		}),
 	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/rowCanReceiveMigrationDraft.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/rowCanReceiveMigrationDraft.ts
@@ -1,0 +1,24 @@
+import { productToProductKey } from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
+
+/** This `(plan_id, version)` can appear in a draft `plan_filter`. */
+export const rowCanReceiveMigrationDraft = ({
+	upsertProductPlan,
+	productStatesContext,
+}: {
+	upsertProductPlan: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
+}): boolean => {
+	if (upsertProductPlan.row.versioning === "new_version") return false;
+	if (!upsertProductPlan.row.currentFullProduct) return false;
+
+	const { customerUsage } = productKeyToState({
+		productKey: productToProductKey({
+			product: upsertProductPlan.row.currentFullProduct,
+		}),
+		productStatesContext,
+	});
+	return customerUsage.hasVersionableDirectCustomerProducts;
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/versionsWithCustomersByPlanId.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/versionsWithCustomersByPlanId.ts
@@ -1,0 +1,26 @@
+import { productToProductKey } from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
+
+/** Customer-bearing versions per plan — input to filter collapse. */
+export const versionsWithCustomersByPlanId = ({
+	productStatesContext,
+}: {
+	productStatesContext: ProductStatesContext;
+}): Record<string, number[]> => {
+	const result: Record<string, number[]> = {};
+	for (const [planId, versions] of Object.entries(
+		productStatesContext.versionsByPlanId,
+	)) {
+		result[planId] = versions
+			.filter(
+				(product) =>
+					productKeyToState({
+						productKey: productToProductKey({ product }),
+						productStatesContext,
+					}).customerUsage.hasVersionableDirectCustomerProducts,
+			)
+			.map((product) => product.version);
+	}
+	return result;
+};

--- a/server/src/internal/migrations/v2/batchOperations/types/batchMigrationComputeResult.ts
+++ b/server/src/internal/migrations/v2/batchOperations/types/batchMigrationComputeResult.ts
@@ -12,6 +12,7 @@ export type BatchMigrationRejectionCode =
 	| "feature_quantity_strategy"
 	| "deprecated_update_items"
 	| "unsupported_remove_items"
+	| "unsupported_upsert_licenses"
 	| "base_price_customize"
 	| "priced_add_item"
 	| "priced_remove_item"

--- a/server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts
@@ -131,6 +131,7 @@ export const setupUpdatePlanProductContext = async ({
 		customPrices,
 		customEnts,
 		insertPlanLicenses,
+		customerLicenseQuantities: productContextLicenseQuantities,
 	} = await setupUpdateSubscriptionProductContext({
 		ctx,
 		fullCustomer: productFullCustomer,
@@ -206,6 +207,7 @@ export const setupUpdatePlanProductContext = async ({
 		customPrices,
 		customEnts,
 		insertPlanLicenses,
+		customerLicenseQuantities: productContextLicenseQuantities,
 		trialContext: operationBillingContext.trialContext,
 		isCustom: targetCustomerProduct.is_custom,
 		billingVersion: BillingVersion.V2,

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/mix/declared-compose-parent-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/mix/declared-compose-parent-drafts.test.ts
@@ -1,0 +1,259 @@
+/**
+ * catalogV2.update — declared licenses[] is the FINAL parent op, exclusive
+ * with propagate on that parent. Two parents with different customize
+ * must not share an $or op.
+ *
+ * Contract:
+ *   D1 child adds Dashboard + Team declares $20 → one Team op with both
+ *   D2 Team declares $20, Scale only propagates → two parent ops
+ *   D3 child 10→200, Team declares 300 → Team op is 300
+ */
+
+import { test } from "bun:test";
+import { BillingInterval } from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import {
+	dashboardItem,
+	messagesItem,
+	seedLinkedChildParent,
+	seedTwoParents,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import {
+	dashboardAddItem,
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	orVersionPinnedFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+
+const monthPrice = ({ amount }: { amount: number }) => ({
+	amount,
+	interval: BillingInterval.Month,
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: declared compose is one parent op (boolean + price)")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_d1_c");
+		const teamId = uniqueTestId("cv2_ml_d1_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: teamId });
+				const plans = [
+					{
+						plan_id: childId,
+						items: [messagesItem(10), dashboardItem()],
+						propagate: { license_parents: [{ plan_id: teamId }] },
+						migration: { draft: true },
+					},
+					{
+						plan_id: teamId,
+						licenses: [
+							{
+								license_plan_id: childId,
+								included: 2,
+								customize: { price: monthPrice({ amount: 20 }) },
+							},
+						],
+						migration: { draft: true },
+					},
+				];
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans,
+					preview: true,
+					responsePlans: [[{ plan_id: teamId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId],
+							noBillingChanges: false,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: {
+										price: monthPrice({ amount: 20 }),
+										add_items: [dashboardAddItem],
+									},
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: declared vs propagate parents do not share an op")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_d2_c");
+		const teamId = uniqueTestId("cv2_ml_d2_t");
+		const scaleId = uniqueTestId("cv2_ml_d2_s");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, scaleId],
+			run: async () => {
+				await seedTwoParents({
+					autumn: autumnV2_3,
+					childId,
+					parentIds: [teamId, scaleId],
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: scaleId, version: 1 });
+
+				const teamFilter = versionPinnedFilter({ planId: teamId });
+				const scaleFilter = versionPinnedFilter({ planId: scaleId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(10), dashboardItem()],
+							propagate: {
+								license_parents: [{ plan_id: teamId }, { plan_id: scaleId }],
+							},
+							migration: { draft: true },
+						},
+						{
+							plan_id: teamId,
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: { price: monthPrice({ amount: 20 }) },
+								},
+							],
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: teamId, versions: [1] },
+							{ plan_id: scaleId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [teamId, scaleId],
+							omitPlanIds: [childId],
+							noBillingChanges: false,
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [
+											{ planId: teamId },
+											{ planId: scaleId },
+										],
+									}),
+								},
+							},
+							operations: [
+								parentLicenseOp({
+									planFilter: teamFilter,
+									childId,
+									customize: {
+										price: monthPrice({ amount: 20 }),
+										add_items: [dashboardAddItem],
+									},
+								}),
+								parentLicenseOp({
+									planFilter: scaleFilter,
+									childId,
+									customize: { add_items: [dashboardAddItem] },
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: declared messages customize wins over the child edit")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_d3_c");
+		const teamId = uniqueTestId("cv2_ml_d3_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+						{
+							plan_id: teamId,
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: {
+										remove_items: [{ feature_id: TestFeature.Messages }],
+										add_items: [messagesItem(300)],
+									},
+								},
+							],
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: teamId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({ included: 300 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/pinned/pin-omits-parent-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/pinned/pin-omits-parent-drafts.test.ts
@@ -1,0 +1,142 @@
+/**
+ * catalogV2.update — pin (omit from propagate.license_parents) never drafts
+ * a parent op. Child new_version + migration.draft is already 400 in
+ * validation/plan-errors.test.ts — do not duplicate.
+ *
+ * Contract:
+ *   C1 Team in plans[] but not in propagate, Team has customers, child has none → no draft
+ *   C2 Team absent from plans[] (derived pin) → no draft
+ *   C3 Child new_version + pin, no draft flag → no draft
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { expectPlanMessagesAllowance } from "../../../licenses/utils/expectLicenseLinkCorrect.js";
+import {
+	messagesItem,
+	seedLinkedChildParent,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import { expectLicenseDraftCase } from "../utils/expectLicenseMigrationDrafts.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: in-batch pin does not draft the parent")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_c1_c");
+		const teamId = uniqueTestId("cv2_ml_c1_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							migration: { draft: true },
+						},
+						{ plan_id: teamId },
+					],
+					preview: true,
+					expected: [],
+				});
+				await expectPlanMessagesAllowance({
+					ctx,
+					planId: childId,
+					allowance: 200,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: derived pin (absent parent) does not draft")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_c2_c");
+		const teamId = uniqueTestId("cv2_ml_c2_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							migration: { draft: true },
+						},
+					],
+					expected: [],
+				});
+				await expectPlanMessagesAllowance({
+					ctx,
+					planId: childId,
+					allowance: 200,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child new_version + pin without draft flag → no draft")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_c3_c");
+		const teamId = uniqueTestId("cv2_ml_c3_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+						},
+					],
+					expected: [],
+				});
+				await expectPlanMessagesAllowance({
+					ctx,
+					planId: childId,
+					allowance: 200,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-seats-direct-and-overlay-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-seats-direct-and-overlay-drafts.test.ts
@@ -1,0 +1,231 @@
+/**
+ * catalogV2.update — who counts as a draft population for propagate.
+ *
+ * Contract:
+ *   B1 assigned seats are parent customers, never the child plan_id
+ *   B2 direct child attach + parent customers → 1 draft, 2 disjoint ops
+ *   B3 overlay on the edited slot → empty delta, that parent omitted
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import {
+	messagesItem,
+	messagesOverride,
+	seedLinkedChildParent,
+	seedSeatAssignmentOnChild,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import {
+	childItemOp,
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	orVersionPinnedFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: seat assignment CPs never appear as the child plan")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_b1_c");
+		const teamId = uniqueTestId("cv2_ml_b1_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedSeatAssignmentOnChild({
+					ctx,
+					parentId: teamId,
+					childId,
+				});
+
+				const planFilter = versionPinnedFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: teamId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: direct child + parent customers → two disjoint ops")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_b2_c");
+		const teamId = uniqueTestId("cv2_ml_b2_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const childFilter = versionPinnedFilter({ planId: childId });
+				const teamFilter = versionPinnedFilter({ planId: teamId });
+				const plans = [
+					{
+						plan_id: childId,
+						items: [messagesItem(200)],
+						propagate: { license_parents: [{ plan_id: teamId }] },
+						migration: { draft: true },
+					},
+				];
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans,
+					preview: true,
+					responsePlans: [
+						[
+							{ plan_id: childId, versions: [1] },
+							{ plan_id: teamId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [childId, teamId],
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [
+											{ planId: childId },
+											{ planId: teamId },
+										],
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+								parentLicenseOp({
+									planFilter: teamFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: overlay on the edited slot omits that parent")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_b3_c");
+		const teamId = uniqueTestId("cv2_ml_b3_t");
+		const scaleId = uniqueTestId("cv2_ml_b3_s");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, scaleId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							name: "Seat",
+							items: [messagesItem(500)],
+						},
+						{
+							plan_id: teamId,
+							name: "Team",
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: messagesOverride(900),
+								},
+							],
+						},
+						{
+							plan_id: scaleId,
+							name: "Scale",
+							licenses: [{ license_plan_id: childId, included: 2 }],
+						},
+					],
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: scaleId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: scaleId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(1000)],
+							propagate: {
+								license_parents: [{ plan_id: teamId }, { plan_id: scaleId }],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: scaleId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [scaleId],
+							omitPlanIds: [childId, teamId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({ included: 1000 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-shared-parent-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-shared-parent-drafts.test.ts
@@ -1,0 +1,233 @@
+/**
+ * catalogV2.update — propagate parents that share one license delta collapse
+ * into one upsert_licenses op. Empty / price-overridden parents are omitted.
+ *
+ * Contract:
+ *   A1 Team+Scale same 10→200, both have customers, child has none
+ *      → 1 draft, 1 op, $or of both parents, upsert_licenses only
+ *   A2 Scale has no customers → Team only
+ *   A3 Seat price 10→20; Team follows, Ent already $15 → Team only,
+ *      nested price 20, no_billing_changes false
+ */
+
+import { test } from "bun:test";
+import { BillingInterval } from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import {
+	messagesItem,
+	seedTwoParents,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import {
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	orVersionPinnedFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+
+const monthPrice = ({ amount }: { amount: number }) => ({
+	amount,
+	interval: BillingInterval.Month,
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: two propagate parents share one $or upsert_licenses op")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_a1_c");
+		const teamId = uniqueTestId("cv2_ml_a1_t");
+		const scaleId = uniqueTestId("cv2_ml_a1_s");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, scaleId],
+			run: async () => {
+				await seedTwoParents({
+					autumn: autumnV2_3,
+					childId,
+					parentIds: [teamId, scaleId],
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: scaleId, version: 1 });
+
+				const plans = [
+					{
+						plan_id: childId,
+						items: [messagesItem(200)],
+						propagate: {
+							license_parents: [{ plan_id: teamId }, { plan_id: scaleId }],
+						},
+						migration: { draft: true },
+					},
+				];
+				const planFilter = orVersionPinnedFilter({
+					branches: [
+						{ planId: teamId },
+						{ planId: scaleId },
+					],
+				});
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans,
+					preview: true,
+					responsePlans: [
+						[
+							{ plan_id: teamId, versions: [1] },
+							{ plan_id: scaleId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [teamId, scaleId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: propagate parent without customers is omitted")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_a2_c");
+		const teamId = uniqueTestId("cv2_ml_a2_t");
+		const scaleId = uniqueTestId("cv2_ml_a2_s");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, scaleId],
+			run: async () => {
+				await seedTwoParents({
+					autumn: autumnV2_3,
+					childId,
+					parentIds: [teamId, scaleId],
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [{ plan_id: teamId }, { plan_id: scaleId }],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: teamId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId, scaleId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: priced propagate excludes a price-overridden parent")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_a3_c");
+		const teamId = uniqueTestId("cv2_ml_a3_t");
+		const entId = uniqueTestId("cv2_ml_a3_e");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, entId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							name: "Seat",
+							items: [messagesItem(10)],
+							price: monthPrice({ amount: 10 }),
+						},
+						{
+							plan_id: teamId,
+							name: "Team",
+							licenses: [{ license_plan_id: childId, included: 2 }],
+						},
+						{
+							plan_id: entId,
+							name: "Ent",
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: { price: monthPrice({ amount: 15 }) },
+								},
+							],
+						},
+					],
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: entId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(10)],
+							price: monthPrice({ amount: 20 }),
+							propagate: {
+								license_parents: [{ plan_id: teamId }, { plan_id: entId }],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: teamId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId, entId],
+							noBillingChanges: false,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: { price: monthPrice({ amount: 20 }) },
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-two-children-collapse-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-two-children-collapse-drafts.test.ts
@@ -1,0 +1,289 @@
+/**
+ * catalogV2.update — groupTargetsByCustomize collapses identical customize
+ * across plans. Two children with the same item delta share one child op.
+ * Two parents share one upsert_licenses op only when that payload is identical
+ * (same license_plan_ids + nested customize). Different children on different
+ * parents must not $or together — customizeToKey has to see upsert_licenses.
+ *
+ * Contract:
+ *   H1 both children add Dashboard; Team+Scale each offer both
+ *      → 1 child $or + 1 parent $or with two upserts
+ *   H2 both children replace Messages with Words (same remove+add)
+ *      → same collapse, richer customize
+ *   H3 same Dashboard add; Team offers Seat only, Scale offers Pack only
+ *      → child ops still collapse; parent ops stay split
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import {
+	dashboardItem,
+	messagesItem,
+	seedTwoParentsWithTwoChildren,
+	withCatalogPlans,
+	wordsItem,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import {
+	childItemOp,
+	dashboardAddCustomize,
+	expectLicenseDraftCase,
+	messagesToWordsDelta,
+	orVersionPinnedFilter,
+	parentLicenseOp,
+	parentLicensesOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+
+const seedCustomersOn = async ({
+	ctx,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+}) => {
+	for (const planId of planIds) {
+		await seedVersionableCustomer({ ctx, planId, version: 1 });
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: two children adding the same boolean collapse child + parent ops")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const seatId = uniqueTestId("cv2_ml_h1_seat");
+		const packId = uniqueTestId("cv2_ml_h1_pack");
+		const teamId = uniqueTestId("cv2_ml_h1_team");
+		const scaleId = uniqueTestId("cv2_ml_h1_scale");
+		const planIds = [seatId, packId, teamId, scaleId];
+		await withCatalogPlans({
+			ctx,
+			planIds,
+			run: async () => {
+				await seedTwoParentsWithTwoChildren({
+					autumn: autumnV2_3,
+					childIds: [seatId, packId],
+					parentIds: [teamId, scaleId],
+				});
+				await seedCustomersOn({ ctx, planIds });
+
+				const childFilter = orVersionPinnedFilter({
+					branches: [{ planId: seatId }, { planId: packId }],
+				});
+				const parentFilter = orVersionPinnedFilter({
+					branches: [{ planId: teamId }, { planId: scaleId }],
+				});
+				const plans = [seatId, packId].map((planId) => ({
+					plan_id: planId,
+					items: [messagesItem(10), dashboardItem()],
+					propagate: {
+						license_parents: [{ plan_id: teamId }, { plan_id: scaleId }],
+					},
+					migration: { draft: true },
+				}));
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans,
+					preview: true,
+					responsePlans: [planIds.map((plan_id) => ({ plan_id, versions: [1] }))],
+					expected: [
+						{
+							planIds,
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: planIds.map((planId) => ({ planId })),
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: dashboardAddCustomize,
+								}),
+								parentLicensesOp({
+									planFilter: parentFilter,
+									upserts: [
+										{ childId: seatId, customize: dashboardAddCustomize },
+										{ childId: packId, customize: dashboardAddCustomize },
+									],
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: two children replacing Messages with Words collapse the same way")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const seatId = uniqueTestId("cv2_ml_h2_seat");
+		const packId = uniqueTestId("cv2_ml_h2_pack");
+		const teamId = uniqueTestId("cv2_ml_h2_team");
+		const scaleId = uniqueTestId("cv2_ml_h2_scale");
+		const planIds = [seatId, packId, teamId, scaleId];
+		await withCatalogPlans({
+			ctx,
+			planIds,
+			run: async () => {
+				await seedTwoParentsWithTwoChildren({
+					autumn: autumnV2_3,
+					childIds: [seatId, packId],
+					parentIds: [teamId, scaleId],
+				});
+				await seedCustomersOn({ ctx, planIds });
+
+				const childFilter = orVersionPinnedFilter({
+					branches: [{ planId: seatId }, { planId: packId }],
+				});
+				const parentFilter = orVersionPinnedFilter({
+					branches: [{ planId: teamId }, { planId: scaleId }],
+				});
+				const customize = messagesToWordsDelta();
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [seatId, packId].map((planId) => ({
+						plan_id: planId,
+						items: [wordsItem(100)],
+						propagate: {
+							license_parents: [{ plan_id: teamId }, { plan_id: scaleId }],
+						},
+						migration: { draft: true },
+					})),
+					responsePlans: [planIds.map((plan_id) => ({ plan_id, versions: [1] }))],
+					expected: [
+						{
+							planIds,
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: planIds.map((planId) => ({ planId })),
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize,
+								}),
+								parentLicensesOp({
+									planFilter: parentFilter,
+									upserts: [
+										{ childId: seatId, customize },
+										{ childId: packId, customize },
+									],
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: same child delta on different license_plan_ids does not $or parents")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const seatId = uniqueTestId("cv2_ml_h3_seat");
+		const packId = uniqueTestId("cv2_ml_h3_pack");
+		const teamId = uniqueTestId("cv2_ml_h3_team");
+		const scaleId = uniqueTestId("cv2_ml_h3_scale");
+		const planIds = [seatId, packId, teamId, scaleId];
+		await withCatalogPlans({
+			ctx,
+			planIds,
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: seatId,
+							name: "Seat",
+							items: [messagesItem(10)],
+						},
+						{
+							plan_id: packId,
+							name: "Pack",
+							items: [messagesItem(10)],
+						},
+						{
+							plan_id: teamId,
+							name: "Team",
+							licenses: [{ license_plan_id: seatId, included: 2 }],
+						},
+						{
+							plan_id: scaleId,
+							name: "Scale",
+							licenses: [{ license_plan_id: packId, included: 2 }],
+						},
+					],
+				});
+				await seedCustomersOn({ ctx, planIds });
+
+				const childFilter = orVersionPinnedFilter({
+					branches: [{ planId: seatId }, { planId: packId }],
+				});
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: seatId,
+							items: [messagesItem(10), dashboardItem()],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+						{
+							plan_id: packId,
+							items: [messagesItem(10), dashboardItem()],
+							propagate: { license_parents: [{ plan_id: scaleId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [planIds.map((plan_id) => ({ plan_id, versions: [1] }))],
+					expected: [
+						{
+							planIds,
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: planIds.map((planId) => ({ planId })),
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: dashboardAddCustomize,
+								}),
+								parentLicenseOp({
+									planFilter: versionPinnedFilter({ planId: teamId }),
+									childId: seatId,
+									customize: dashboardAddCustomize,
+								}),
+								parentLicenseOp({
+									planFilter: versionPinnedFilter({ planId: scaleId }),
+									childId: packId,
+									customize: dashboardAddCustomize,
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/run/run-license-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/run/run-license-drafts.test.ts
@@ -1,0 +1,333 @@
+/**
+ * catalogV2.update drafts are runnable: confirm applies upsert_licenses and
+ * skips seat-assignment CPs.
+ *
+ * Contract:
+ *   upsert_licenses-only parent op updates the attached parent's license pool
+ *   combined child + parent draft applies both ops
+ *   assignment CPs (customer_license_link_id set) are not child matches
+ */
+
+import { test } from "bun:test";
+import type {
+	ApiCustomerV5,
+	AttachParamsV1Input,
+	UpdateCatalogResponse,
+} from "@autumn/shared";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import {
+	dashboardItem,
+	messagesItem,
+	messagesOverride,
+	seedLinkedChildParent,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import { deleteMigrations } from "../../utils/expectMigrationDrafts.js";
+import {
+	childItemOp,
+	dashboardAddCustomize,
+	expectLicenseMigrationDraftsCorrect,
+	orVersionPinnedFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+import {
+	expectAssignmentCustomerProductUntouched,
+	expectCustomerLicenseEntitlementsCorrect,
+} from "./utils/expectCustomerLicenseEntitlementsCorrect.js";
+import { runCatalogDraftInline } from "./utils/runCatalogDraftInline.js";
+import { seedAssignmentCpOnExistingCustomer } from "./utils/seedAssignmentCpOnExistingCustomer.js";
+
+const attachPlan = async ({
+	autumn,
+	customerId,
+	planId,
+	childId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	customerId: string;
+	planId: string;
+	childId?: string;
+}) => {
+	await autumn.billing.attach<AttachParamsV1Input>({
+		customer_id: customerId,
+		plan_id: planId,
+		redirect_mode: "if_required",
+		...(childId
+			? { license_quantities: [{ license_plan_id: childId, quantity: 2 }] }
+			: {}),
+	});
+};
+
+const draftChildAddsDashboard = ({
+	childId,
+	parentId,
+}: {
+	childId: string;
+	parentId: string;
+}) => ({
+	plan_id: childId,
+	items: [messagesItem(10), dashboardItem()],
+	propagate: { license_parents: [{ plan_id: parentId }] },
+	migration: { draft: true },
+});
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts run: upsert_licenses-only applies to the parent pool")}`,
+	async () => {
+		const customerId = uniqueTestId("lic_run_p");
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer({ paymentMethod: "success", testClock: false })],
+			actions: [],
+		});
+		const childId = uniqueTestId("cv2_ml_run1_c");
+		const parentId = uniqueTestId("cv2_ml_run1_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					customize: messagesOverride(500),
+				});
+				await attachPlan({
+					autumn: autumnV2_3,
+					customerId,
+					planId: parentId,
+					childId,
+				});
+
+				const response = (await autumnV2_3.catalogV2.update({
+					plans: [draftChildAddsDashboard({ childId, parentId })],
+				})) as UpdateCatalogResponse;
+				const migrationId = response.migrations?.[0]?.id;
+				if (!migrationId) throw new Error("expected a catalog draft");
+
+				const planFilter = versionPinnedFilter({ planId: parentId });
+				expectLicenseMigrationDraftsCorrect({
+					migrations: await migrationRepo.get({ ctx, id: migrationId }),
+					expected: [
+						{
+							planIds: [parentId],
+							omitPlanIds: [childId],
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: dashboardAddCustomize,
+								}),
+							],
+						},
+					],
+				});
+
+				await expectCustomerLicenseEntitlementsCorrect({
+					ctx,
+					customerId,
+					parentPlanId: parentId,
+					omitFeatureIds: [TestFeature.Dashboard],
+				});
+
+				try {
+					await runCatalogDraftInline({
+						ctx,
+						migrationId,
+						customerIds: [customerId],
+					});
+					await expectCustomerLicenseEntitlementsCorrect({
+						ctx,
+						customerId,
+						parentPlanId: parentId,
+						featureIds: [TestFeature.Dashboard],
+					});
+				} finally {
+					await deleteMigrations({ ctx, ids: [migrationId] });
+				}
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts run: combined child + parent ops both apply")}`,
+	async () => {
+		const parentCustomerId = uniqueTestId("lic_run_2p");
+		const childCustomerId = uniqueTestId("lic_run_2c");
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId: parentCustomerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.otherCustomers([{ id: childCustomerId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+		const childId = uniqueTestId("cv2_ml_run2_c");
+		const parentId = uniqueTestId("cv2_ml_run2_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					customize: messagesOverride(500),
+				});
+				await attachPlan({
+					autumn: autumnV2_3,
+					customerId: parentCustomerId,
+					planId: parentId,
+					childId,
+				});
+				await attachPlan({
+					autumn: autumnV2_3,
+					customerId: childCustomerId,
+					planId: childId,
+				});
+
+				const response = (await autumnV2_3.catalogV2.update({
+					plans: [draftChildAddsDashboard({ childId, parentId })],
+				})) as UpdateCatalogResponse;
+				const migrationId = response.migrations?.[0]?.id;
+				if (!migrationId) throw new Error("expected a catalog draft");
+
+				const childFilter = versionPinnedFilter({ planId: childId });
+				const parentFilter = versionPinnedFilter({ planId: parentId });
+				expectLicenseMigrationDraftsCorrect({
+					migrations: await migrationRepo.get({ ctx, id: migrationId }),
+					expected: [
+						{
+							planIds: [childId, parentId],
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [
+											{ planId: childId },
+											{ planId: parentId },
+										],
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: dashboardAddCustomize,
+								}),
+								parentLicenseOp({
+									planFilter: parentFilter,
+									childId,
+									customize: dashboardAddCustomize,
+								}),
+							],
+						},
+					],
+				});
+
+				try {
+					await runCatalogDraftInline({
+						ctx,
+						migrationId,
+						customerIds: [parentCustomerId, childCustomerId],
+					});
+					await expectCustomerLicenseEntitlementsCorrect({
+						ctx,
+						customerId: parentCustomerId,
+						parentPlanId: parentId,
+						featureIds: [TestFeature.Dashboard],
+					});
+					expectFlagCorrect({
+						customer: await autumnV2_3.customers.get<ApiCustomerV5>(
+							childCustomerId,
+						),
+						featureId: TestFeature.Dashboard,
+						planId: childId,
+					});
+				} finally {
+					await deleteMigrations({ ctx, ids: [migrationId] });
+				}
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts run: assignment CPs are not child matches")}`,
+	async () => {
+		const parentCustomerId = uniqueTestId("lic_run_3p");
+		const childCustomerId = uniqueTestId("lic_run_3c");
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId: parentCustomerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.otherCustomers([{ id: childCustomerId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+		const childId = uniqueTestId("cv2_ml_run3_c");
+		const parentId = uniqueTestId("cv2_ml_run3_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					customize: messagesOverride(500),
+				});
+				await attachPlan({
+					autumn: autumnV2_3,
+					customerId: parentCustomerId,
+					planId: parentId,
+					childId,
+				});
+				await attachPlan({
+					autumn: autumnV2_3,
+					customerId: childCustomerId,
+					planId: childId,
+				});
+				const assigned = await seedAssignmentCpOnExistingCustomer({
+					ctx,
+					customerId: parentCustomerId,
+					childId,
+				});
+
+				const response = (await autumnV2_3.catalogV2.update({
+					plans: [draftChildAddsDashboard({ childId, parentId })],
+				})) as UpdateCatalogResponse;
+				const migrationId = response.migrations?.[0]?.id;
+				if (!migrationId) throw new Error("expected a catalog draft");
+
+				try {
+					await runCatalogDraftInline({
+						ctx,
+						migrationId,
+						customerIds: [parentCustomerId, childCustomerId],
+					});
+					await expectAssignmentCustomerProductUntouched({
+						ctx,
+						assignmentCustomerProductId: assigned.assignmentCustomerProductId,
+					});
+					expectFlagCorrect({
+						customer: await autumnV2_3.customers.get<ApiCustomerV5>(
+							childCustomerId,
+						),
+						featureId: TestFeature.Dashboard,
+						planId: childId,
+					});
+				} finally {
+					await deleteMigrations({ ctx, ids: [migrationId] });
+				}
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/expectCustomerLicenseEntitlementsCorrect.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/expectCustomerLicenseEntitlementsCorrect.ts
@@ -1,0 +1,64 @@
+import { expect } from "bun:test";
+import { customerEntitlements } from "@autumn/shared";
+import { eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { CusService } from "@/internal/customers/CusService.js";
+
+/** Features on the customer's license-pool product — only ids passed are checked. */
+export const expectCustomerLicenseEntitlementsCorrect = async ({
+	ctx,
+	customerId,
+	parentPlanId,
+	featureIds,
+	omitFeatureIds,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	parentPlanId: string;
+	featureIds?: string[];
+	omitFeatureIds?: string[];
+}) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const parent = fullCustomer.customer_products.find(
+		(customerProduct) => customerProduct.product_id === parentPlanId,
+	);
+	const pool = parent?.customer_licenses?.[0];
+	const licenseProduct = pool?.planLicense?.product;
+	expect(licenseProduct, `no license pool on ${parentPlanId}`).toBeDefined();
+	if (!licenseProduct) throw new Error(`no license pool on ${parentPlanId}`);
+	for (const featureId of featureIds ?? []) {
+		expect(
+			licenseProduct.entitlements.some(
+				(entitlement) => entitlement.feature_id === featureId,
+			),
+			`license missing ${featureId}`,
+		).toBe(true);
+	}
+	for (const featureId of omitFeatureIds ?? []) {
+		expect(
+			licenseProduct.entitlements.some(
+				(entitlement) => entitlement.feature_id === featureId,
+			),
+			`license still has ${featureId}`,
+		).toBe(false);
+	}
+};
+
+export const expectAssignmentCustomerProductUntouched = async ({
+	ctx,
+	assignmentCustomerProductId,
+}: {
+	ctx: AutumnContext;
+	assignmentCustomerProductId: string;
+}) => {
+	const entitlements = await ctx.db.query.customerEntitlements.findMany({
+		where: eq(
+			customerEntitlements.customer_product_id,
+			assignmentCustomerProductId,
+		),
+	});
+	expect(entitlements).toHaveLength(0);
+};

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/runCatalogDraftInline.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/runCatalogDraftInline.ts
@@ -1,0 +1,35 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { prepare } from "@/internal/migrations/v2/prepare/prepare.js";
+import { preProcessMigration } from "@/internal/migrations/v2/run/preProcess/preProcessMigration.js";
+import { migrateCustomer } from "@/internal/migrations/v2/run/migrateCustomer/migrateCustomer.js";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+
+/** Prepare + apply a persisted catalog draft in-process (no Trigger). */
+export const runCatalogDraftInline = async ({
+	ctx,
+	migrationId,
+	customerIds,
+}: {
+	ctx: AutumnContext;
+	migrationId: string;
+	customerIds: string[];
+}) => {
+	const [migration] = await migrationRepo.get({ ctx, id: migrationId });
+	if (!migration) throw new Error(`Migration ${migrationId} not found`);
+
+	const guarded = preProcessMigration(migration);
+	const { preparedState } = await prepare({
+		ctx,
+		migration: guarded,
+		dryRun: false,
+	});
+	const prepared = { ...guarded, prepared_state: preparedState };
+
+	const results = [];
+	for (const customerId of customerIds) {
+		results.push(
+			await migrateCustomer({ ctx, customerId, migration: prepared }),
+		);
+	}
+	return results;
+};

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/seedAssignmentCpOnExistingCustomer.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/run/utils/seedAssignmentCpOnExistingCustomer.ts
@@ -1,0 +1,43 @@
+import { CusProductStatus, customerProducts } from "@autumn/shared";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { generateId } from "@/utils/genUtils.js";
+import { getFullPlan } from "../../../../licenses/utils/seedLicensePlans.js";
+
+/** Seat-assignment CP on an already-attached parent customer. */
+export const seedAssignmentCpOnExistingCustomer = async ({
+	ctx,
+	customerId,
+	childId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	childId: string;
+}) => {
+	const state = await getLicenseDbState({ db: ctx.db, customerId });
+	const pool = state.pools[0];
+	if (!pool) throw new Error(`no license pool for ${customerId}`);
+	const parentCustomerProduct = state.products.find(
+		(customerProduct) => customerProduct.customer_license_link_id == null,
+	);
+	if (!parentCustomerProduct) {
+		throw new Error(`no parent customer product for ${customerId}`);
+	}
+
+	const child = await getFullPlan({ ctx, planId: childId });
+	const assignmentCustomerProductId = generateId("cus_prod");
+	await ctx.db.insert(customerProducts).values({
+		id: assignmentCustomerProductId,
+		internal_customer_id: parentCustomerProduct.internal_customer_id,
+		product_id: childId,
+		internal_product_id: child.internal_id,
+		status: CusProductStatus.Active,
+		created_at: Date.now(),
+		starts_at: Date.now(),
+		quantity: 1,
+		options: [],
+		is_custom: false,
+		customer_license_link_id: pool.link_id,
+	});
+	return { assignmentCustomerProductId };
+};

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/utils/expectLicenseMigrationDrafts.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/utils/expectLicenseMigrationDrafts.ts
@@ -1,0 +1,349 @@
+import { expect } from "bun:test";
+import type {
+	UpdateCatalogPlanParams,
+	UpdateCatalogResponse,
+} from "@autumn/shared";
+import {
+	collectCustomerPlanIds,
+	collectPlanFilterPlanIds,
+	formatPlanFilter,
+	planFiltersAreSame,
+} from "@autumn/shared/api/products/utils/compare/planFiltersAreSame.js";
+import type { MigrationFilter } from "@autumn/shared/api/migrations/filters/migrationFilter.js";
+import type { PlanFilter } from "@autumn/shared/api/migrations/filters/planFilter.js";
+import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { parsePlanPreview } from "../../../preview/utils/expectPlanPreview.js";
+import {
+	deleteMigrations,
+	expectUpdateMigrations,
+} from "../../utils/expectMigrationDrafts.js";
+import type { CatalogV2Client } from "../../../licenses/utils/seedLicensePlans.js";
+
+export const messagesItemDelta = ({ included }: { included: number }) => ({
+	remove_items: [
+		{
+			feature_id: TestFeature.Messages,
+			interval: ResetInterval.Month,
+			interval_count: 1,
+		},
+	],
+	add_items: [
+		{
+			feature_id: TestFeature.Messages,
+			included,
+			unlimited: false,
+			reset: { interval: ResetInterval.Month },
+		},
+	],
+});
+
+export const dashboardAddItem = { feature_id: TestFeature.Dashboard };
+
+export const dashboardAddCustomize = {
+	add_items: [dashboardAddItem],
+};
+
+/** Delete Messages and add Words — same replace across every child. */
+export const messagesToWordsDelta = ({
+	included = 100,
+}: {
+	included?: number;
+} = {}) => ({
+	remove_items: [
+		{
+			feature_id: TestFeature.Messages,
+			interval: ResetInterval.Month,
+			interval_count: 1,
+		},
+	],
+	add_items: [
+		{
+			feature_id: TestFeature.Words,
+			included,
+			unlimited: false,
+			reset: { interval: ResetInterval.Month },
+		},
+	],
+});
+
+export const versionPinnedFilter = ({
+	planId,
+	version = 1,
+}: {
+	planId: string;
+	version?: number;
+}): PlanFilter => ({
+	plan_id: planId,
+	version,
+	custom: false,
+});
+
+export const collapsedPlanFilter = ({
+	planId,
+}: {
+	planId: string;
+}): PlanFilter => ({
+	plan_id: planId,
+	custom: false,
+});
+
+/** CatalogV2 buckets multiple plans as $or of per-plan branches, sorted by plan_id. */
+export const orPlanFilter = ({
+	branches,
+}: {
+	branches: PlanFilter[];
+}): PlanFilter => ({
+	$or: [...branches].sort((left, right) =>
+		String(left.plan_id).localeCompare(String(right.plan_id)),
+	),
+	custom: false,
+});
+
+export const orVersionPinnedFilter = ({
+	branches,
+}: {
+	branches: { planId: string; version?: number }[];
+}): PlanFilter =>
+	orPlanFilter({
+		branches: branches.map(({ planId, version = 1 }) => ({
+			plan_id: planId,
+			version,
+		})),
+	});
+
+type LicenseCustomize = NonNullable<
+	NonNullable<UpdatePlanOp["customize"]>["upsert_licenses"]
+>[number]["customize"];
+
+export const parentLicensesOp = ({
+	planFilter,
+	upserts,
+}: {
+	planFilter: PlanFilter;
+	upserts: { childId: string; customize: LicenseCustomize }[];
+}): UpdatePlanOp => ({
+	type: "update_plan",
+	plan_filter: planFilter,
+	customize: {
+		upsert_licenses: [...upserts]
+			.sort((left, right) => left.childId.localeCompare(right.childId))
+			.map(({ childId, customize }) => ({
+				license_plan_id: childId,
+				customize,
+			})),
+	},
+});
+
+export const parentLicenseOp = ({
+	planFilter,
+	childId,
+	customize,
+}: {
+	planFilter: PlanFilter;
+	childId: string;
+	customize: LicenseCustomize;
+}): UpdatePlanOp =>
+	parentLicensesOp({
+		planFilter,
+		upserts: [{ childId, customize }],
+	});
+
+export const childItemOp = ({
+	planFilter,
+	customize,
+}: {
+	planFilter: PlanFilter;
+	customize: NonNullable<UpdatePlanOp["customize"]>;
+}): UpdatePlanOp => ({
+	type: "update_plan",
+	plan_filter: planFilter,
+	customize,
+});
+
+type DraftOp = {
+	type: string;
+	plan_filter?: PlanFilter;
+	customize?: UpdatePlanOp["customize"];
+	version?: number;
+};
+
+type DraftLike = {
+	filter?: MigrationFilter | null;
+	operations?: { customer?: DraftOp[] } | null;
+	no_billing_changes?: boolean | null;
+};
+
+export type ExpectedLicenseDraft = {
+	filter: MigrationFilter;
+	noBillingChanges?: boolean;
+	planIds: string[];
+	omitPlanIds?: string[];
+	operations: UpdatePlanOp[];
+};
+
+const collectDraftPlanIds = ({
+	filter,
+	operations,
+}: {
+	filter?: MigrationFilter | null;
+	operations: DraftOp[];
+}): string[] => [
+	...collectCustomerPlanIds({ plan: filter?.customer?.plan }),
+	...operations.flatMap((operation) =>
+		collectPlanFilterPlanIds({ planFilter: operation.plan_filter }),
+	),
+];
+
+const asUpdatePlanOp = (operation: DraftOp) => {
+	expect(operation.type).toBe("update_plan");
+	return operation as UpdatePlanOp;
+};
+
+/** Exact filter; ops matched by plan_filter (order-independent). Customize via toMatchObject. */
+export const expectLicenseMigrationDraftsCorrect = ({
+	expected,
+	migrations,
+}: {
+	expected: ExpectedLicenseDraft[];
+	migrations: DraftLike[];
+}) => {
+	expect(migrations).toHaveLength(expected.length);
+
+	const remaining = [...migrations];
+	for (const expectedDraft of expected) {
+		const index = remaining.findIndex((migration) => {
+			const planIds = collectDraftPlanIds({
+				filter: migration.filter,
+				operations: migration.operations?.customer ?? [],
+			});
+			return expectedDraft.planIds.every((planId) => planIds.includes(planId));
+		});
+		expect(index).toBeGreaterThanOrEqual(0);
+
+		const [migration] = remaining.splice(index, 1);
+		const operations = migration.operations?.customer ?? [];
+
+		expect(migration.filter).toEqual(expectedDraft.filter);
+		if (expectedDraft.noBillingChanges !== undefined) {
+			expect(migration.no_billing_changes).toBe(expectedDraft.noBillingChanges);
+		}
+		expect(operations).toHaveLength(expectedDraft.operations.length);
+
+		const remainingOps = [...operations];
+		for (const expectedOp of expectedDraft.operations) {
+			const opIndex = remainingOps.findIndex((operation) => {
+				if (operation.type !== "update_plan") return false;
+				return planFiltersAreSame({
+					left: operation.plan_filter,
+					right: expectedOp.plan_filter,
+				});
+			});
+			expect(
+				opIndex,
+				`missing update_plan for ${formatPlanFilter(expectedOp.plan_filter)}`,
+			).toBeGreaterThanOrEqual(0);
+
+			const operation = asUpdatePlanOp(remainingOps.splice(opIndex, 1)[0]!);
+			expect(operation).not.toHaveProperty("version");
+
+			const expectedLicenses = expectedOp.customize?.upsert_licenses;
+			if (expectedLicenses) {
+				expect(operation.customize?.add_items).toBeUndefined();
+				expect(operation.customize?.remove_items).toBeUndefined();
+				expect(operation.customize?.price).toBeUndefined();
+				const byLicensePlanId = (
+					licenses: NonNullable<typeof expectedLicenses>,
+				) =>
+					[...licenses].sort((left, right) =>
+						left.license_plan_id.localeCompare(right.license_plan_id),
+					);
+				expect(
+					byLicensePlanId(operation.customize?.upsert_licenses ?? []),
+				).toMatchObject(byLicensePlanId(expectedLicenses));
+			} else {
+				expect(operation.customize?.upsert_licenses).toBeUndefined();
+				expect(operation.customize).toMatchObject(expectedOp.customize ?? {});
+			}
+		}
+
+		for (const omitPlanId of expectedDraft.omitPlanIds ?? []) {
+			expect(
+				collectDraftPlanIds({
+					filter: migration.filter,
+					operations,
+				}),
+			).not.toContain(omitPlanId);
+		}
+	}
+};
+
+export const expectUpdateHasNoMigrations = ({
+	response,
+}: {
+	response: UpdateCatalogResponse;
+}) => {
+	expect(response.migrations ?? []).toHaveLength(0);
+};
+
+export const expectLicenseDraftCase = async ({
+	autumn,
+	ctx,
+	plans,
+	expected,
+	responsePlans,
+	preview = false,
+}: {
+	autumn: CatalogV2Client;
+	ctx: AutumnContext;
+	plans: UpdateCatalogPlanParams[];
+	expected: ExpectedLicenseDraft[];
+	responsePlans?: { plan_id: string; versions: number[] }[][];
+	preview?: boolean;
+}) => {
+	if (preview) {
+		const before = await migrationRepo.get({ ctx });
+		const parsed = parsePlanPreview(
+			await autumn.catalogV2.previewUpdate({ plans }),
+		);
+		expect(parsed.migrations).toHaveLength(expected.length);
+		if (expected.length > 0) {
+			expect(parsed.migrations[0]).not.toHaveProperty("id");
+			expectLicenseMigrationDraftsCorrect({
+				migrations: parsed.migrations,
+				expected,
+			});
+		}
+		expect(await migrationRepo.get({ ctx })).toHaveLength(before.length);
+	}
+
+	const response = await autumn.catalogV2.update({ plans });
+	if (expected.length === 0) {
+		expectUpdateHasNoMigrations({
+			response: response as UpdateCatalogResponse,
+		});
+		return { response: response as UpdateCatalogResponse };
+	}
+
+	const typed = response as UpdateCatalogResponse;
+	expectUpdateMigrations({
+		response: typed,
+		plans: responsePlans ?? [expected[0]!.planIds.map((plan_id) => ({
+			plan_id,
+			versions: [1],
+		}))],
+	});
+	const migrationId = typed.migrations![0]!.id;
+	expectLicenseMigrationDraftsCorrect({
+		migrations: await migrationRepo.get({
+			ctx,
+			id: migrationId,
+		}),
+		expected,
+	});
+	await deleteMigrations({ ctx, ids: [migrationId] });
+	return { response: typed, migrationId };
+};

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/utils/seedLicenseDraftPlans.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/utils/seedLicenseDraftPlans.ts
@@ -1,0 +1,37 @@
+import type { CatalogV2Client } from "../../../licenses/utils/seedLicensePlans.js";
+import { messagesItem } from "../../../licenses/utils/seedLicensePlans.js";
+
+/** Child v1..n first, then the parent link — so the license points at latest. */
+export const seedChildVersionsThenParent = async ({
+	autumn,
+	childId,
+	parentId,
+	childVersions = [1, 2],
+}: {
+	autumn: CatalogV2Client;
+	childId: string;
+	parentId: string;
+	childVersions?: number[];
+}) => {
+	for (const version of childVersions) {
+		await autumn.catalogV2.update({
+			plans: [
+				{
+					plan_id: childId,
+					...(version > 1 ? { version } : {}),
+					name: `Seat v${version}`,
+					items: [messagesItem(10)],
+				},
+			],
+		});
+	}
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: parentId,
+				name: "Team",
+				licenses: [{ license_plan_id: childId, included: 2 }],
+			},
+		],
+	});
+};

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-and-parent-versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-and-parent-versioning-drafts.test.ts
@@ -1,0 +1,418 @@
+/**
+ * catalogV2.update — child versioning × parent/propagate versioning.
+ *
+ * Contract:
+ *   G1 child all_versions + Team existing: child ops v1+v2; parent latest only
+ *   G2 child all_versions + Team all_versions: child v1, parent v2
+ *   G3 Team all_versions rename + propagate all_versions → license-only parent op
+ *   G4 child new_version + Team all_versions, no draft → no draft
+ *   G5 Team new_version in plans[] + propagate latest → no parent op
+ *   G6 preview of G1 equals the update draft minus id; preview persists nothing
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { expectPlanMessagesAllowance } from "../../../licenses/utils/expectLicenseLinkCorrect.js";
+import {
+	messagesItem,
+	seedLinkedChildParent,
+	seedParentVersionWithLicense,
+	seedTwoParentVersions,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import {
+	childItemOp,
+	collapsedPlanFilter,
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	orPlanFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+import { seedChildVersionsThenParent } from "../utils/seedLicenseDraftPlans.js";
+
+const g1Expected = ({
+	childId,
+	teamId,
+}: {
+	childId: string;
+	teamId: string;
+}) => {
+	const childFilter = collapsedPlanFilter({ planId: childId });
+	const teamFilter = versionPinnedFilter({ planId: teamId, version: 2 });
+	return {
+		planIds: [childId, teamId],
+		noBillingChanges: true as const,
+		filter: {
+			customer: {
+				plan: orPlanFilter({
+					branches: [
+						{ plan_id: childId },
+						{ plan_id: teamId, version: 2 },
+					],
+				}),
+			},
+		},
+		operations: [
+			childItemOp({
+				planFilter: childFilter,
+				customize: messagesItemDelta({ included: 200 }),
+			}),
+			parentLicenseOp({
+				planFilter: teamFilter,
+				childId,
+				customize: messagesItemDelta({ included: 200 }),
+			}),
+		],
+	};
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child all_versions + parent existing keeps the parent version pin")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_g1_c");
+		const teamId = uniqueTestId("cv2_ml_g1_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedChildVersionsThenParent({
+					autumn: autumnV2_3,
+					childId,
+					parentId: teamId,
+				});
+				await seedParentVersionWithLicense({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: childId, version: 2 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 2 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: childId, versions: [1, 2] },
+							{ plan_id: teamId, versions: [2] },
+						],
+					],
+					expected: [g1Expected({ childId, teamId })],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child all_versions + parent all_versions target disjoint versions")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_g2_c");
+		const teamId = uniqueTestId("cv2_ml_g2_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedChildVersionsThenParent({
+					autumn: autumnV2_3,
+					childId,
+					parentId: teamId,
+				});
+				await seedParentVersionWithLicense({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 2 });
+
+				const childFilter = versionPinnedFilter({
+					planId: childId,
+					version: 1,
+				});
+				const teamFilter = versionPinnedFilter({
+					planId: teamId,
+					version: 2,
+				});
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: teamId, versioning: "all_versions" },
+								],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: childId, versions: [1] },
+							{ plan_id: teamId, versions: [2] },
+						],
+					],
+					expected: [
+						{
+							planIds: [childId, teamId],
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orPlanFilter({
+										branches: [
+											{ plan_id: childId, version: 1 },
+											{ plan_id: teamId, version: 2 },
+										],
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+								parentLicenseOp({
+									planFilter: teamFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: parent all_versions rename is not migratable; license op remains")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_g3_c");
+		const teamId = uniqueTestId("cv2_ml_g3_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 2 });
+
+				const teamFilter = collapsedPlanFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: teamId, versioning: "all_versions" },
+								],
+							},
+							migration: { draft: true },
+						},
+						{
+							plan_id: teamId,
+							versioning: "all_versions",
+							name: "Team renamed",
+						},
+					],
+					responsePlans: [[{ plan_id: teamId, versions: [1, 2] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: teamFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter: teamFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child new_version + parent all_versions without draft → no draft")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_g4_c");
+		const teamId = uniqueTestId("cv2_ml_g4_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 2 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+							propagate: {
+								license_parents: [
+									{ plan_id: teamId, versioning: "all_versions" },
+								],
+							},
+						},
+					],
+					expected: [],
+				});
+				await expectPlanMessagesAllowance({
+					ctx,
+					planId: childId,
+					allowance: 200,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: parent new_version in plans[] + propagate latest → child op only")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_g5_c");
+		const teamId = uniqueTestId("cv2_ml_g5_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const childFilter = versionPinnedFilter({ planId: childId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+						{
+							plan_id: teamId,
+							versioning: "new_version",
+							name: "Team v2",
+						},
+					],
+					responsePlans: [[{ plan_id: childId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [childId],
+							omitPlanIds: [teamId],
+							noBillingChanges: true,
+							filter: { customer: { plan: childFilter } },
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: preview of child all_versions + parent existing matches update and persists nothing")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_g6_c");
+		const teamId = uniqueTestId("cv2_ml_g6_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedChildVersionsThenParent({
+					autumn: autumnV2_3,
+					childId,
+					parentId: teamId,
+				});
+				await seedParentVersionWithLicense({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: childId, version: 2 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 2 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+					],
+					preview: true,
+					responsePlans: [
+						[
+							{ plan_id: childId, versions: [1, 2] },
+							{ plan_id: teamId, versions: [2] },
+						],
+					],
+					expected: [g1Expected({ childId, teamId })],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-versioning-drafts.test.ts
@@ -1,0 +1,269 @@
+/**
+ * catalogV2.update — child versioning × who has customers.
+ * A version with no customers is never a target. new_version never drafts.
+ *
+ * Contract:
+ *   E1 existing (latest): customers only on v1, link on latest → no child op;
+ *      parent op if Team's link is latest
+ *   E2 all_versions: customers on v1 only → child op pinned to v1 + parent op
+ *   E3 all_versions: customers on v1+v2, identical delta → child op collapses
+ *   E4 new_version without draft + Team propagates → no draft
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { expectPlanMessagesAllowance } from "../../../licenses/utils/expectLicenseLinkCorrect.js";
+import {
+	messagesItem,
+	seedLinkedChildParent,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import {
+	childItemOp,
+	collapsedPlanFilter,
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	orPlanFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+import { seedChildVersionsThenParent } from "../utils/seedLicenseDraftPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child existing skips v1 customers; parent follows latest")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_e1_c");
+		const teamId = uniqueTestId("cv2_ml_e1_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedChildVersionsThenParent({
+					autumn: autumnV2_3,
+					childId,
+					parentId: teamId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: teamId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child all_versions pins the child op to versions with customers")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_e2_c");
+		const teamId = uniqueTestId("cv2_ml_e2_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedChildVersionsThenParent({
+					autumn: autumnV2_3,
+					childId,
+					parentId: teamId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const childFilter = versionPinnedFilter({ planId: childId, version: 1 });
+				const teamFilter = versionPinnedFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+					],
+					preview: true,
+					responsePlans: [
+						[
+							{ plan_id: childId, versions: [1] },
+							{ plan_id: teamId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [childId, teamId],
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orPlanFilter({
+										branches: [
+											{ plan_id: childId, version: 1 },
+											{ plan_id: teamId, version: 1 },
+										],
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+								parentLicenseOp({
+									planFilter: teamFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child all_versions collapses identical per-version deltas")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_e3_c");
+		const teamId = uniqueTestId("cv2_ml_e3_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedChildVersionsThenParent({
+					autumn: autumnV2_3,
+					childId,
+					parentId: teamId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: childId, version: 2 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const childFilter = collapsedPlanFilter({ planId: childId });
+				const teamFilter = versionPinnedFilter({ planId: teamId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							versioning: "all_versions",
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: childId, versions: [1, 2] },
+							{ plan_id: teamId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [childId, teamId],
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orPlanFilter({
+										branches: [
+											{ plan_id: childId },
+											{ plan_id: teamId, version: 1 },
+										],
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+								parentLicenseOp({
+									planFilter: teamFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child new_version without draft never drafts parents")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_e4_c");
+		const teamId = uniqueTestId("cv2_ml_e4_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+							propagate: { license_parents: [{ plan_id: teamId }] },
+						},
+					],
+					expected: [],
+				});
+				await expectPlanMessagesAllowance({
+					ctx,
+					planId: childId,
+					allowance: 200,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/parent-propagate-versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/parent-propagate-versioning-drafts.test.ts
@@ -1,0 +1,295 @@
+/**
+ * catalogV2.update — parent propagate versioning is independent of the child.
+ * Parent versions without customers are omitted. Child all_versions does
+ * not strip the parent version pin.
+ *
+ * Contract:
+ *   F1 propagate latest; Team v1+v2, customers only on v1 → no parent op
+ *   F2 propagate version:1, customers on v1 → parent op pinned to 1
+ *   F3 all_versions: customers on v1 only → pin v1; v1+v2 same delta → collapse
+ *   F4 new_version: mint empty, old pins → no parent op
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../../utils/uniqueTestId.js";
+import { expectPlanMessagesAllowance } from "../../../licenses/utils/expectLicenseLinkCorrect.js";
+import {
+	messagesItem,
+	seedLinkedChildParent,
+	seedTwoParentVersions,
+	withCatalogPlans,
+} from "../../../licenses/utils/seedLicensePlans.js";
+import { seedVersionableCustomer } from "../../utils/seedVersionableCustomer.js";
+import {
+	childItemOp,
+	collapsedPlanFilter,
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../utils/expectLicenseMigrationDrafts.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: propagate latest skips a customered historical parent")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_f1_c");
+		const teamId = uniqueTestId("cv2_ml_f1_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: { license_parents: [{ plan_id: teamId }] },
+							migration: { draft: true },
+						},
+					],
+					preview: true,
+					expected: [],
+				});
+				await expectPlanMessagesAllowance({
+					ctx,
+					planId: childId,
+					allowance: 200,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: propagate explicit version pins the parent op")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_f2_c");
+		const teamId = uniqueTestId("cv2_ml_f2_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: teamId, version: 1 });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [{ plan_id: teamId, version: 1 }],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: teamId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [teamId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: propagate all_versions pins or collapses by who has customers")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const pinnedChild = uniqueTestId("cv2_ml_f3a_c");
+		const pinnedTeam = uniqueTestId("cv2_ml_f3a_t");
+		const collapsedChild = uniqueTestId("cv2_ml_f3b_c");
+		const collapsedTeam = uniqueTestId("cv2_ml_f3b_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [pinnedChild, pinnedTeam, collapsedChild, collapsedTeam],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId: pinnedTeam,
+					childId: pinnedChild,
+				});
+				await seedVersionableCustomer({
+					ctx,
+					planId: pinnedTeam,
+					version: 1,
+				});
+
+				const pinnedFilter = versionPinnedFilter({
+					planId: pinnedTeam,
+					version: 1,
+				});
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: pinnedChild,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: pinnedTeam, versioning: "all_versions" },
+								],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: pinnedTeam, versions: [1] }]],
+					expected: [
+						{
+							planIds: [pinnedTeam],
+							omitPlanIds: [pinnedChild],
+							noBillingChanges: true,
+							filter: { customer: { plan: pinnedFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter: pinnedFilter,
+									childId: pinnedChild,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId: collapsedTeam,
+					childId: collapsedChild,
+				});
+				await seedVersionableCustomer({
+					ctx,
+					planId: collapsedTeam,
+					version: 1,
+				});
+				await seedVersionableCustomer({
+					ctx,
+					planId: collapsedTeam,
+					version: 2,
+				});
+
+				const collapsedFilter = collapsedPlanFilter({ planId: collapsedTeam });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: collapsedChild,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: collapsedTeam, versioning: "all_versions" },
+								],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: collapsedTeam, versions: [1, 2] }]],
+					expected: [
+						{
+							planIds: [collapsedTeam],
+							omitPlanIds: [collapsedChild],
+							noBillingChanges: true,
+							filter: { customer: { plan: collapsedFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter: collapsedFilter,
+									childId: collapsedChild,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: propagate new_version never drafts the mint or the pin")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_f4_c");
+		const teamId = uniqueTestId("cv2_ml_f4_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId: teamId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: childId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+
+				const childFilter = versionPinnedFilter({ planId: childId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: teamId, versioning: "new_version" },
+								],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: childId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [childId],
+							omitPlanIds: [teamId],
+							noBillingChanges: true,
+							filter: { customer: { plan: childFilter } },
+							operations: [
+								childItemOp({
+									planFilter: childFilter,
+									customize: messagesItemDelta({ included: 200 }),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/utils/expectMigrationDrafts.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/utils/expectMigrationDrafts.ts
@@ -1,5 +1,9 @@
 import { expect } from "bun:test";
 import type { Migration, UpdateCatalogResponse } from "@autumn/shared";
+import {
+	collectCustomerPlanIds,
+	collectPlanFilterPlanIds,
+} from "@autumn/shared/api/products/utils/compare/planFiltersAreSame.js";
 import type { MigrationFilter } from "@autumn/shared/api/migrations/filters/migrationFilter.js";
 import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -28,8 +32,10 @@ export const expectUpdateMigrations = ({
 					migration.plans.some(
 						(plan) =>
 							plan.plan_id === expected.plan_id &&
-							JSON.stringify(plan.versions) ===
-								JSON.stringify(expected.versions),
+							plan.versions.length === expected.versions.length &&
+							plan.versions.every(
+								(version, index) => version === expected.versions[index],
+							),
 					),
 				),
 		);
@@ -52,13 +58,20 @@ export const expectMigrationDraftsCorrect = ({
 	const remaining = [...migrations];
 	for (const expectedDraft of expected) {
 		const index = remaining.findIndex((migration) => {
-			const serialized = JSON.stringify({
-				filter: migration.filter,
-				operations: migration.operations,
-			});
-			return expectedDraft.planIds.every((planId) =>
-				serialized.includes(planId),
-			);
+			const planIds = [
+				...collectCustomerPlanIds({
+					plan: migration.filter?.customer?.plan,
+				}),
+				...(migration.operations?.customer ?? []).flatMap((operation) =>
+					collectPlanFilterPlanIds({
+						planFilter:
+							operation.type === "update_plan"
+								? operation.plan_filter
+								: undefined,
+					}),
+				),
+			];
+			return expectedDraft.planIds.every((planId) => planIds.includes(planId));
 		});
 		expect(index).toBeGreaterThanOrEqual(0);
 

--- a/server/tests/unit/billing/merge-autumn-billing-plans.test.ts
+++ b/server/tests/unit/billing/merge-autumn-billing-plans.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { AutumnBillingPlan } from "@autumn/shared";
+import { mergeAutumnBillingPlans } from "@/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.js";
+
+const emptyPlan = ({
+	customerId = "cus_1",
+}: {
+	customerId?: string;
+} = {}): AutumnBillingPlan => ({
+	customerId,
+	insertCustomerProducts: [],
+});
+
+describe("mergeAutumnBillingPlans", () => {
+	test("keeps insertPlanLicenses and customerLicenseTransitions from incoming", () => {
+		const incoming = {
+			...emptyPlan(),
+			insertPlanLicenses: [
+				{
+					row: { id: "plan_lic_1" },
+					customPrices: [],
+					customEntitlements: [],
+					items: [],
+				},
+			],
+			customerLicenseTransitions: [
+				{
+					outgoingCustomerLicense: { id: "cl_1" },
+					incomingCustomerLicense: { id: "cl_1" },
+					updates: {
+						linkId: "link_1",
+						granted: 2,
+						remaining: 2,
+						paidQuantity: 1,
+					},
+				},
+			],
+		} as unknown as AutumnBillingPlan;
+
+		const merged = mergeAutumnBillingPlans({
+			base: emptyPlan(),
+			incoming,
+		});
+
+		expect(merged.insertPlanLicenses?.map((spec) => spec.row.id)).toEqual([
+			"plan_lic_1",
+		]);
+		expect(
+			merged.customerLicenseTransitions?.map(
+				(transition) => transition.incomingCustomerLicense.id,
+			),
+		).toEqual(["cl_1"]);
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/update-plan-op-eligibility.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/update-plan-op-eligibility.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { checkUpdatePlanOpEligibility } from "@/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanOpEligibility.js";
+
+describe("checkUpdatePlanOpEligibility", () => {
+	test("upsert_licenses is not batch-lowered", () => {
+		const rejections = checkUpdatePlanOpEligibility({
+			opIndex: 0,
+			op: {
+				type: "update_plan",
+				plan_filter: { plan_id: "team" },
+				customize: {
+					upsert_licenses: [
+						{
+							license_plan_id: "seat",
+							customize: { add_items: [{ feature_id: "dashboard" }] },
+						},
+					],
+				},
+			},
+		});
+
+		expect(rejections.map((rejection) => rejection.code)).toContain(
+			"unsupported_upsert_licenses",
+		);
+	});
+});

--- a/server/tests/unit/migrations-v2/filters/plan-filters-are-same.test.ts
+++ b/server/tests/unit/migrations-v2/filters/plan-filters-are-same.test.ts
@@ -1,0 +1,122 @@
+/**
+ * planFiltersAreSame: field-by-field. Key order, omitted vs false, and
+ * bare vs `$eq` are the cases JSON.stringify gets wrong.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	collectPlanFilterPlanIds,
+	planFiltersAreSame,
+} from "@autumn/shared/api/products/utils/compare/planFiltersAreSame.js";
+import type { PlanFilter } from "@autumn/shared/api/migrations/filters/planFilter.js";
+
+const same = (left: PlanFilter, right: PlanFilter) =>
+	planFiltersAreSame({ left, right });
+
+describe("planFiltersAreSame — identity / key order", () => {
+	test("undefined vs {} are both unconstrained", () => {
+		expect(planFiltersAreSame({ left: undefined, right: {} })).toBe(true);
+	});
+
+	test("key order does not matter", () => {
+		expect(
+			same(
+				{ plan_id: "pro", version: 1, custom: false },
+				{ custom: false, plan_id: "pro", version: 1 },
+			),
+		).toBe(true);
+	});
+});
+
+describe("planFiltersAreSame — falsey / omitted", () => {
+	test("omitted custom !== custom: false", () => {
+		expect(same({ plan_id: "pro" }, { plan_id: "pro", custom: false })).toBe(
+			false,
+		);
+	});
+
+	test("omitted version !== version: 1", () => {
+		expect(
+			same(
+				{ plan_id: "pro", custom: false },
+				{ plan_id: "pro", version: 1, custom: false },
+			),
+		).toBe(false);
+	});
+
+	test("custom: false !== custom: true", () => {
+		expect(
+			same({ plan_id: "pro", custom: false }, { plan_id: "pro", custom: true }),
+		).toBe(false);
+	});
+
+	test("omitted $or !== empty $or (empty matches nothing)", () => {
+		expect(same({ plan_id: "pro" }, { plan_id: "pro", $or: [] })).toBe(false);
+	});
+});
+
+describe("planFiltersAreSame — matchers", () => {
+	test("bare plan_id === { $eq }", () => {
+		expect(same({ plan_id: "pro" }, { plan_id: { $eq: "pro" } })).toBe(true);
+	});
+
+	test("bare version === { $eq }", () => {
+		expect(same({ version: 1 }, { version: { $eq: 1 } })).toBe(true);
+	});
+
+	test("$in order does not matter", () => {
+		expect(
+			same(
+				{ plan_id: { $in: ["pro", "free"] } },
+				{ plan_id: { $in: ["free", "pro"] } },
+			),
+		).toBe(true);
+	});
+
+	test("bare plan_id !== $eq plus another op", () => {
+		expect(
+			same({ plan_id: "pro" }, { plan_id: { $eq: "pro", $ne: "free" } }),
+		).toBe(false);
+	});
+});
+
+describe("planFiltersAreSame — $or", () => {
+	test("branch order does not matter", () => {
+		expect(
+			same(
+				{ $or: [{ plan_id: "team" }, { plan_id: "scale" }], custom: false },
+				{ $or: [{ plan_id: "scale" }, { plan_id: "team" }], custom: false },
+			),
+		).toBe(true);
+	});
+
+	test("different branches are not the same", () => {
+		expect(
+			same(
+				{ $or: [{ plan_id: "team" }], custom: false },
+				{ $or: [{ plan_id: "scale" }], custom: false },
+			),
+		).toBe(false);
+	});
+});
+
+describe("collectPlanFilterPlanIds", () => {
+	test("collects bare, $eq, $in, and $or — not $ne", () => {
+		expect(
+			collectPlanFilterPlanIds({
+				planFilter: {
+					plan_id: { $eq: "team", $ne: "ghost" },
+					$or: [{ plan_id: "scale" }, { plan_id: { $in: ["plus"] } }],
+				},
+			}),
+		).toEqual(["team", "scale", "plus"]);
+	});
+
+	test("substring ids are distinct", () => {
+		const ids = collectPlanFilterPlanIds({
+			planFilter: { plan_id: "pro_plus" },
+		});
+		expect(ids).toEqual(["pro_plus"]);
+		expect(ids.includes("pro")).toBe(false);
+	});
+});

--- a/shared/api/migrations/compiler/registry/customerRegistry.ts
+++ b/shared/api/migrations/compiler/registry/customerRegistry.ts
@@ -105,7 +105,8 @@ const itemPaidScope: NavScope = {
 
 const planScope: NavScope = {
 	from: "customer_products cp JOIN products p ON p.internal_id = cp.internal_product_id",
-	correlation: "cp.internal_customer_id = c.internal_id",
+	correlation:
+		"cp.internal_customer_id = c.internal_id AND cp.customer_license_link_id IS NULL",
 	ambient: [
 		{
 			column: "cp.status",

--- a/shared/api/migrations/filters/compare/matchersAreSame.ts
+++ b/shared/api/migrations/filters/compare/matchersAreSame.ts
@@ -1,0 +1,115 @@
+import type { NumberMatcher, StringMatcher } from "../matcher.js";
+
+/** Omitted `$in` is not `[]` — a missing op is not an empty set. */
+const stringSetsAreSame = (left?: string[], right?: string[]): boolean => {
+	if (left === undefined && right === undefined) return true;
+	if (left === undefined || right === undefined) return false;
+	if (left.length !== right.length) return false;
+	const unmatched = [...right];
+	return left.every((value) => {
+		const index = unmatched.indexOf(value);
+		if (index === -1) return false;
+		unmatched.splice(index, 1);
+		return true;
+	});
+};
+
+const numberSetsAreSame = (left?: number[], right?: number[]): boolean => {
+	if (left === undefined && right === undefined) return true;
+	if (left === undefined || right === undefined) return false;
+	if (left.length !== right.length) return false;
+	const unmatched = [...right];
+	return left.every((value) => {
+		const index = unmatched.indexOf(value);
+		if (index === -1) return false;
+		unmatched.splice(index, 1);
+		return true;
+	});
+};
+
+/** Bare `"x"` and `{ $eq: "x" }` are the same matcher. Other ops are listed. */
+export const stringMatchersAreSame = (
+	left?: StringMatcher,
+	right?: StringMatcher,
+): boolean => {
+	if (left === undefined && right === undefined) return true;
+	if (left === undefined || right === undefined) return false;
+
+	const leftEq = stringMatcherAsEq(left);
+	const rightEq = stringMatcherAsEq(right);
+	if (leftEq.eq && rightEq.eq) return leftEq.value === rightEq.value;
+	if (leftEq.eq || rightEq.eq) return false;
+	if (typeof left === "string" || typeof right === "string") return false;
+	if (left === null || right === null) return false;
+
+	return (
+		left.$eq === right.$eq &&
+		left.$ne === right.$ne &&
+		stringSetsAreSame(left.$in, right.$in) &&
+		stringSetsAreSame(left.$nin, right.$nin) &&
+		left.$regex === right.$regex &&
+		left.$startsWith === right.$startsWith
+	);
+};
+
+const stringMatcherAsEq = (
+	matcher: StringMatcher,
+): { eq: true; value: string | null } | { eq: false } => {
+	if (matcher === null) return { eq: true, value: null };
+	if (typeof matcher === "string") return { eq: true, value: matcher };
+	const hasOther =
+		matcher.$ne !== undefined ||
+		matcher.$in !== undefined ||
+		matcher.$nin !== undefined ||
+		matcher.$regex !== undefined ||
+		matcher.$startsWith !== undefined;
+	if (!hasOther && matcher.$eq !== undefined) {
+		return { eq: true, value: matcher.$eq };
+	}
+	return { eq: false };
+};
+
+export const numberMatchersAreSame = (
+	left?: NumberMatcher,
+	right?: NumberMatcher,
+): boolean => {
+	if (left === undefined && right === undefined) return true;
+	if (left === undefined || right === undefined) return false;
+
+	const leftEq = numberMatcherAsEq(left);
+	const rightEq = numberMatcherAsEq(right);
+	if (leftEq.eq && rightEq.eq) return leftEq.value === rightEq.value;
+	if (leftEq.eq || rightEq.eq) return false;
+	if (typeof left === "number" || typeof right === "number") return false;
+	if (left === null || right === null) return false;
+
+	return (
+		left.$eq === right.$eq &&
+		left.$ne === right.$ne &&
+		numberSetsAreSame(left.$in, right.$in) &&
+		numberSetsAreSame(left.$nin, right.$nin) &&
+		left.$gt === right.$gt &&
+		left.$gte === right.$gte &&
+		left.$lt === right.$lt &&
+		left.$lte === right.$lte
+	);
+};
+
+const numberMatcherAsEq = (
+	matcher: NumberMatcher,
+): { eq: true; value: number | null } | { eq: false } => {
+	if (matcher === null) return { eq: true, value: null };
+	if (typeof matcher === "number") return { eq: true, value: matcher };
+	const hasOther =
+		matcher.$ne !== undefined ||
+		matcher.$in !== undefined ||
+		matcher.$nin !== undefined ||
+		matcher.$gt !== undefined ||
+		matcher.$gte !== undefined ||
+		matcher.$lt !== undefined ||
+		matcher.$lte !== undefined;
+	if (!hasOther && matcher.$eq !== undefined) {
+		return { eq: true, value: matcher.$eq };
+	}
+	return { eq: false };
+};

--- a/shared/api/migrations/filters/index.ts
+++ b/shared/api/migrations/filters/index.ts
@@ -1,4 +1,5 @@
 export * from "./arrayFilter.js";
+export * from "./compare/matchersAreSame.js";
 export * from "./customerFilter.js";
 export * from "./match/index.js";
 export * from "./matcher.js";

--- a/shared/api/migrations/filters/planner/accessPaths/planPlanIdAccessPath.ts
+++ b/shared/api/migrations/filters/planner/accessPaths/planPlanIdAccessPath.ts
@@ -101,7 +101,11 @@ export const buildCustomerProductWhereSql = (
 		renderExtra(extra, params),
 	);
 	return {
-		sql: [`cp.status IN (${statusPlaceholders})`, ...extraSql].join(" "),
+		sql: [
+			`cp.status IN (${statusPlaceholders})`,
+			"AND cp.customer_license_link_id IS NULL",
+			...extraSql,
+		].join(" "),
 		params,
 	};
 };

--- a/shared/api/products/index.ts
+++ b/shared/api/products/index.ts
@@ -17,6 +17,7 @@ export * from "./previousVersions/apiPlanV0";
 export * from "./previousVersions/apiProduct";
 export * from "./productOpModels";
 export * from "./productsOpenApi";
+export * from "./utils/compare";
 export * from "./utils/display";
 
 // Note: V1.2_ProductChanges.js is NOT exported here to avoid circular deps

--- a/shared/api/products/utils/compare/index.ts
+++ b/shared/api/products/utils/compare/index.ts
@@ -1,0 +1,1 @@
+export * from "./planFiltersAreSame.js";

--- a/shared/api/products/utils/compare/planFiltersAreSame.ts
+++ b/shared/api/products/utils/compare/planFiltersAreSame.ts
@@ -1,0 +1,217 @@
+import {
+	numberMatchersAreSame,
+	stringMatchersAreSame,
+} from "../../../migrations/filters/compare/matchersAreSame.js";
+import type { CustomerFilter } from "../../../migrations/filters/customerFilter.js";
+import type { StringMatcher } from "../../../migrations/filters/matcher.js";
+import type { PlanFilter } from "../../../migrations/filters/planFilter.js";
+import type { PlanItemFilter } from "../../../migrations/filters/planItemFilter.js";
+
+/** Unset vs `false` is a real difference — unset does not constrain. */
+const booleansAreSame = (left?: boolean, right?: boolean): boolean =>
+	left === right;
+
+type NullEqualityFilter = {
+	$eq?: null;
+	$ne?: null;
+} | null;
+
+const asNullEquality = (
+	value: PlanFilter["price"] | PlanItemFilter["price"] | PlanItemFilter["rollover"],
+): NullEqualityFilter | undefined => {
+	if (value === undefined) return undefined;
+	if (value === null) return null;
+	return {
+		$eq: "$eq" in value ? value.$eq : undefined,
+		$ne: "$ne" in value ? value.$ne : undefined,
+	};
+};
+
+const nullEqualityFiltersAreSame = (
+	left: PlanFilter["price"] | PlanItemFilter["price"] | PlanItemFilter["rollover"],
+	right: PlanFilter["price"] | PlanItemFilter["price"] | PlanItemFilter["rollover"],
+): boolean => {
+	const a = asNullEquality(left);
+	const b = asNullEquality(right);
+	if (a === undefined && b === undefined) return true;
+	if (a === undefined || b === undefined) return false;
+	if (a === null) return b === null || isEqNull(b);
+	if (b === null) return isEqNull(a);
+	if (isEqNull(a) && isEqNull(b)) return true;
+	return a.$ne === b.$ne && a.$eq === b.$eq;
+};
+
+const isEqNull = (filter: { $eq?: null; $ne?: null }) =>
+	filter.$eq === null && filter.$ne === undefined;
+
+const itemPriceBillingMethod = (
+	price: Exclude<PlanItemFilter["price"], null | undefined>,
+): StringMatcher | undefined =>
+	"billing_method" in price ? price.billing_method : undefined;
+
+const itemPriceFiltersAreSame = (
+	left: PlanItemFilter["price"],
+	right: PlanItemFilter["price"],
+): boolean => {
+	if (!nullEqualityFiltersAreSame(left, right)) return false;
+	if (left == null || right == null) return true;
+	return stringMatchersAreSame(
+		itemPriceBillingMethod(left),
+		itemPriceBillingMethod(right),
+	);
+};
+
+const itemFiltersAreSame = (
+	left: PlanFilter["item"],
+	right: PlanFilter["item"],
+): boolean => {
+	if (left === undefined && right === undefined) return true;
+	if (left === undefined || right === undefined) return false;
+	if (isItemQuantifier(left) || isItemQuantifier(right)) {
+		if (!isItemQuantifier(left) || !isItemQuantifier(right)) return false;
+		return (
+			planItemFiltersAreSame(left.$some, right.$some) &&
+			planItemFiltersAreSame(left.$every, right.$every) &&
+			planItemFiltersAreSame(left.$none, right.$none)
+		);
+	}
+	return planItemFiltersAreSame(left, right);
+};
+
+const isItemQuantifier = (
+	item: object,
+): item is {
+	$some?: PlanItemFilter;
+	$every?: PlanItemFilter;
+	$none?: PlanItemFilter;
+} => "$some" in item || "$every" in item || "$none" in item;
+
+const planItemFiltersAreSame = (
+	left?: PlanItemFilter,
+	right?: PlanItemFilter,
+): boolean => {
+	if (left === undefined && right === undefined) return true;
+	if (left === undefined || right === undefined) return false;
+	return (
+		stringMatchersAreSame(left.feature_id, right.feature_id) &&
+		booleansAreSame(left.unlimited, right.unlimited) &&
+		itemPriceFiltersAreSame(left.price, right.price) &&
+		nullEqualityFiltersAreSame(left.rollover, right.rollover)
+	);
+};
+
+/** Empty `$or` matches nothing; omitted `$or` means no OR. Not the same. */
+const orBranchesAreSame = (
+	left?: PlanFilter[],
+	right?: PlanFilter[],
+): boolean => {
+	if (left === undefined && right === undefined) return true;
+	if (left === undefined || right === undefined) return false;
+	if (left.length !== right.length) return false;
+	const unmatched = [...right];
+	return left.every((branch) => {
+		const index = unmatched.findIndex((other) =>
+			planFiltersAreSame({ left: branch, right: other }),
+		);
+		if (index === -1) return false;
+		unmatched.splice(index, 1);
+		return true;
+	});
+};
+
+export const planFiltersAreSame = ({
+	left,
+	right,
+}: {
+	left?: PlanFilter | null;
+	right?: PlanFilter | null;
+}): boolean => {
+	const a = left ?? {};
+	const b = right ?? {};
+
+	const diffs = {
+		plan_id: !stringMatchersAreSame(a.plan_id, b.plan_id),
+		version: !numberMatchersAreSame(a.version, b.version),
+		price: !nullEqualityFiltersAreSame(a.price, b.price),
+		addon: !booleansAreSame(a.addon, b.addon),
+		paid: !booleansAreSame(a.paid, b.paid),
+		recurring: !booleansAreSame(a.recurring, b.recurring),
+		custom: !booleansAreSame(a.custom, b.custom),
+		item: !itemFiltersAreSame(a.item, b.item),
+		$or: !orBranchesAreSame(a.$or, b.$or),
+	};
+
+	return !Object.values(diffs).some(Boolean);
+};
+
+/** Equality / `$in` plan_ids only — `$ne` / `$nin` are exclusions, not targets. */
+export const collectPlanFilterPlanIds = ({
+	planFilter,
+}: {
+	planFilter?: PlanFilter | null;
+}): string[] => {
+	if (!planFilter) return [];
+	return [
+		...stringMatcherTargetIds(planFilter.plan_id),
+		...(planFilter.$or ?? []).flatMap((branch) =>
+			collectPlanFilterPlanIds({ planFilter: branch }),
+		),
+	];
+};
+
+const isPlanQuantifier = (
+	plan: object,
+): plan is {
+	$some?: PlanFilter;
+	$every?: PlanFilter;
+	$none?: PlanFilter;
+} => "$some" in plan || "$every" in plan || "$none" in plan;
+
+export const collectCustomerPlanIds = ({
+	plan,
+}: {
+	plan?: CustomerFilter["plan"];
+}): string[] => {
+	if (!plan) return [];
+	if (isPlanQuantifier(plan)) {
+		return [
+			...collectPlanFilterPlanIds({ planFilter: plan.$some }),
+			...collectPlanFilterPlanIds({ planFilter: plan.$every }),
+			...collectPlanFilterPlanIds({ planFilter: plan.$none }),
+		];
+	}
+	return collectPlanFilterPlanIds({ planFilter: plan });
+};
+
+const stringMatcherTargetIds = (matcher?: StringMatcher): string[] => {
+	if (matcher === undefined || matcher === null) return [];
+	if (typeof matcher === "string") return [matcher];
+	return [
+		...(typeof matcher.$eq === "string" ? [matcher.$eq] : []),
+		...(matcher.$in ?? []),
+	];
+};
+
+export const formatPlanFilter = (planFilter?: PlanFilter | null): string => {
+	const filter = planFilter ?? {};
+	const parts = [
+		filter.plan_id !== undefined
+			? `plan_id=${JSON.stringify(filter.plan_id)}`
+			: undefined,
+		filter.version !== undefined
+			? `version=${JSON.stringify(filter.version)}`
+			: undefined,
+		filter.custom !== undefined ? `custom=${filter.custom}` : undefined,
+		filter.addon !== undefined ? `addon=${filter.addon}` : undefined,
+		filter.paid !== undefined ? `paid=${filter.paid}` : undefined,
+		filter.recurring !== undefined ? `recurring=${filter.recurring}` : undefined,
+		filter.price !== undefined
+			? `price=${JSON.stringify(filter.price)}`
+			: undefined,
+		filter.item !== undefined ? `item=${JSON.stringify(filter.item)}` : undefined,
+		filter.$or
+			? `$or=[${filter.$or.map((branch) => formatPlanFilter(branch)).join(" | ")}]`
+			: undefined,
+	].filter((part) => part !== undefined);
+	return `{ ${parts.join(" ")} }`;
+};

--- a/shared/api/products/utils/match/planFilterMatchesCustomerProduct.ts
+++ b/shared/api/products/utils/match/planFilterMatchesCustomerProduct.ts
@@ -24,6 +24,8 @@ export const planFilterMatchesCustomerProduct = ({
 	filter: PlanFilter;
 	cusProduct: FullCusProduct;
 }): boolean => {
+	if (cusProduct.customer_license_link_id != null) return false;
+
 	if (filter.$or !== undefined) {
 		if (
 			!filter.$or.some((subFilter) =>


### PR DESCRIPTION
## Summary
- Catalog update writes at most one draft; child item changes and parent license changes are separate ops when customize differs.
- Parent op customize is `upsert_licenses: [{ license_plan_id, customize: effective delta }]`.
- Run applies those ops through migrations-v2 `update_plan`. Assignment CPs (`customer_license_link_id` set) are not child matches. `mergeAutumnBillingPlans` keeps license inserts/transitions.

## Test plan
- [ ] `bun t tests/integration/catalog-v2/plans/migrations/licenses --headless`
- [ ] `bun t tests/unit/billing/merge-autumn-billing-plans.test.ts tests/unit/migrations-v2/batch-operations/update-plan-op-eligibility.test.ts tests/unit/migrations-v2/filters/plan-filters-are-same.test.ts --headless`

Note: local `run-license-drafts` can 401 on Trigger after the pool repoints if Infisical injects a bad `TRIGGER_SECRET_KEY`. The pool write itself is the apply.

Stacked on #2828.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drafts and applies parent-license migrations in Catalog V2 via `upsert_licenses`, and excludes seat-assignment customer products from draft populations. Previously, parent license changes were not drafted and plan filters could match assignment CPs; now identical parent deltas collapse into one op, linked CPs are ignored, and runs apply per-customer license updates through `update_plan`.

- Drafting: converts declared and propagated parent deltas into `upsert_licenses`; collapses identical parent ops; omits empty or price-overridden parents; preserves version pins; child `new_version` never drafts.
- Filters: uses structural `planFiltersAreSame` and excludes linked CPs in both matchers and SQL/access paths (`customer_license_link_id IS NULL`), targeting only parent products.
- Run and batching: `update_plan` accepts `upsert_licenses` but is not batch-lowered (`unsupported_upsert_licenses`); apply persists plan-license inserts/updates and license transitions; billing merge keeps `insertPlanLicenses`, `customerLicenseUpdates`, and `customerLicenseTransitions`; `previous_price` stamping uses stable keys via `basePriceToKey`.
- Review focus: core logic in `resolveLicenseMigrationTarget/*` and `resolveOwnMigrationTarget`; eligibility via `rowCanReceiveMigrationDraft` and `versionsWithCustomersByPlanId`; `computeMigrationDraftPlans` composes these.

<sup>Written for commit 4511465531058f51c0050e8745998bb97910da90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds drafting and application support for parent-license migrations while preventing assignment customer products from being treated as parent-plan matches.
- **[API changes, Improvements]** Represents parent-license changes as `update_plan` operations containing `upsert_licenses`.
- **[Improvements]** Applies license inserts, updates, transitions, and quantities through the per-customer migration and billing-plan paths.
- **[Bug fixes]** Excludes assignment customer products from plan-filter matching and customer-bearing version calculations.
- **[Improvements]** Adds integration and unit coverage for declared, propagated, pinned, versioned, and executed license migrations.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because an unrelated draft can still expand a parent-license migration to customized customers.

The declared-parent path derives `includeCustom` from every claimed child in the catalog update rather than only children linked to that parent, so an update containing one legitimate linked child and one unrelated `include_custom` child can remove the customized-product guard from the parent operation.

**Files Needing Attention:** server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/declaredLicenseDraftUpserts.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/declaredLicenseDraftUpserts.ts | Builds parent-license draft upserts from declared license links and propagates the migration customization setting. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/resolveLicenseMigrationTarget.ts | Converts declared or propagated parent-license differences into migration targets. |
| server/src/internal/migrations/v2/operations/updatePlan/setup/setupUpdatePlanProductContext.ts | Carries computed customer-license quantities into the update-plan billing context. |
| server/src/internal/billing/v2/utils/billingPlan/mergeAutumnBillingPlans.ts | Preserves customer-license updates, inserts, and transitions when billing plans are merged. |
| shared/api/products/utils/match/planFilterMatchesCustomerProduct.ts | Refines plan-filter matching so assignment customer products are excluded from parent-plan migration populations. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Catalog as Catalog update
    participant Draft as Draft computation
    participant Migration as update_plan migration
    participant Billing as Billing plan
    participant DB as Customer license state
    Catalog->>Draft: Compute child and parent-license deltas
    Draft->>Migration: Emit upsert_licenses operations
    Migration->>Billing: Build each customer's target plan
    Billing->>DB: Persist license inserts, updates, and transitions
```
</details>

<sub>Reviews (4): Last reviewed commit: ["feat(catalog-v2): draft and apply licens..."](https://github.com/useautumn/autumn/commit/4511465531058f51c0050e8745998bb97910da90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53763503)</sub>

<!-- /greptile_comment -->