### PR TITLE
fix(package): fix price amount display unit in products readback

### DIFF
--- a/packages/atmn/src/commands/products/headless.ts
+++ b/packages/atmn/src/commands/products/headless.ts
@@ -7,6 +7,7 @@ import { AppEnv } from "../../lib/env/detect.js";
 import { getKey } from "../../lib/env/keys.js";
 import { fetchPlans } from "../../lib/api/endpoints/plans.js";
 import type { ApiPlan } from "../../lib/api/types/index.js";
+import { formatAmount } from "@autumn/shared";
 import { formatError } from "../../lib/api/client.js";
 
 export interface HeadlessProductsOptions {
@@ -297,12 +298,23 @@ function outputSingleProduct(
 /**
  * Format a price amount and interval for display
  */
-function formatPrice(amount: number, interval?: string): string {
-	const dollars = (amount / 100).toFixed(2);
+export function formatPrice(
+	amount: number,
+	interval?: string,
+	currency = "USD",
+): string {
+	const formatted = formatAmount({
+		amount,
+		currency,
+		amountFormatOptions: {
+			currencyDisplay: "narrowSymbol",
+			maximumFractionDigits: 2,
+		},
+	});
 	if (interval) {
-		return `$${dollars}/${interval}`;
+		return `${formatted}/${interval}`;
 	}
-	return `$${dollars}`;
+	return formatted;
 }
 
 /**

--- a/packages/atmn/src/views/react/products/ProductsView.tsx
+++ b/packages/atmn/src/views/react/products/ProductsView.tsx
@@ -1,6 +1,7 @@
 import { Text, useApp, useInput } from "ink";
 import open from "open";
 import { useCallback, useEffect, useMemo } from "react";
+import { formatAmount } from "@autumn/shared";
 import type { ApiPlan } from "../../../lib/api/types/index.js";
 import { AppEnv } from "../../../lib/env/detect.js";
 import { APP_VERSION } from "../../../lib/version.js";
@@ -53,7 +54,14 @@ const columns: Column<ApiPlan>[] = [
 		render: (p) =>
 			!p.price
 				? "Free"
-				: `$${(p.price.amount / 100).toFixed(2)}/${p.price.interval}`,
+				: `${formatAmount({
+						amount: p.price.amount,
+						currency: "USD",
+						amountFormatOptions: {
+							currencyDisplay: "narrowSymbol",
+							maximumFractionDigits: 2,
+						},
+				  })}/${p.price.interval}`,
 		minWidth: 12,
 	},
 	{

--- a/packages/atmn/test/products.test.ts
+++ b/packages/atmn/test/products.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { formatPrice } from "../src/commands/products/headless";
+
+describe("formatPrice", () => {
+	test("formats dollar amounts with interval correctly without dividing by 100", () => {
+		expect(formatPrice(3000, "month")).toBe("$3,000/month");
+		expect(formatPrice(100, "month")).toBe("$100/month");
+		expect(formatPrice(20, "month")).toBe("$20/month");
+		expect(formatPrice(30, "year")).toBe("$30/year");
+	});
+
+	test("formats dollar amounts without interval", () => {
+		expect(formatPrice(3000)).toBe("$3,000");
+		expect(formatPrice(100)).toBe("$100");
+		expect(formatPrice(0)).toBe("$0");
+	});
+
+	test("formats decimal amounts correctly", () => {
+		expect(formatPrice(0.05, "month")).toBe("$0.05/month");
+		expect(formatPrice(19.99, "month")).toBe("$19.99/month");
+	});
+
+	test("formats with custom currency", () => {
+		expect(formatPrice(50, "month", "EUR")).toMatch(/50.*\/month/);
+	});
+});


### PR DESCRIPTION
fixes #1855

The PR fixes an issue where `atmn plans` (readback) and the interactive TUI table rendered product price amounts 100x smaller (treating amounts as cents instead of dollars).

In `autumn.config.ts`, plans define `price: { amount: 3000, interval: "month" }` expecting `$3,000/month`.
- `atmn preview` rendered `$3,000/month`
- `atmn plans` (readback) rendered `$30.00/month` (<< inconsistent cent conversion here)
- `atmn products` table in interactive TUI rendered `$30.00/month` (<< shows incorrect value here) while the detail sheet rendered `$3,000.00`

### Changes
- Reusing the exported `@autumn/shared`'s `formatAmount` utility function in [headless.ts](https://github.com/useautumn/autumn/compare/dev...BeeBombshell:autumn:fix/incorrect-amount-conversion?expand=1#diff-420ba8b5dab8c62443fde8c5906b068a26392a9f6b196334f45564f5b607b63aR306)
- Updated the table `Price` column to use `formatAmount` (w/o incorrect cent conversion) in [ProductsView.tsx](https://github.com/useautumn/autumn/compare/dev...BeeBombshell:autumn:fix/incorrect-amount-conversion?expand=1#diff-6414c6ac846d3dc030f2cebdf66abef2ce33cea501c5295e0a02ea8fcfe528feR57)
- Added tests to ensure amount units are formatted correctly (with and without intervals)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect product price display units in CLI readback and the TUI products table. Previously amounts were treated as cents (e.g., 3000 → $30.00/month); now they display in currency units (3000 → $3,000/month) and match preview/detail views.

- Replaces manual cent conversion with `@autumn/shared`’s `formatAmount` in headless products output and the TUI Products table.
- Exports a unified helper `formatPrice(amount, interval?, currency="USD")` for consistent rendering.
- Adds tests for amounts with/without intervals, decimals, and custom currency.
- Confirms `autumn.config.ts` continues to define `price.amount` in major currency units (e.g., 3000 => $3,000).

<sup>Written for commit f506d10afa831b3f53a392d81dbfcfc213ac9d8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

