### PR TITLE
fix(pricing-agent): stop returning a sandbox secret key from /preview/setup

### DIFF
--- a/apps/scope-picker/routes.json
+++ b/apps/scope-picker/routes.json
@@ -891,6 +891,23 @@
       "isWebhookExempt": false
     },
     {
+      "handlerName": "handlePreviewCheckout",
+      "handlerFile": "src/internal/misc/pricingAgent/handlers/handlePreviewCheckout.ts",
+      "method": "POST",
+      "path": "/pricing-agent/preview/checkout",
+      "style": "REST",
+      "group": "pricing-agent",
+      "mountChain": [
+        "",
+        "/pricing-agent",
+        "/preview/checkout"
+      ],
+      "sourceRouterFile": "src/internal/misc/pricingAgent/pricingAgentRouter.ts",
+      "routeKind": "createRoute",
+      "needsScopes": true,
+      "isWebhookExempt": false
+    },
+    {
       "handlerName": "handleSetupPreviewOrg",
       "handlerFile": "src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts",
       "method": "POST",

--- a/server/src/internal/billing/checkout/handleLegacyApiCheckout.ts
+++ b/server/src/internal/billing/checkout/handleLegacyApiCheckout.ts
@@ -1,24 +1,11 @@
 import {
 	AffectedResource,
 	ApiVersion,
-	AttachFunction,
 	CheckoutParamsV0Schema,
 	Scopes,
 } from "@autumn/shared";
 import { createRoute } from "../../../honoMiddlewares/routeHandler";
-import { handleCreateCheckout } from "../../customers/add-product/handleCreateCheckout";
-import { handleCreateInvoiceCheckout } from "../../customers/add-product/handleCreateInvoiceCheckout";
-import {
-	checkStripeConnections,
-	handlePrepaidErrors,
-} from "../../customers/attach/attachRouter";
-import { handleCheckoutErrors } from "../../customers/attach/attachUtils/handleAttachErrors/handleCheckoutErrors";
-import { insertCustomItems } from "../../customers/attach/attachUtils/insertCustomItems";
-import { attachParamsToPreview } from "../attachPreview/attachParamsToPreview";
-import { getHasProrations } from "./getHasProrations";
-import { previewToCheckoutRes } from "./previewToCheckoutRes";
-import { checkoutToAttachContext } from "./utils/checkoutToAttachContext";
-import { getCheckoutOptions } from "./utils/getCheckoutOptions";
+import { runCheckout } from "./runCheckout";
 
 export const handleLegacyApiCheckout = createRoute({
 	scopes: [Scopes.Billing.Write],
@@ -31,89 +18,8 @@ export const handleLegacyApiCheckout = createRoute({
 		const ctx = c.get("ctx");
 		const body = c.req.valid("json");
 
-		const { attachParams, branch, func, config, customPrices, customEnts } =
-			await checkoutToAttachContext({
-				ctx,
-				checkoutParams: body,
-			});
+		const checkoutRes = await runCheckout({ ctx, checkoutParams: body });
 
-		let checkoutUrl = null;
-
-		handleCheckoutErrors({
-			attachParams,
-			branch,
-		});
-
-		if (func === AttachFunction.CreateCheckout) {
-			await checkStripeConnections({
-				ctx,
-				attachParams,
-				createCus: true,
-				useCheckout: true,
-			});
-
-			await insertCustomItems({
-				db: ctx.db,
-				customPrices: customPrices || [],
-				customEnts: customEnts || [],
-			});
-
-			await handlePrepaidErrors({
-				attachParams,
-				config,
-				useCheckout: config.onlyCheckout,
-			});
-
-			if (config.invoiceCheckout) {
-				const result = await handleCreateInvoiceCheckout({
-					ctx,
-					attachParams,
-					config,
-					branch,
-				});
-
-				checkoutUrl = result?.checkout_url;
-			} else {
-				const result = await handleCreateCheckout({
-					ctx,
-					attachParams,
-					config,
-					returnCheckout: true,
-				});
-
-				checkoutUrl = result?.checkout_url;
-			}
-		}
-
-		await getCheckoutOptions({
-			ctx,
-			attachParams,
-		});
-
-		const preview = await attachParamsToPreview({
-			ctx,
-			attachParams,
-			attachBody: body,
-			withPrepaid: true,
-		});
-
-		const checkoutRes = await previewToCheckoutRes({
-			ctx,
-			attachParams,
-			preview,
-			branch,
-		});
-
-		// Get has prorations
-		const hasProrations = await getHasProrations({
-			branch,
-			attachParams,
-		});
-
-		return c.json({
-			...checkoutRes,
-			url: checkoutUrl,
-			has_prorations: hasProrations,
-		});
+		return c.json(checkoutRes);
 	},
 });

--- a/server/src/internal/billing/checkout/runCheckout.ts
+++ b/server/src/internal/billing/checkout/runCheckout.ts
@@ -1,0 +1,112 @@
+import { AttachFunction, type CheckoutParamsV0 } from "@autumn/shared";
+import type { AutumnContext } from "../../../honoUtils/HonoEnv";
+import { handleCreateCheckout } from "../../customers/add-product/handleCreateCheckout";
+import { handleCreateInvoiceCheckout } from "../../customers/add-product/handleCreateInvoiceCheckout";
+import {
+	checkStripeConnections,
+	handlePrepaidErrors,
+} from "../../customers/attach/attachRouter";
+import { handleCheckoutErrors } from "../../customers/attach/attachUtils/handleAttachErrors/handleCheckoutErrors";
+import { insertCustomItems } from "../../customers/attach/attachUtils/insertCustomItems";
+import { attachParamsToPreview } from "../attachPreview/attachParamsToPreview";
+import { getHasProrations } from "./getHasProrations";
+import { previewToCheckoutRes } from "./previewToCheckoutRes";
+import { checkoutToAttachContext } from "./utils/checkoutToAttachContext";
+import { getCheckoutOptions } from "./utils/getCheckoutOptions";
+
+/**
+ * Core checkout flow, shared by the public `/v1/checkout` route and internal
+ * callers that run checkout against a context they build themselves (e.g. the
+ * pricing agent's preview sandbox org).
+ */
+export const runCheckout = async ({
+	ctx,
+	checkoutParams,
+}: {
+	ctx: AutumnContext;
+	checkoutParams: CheckoutParamsV0;
+}) => {
+	const { attachParams, branch, func, config, customPrices, customEnts } =
+		await checkoutToAttachContext({
+			ctx,
+			checkoutParams,
+		});
+
+	let checkoutUrl = null;
+
+	handleCheckoutErrors({
+		attachParams,
+		branch,
+	});
+
+	if (func === AttachFunction.CreateCheckout) {
+		await checkStripeConnections({
+			ctx,
+			attachParams,
+			createCus: true,
+			useCheckout: true,
+		});
+
+		await insertCustomItems({
+			db: ctx.db,
+			customPrices: customPrices || [],
+			customEnts: customEnts || [],
+		});
+
+		await handlePrepaidErrors({
+			attachParams,
+			config,
+			useCheckout: config.onlyCheckout,
+		});
+
+		if (config.invoiceCheckout) {
+			const result = await handleCreateInvoiceCheckout({
+				ctx,
+				attachParams,
+				config,
+				branch,
+			});
+
+			checkoutUrl = result?.checkout_url;
+		} else {
+			const result = await handleCreateCheckout({
+				ctx,
+				attachParams,
+				config,
+				returnCheckout: true,
+			});
+
+			checkoutUrl = result?.checkout_url;
+		}
+	}
+
+	await getCheckoutOptions({
+		ctx,
+		attachParams,
+	});
+
+	const preview = await attachParamsToPreview({
+		ctx,
+		attachParams,
+		attachBody: checkoutParams,
+		withPrepaid: true,
+	});
+
+	const checkoutRes = await previewToCheckoutRes({
+		ctx,
+		attachParams,
+		preview,
+		branch,
+	});
+
+	const hasProrations = await getHasProrations({
+		branch,
+		attachParams,
+	});
+
+	return {
+		...checkoutRes,
+		url: checkoutUrl,
+		has_prorations: hasProrations,
+	};
+};

--- a/server/src/internal/dev/repos/deleteApiKeysByOrg.ts
+++ b/server/src/internal/dev/repos/deleteApiKeysByOrg.ts
@@ -1,0 +1,18 @@
+import { apiKeys } from "@autumn/shared";
+import { eq } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/**
+ * Deletes every API key belonging to an org, across environments.
+ * Used to revoke keys for machine-managed orgs (e.g. pricing agent preview
+ * sandboxes) that no human is able to manage from the dashboard.
+ */
+export const deleteApiKeysByOrg = async ({
+	db,
+	orgId,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+}) => {
+	return await db.delete(apiKeys).where(eq(apiKeys.org_id, orgId)).returning();
+};

--- a/server/src/internal/dev/repos/index.ts
+++ b/server/src/internal/dev/repos/index.ts
@@ -1,4 +1,5 @@
 import { deleteApiKey } from "./deleteApiKey.js";
+import { deleteApiKeysByOrg } from "./deleteApiKeysByOrg.js";
 import { getApiKeyVerificationData } from "./getApiKeyVerificationData.js";
 import { insertApiKey } from "./insertApiKey.js";
 import { listApiKeysByOrg } from "./listApiKeysByOrg.js";
@@ -8,4 +9,5 @@ export const apiKeyRepo = {
 	listByOrg: listApiKeysByOrg,
 	insert: insertApiKey,
 	delete: deleteApiKey,
+	deleteByOrg: deleteApiKeysByOrg,
 };

--- a/server/src/internal/misc/pricingAgent/handlers/handlePreviewCheckout.ts
+++ b/server/src/internal/misc/pricingAgent/handlers/handlePreviewCheckout.ts
@@ -1,0 +1,83 @@
+import { Scopes } from "@autumn/shared";
+import { z } from "zod/v4";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { runCheckout } from "@/internal/billing/checkout/runCheckout.js";
+import {
+	buildPreviewContext,
+	getSessionPreviewOrg,
+} from "./previewOrgUtils.js";
+
+/** Every preview checkout runs against this single throwaway customer. */
+const PREVIEW_CUSTOMER_ID = "preview_customer";
+
+const PreviewCheckoutSchema = z.object({
+	product_id: z.string(),
+	/**
+	 * Dashboard-relative path Stripe returns the user to. Only a path is
+	 * accepted — the origin is fixed server-side so this can't be turned into
+	 * an open redirect.
+	 */
+	success_path: z.string().optional(),
+});
+
+/**
+ * Resolves the client-supplied path against the dashboard origin and drops it
+ * if it escapes that origin — so an absolute or protocol-relative value can't
+ * turn the Stripe success redirect into an open redirect.
+ */
+export const buildSuccessUrl = ({
+	successPath,
+}: {
+	successPath?: string;
+}): string => {
+	const origin = (process.env.CLIENT_URL || "http://localhost:3000").replace(
+		/\/+$/,
+		"",
+	);
+
+	if (!successPath) return origin;
+
+	try {
+		const base = new URL(`${origin}/`);
+		const resolved = new URL(successPath, base);
+
+		return resolved.origin === base.origin ? resolved.toString() : origin;
+	} catch {
+		return origin;
+	}
+};
+
+/**
+ * Creates a Stripe checkout session against the user's preview sandbox org.
+ *
+ * Runs server-side under session auth: the preview org is resolved from the
+ * session, so no sandbox API key has to be handed to the browser.
+ */
+export const handlePreviewCheckout = createRoute({
+	scopes: { ALL: [Scopes.Billing.Write, Scopes.Customers.Write] },
+	body: PreviewCheckoutSchema,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const body = c.req.valid("json");
+
+		const previewOrg = await getSessionPreviewOrg({ ctx });
+		const previewCtx = await buildPreviewContext({
+			ctx,
+			previewOrg,
+			withFeatures: true,
+		});
+
+		const checkoutRes = await runCheckout({
+			ctx: previewCtx,
+			checkoutParams: {
+				customer_id: PREVIEW_CUSTOMER_ID,
+				product_id: body.product_id,
+				success_url: buildSuccessUrl({ successPath: body.success_path }),
+			},
+		});
+
+		// Only the checkout URL is needed by the preview UI — the rest of the
+		// checkout response describes sandbox pricing the client already has.
+		return c.json({ url: checkoutRes.url });
+	},
+});

--- a/server/src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts
+++ b/server/src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts
@@ -1,38 +1,32 @@
 import {
-	AppEnv,
 	type Organization,
 	RecaseError,
-	user as userTable,
 	Scopes,
+	user as userTable,
 } from "@autumn/shared";
 import { generateId } from "better-auth";
 import { eq } from "drizzle-orm";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
-import { createKey } from "@/internal/dev/apiKeys/apiKeyUtils.js";
+import { apiKeyRepo } from "@/internal/dev/repos/index.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
 import { afterOrgCreated } from "@/utils/authUtils/afterOrgCreated.js";
-
-/**
- * Builds the deterministic preview org slug for a user
- */
-export function buildPreviewOrgSlug({
-	userId,
-	masterOrgId,
-}: {
-	userId: string;
-	masterOrgId: string;
-}): string {
-	return `preview|${userId}|${masterOrgId}`;
-}
+import { buildPreviewOrgSlug } from "./previewOrgUtils.js";
 
 /**
  * Sets up a preview sandbox organization for the current user.
  * - Creates a new preview org if one doesn't exist
  * - Reuses existing preview org if found
- * - Returns a sandbox API key for making checkout calls
+ *
+ * No API key is ever returned to the client. Preview operations (syncing
+ * pricing, creating a checkout) run server-side against this org, keyed off
+ * the caller's session. Historically this route minted an unrestricted
+ * sandbox secret key and returned it in the response body; those keys are
+ * revoked here so any that leaked to a browser stop working.
  */
 export const handleSetupPreviewOrg = createRoute({
-	scopes: { ALL: [Scopes.Plans.Write, Scopes.Features.Write, Scopes.Customers.Write] },
+	scopes: {
+		ALL: [Scopes.Plans.Write, Scopes.Features.Write, Scopes.Customers.Write],
+	},
 	handler: async (c) => {
 		const ctx = c.get("ctx");
 		const { db, org: masterOrg, logger, userId } = ctx;
@@ -67,6 +61,20 @@ export const handleSetupPreviewOrg = createRoute({
 			logger.info(
 				`[Preview] Found existing preview org: ${previewOrg.id} (${previewSlug})`,
 			);
+
+			// Revoke any keys previously handed out for this preview org. The org
+			// is fully machine-managed and has no members, so every key on it was
+			// minted by the old setup flow.
+			const revoked = await apiKeyRepo.deleteByOrg({
+				db,
+				orgId: previewOrg.id,
+			});
+
+			if (revoked.length > 0) {
+				logger.info(
+					`[Preview] Revoked ${revoked.length} legacy preview API key(s) for org: ${previewOrg.id}`,
+				);
+			}
 		} else {
 			// Create new preview organization
 			const orgId = generateId();
@@ -85,7 +93,7 @@ export const handleSetupPreviewOrg = createRoute({
 
 			// Note: We intentionally do NOT create a membership here.
 			// The preview org should not be accessible to the user via the dashboard.
-			// They can only interact with it via the returned API key.
+			// They can only interact with it via the /preview/* routes.
 
 			// Initialize org (creates Stripe test account, svix apps, etc.)
 			await afterOrgCreated({ org: previewOrg, user });
@@ -95,18 +103,7 @@ export const handleSetupPreviewOrg = createRoute({
 			);
 		}
 
-		// Generate a new sandbox API key for this session
-		const apiKey = await createKey({
-			db,
-			orgId: previewOrg.id,
-			env: AppEnv.Sandbox,
-			name: "Preview API Key",
-			prefix: "am_sk_test",
-			meta: { preview: true },
-		});
-
 		return c.json({
-			api_key: apiKey,
 			org_slug: previewSlug,
 			org_id: previewOrg.id,
 		});

--- a/server/src/internal/misc/pricingAgent/handlers/handleSyncPreviewPricing.ts
+++ b/server/src/internal/misc/pricingAgent/handlers/handleSyncPreviewPricing.ts
@@ -5,7 +5,6 @@ import {
 	CreateFreeTrialSchema,
 	CreateProductItemParamsSchema,
 	CreateProductSchema,
-	RecaseError,
 	Scopes,
 } from "@autumn/shared";
 import { z } from "zod/v4";
@@ -15,10 +14,9 @@ import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { createFeature } from "@/internal/features/featureActions/createFeature.js";
-import { OrgService } from "@/internal/orgs/OrgService.js";
 import { createProduct } from "@/internal/product/actions/createProduct.js";
 import { ProductService } from "@/internal/products/ProductService.js";
-import { buildPreviewOrgSlug } from "./handleSetupPreviewOrg.js";
+import { getSessionPreviewOrg } from "./previewOrgUtils.js";
 
 const SyncPreviewPricingSchema = z.object({
 	features: z.array(CreateFeatureV0ParamsSchema).optional().default([]),
@@ -43,31 +41,11 @@ export const handleSyncPreviewPricing = createRoute({
 	body: SyncPreviewPricingSchema,
 	handler: async (c) => {
 		const ctx = c.get("ctx");
-		const { db, org: masterOrg, userId } = ctx;
+		const { db } = ctx;
 		const body = c.req.valid("json");
 
-		if (!userId) {
-			throw new RecaseError({
-				message: "User not authenticated",
-				code: "unauthenticated",
-				statusCode: 401,
-			});
-		}
-
 		// Find the preview org using session auth
-		const previewSlug = buildPreviewOrgSlug({
-			userId,
-			masterOrgId: masterOrg.id,
-		});
-
-		const previewOrg = await OrgService.getBySlug({ db, slug: previewSlug });
-		if (!previewOrg) {
-			throw new RecaseError({
-				message: "Preview org not found. Call /preview/setup first.",
-				code: "preview_org_not_found",
-				statusCode: 404,
-			});
-		}
+		const previewOrg = await getSessionPreviewOrg({ ctx });
 
 		ctx.logger.debug(
 			`[Preview Sync] Starting sync for preview org: ${previewOrg.id}, features: ${body.features.length}, products: ${body.products.length}`,

--- a/server/src/internal/misc/pricingAgent/handlers/previewOrgUtils.ts
+++ b/server/src/internal/misc/pricingAgent/handlers/previewOrgUtils.ts
@@ -1,0 +1,94 @@
+import {
+	AppEnv,
+	createdAtToVersion,
+	type Organization,
+	RecaseError,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+
+/**
+ * Builds the deterministic preview org slug for a user
+ */
+export function buildPreviewOrgSlug({
+	userId,
+	masterOrgId,
+}: {
+	userId: string;
+	masterOrgId: string;
+}): string {
+	return `preview|${userId}|${masterOrgId}`;
+}
+
+/**
+ * Resolves the preview sandbox org that belongs to the session user.
+ *
+ * The preview org is derived from the session (user + active org), never from
+ * request input, so a caller can only ever reach their own sandbox.
+ */
+export async function getSessionPreviewOrg({
+	ctx,
+}: {
+	ctx: AutumnContext;
+}): Promise<Organization> {
+	const { db, org: masterOrg, userId } = ctx;
+
+	if (!userId) {
+		throw new RecaseError({
+			message: "User not authenticated",
+			code: "unauthenticated",
+			statusCode: 401,
+		});
+	}
+
+	const previewSlug = buildPreviewOrgSlug({
+		userId,
+		masterOrgId: masterOrg.id,
+	});
+
+	const previewOrg = await OrgService.getBySlug({ db, slug: previewSlug });
+	if (!previewOrg) {
+		throw new RecaseError({
+			message: "Preview org not found. Call /preview/setup first.",
+			code: "preview_org_not_found",
+			statusCode: 404,
+		});
+	}
+
+	return previewOrg;
+}
+
+/**
+ * Builds a request context scoped to the preview sandbox org, so preview
+ * operations run against the sandbox instead of the user's real org.
+ */
+export async function buildPreviewContext({
+	ctx,
+	previewOrg,
+	withFeatures = false,
+}: {
+	ctx: AutumnContext;
+	previewOrg: Organization;
+	withFeatures?: boolean;
+}): Promise<AutumnContext> {
+	const features = withFeatures
+		? await FeatureService.list({
+				db: ctx.db,
+				orgId: previewOrg.id,
+				env: AppEnv.Sandbox,
+			})
+		: [];
+
+	return {
+		...ctx,
+		org: previewOrg,
+		env: AppEnv.Sandbox,
+		features,
+		// The preview org is its own tenant: resolve its API version from its
+		// own creation date rather than inheriting the dashboard's header.
+		apiVersion: createdAtToVersion({
+			createdAt: previewOrg.created_at ?? undefined,
+		}),
+	};
+}

--- a/server/src/internal/misc/pricingAgent/pricingAgentRouter.ts
+++ b/server/src/internal/misc/pricingAgent/pricingAgentRouter.ts
@@ -5,6 +5,7 @@ import { convertToModelMessages, streamText, type UIMessage } from "ai";
 import { Hono } from "hono";
 import { PostHog } from "posthog-node";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { handlePreviewCheckout } from "./handlers/handlePreviewCheckout.js";
 import { handleSetupPreviewOrg } from "./handlers/handleSetupPreviewOrg.js";
 import { handleSyncPreviewPricing } from "./handlers/handleSyncPreviewPricing.js";
 import { OrganisationConfigurationSchema } from "./pricingAgentSchemas.js";
@@ -203,3 +204,9 @@ pricingAgentRouter.post("/preview/setup", ...handleSetupPreviewOrg);
  * Syncs pricing configuration to the preview sandbox org
  */
 pricingAgentRouter.post("/preview/sync", ...handleSyncPreviewPricing);
+
+/**
+ * POST /preview/checkout
+ * Creates a checkout session against the preview sandbox org
+ */
+pricingAgentRouter.post("/preview/checkout", ...handlePreviewCheckout);

--- a/server/tests/integration/scopes/scope-403.test.ts
+++ b/server/tests/integration/scopes/scope-403.test.ts
@@ -746,6 +746,20 @@ const ROUTES = [
 		isWebhookExempt: false,
 	},
 	{
+		handlerName: "handlePreviewCheckout",
+		handlerFile:
+			"src/internal/misc/pricingAgent/handlers/handlePreviewCheckout.ts",
+		method: "POST",
+		path: "/pricing-agent/preview/checkout",
+		style: "REST",
+		group: "pricing-agent",
+		mountChain: ["", "/pricing-agent", "/preview/checkout"],
+		sourceRouterFile: "src/internal/misc/pricingAgent/pricingAgentRouter.ts",
+		routeKind: "createRoute",
+		needsScopes: true,
+		isWebhookExempt: false,
+	},
+	{
 		handlerName: "handleSetupPreviewOrg",
 		handlerFile:
 			"src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts",
@@ -3979,6 +3993,13 @@ const SCOPE_DECISIONS: Record<
 		scopes: ["organisation:write"],
 		shape: "array",
 		decidedAt: "2026-04-24T15:25:47.915Z",
+	},
+	"POST|/pricing-agent/preview/checkout|handlePreviewCheckout": {
+		decision: "decided",
+		scopes: ["billing:write", "customers:write"],
+		shape: "all",
+		note: "pricing-agent preview checkout \u2014 creates a checkout session in the caller's preview sandbox org",
+		decidedAt: "2026-04-24T17:16:14.920Z",
 	},
 	"POST|/pricing-agent/preview/setup|handleSetupPreviewOrg": {
 		decision: "decided",

--- a/server/tests/unit/pricingAgent/previewCheckoutSuccessUrl.test.ts
+++ b/server/tests/unit/pricingAgent/previewCheckoutSuccessUrl.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { buildSuccessUrl } from "@/internal/misc/pricingAgent/handlers/handlePreviewCheckout.js";
+
+const DASHBOARD_ORIGIN = "https://app.useautumn.com";
+
+let previousClientUrl: string | undefined;
+
+beforeAll(() => {
+	previousClientUrl = process.env.CLIENT_URL;
+	process.env.CLIENT_URL = `${DASHBOARD_ORIGIN}/`;
+});
+
+afterAll(() => {
+	if (previousClientUrl === undefined) {
+		delete process.env.CLIENT_URL;
+	} else {
+		process.env.CLIENT_URL = previousClientUrl;
+	}
+});
+
+describe("buildSuccessUrl", () => {
+	test("keeps a dashboard-relative path", () => {
+		expect(buildSuccessUrl({ successPath: "/onboarding?step=2" })).toBe(
+			`${DASHBOARD_ORIGIN}/onboarding?step=2`,
+		);
+	});
+
+	test("falls back to the dashboard origin when no path is given", () => {
+		expect(buildSuccessUrl({})).toBe(DASHBOARD_ORIGIN);
+	});
+
+	test("rejects absolute urls pointing elsewhere", () => {
+		expect(buildSuccessUrl({ successPath: "https://evil.com/steal" })).toBe(
+			DASHBOARD_ORIGIN,
+		);
+	});
+
+	test("rejects protocol-relative and backslash-escaped paths", () => {
+		expect(buildSuccessUrl({ successPath: "//evil.com" })).toBe(
+			DASHBOARD_ORIGIN,
+		);
+		expect(buildSuccessUrl({ successPath: "/\\evil.com" })).toBe(
+			DASHBOARD_ORIGIN,
+		);
+	});
+});

--- a/vite/src/views/onboarding4/PricingPreview.tsx
+++ b/vite/src/views/onboarding4/PricingPreview.tsx
@@ -10,7 +10,6 @@ import {
 } from "./preview/previewTypes";
 
 interface PreviewOrg {
-	apiKey: string;
 	orgId: string;
 	orgSlug: string;
 }
@@ -98,7 +97,7 @@ export function PricingPreview({
 					<div className="flex flex-col gap-6 my-auto">
 						<GroupedPlanCards
 							products={previewProducts}
-							previewApiKey={previewOrg?.apiKey}
+							isPreviewOrgReady={previewOrg != null}
 							isSyncing={isSyncing}
 							changedProductIds={changedProductIds}
 						/>

--- a/vite/src/views/onboarding4/components/ChatInputComponents.tsx
+++ b/vite/src/views/onboarding4/components/ChatInputComponents.tsx
@@ -29,7 +29,6 @@ export type BuildPricingToolPart = {
  * Preview org configuration for syncing pricing
  */
 export interface PreviewOrg {
-	apiKey: string;
 	orgId: string;
 	orgSlug: string;
 }

--- a/vite/src/views/onboarding4/hooks/usePricingAgentChat.ts
+++ b/vite/src/views/onboarding4/hooks/usePricingAgentChat.ts
@@ -64,7 +64,6 @@ export function usePricingAgentChat(options?: UsePricingAgentChatOptions) {
 
 				const data = await response.json();
 				const org: PreviewOrg = {
-					apiKey: data.api_key,
 					orgId: data.org_id,
 					orgSlug: data.org_slug,
 				};

--- a/vite/src/views/onboarding4/preview/GroupedPlanCards.tsx
+++ b/vite/src/views/onboarding4/preview/GroupedPlanCards.tsx
@@ -4,14 +4,14 @@ import { groupPreviewProducts, type PreviewProduct } from "./previewTypes";
 
 interface GroupedPlanCardsProps {
 	products: PreviewProduct[];
-	previewApiKey?: string;
+	isPreviewOrgReady: boolean;
 	isSyncing: boolean;
 	changedProductIds: Set<string>;
 }
 
 export function GroupedPlanCards({
 	products,
-	previewApiKey,
+	isPreviewOrgReady,
 	isSyncing,
 	changedProductIds,
 }: GroupedPlanCardsProps) {
@@ -29,7 +29,7 @@ export function GroupedPlanCards({
 						<PreviewPlanCard
 							key={product.id}
 							product={product}
-							previewApiKey={previewApiKey}
+							isPreviewOrgReady={isPreviewOrgReady}
 							isSyncing={isSyncing}
 							isChanged={changedProductIds.has(product.id)}
 						/>

--- a/vite/src/views/onboarding4/preview/PreviewCheckoutButton.tsx
+++ b/vite/src/views/onboarding4/preview/PreviewCheckoutButton.tsx
@@ -1,58 +1,40 @@
 import { Button } from "@autumn/ui";
 import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
 
 type CheckoutState = "idle" | "waiting_for_sync" | "creating_checkout";
 
 interface PreviewCheckoutButtonProps {
 	productId: string;
-	previewApiKey?: string;
+	isPreviewOrgReady: boolean;
 	isSyncing: boolean;
 }
 
 export function PreviewCheckoutButton({
 	productId,
-	previewApiKey,
+	isPreviewOrgReady,
 	isSyncing,
 }: PreviewCheckoutButtonProps) {
 	const [checkoutState, setCheckoutState] = useState<CheckoutState>("idle");
+	const axiosInstance = useAxiosInstance();
 
 	const createCheckout = useCallback(async () => {
-		if (!previewApiKey) return;
+		if (!isPreviewOrgReady) return;
 		setCheckoutState("creating_checkout");
 		try {
-			console.log(
-				`[Preview Checkout] Starting checkout for product: ${productId}`,
-			);
-
-			const response = await fetch(
-				`${import.meta.env.VITE_BACKEND_URL}/v1/checkout`,
+			// Checkout runs server-side against the preview sandbox org, keyed off
+			// the dashboard session — no sandbox API key is exposed to the browser.
+			const response = await axiosInstance.post(
+				"/pricing-agent/preview/checkout",
 				{
-					method: "POST",
-					headers: {
-						Authorization: `Bearer ${previewApiKey}`,
-						"Content-Type": "application/json",
-					},
-					body: JSON.stringify({
-						customer_id: "preview_customer",
-						product_id: productId,
-						success_url: window.location.href,
-					}),
+					product_id: productId,
+					success_path: window.location.pathname + window.location.search,
 				},
 			);
 
-			if (!response.ok) {
-				const error = await response.json();
-				console.error("[Preview Checkout] Failed:", error);
-				setCheckoutState("idle");
-				return;
-			}
-
-			const result = await response.json();
-			console.log("[Preview Checkout] Result:", result);
-
-			if (result.url) {
-				window.open(result.url, "_blank");
+			if (response.data?.url) {
+				window.open(response.data.url, "_blank");
 			} else {
 				console.error("[Preview Checkout] No URL in response");
 			}
@@ -61,7 +43,7 @@ export function PreviewCheckoutButton({
 		} finally {
 			setCheckoutState("idle");
 		}
-	}, [productId, previewApiKey]);
+	}, [axiosInstance, productId, isPreviewOrgReady]);
 
 	// When syncing finishes and we were waiting for it, create checkout
 	useEffect(() => {
@@ -71,7 +53,7 @@ export function PreviewCheckoutButton({
 	}, [checkoutState, isSyncing, createCheckout]);
 
 	const handleClick = () => {
-		if (!previewApiKey) return;
+		if (!isPreviewOrgReady) return;
 		if (isSyncing) {
 			// Wait for sync to complete
 			setCheckoutState("waiting_for_sync");
@@ -82,7 +64,7 @@ export function PreviewCheckoutButton({
 	};
 
 	const isLoading = checkoutState !== "idle";
-	const isDisabled = isLoading || !previewApiKey;
+	const isDisabled = isLoading || !isPreviewOrgReady;
 
 	const getButtonText = () => {
 		switch (checkoutState) {

--- a/vite/src/views/onboarding4/preview/PreviewPlanCard.tsx
+++ b/vite/src/views/onboarding4/preview/PreviewPlanCard.tsx
@@ -7,14 +7,14 @@ import type { PreviewProduct } from "./previewTypes";
 
 interface PreviewPlanCardProps {
 	product: PreviewProduct;
-	previewApiKey?: string;
+	isPreviewOrgReady: boolean;
 	isSyncing: boolean;
 	isChanged?: boolean;
 }
 
 export function PreviewPlanCard({
 	product,
-	previewApiKey,
+	isPreviewOrgReady,
 	isSyncing,
 	isChanged = false,
 }: PreviewPlanCardProps) {
@@ -47,7 +47,7 @@ export function PreviewPlanCard({
 				<CardFooter className="pt-3">
 					<PreviewCheckoutButton
 						productId={product.id}
-						previewApiKey={previewApiKey}
+						isPreviewOrgReady={isPreviewOrgReady}
 						isSyncing={isSyncing}
 					/>
 				</CardFooter>


### PR DESCRIPTION
Addresses a security finding against `POST /pricing-agent/preview/setup` (reported as "Hidden Key Leaked That Users Didn't Create and Can't Manage").

## The finding

`/preview/setup` minted a sandbox secret key for the user's hidden preview org and returned it in the response body, so the browser could call `POST /v1/checkout` directly for the "Preview Checkout" buttons in the AI onboarding chat.

The report overstates the blast radius: the key was scoped to a **throwaway preview sandbox org**, not the caller's real org, so listing/creating customers with it only touched preview data the same user had just generated. It was not access to production data or to the user's actual organization.

Three things were nonetheless wrong:

1. **The key was unrestricted.** `createKey` was called with no `scopes`, and the scope middleware (`routeHandler.ts:227`) treats a null/empty scope set as a legacy fail-open — so it passed *every* scope check on that org, including `apiKeys:write` and `organisation:write`. Only `billing:write` was ever needed.
2. **Nobody could revoke it.** The preview org is created without a membership (intentionally — it's invisible in the dashboard), so its keys never surface in any key-management UI.
3. **It accumulated.** A fresh, non-expiring key was minted on every setup call, i.e. every visit to the onboarding chat.

## The fix

Rather than narrowing the key's scopes, the key is removed from the flow entirely.

- **New `POST /pricing-agent/preview/checkout`** runs checkout server-side under session auth. The preview org is resolved from the session (`userId` + active org), never from request input, so a caller can only reach their own sandbox.
- **`/preview/setup` no longer creates or returns a key**, and deletes any keys already on the preview org — so keys leaked by the current production code stop working the next time a user loads the page.
- **The Stripe `success_url` is built server-side.** The client previously sent `window.location.href` verbatim; it now sends only a path, resolved against `CLIENT_URL` and discarded if it escapes that origin (blocks `//evil.com`, `/\evil.com`, absolute URLs).

Supporting refactors:

- Extracted the checkout flow out of `handleLegacyApiCheckout` into `runCheckout.ts` so `/v1/checkout` and the preview route share one implementation.
- Moved the preview-org slug/lookup helpers into `previewOrgUtils.ts`.
- Added `apiKeyRepo.deleteByOrg`.

## Verification

- `bun ts` passes in both `server/` and `vite/`
- Biome clean on the touched files
- 4 new unit tests covering the redirect guard (`tests/unit/pricingAgent/previewCheckoutSuccessUrl.test.ts`)
- `apps/scope-picker/routes.json` and the `scope-403` route manifest updated, so the new route is covered by the existing scope-enforcement test

## Not addressed here

Two adjacent items left alone deliberately, worth separate discussion:

- The scope middleware's blanket fail-open on empty `ctx.scopes` is what turned a null-scope key into an effective admin key.
- `/preview/sync` still builds its preview context inline without setting `apiVersion`; changing that would alter product-creation behavior, so it's out of scope for this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvyiRc4RLF3h1xZwPDjf4i)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops minting and returning a sandbox secret key from /pricing-agent/preview/setup and runs preview checkout server-side under session auth. The old behavior handed the browser an unrestricted, non-expiring sandbox key; the new flow revokes any existing keys and constrains the Stripe success redirect to the dashboard origin.

- Adds POST /pricing-agent/preview/checkout (scopes: billing:write, customers:write) that resolves the caller’s preview org from the session and runs the shared checkout flow extracted to runCheckout; no org or key comes from request input.
- /pricing-agent/preview/setup no longer creates or returns a key and deletes any keys on the preview org via apiKeyRepo.deleteByOrg (keys issued by current production stop working on the next setup call).
- Builds Stripe success_url server-side from a client-supplied path against CLIENT_URL; off-origin or invalid paths fall back to the dashboard origin (unit test added).
- Frontend stops plumbing a preview API key and now calls /pricing-agent/preview/checkout; removes apiKey from PreviewOrg and related component props in PricingPreview, GroupedPlanCards, PreviewPlanCard, and PreviewCheckoutButton.
- Updates routes.json and scope-403 fixtures for the new route; refactors preview org helpers into previewOrgUtils; keeps /v1/checkout behavior unchanged by moving logic into runCheckout.
- Also fixes entity defaults: emits customer.products.updated and billing.updated webhooks during entity default-plan attach and includes defaults in the create response (new unit test).

Migration
- Remove any internal use of the api_key field from /pricing-agent/preview/setup and call /pricing-agent/preview/checkout instead.
- Set CLIENT_URL to the dashboard origin in each environment.

<sup>Written for commit f9d9dded9180b70b1562a3eac89b4935239b8c32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes browser access to preview sandbox secret keys and moves preview checkout behind a session-authenticated server endpoint. It also adds missing entity default-product webhook behavior.

- **[Bug fixes, API changes]** Stops `/pricing-agent/preview/setup` from creating or returning sandbox secret keys and attempts to revoke existing preview keys.
- **[Improvements, API changes]** Adds `/pricing-agent/preview/checkout`, scopes checkout to the session-derived preview organization, and restricts Stripe success redirects to the configured dashboard origin.
- **[Improvements]** Extracts the shared checkout implementation and centralizes preview-organization context helpers.
- **[Bug fixes]** Emits product and billing update webhooks when default products are attached to newly created entities.
</details>

<h3>Confidence Score: 3/5</h3>

This PR should not merge until bulk preview-key revocation also clears cached verification records, otherwise recently used leaked keys remain accepted.

The new setup cleanup deletes legacy keys from the database but leaves positive authentication cache entries valid for up to one hour, so the security boundary the PR intends to restore is not immediate.

**Files Needing Attention:** server/src/internal/dev/repos/deleteApiKeysByOrg.ts, server/src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts

<details open><summary><h3>Security Review</h3></summary>

One security issue remains: deleting legacy preview-key rows does not invalidate cached verification data, so recently used leaked keys can continue authenticating for up to one hour.

**How this was verified:** The new bulk deletion only removes database rows, while authentication accepts cached verification records with a 3,600-second lifetime and the existing single-key deletion path explicitly clears that cache.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/dev/repos/deleteApiKeysByOrg.ts | Adds organization-wide key deletion but omits verification-cache invalidation, leaving deleted keys temporarily usable. |
| server/src/internal/misc/pricingAgent/handlers/handleSetupPreviewOrg.ts | Stops minting preview keys and invokes bulk revocation, but currently relies on incomplete repository-level deletion. |
| server/src/internal/misc/pricingAgent/handlers/handlePreviewCheckout.ts | Adds session-scoped server-side preview checkout with an origin-constrained success URL. |
| server/src/internal/billing/checkout/runCheckout.ts | Extracts the existing checkout flow without materially changing its response contract. |
| server/src/internal/misc/pricingAgent/handlers/previewOrgUtils.ts | Centralizes deterministic preview-org lookup and builds an organization- and sandbox-scoped context. |
| server/src/internal/entities/actions/batchCreateEntities/attachDefaultProductsToEntities.ts | Adds entity default-product webhook delivery and updates the aggregate used to construct entity responses. |
| vite/src/views/onboarding4/preview/PreviewCheckoutButton.tsx | Replaces direct secret-key checkout calls with the authenticated preview checkout endpoint. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Browser
  participant Setup as Preview Setup
  participant Checkout as Preview Checkout
  participant PreviewOrg as Preview Sandbox
  participant Stripe
  Browser->>Setup: POST /pricing-agent/preview/setup (session)
  Setup->>PreviewOrg: Resolve/create session-derived org
  Setup->>PreviewOrg: Delete legacy API-key rows
  Browser->>Checkout: product_id + success_path (session)
  Checkout->>PreviewOrg: Build sandbox checkout context
  Checkout->>Stripe: Create checkout session
  Stripe-->>Browser: Dashboard-origin success redirect
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/dev/repos/deleteApiKeysByOrg.ts:1-18
**Revoked keys remain cached**

When a previously used preview key is deleted during setup, `deleteByOrg` leaves its cached verification record intact, causing the leaked key to continue authenticating for up to the one-hour Redis cache lifetime. Invalidate each deleted key as the existing single-key deletion flow does. **How this was verified:** Authentication reads cached key verification before persistent state, and this bulk deletion performs no cache invalidation.

```suggestion
import { apiKeys } from "@autumn/shared";
import { eq } from "drizzle-orm";
import type { DrizzleCli } from "@/db/initDrizzle.js";
import { clearSecretKeyCache } from "@/external/redis/actions/secretKeyCache/secretKeyCache.js";

/**
 * Deletes every API key belonging to an org, across environments.
 * Used to revoke keys for machine-managed orgs (e.g. pricing agent preview
 * sandboxes) that no human is able to manage from the dashboard.
 */
export const deleteApiKeysByOrg = async ({
	db,
	orgId,
}: {
	db: DrizzleCli;
	orgId: string;
}) => {
	const deletedKeys = await db
		.delete(apiKeys)
		.where(eq(apiKeys.org_id, orgId))
		.returning();

	await Promise.all(
		deletedKeys.map((apiKey) =>
			clearSecretKeyCache({ hashedKey: apiKey.hashed_key! }),
		),
	);

	return deletedKeys;
};
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pricing-agent): stop returning a san..."](https://github.com/useautumn/autumn/commit/f9d9dded9180b70b1562a3eac89b4935239b8c32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53961806)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->