### PR TITLE
Add admin-only Scraps dashboard theme

### DIFF
--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -4,6 +4,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Rubik+Glitch&family=Nabla&family=Noto+Sans+Cuneiform&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,700;1,400&display=swap");
 
 @import "tailwindcss";
 @import "tailwind-scrollbar-hide/v4";
@@ -259,6 +260,288 @@ html {
 .preset-cursed * {
 	/* biome-ignore lint/complexity/noImportantStyles: force joke font over component fonts */
 	font-family: inherit !important;
+}
+
+.preset-scraps {
+	font-family: "Courier Prime", "Courier New", monospace;
+	background-color: #33534a;
+	--background: #f7f3e7;
+	--outer-background: #33534a;
+	--foreground: #2a241c;
+	--muted-foreground: #5c5142;
+	--tertiary-foreground: #6b5f4c;
+	--subtle: #796c58;
+	--placeholder: #8a7a5e;
+	--primary: #e25336;
+	--primary-foreground: #fffdf4;
+	--hover-primary: #f2e4d3;
+	--active-primary: #ead7bd;
+	--radio-group-hover-primary: #efe1cc;
+	--interactive-secondary: #efe9d9;
+	--interactive-secondary-hover: #e8ddc8;
+	--input: #8a7a5e;
+	--input-background: #c9a66b;
+	--card: #efe9d9;
+	--card-foreground: #2a241c;
+	--popover: #f7f3e7;
+	--popover-foreground: #2a241c;
+	--secondary: #c9a66b;
+	--secondary-foreground: #2a241c;
+	--accent: #efa62e;
+	--accent-foreground: #2a241c;
+	--muted: #e5dcc9;
+	--border: #8a7a5e;
+	--border-sheet: #8a7a5e;
+	--border-table: #a59273;
+	--card-border: #8a7a5e;
+	--ring: #3e6fb0;
+	--chart-1: #e25336;
+	--chart-2: #efa62e;
+	--chart-3: #3e6fb0;
+	--chart-4: #c9a66b;
+	--chart-5: #33534a;
+	--chart-6: #b03e24;
+	--chart-7: #d8ba7a;
+	--chart-8: #507ead;
+	--chart-9: #6b5f4c;
+	--chart-10: #26211a;
+	--chart-grid-stroke: #8a7a5e66;
+	--sidebar: #33534a;
+	--sidebar-foreground: #f7f3e7;
+	--sidebar-primary: #efa62e;
+	--sidebar-primary-foreground: #26211a;
+	--sidebar-accent: #3f6258;
+	--sidebar-accent-foreground: #fffdf4;
+	--sidebar-border: #70877d;
+	--sidebar-ring: #efa62e;
+	--radius: 0.15rem;
+	letter-spacing: 0.015em;
+}
+
+.preset-scraps.dark {
+	background-color: #1b2f29;
+	--background: #26211a;
+	--outer-background: #1b2f29;
+	--foreground: #f6f1e4;
+	--muted-foreground: #d0c5ae;
+	--tertiary-foreground: #aa9d83;
+	--subtle: #9a8f78;
+	--placeholder: #8d826e;
+	--hover-primary: #3a3026;
+	--active-primary: #493a2b;
+	--radio-group-hover-primary: #3a3026;
+	--interactive-secondary: #332d25;
+	--interactive-secondary-hover: #40372c;
+	--input: #9a8f78;
+	--input-background: #332d25;
+	--card: #302a22;
+	--card-foreground: #f6f1e4;
+	--popover: #302a22;
+	--popover-foreground: #f6f1e4;
+	--secondary: #493d30;
+	--secondary-foreground: #f6f1e4;
+	--accent: #735d38;
+	--accent-foreground: #fffdf4;
+	--muted: #332d25;
+	--border: #9a8f78;
+	--border-sheet: #8c816d;
+	--border-table: #6e6454;
+	--card-border: #b8aa90;
+	--ring: #efa62e;
+	--chart-grid-stroke: #9a8f7855;
+	--sidebar: #1b2f29;
+	--sidebar-foreground: #f6f1e4;
+	--sidebar-accent: #29473f;
+	--sidebar-accent-foreground: #fffdf4;
+	--sidebar-border: #526a62;
+}
+
+.preset-scraps [class~="bg-outer-background"] {
+	background-image:
+		radial-gradient(
+			1100px 700px at 50% -10%,
+			rgb(255 255 255 / 0.055),
+			transparent 60%
+		),
+		repeating-linear-gradient(
+			0deg,
+			transparent 0 47px,
+			rgb(225 240 228 / 0.075) 47px 48px
+		),
+		repeating-linear-gradient(
+			90deg,
+			transparent 0 47px,
+			rgb(225 240 228 / 0.075) 47px 48px
+		);
+}
+
+.preset-scraps [data-main-content],
+.preset-scraps [data-slot="card"],
+.preset-scraps [data-slot="dialog-content"],
+.preset-scraps [data-slot="sheet-content"],
+.preset-scraps [data-slot="popover-content"],
+.preset-scraps [data-slot="dropdown-menu-content"],
+.preset-scraps [data-slot="select-content"],
+.preset-scraps [data-slot="tooltip-content"] {
+	background-image:
+		repeating-linear-gradient(
+			17deg,
+			transparent 0 7px,
+			rgb(38 33 26 / 0.018) 7px 8px
+		),
+		repeating-linear-gradient(
+			103deg,
+			transparent 0 11px,
+			rgb(255 253 244 / 0.1) 11px 12px
+		);
+}
+
+.preset-scraps [data-slot="card"],
+.preset-scraps [data-slot="dialog-content"],
+.preset-scraps [data-slot="popover-content"],
+.preset-scraps [data-slot="dropdown-menu-content"],
+.preset-scraps [data-slot="select-content"],
+.preset-scraps [data-slot="tooltip-content"] {
+	border-style: solid;
+	border-width: 1.5px;
+	border-radius: 0;
+	clip-path: polygon(
+		0.7% 1.8%,
+		7% 0.4%,
+		14% 1.3%,
+		23% 0.2%,
+		32% 1.5%,
+		43% 0.5%,
+		55% 1.4%,
+		65% 0.1%,
+		77% 1.2%,
+		88% 0.3%,
+		99.2% 1.5%,
+		100% 12%,
+		99.1% 25%,
+		100% 39%,
+		99.2% 55%,
+		100% 70%,
+		99.1% 86%,
+		99.4% 98.5%,
+		89% 99.4%,
+		78% 98.7%,
+		66% 100%,
+		54% 98.8%,
+		42% 99.7%,
+		31% 98.5%,
+		19% 99.8%,
+		8% 98.6%,
+		0.6% 99%,
+		1.2% 85%,
+		0.2% 69%,
+		1% 52%,
+		0.1% 36%,
+		1.1% 19%
+	);
+	filter: drop-shadow(2px 3px 2px rgb(12 22 16 / 0.24));
+}
+
+.preset-scraps [data-slot="card"] {
+	position: relative;
+	margin-top: 6px;
+}
+
+.preset-scraps [data-slot="card"]::before {
+	content: "";
+	position: absolute;
+	top: -7px;
+	left: 50%;
+	z-index: 2;
+	width: 72px;
+	height: 17px;
+	pointer-events: none;
+	background: repeating-linear-gradient(
+		90deg,
+		rgb(233 220 175 / 0.62) 0 9px,
+		rgb(220 205 157 / 0.58) 9px 10px
+	);
+	clip-path: polygon(2% 12%, 97% 0, 100% 86%, 4% 100%);
+	transform: translateX(-50%) rotate(-1.5deg);
+	mix-blend-mode: multiply;
+}
+
+.preset-scraps [data-slot="button"],
+.preset-scraps [data-slot="input"],
+.preset-scraps [data-slot="textarea"],
+.preset-scraps [data-slot="select-trigger"],
+.preset-scraps [data-slot="input-group"],
+.preset-scraps [data-slot="badge"] {
+	border-radius: 0;
+	clip-path: polygon(
+		1.5% 4%,
+		16% 0,
+		34% 3%,
+		52% 0,
+		73% 3%,
+		98.5% 1%,
+		100% 30%,
+		98.8% 68%,
+		100% 97%,
+		76% 100%,
+		55% 97%,
+		31% 100%,
+		1% 97%,
+		0 65%
+	);
+	filter: drop-shadow(1px 2px 1px rgb(12 22 16 / 0.2));
+}
+
+.preset-scraps [data-slot="button"]:hover {
+	filter: drop-shadow(2px 4px 2px rgb(12 22 16 / 0.3));
+}
+
+.preset-scraps [data-slot="button"]:active {
+	filter: drop-shadow(0.5px 1px 0.5px rgb(12 22 16 / 0.22));
+}
+
+.preset-scraps [data-slot="input"],
+.preset-scraps [data-slot="textarea"],
+.preset-scraps [data-slot="select-trigger"],
+.preset-scraps [data-slot="input-group"] {
+	background-image: repeating-linear-gradient(
+		103deg,
+		transparent 0 9px,
+		rgb(38 33 26 / 0.035) 9px 10px
+	);
+}
+
+.preset-scraps [data-slot="checkbox"],
+.preset-scraps [data-slot="switch"],
+.preset-scraps [data-slot="switch-thumb"] {
+	border-radius: 1px;
+	transform: rotate(-1deg);
+}
+
+.preset-scraps [data-slot="separator-root"],
+.preset-scraps [data-slot="dropdown-menu-separator"],
+.preset-scraps [data-slot="select-separator"],
+.preset-scraps [data-slot="command-separator"] {
+	border-top: 2px dashed currentColor;
+	background: transparent;
+	opacity: 0.35;
+}
+
+.preset-scraps [data-slot="table-row"] {
+	border-bottom-style: dashed;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.preset-scraps [data-slot="card"],
+	.preset-scraps [data-slot="button"] {
+		transition:
+			filter 120ms ease,
+			transform 120ms ease;
+	}
+
+	.preset-scraps [data-slot="card"]:hover {
+		transform: rotate(-0.12deg);
+	}
 }
 
 @theme inline {

--- a/vite/src/contexts/ThemeProvider.tsx
+++ b/vite/src/contexts/ThemeProvider.tsx
@@ -3,7 +3,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 
 type ThemeMode = "light" | "dark" | "system";
-export type ThemePreset = "modern" | "classic" | "cursed";
+export type ThemePreset = "modern" | "classic" | "cursed" | "scraps";
 
 interface ThemeContextType {
 	mode: ThemeMode;
@@ -45,7 +45,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
 	useEffect(() => {
 		const root = document.documentElement;
-		root.classList.remove("preset-classic", "preset-modern", "preset-cursed");
+		root.classList.remove(
+			"preset-classic",
+			"preset-modern",
+			"preset-cursed",
+			"preset-scraps",
+		);
 		root.classList.add(`preset-${preset}`);
 	}, [preset]);
 

--- a/vite/src/views/settings/sections/AppearanceSection.tsx
+++ b/vite/src/views/settings/sections/AppearanceSection.tsx
@@ -5,7 +5,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@autumn/ui";
-import { Leaf, Monitor, Moon, Skull, Sun } from "lucide-react";
+import { Leaf, Monitor, Moon, Scissors, Skull, Sun } from "lucide-react";
 import { useTheme } from "@/contexts/ThemeProvider";
 import { cn } from "@/lib/utils";
 import { useAdmin } from "@/views/admin/hooks/useAdmin";
@@ -111,6 +111,28 @@ const PRESET_OPTIONS = [
 			dot: "bg-[#00ff88]",
 		},
 	},
+	{
+		id: "scraps",
+		label: "Scraps",
+		description: "Cut, torn, taped, and slightly crooked",
+		icon: <Scissors className="size-5 text-muted-foreground" />,
+		light: {
+			bg: "bg-[#f7f3e7]",
+			sidebar: "bg-[#33534a]",
+			card: "bg-[#c9a66b]",
+			line: "bg-[#e25336]",
+			header: "bg-[#efe9d9]",
+			dot: "bg-[#efa62e]",
+		},
+		dark: {
+			bg: "bg-[#26211a]",
+			sidebar: "bg-[#1b2f29]",
+			card: "bg-[#332d25]",
+			line: "bg-[#c9a66b]",
+			header: "bg-[#302a22]",
+			dot: "bg-[#e25336]",
+		},
+	},
 ] as const;
 
 const tc = "transition-colors duration-200";
@@ -173,7 +195,7 @@ export const AppearanceSection = () => {
 	const { mode, setMode, preset, setPreset, isDark } = useTheme();
 	const { isAdmin } = useAdmin();
 	const presetOptions = PRESET_OPTIONS.filter(
-		(p) => p.id !== "cursed" || isAdmin,
+		(p) => !["cursed", "scraps"].includes(p.id) || isAdmin,
 	);
 
 	return (
@@ -234,7 +256,7 @@ export const AppearanceSection = () => {
 									onClick={() => setPreset(option.id)}
 									className={cn(
 										"flex flex-col gap-2.5 rounded-lg border p-2.5 transition-all duration-200 cursor-pointer text-left",
-										option.id === "cursed" && "col-span-2",
+										["cursed", "scraps"].includes(option.id) && "col-span-2",
 										isActive
 											? "border-primary ring-2 ring-primary/20 ring-offset-1 ring-offset-background"
 											: "border-border hover:border-muted-foreground/30",


### PR DESCRIPTION
Adds a Scraps preset to the dashboard appearance controls for admins, alongside the existing Cursed preset.

The preset ports the paper-cut visual language from scraps.ogme01.com through theme CSS: Courier typography, cutting-mat grids, paper grain, torn edges, tape, rough controls, and a matching color system. It supports both light and dark modes without replacing existing UI primitives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin-only “Scraps” dashboard theme. Previously presets were Modern/Classic and the admin-only Cursed; now admins can also choose Scraps, which applies a paper‑cut look in light and dark without changing UI primitives.

- Adds a new `scraps` preset to theme state and applies `preset-scraps` on the root element.
- Appearance settings show Scraps only for admins; both Scraps and Cursed tiles span two columns.
- Implements `.preset-scraps` variables and component styles in CSS (background textures, torn edges, tape, shadows); imports the Courier Prime webfont.
- No migrations. Non-admins are unaffected. Gating is in the settings UI only; a stored `preset` value will still apply if present.

<sup>Written for commit d55e2bb89083ef61268f198d5be42b6ad8d834a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an admin-facing Scraps dashboard preset with coordinated light and dark paper-cut styling.
- **Improvements:** Adds Scraps to the appearance controls with a dedicated preview, icon, and admin-only option visibility.
- **Improvements:** Adds Courier typography, paper textures, torn edges, tape effects, rough controls, and matching light/dark color variables.
- **Improvements:** Extends theme state and root-class management to recognize the new preset.
</details>

<h3>Confidence Score: 3/5</h3>

The PR should be fixed before merging because non-admin sessions can retain the admin-only theme and key Scraps decorations are clipped away.

Preset access is checked only in the settings UI rather than where persisted state is applied, and the new polygon clipping removes the card tape and tooltip arrows that extend beyond their containers.

**Files Needing Attention:** vite/src/views/settings/sections/AppearanceSection.tsx, vite/src/contexts/ThemeProvider.tsx, packages/ui/src/styles/index.css

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/styles/index.css | Adds the complete Scraps visual system, but its container clip paths hide decorations positioned outside cards and tooltips. |
| vite/src/contexts/ThemeProvider.tsx | Registers and applies the Scraps preset, but applies persisted presets without enforcing current admin status. |
| vite/src/views/settings/sections/AppearanceSection.tsx | Adds the Scraps preview and hides it from non-admins, but visibility filtering alone does not prevent a persisted selection from remaining active. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/settings/sections/AppearanceSection.tsx:197-199
**Admin-only preset remains active**

When an admin selects Scraps and then stops impersonating, loses admin access, or signs out before another user uses the same browser, the preset remains in shared localStorage and `ThemeProvider` applies it without an admin check, causing a non-admin to retain the restricted theme while its option is hidden.

### Issue 2
packages/ui/src/styles/index.css:408-441
**Clip path hides decorations**

When Scraps renders a card or tooltip, this `clip-path` also clips pseudo-elements positioned outside the container, causing the card tape at `top: -7px` and tooltip arrows with negative offsets to disappear.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add admin-only Scraps dashboard th..."](https://github.com/useautumn/autumn/commit/d55e2bb89083ef61268f198d5be42b6ad8d834a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54069272)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->