### PR TITLE
fix: align balance filters with displayed usage

### DIFF
--- a/server/src/external/motherduck/refreshCeBalancesCache.ts
+++ b/server/src/external/motherduck/refreshCeBalancesCache.ts
@@ -16,6 +16,9 @@ const metadataLocationPattern = (table: string) =>
 
 const glueClient = new GlueClient({ region: GLUE_REGION });
 
+export const LIVE_LOOSE_BALANCE_CACHE_PREDICATE =
+	"b.balance != 0 OR b.unlimited IS TRUE OR a.feature_type = 'boolean'";
+
 /** The Glue pointer advances on every RW sink commit — always read it fresh;
  * a pinned metadata.json 404s within hours once compaction expires it. */
 export const getCurrentLakeMetadataLocation = async ({
@@ -51,12 +54,17 @@ export const refreshCeBalancesCache = async ({
 
 	inFlight = (async () => {
 		const startedAt = performance.now();
-		const [ceMetadataLocation, entMetadataLocation, cpMetadataLocation] =
-			await Promise.all([
-				getCurrentLakeMetadataLocation({ table: "customer_entitlements" }),
-				getCurrentLakeMetadataLocation({ table: "entitlements" }),
-				getCurrentLakeMetadataLocation({ table: "customer_products" }),
-			]);
+		const [
+			ceMetadataLocation,
+			entMetadataLocation,
+			cpMetadataLocation,
+			featureMetadataLocation,
+		] = await Promise.all([
+			getCurrentLakeMetadataLocation({ table: "customer_entitlements" }),
+			getCurrentLakeMetadataLocation({ table: "entitlements" }),
+			getCurrentLakeMetadataLocation({ table: "customer_products" }),
+			getCurrentLakeMetadataLocation({ table: "features" }),
+		]);
 
 		const rowCount = await withMotherDuckRw({
 			run: async (db) => {
@@ -70,8 +78,10 @@ export const refreshCeBalancesCache = async ({
 				await db.execute(
 					sql.raw(`
 						CREATE OR REPLACE TABLE main.ent_allowances AS
-						SELECT id, allowance
-						FROM iceberg_scan('${entMetadataLocation}')
+						SELECT e.id, e.allowance, f.type AS feature_type
+						FROM iceberg_scan('${entMetadataLocation}') e
+						JOIN iceberg_scan('${featureMetadataLocation}') f
+							ON f.internal_id = e.internal_feature_id
 					`),
 				);
 				// Statuses must mirror PG's ACTIVE_STATUSES — dead product-history
@@ -106,7 +116,7 @@ export const refreshCeBalancesCache = async ({
 							AND (
 								(
 									b.customer_product_id IS NULL
-									AND (b.balance != 0 OR b.unlimited IS TRUE)
+									AND (${LIVE_LOOSE_BALANCE_CACHE_PREDICATE})
 								)
 								OR b.customer_product_id IN (SELECT id FROM main.cp_active)
 							)

--- a/server/src/external/motherduck/refreshCeBalancesCache.ts
+++ b/server/src/external/motherduck/refreshCeBalancesCache.ts
@@ -104,7 +104,10 @@ export const refreshCeBalancesCache = async ({
 						LEFT JOIN main.ent_allowances a ON a.id = b.entitlement_id
 						WHERE (b.expires_at IS NULL OR b.expires_at > epoch_ms(now()))
 							AND (
-								b.customer_product_id IS NULL
+								(
+									b.customer_product_id IS NULL
+									AND (b.balance != 0 OR b.unlimited IS TRUE)
+								)
 								OR b.customer_product_id IN (SELECT id FROM main.cp_active)
 							)
 						GROUP BY 1, 2

--- a/server/src/internal/customers/resolveByFeatureBalanceSort.ts
+++ b/server/src/internal/customers/resolveByFeatureBalanceSort.ts
@@ -19,6 +19,7 @@ import {
 import { getMiscRedis } from "@/external/redis/initRedis.js";
 import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
 import { buildSearchPredicates } from "./CusSearchService.js";
+import { looseEntitlementIsLiveSql } from "./looseEntitlementSql.js";
 
 /** `total` is the value of the REQUESTED basis (remaining/granted/usage) —
  * the cursor and ranking key on both the lake and PG sides. */
@@ -115,14 +116,14 @@ export const balanceThresholdSql = ({
 	op === ">" ? sql`${totalExpr} > ${value}` : sql`${totalExpr} < ${value}`;
 
 /** "Live" must match what the Usage column sums (cusEnts of ACTIVE_STATUSES
- * products + loose rows) — NOT `ce.expired`, whose NULL→true backfill lags and
- * leaves churned-product rows looking live. Requires `cp` joined on
- * ce.customer_product_id. */
+ * products + non-drained loose rows) — NOT `ce.expired`, whose NULL→true
+ * backfill lags and leaves churned-product rows looking live. Requires `cp`
+ * joined on ce.customer_product_id. */
 export const liveCusEntPredicate = (): SQL => sql`
 	(ce.expires_at IS NULL OR ce.expires_at > EXTRACT(EPOCH FROM now()) * 1000)
 	AND ce.pooled_contribution_id IS NULL
 	AND (
-		ce.customer_product_id IS NULL
+		(ce.customer_product_id IS NULL AND ${looseEntitlementIsLiveSql()})
 		OR cp.status IN (${activeStatusList()})
 	)
 `;

--- a/server/tests/unit/customers/balance-sort-predicates.test.ts
+++ b/server/tests/unit/customers/balance-sort-predicates.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { liveCusEntPredicate } from "@/internal/customers/resolveByFeatureBalanceSort.js";
+
+const dialect = new PgDialect();
+
+describe("balance sort predicates", () => {
+	test("excludes drained loose entitlements from exact balance totals", () => {
+		const { sql: query, params } = dialect.sqlToQuery(
+			sql`SELECT 1 FROM customer_entitlements ce LEFT JOIN customer_products cp ON cp.id = ce.customer_product_id WHERE ${liveCusEntPredicate()}`,
+		);
+		const normalized = query.replace(/\s+/g, " ").trim();
+
+		expect(normalized).toContain(
+			"ce.customer_product_id IS NULL AND ( ce.balance != 0 OR ce.unlimited IS TRUE",
+		);
+		expect(normalized).toContain("AND f.type = 'boolean'");
+		expect(normalized).toContain("OR cp.status IN ($1, $2)");
+		expect(params).toEqual(["active", "past_due"]);
+	});
+});

--- a/server/tests/unit/customers/balance-sort-predicates.test.ts
+++ b/server/tests/unit/customers/balance-sort-predicates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { sql } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
+import { LIVE_LOOSE_BALANCE_CACHE_PREDICATE } from "@/external/motherduck/refreshCeBalancesCache.js";
 import { liveCusEntPredicate } from "@/internal/customers/resolveByFeatureBalanceSort.js";
 
 const dialect = new PgDialect();
@@ -18,5 +19,11 @@ describe("balance sort predicates", () => {
 		expect(normalized).toContain("AND f.type = 'boolean'");
 		expect(normalized).toContain("OR cp.status IN ($1, $2)");
 		expect(params).toEqual(["active", "past_due"]);
+	});
+
+	test("keeps the MotherDuck loose-balance predicate aligned", () => {
+		expect(LIVE_LOOSE_BALANCE_CACHE_PREDICATE).toBe(
+			"b.balance != 0 OR b.unlimited IS TRUE OR a.feature_type = 'boolean'",
+		);
 	});
 });


### PR DESCRIPTION
Fixes feature-balance filtering and ordering disagreeing when customers have drained plan-less grants.

- Exclude drained loose entitlements from PostgreSQL’s exact balance verification, matching customer hydration and displayed balances.
- Apply the same exclusion when rebuilding MotherDuck balance totals so nomination uses the same usage definition.
- Cover the exact-balance SQL predicate with a regression test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns feature-balance “live” filters with displayed usage across PostgreSQL and MotherDuck. Drained loose entitlements no longer count as live, and zero‑balance boolean loose entitlements are retained, so sort/threshold queries match UI totals and nominations.

- Updates `liveCusEntPredicate` to use `looseEntitlementIsLiveSql()`: loose rows are live only if `balance != 0`, `unlimited` is true, or the feature type is `boolean`.
- Applies the same rule when rebuilding the MotherDuck CE balances cache by joining features and using `LIVE_LOOSE_BALANCE_CACHE_PREDICATE`, fixing the previous boolean‑grant omission.
- Adds a `drizzle-orm` regression test under `bun:test` to lock the predicate and the `active`/`past_due` status filter.

<sup>Written for commit 06c10a8df491f16b75f216769a523630c927f730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns exact PostgreSQL balance checks and MotherDuck nomination totals with displayed usage by excluding drained loose entitlements.

- **Bug fixes:** Excludes drained plan-less grants while retaining unlimited and boolean grants.
- **Improvements:** Loads feature types into the MotherDuck cache rebuild and adds predicate regression coverage.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/motherduck/refreshCeBalancesCache.ts | Rebuilds cached totals using feature-aware live-loose-entitlement semantics consistent with the intended balance definition. |
| server/src/internal/customers/resolveByFeatureBalanceSort.ts | Reuses the shared loose-entitlement liveness predicate for exact PostgreSQL balance verification. |
| server/tests/unit/customers/balance-sort-predicates.test.ts | Adds regression checks for PostgreSQL status/type handling and the corresponding MotherDuck predicate. |

<sub>Reviews (2): Last reviewed commit: ["fix: preserve loose boolean grants in ba..."](https://github.com/useautumn/autumn/commit/06c10a8df491f16b75f216769a523630c927f730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53976598)</sub>

<!-- /greptile_comment -->