### PR TITLE
feat(vite): add override flow for plan-managed billing controls

### DIFF
--- a/vite/src/components/billing-controls/billingControlSheets.ts
+++ b/vite/src/components/billing-controls/billingControlSheets.ts
@@ -1,0 +1,28 @@
+import type { BillingControlKey } from "@autumn/shared";
+import type { SheetType } from "@/hooks/stores/useSheetStore";
+
+export const BILLING_CONTROL_ADD_SHEETS: Record<BillingControlKey, SheetType> =
+	{
+		auto_topups: "billing-auto-topup-add",
+		spend_limits: "billing-spend-limit-add",
+		usage_limits: "billing-usage-limit-add",
+		usage_alerts: "billing-usage-alert-add",
+		overage_allowed: "billing-overage-allowed-add",
+	};
+
+export const BILLING_CONTROL_EDIT_SHEETS: Record<BillingControlKey, SheetType> =
+	{
+		auto_topups: "billing-auto-topup-edit",
+		spend_limits: "billing-spend-limit-edit",
+		usage_limits: "billing-usage-limit-edit",
+		usage_alerts: "billing-usage-alert-edit",
+		overage_allowed: "billing-overage-allowed-edit",
+	};
+
+export const BILLING_CONTROL_LABELS: Record<BillingControlKey, string> = {
+	auto_topups: "Auto Top-up",
+	spend_limits: "Spend Limit",
+	usage_limits: "Usage Limit",
+	usage_alerts: "Usage Alert",
+	overage_allowed: "Overage Allowed",
+};

--- a/vite/src/hooks/stores/useSheetStore.ts
+++ b/vite/src/hooks/stores/useSheetStore.ts
@@ -40,6 +40,7 @@ export type SheetType =
 	| "billing-usage-alert-edit"
 	| "billing-overage-allowed-add"
 	| "billing-overage-allowed-edit"
+	| "billing-control-plan-managed"
 	| "record-usage"
 	| "check-balance"
 	| "create-schedule"

--- a/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
+++ b/vite/src/views/customers2/components/CustomerBillingControlsSection.tsx
@@ -24,6 +24,7 @@ import {
 	BillingControlsList,
 	hasBillingControls,
 } from "@/components/billing-controls/BillingControlsDisplay";
+import { BILLING_CONTROL_EDIT_SHEETS } from "@/components/billing-controls/billingControlSheets";
 import { Table } from "@/components/general/table";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
@@ -241,19 +242,20 @@ export function CustomerBillingControlsSection() {
 						const planSource = planSourceFor({ key, item });
 						if (planSource) {
 							setSheet({
-								type: "subscription-detail",
-								itemId: planSource.customerProductId,
+								type: "billing-control-plan-managed",
+								data: {
+									key,
+									item,
+									planName: planSource.planName,
+									customerProductId: planSource.customerProductId,
+								},
 							});
 							return;
 						}
-						const sheetType = {
-							auto_topups: "billing-auto-topup-edit",
-							spend_limits: "billing-spend-limit-edit",
-							usage_limits: "billing-usage-limit-edit",
-							usage_alerts: "billing-usage-alert-edit",
-							overage_allowed: "billing-overage-allowed-edit",
-						}[key] as Parameters<typeof setSheet>[0]["type"];
-						setSheet({ type: sheetType, data: { index, item } });
+						setSheet({
+							type: BILLING_CONTROL_EDIT_SHEETS[key],
+							data: { index, item },
+						});
 					}}
 				/>
 			)}

--- a/vite/src/views/customers2/components/sheets/BillingControlPlanManagedSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/BillingControlPlanManagedSheet.tsx
@@ -1,0 +1,108 @@
+import type {
+	BillingControlKey,
+	CustomerBillingControls,
+} from "@autumn/shared";
+import { Button } from "@autumn/ui";
+import { useMemo } from "react";
+import { BillingControlsList } from "@/components/billing-controls/BillingControlsDisplay";
+import {
+	BILLING_CONTROL_ADD_SHEETS,
+	BILLING_CONTROL_LABELS,
+} from "@/components/billing-controls/billingControlSheets";
+import {
+	LayoutGroup,
+	SheetFooter,
+	SheetHeader,
+	SheetSection,
+} from "@/components/v2/sheets/SharedSheetComponents";
+import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
+import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
+
+type BillingControlItem = NonNullable<
+	CustomerBillingControls[BillingControlKey]
+>[number];
+
+export function BillingControlPlanManagedSheet() {
+	const sheetData = useSheetStore((s) => s.data);
+	const setSheet = useSheetStore((s) => s.setSheet);
+	const closeSheet = useSheetStore((s) => s.closeSheet);
+	const { features } = useFeaturesQuery();
+
+	const controlKey = sheetData?.key as BillingControlKey | undefined;
+	const item = sheetData?.item as BillingControlItem | undefined;
+	const planName = (sheetData?.planName as string | undefined) ?? "a plan";
+	const customerProductId = sheetData?.customerProductId as string | undefined;
+
+	const featureNameById = useMemo(
+		() => new Map((features ?? []).map((f) => [f.id, f.name])),
+		[features],
+	);
+
+	const previewControls = useMemo((): CustomerBillingControls => {
+		if (!(controlKey && item)) return {};
+		return {
+			[controlKey]: [item],
+		} as CustomerBillingControls;
+	}, [controlKey, item]);
+
+	if (!(controlKey && item)) return null;
+
+	const label = BILLING_CONTROL_LABELS[controlKey];
+
+	const handleAddOverride = () => {
+		setSheet({
+			type: BILLING_CONTROL_ADD_SHEETS[controlKey],
+			data: { item },
+		});
+	};
+
+	return (
+		<LayoutGroup>
+			<div className="flex h-full flex-col overflow-y-auto">
+				<SheetHeader title={label} description={`Inherited from ${planName}`} />
+
+				<div className="px-4 pt-4">
+					<InfoBox variant="warning" classNames={{ infoBox: "w-full" }}>
+						This billing control is managed by {planName}. Add an override to
+						change it for this customer only.
+					</InfoBox>
+				</div>
+
+				<SheetSection withSeparator={false}>
+					<BillingControlsList
+						billingControls={previewControls}
+						featureNameById={featureNameById}
+						slim
+					/>
+				</SheetSection>
+
+				<SheetFooter>
+					<Button
+						variant="secondary"
+						className="w-full"
+						onClick={() => {
+							if (!customerProductId) {
+								closeSheet();
+								return;
+							}
+							setSheet({
+								type: "subscription-detail",
+								itemId: customerProductId,
+							});
+						}}
+					>
+						{customerProductId ? "View Plan" : "Cancel"}
+					</Button>
+					<Button
+						variant="primary"
+						className="w-full"
+						onClick={handleAddOverride}
+					>
+						Add Override
+					</Button>
+				</SheetFooter>
+			</div>
+		</LayoutGroup>
+	);
+}

--- a/vite/src/views/customers2/customer/CustomerSheets.tsx
+++ b/vite/src/views/customers2/customer/CustomerSheets.tsx
@@ -17,6 +17,7 @@ import { BalanceCreateSheet } from "../components/sheets/BalanceCreateSheet";
 import { BalanceDeleteSheet } from "../components/sheets/BalanceDeleteSheet";
 import { BalanceEditSheet } from "../components/sheets/BalanceEditSheet";
 import { BillingAutoTopupSheet } from "../components/sheets/BillingAutoTopupSheet";
+import { BillingControlPlanManagedSheet } from "../components/sheets/BillingControlPlanManagedSheet";
 import { BillingOverageAllowedSheet } from "../components/sheets/BillingOverageAllowedSheet";
 import { BillingSpendLimitSheet } from "../components/sheets/BillingSpendLimitSheet";
 import { BillingUsageAlertSheet } from "../components/sheets/BillingUsageAlertSheet";
@@ -109,6 +110,8 @@ export function CustomerSheets() {
 			case "billing-overage-allowed-add":
 			case "billing-overage-allowed-edit":
 				return <BillingOverageAllowedSheet />;
+			case "billing-control-plan-managed":
+				return <BillingControlPlanManagedSheet />;
 			case "record-usage":
 				return <RecordUsageSheet />;
 			case "check-balance":


### PR DESCRIPTION
## What

Clicking a billing control that's inherited from a plan used to open the subscription detail sheet — a dead end with no way to customise the control for that customer.

It now opens a small sheet that names the managing plan, shows the control read-only, and offers **Add Override**. That launches the matching billing control sheet with every field pre-populated from the plan's values, so saving creates a customer-level control that replaces the inherited row.

## Changes

- `BillingControlPlanManagedSheet.tsx` — new sheet: warning `InfoBox`, read-only control preview, `View Plan` / `Add Override` footer
- `billingControlSheets.ts` — shared key → sheet-type and key → label maps (replaces the inline map that lived in the section)
- `CustomerBillingControlsSection.tsx` — plan-sourced rows route to the new sheet instead of `subscription-detail`
- `useSheetStore.ts` / `CustomerSheets.tsx` — register `billing-control-plan-managed`

## Notes

The add-sheets already read initial state from `sheetData.item`, so pre-population needed no changes there — passing `data: { item }` without an `index` makes them append a new control rather than edit in place.

Styling follows the schedule notice in `SubscriptionCancelSheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plan-managed billing controls now open an override flow. Previously, clicking a plan-inherited control opened Subscription Detail with no path to customize; now it opens a plan-managed sheet that names the plan, shows the control read-only, and offers Add Override to create a customer-level control pre-populated from the plan.

- Centralizes control key → sheet mappings and labels in `billingControlSheets.ts`; non-plan rows use `BILLING_CONTROL_EDIT_SHEETS` in `CustomerBillingControlsSection`.
- Adds `BillingControlPlanManagedSheet` with View Plan and Add Override; Add Override launches the matching add sheet via `BILLING_CONTROL_ADD_SHEETS` with `data: { item }` (appends a new control).
- Registers `billing-control-plan-managed` in `useSheetStore` and renders it in `CustomerSheets`.
- No data or backend changes; no migration required.

<sup>Written for commit 600e610778068b71199e703faa3f93a475c0a57c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a guided override flow for customer billing controls inherited from plans.

- **[Improvements]** Adds a read-only plan-managed control sheet with clear plan context and actions to view the plan or create an override.
- **[Bug fixes]** Replaces the previous dead-end subscription-detail action with an override form pre-populated from the inherited control.
- **[Improvements]** Centralizes billing-control labels and add/edit sheet mappings and registers the new sheet in the customer sheet system.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new override path consistently using the existing billing-control add sheets and sheet-transition behavior.

Inherited controls are passed to the matching add sheet in add mode, preserving their values while appending a customer-level control, and the new sheet is fully registered in the existing sheet lifecycle.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/billing-controls/billingControlSheets.ts | Adds complete, type-checked mappings from every billing-control key to its add sheet, edit sheet, and display label. |
| vite/src/hooks/stores/useSheetStore.ts | Registers the plan-managed billing-control sheet in the shared sheet type union. |
| vite/src/views/customers2/components/CustomerBillingControlsSection.tsx | Routes inherited rows to the new managed-control flow while retaining mapped edit behavior for customer-owned rows. |
| vite/src/views/customers2/components/sheets/BillingControlPlanManagedSheet.tsx | Provides the inherited-control preview and transitions to the existing plan-detail or pre-populated add flow. |
| vite/src/views/customers2/customer/CustomerSheets.tsx | Registers and renders the new sheet within the existing customer sheet container. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Select inherited billing control] --> B[Plan-managed preview]
  B --> C[View Plan]
  C --> D[Subscription detail]
  B --> E[Add Override]
  E --> F[Matching pre-populated add sheet]
  F --> G[Save customer-level control]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(vite): add override flow for plan-m..."](https://github.com/useautumn/autumn/commit/600e610778068b71199e703faa3f93a475c0a57c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54046772)</sub>

<!-- /greptile_comment -->