### PR TITLE
Inject org rules into the system prompt

### DIFF
--- a/apps/leaf/agent/channels/eve.ts
+++ b/apps/leaf/agent/channels/eve.ts
@@ -32,6 +32,13 @@ const leafInternalAuth = (): AuthFn<Request> => async (request) => {
 	if (chatInstallationId) attributes.chatInstallationId = chatInstallationId;
 	const autumnUserId = request.headers.get("x-leaf-autumn-user-id");
 	if (autumnUserId) attributes.autumnUserId = autumnUserId;
+	const encodedInstructions = request.headers.get("x-leaf-org-instructions");
+	if (encodedInstructions) {
+		attributes.orgInstructions = Buffer.from(
+			encodedInstructions,
+			"base64url",
+		).toString("utf8");
+	}
 
 	return {
 		attributes,

--- a/apps/leaf/agent/instructions/org.ts
+++ b/apps/leaf/agent/instructions/org.ts
@@ -1,0 +1,14 @@
+import { defineDynamic, defineInstructions } from "eve/instructions";
+
+export default defineDynamic({
+	events: {
+		"session.started": (_event, ctx) => {
+			const instructions = ctx.session.auth.current?.attributes.orgInstructions;
+			if (typeof instructions !== "string" || !instructions.trim()) return null;
+
+			return defineInstructions({
+				markdown: `## Custom organization instructions\n\nThe following instructions were configured for this organization:\n\n${instructions}`,
+			});
+		},
+	},
+});

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -56,7 +56,7 @@ export const runAgentTurn = async ({
 			context: ctx,
 		});
 		const session = await startAgentTurn({
-			auth,
+			auth: { ...auth, orgInstructions: orgContext?.instructions },
 			env,
 			message: buildAgentTurnMessage({
 				env,

--- a/apps/leaf/src/internal/agentRuntime/eve/client.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/client.ts
@@ -23,6 +23,12 @@ const eveHeaders = (auth: EveAuthContext, init?: HeadersInit) => {
 	if (auth.autumnUserId) {
 		headers.set("x-leaf-autumn-user-id", auth.autumnUserId);
 	}
+	if (auth.orgInstructions) {
+		headers.set(
+			"x-leaf-org-instructions",
+			Buffer.from(auth.orgInstructions).toString("base64url"),
+		);
+	}
 	return headers;
 };
 

--- a/apps/leaf/src/internal/agentRuntime/eve/types.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/types.ts
@@ -29,6 +29,7 @@ export type EveAuthContext = {
 	channelId: string;
 	chatInstallationId?: string;
 	orgId: string;
+	orgInstructions?: string;
 	provider: string;
 	providerUserId: string;
 	threadId: string;

--- a/apps/leaf/src/internal/autumnMcp/orgContextService.ts
+++ b/apps/leaf/src/internal/autumnMcp/orgContextService.ts
@@ -3,6 +3,7 @@ import type { AppEnv } from "@autumn/shared";
 import { executeAutumnMcpTool } from "./client.js";
 
 export type AutumnOrgContext = {
+	instructions?: string;
 	text: string;
 };
 
@@ -10,6 +11,18 @@ type ExecuteAutumnTool = typeof executeAutumnMcpTool;
 
 const toJsonBlock = ({ label, value }: { label: string; value: unknown }) =>
 	`${label}:\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+
+const withoutNotes = (value: unknown) => {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+	const { notes: _notes, ...rest } = value as Record<string, unknown>;
+	return rest;
+};
+
+const getNotes = (value: unknown) => {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return;
+	const notes = (value as Record<string, unknown>).notes;
+	return typeof notes === "string" && notes.trim() ? notes.trim() : undefined;
+};
 
 export const formatAutumnOrgContext = ({
 	agentRules,
@@ -22,7 +35,9 @@ export const formatAutumnOrgContext = ({
 }) => {
 	const sections: string[] = [];
 	if (agentRules !== undefined) {
-		sections.push(toJsonBlock({ label: "getAgentRules", value: agentRules }));
+		sections.push(
+			toJsonBlock({ label: "getAgentRules", value: withoutNotes(agentRules) }),
+		);
 	}
 	if (plans !== undefined) {
 		sections.push(toJsonBlock({ label: "listPlans", value: plans }));
@@ -92,7 +107,11 @@ export const loadAutumnOrgContext = async ({
 		plans: plansResult.status === "fulfilled" ? plansResult.value : undefined,
 	});
 
-	return text ? { text } : undefined;
+	const instructions =
+		agentRulesResult.status === "fulfilled"
+			? getNotes(agentRulesResult.value)
+			: undefined;
+	return text || instructions ? { instructions, text } : undefined;
 };
 
 export const autumnOrgContextService = {

--- a/apps/leaf/tests/unit/internal/autumnMcp/orgContextService.test.ts
+++ b/apps/leaf/tests/unit/internal/autumnMcp/orgContextService.test.ts
@@ -26,7 +26,10 @@ const createLogger = () => {
 describe("Autumn org context service", () => {
 	test("formats preloaded tool results as raw JSON blocks", () => {
 		const text = formatAutumnOrgContext({
-			agentRules: { entityRules: "workspace scoped" },
+			agentRules: {
+				entityRules: "workspace scoped",
+				notes: "Always use invoice mode.",
+			},
 			features: {
 				features: [
 					{
@@ -54,9 +57,26 @@ describe("Autumn org context service", () => {
 		expect(text).toContain("listFeatures:");
 		expect(text).toContain("```json");
 		expect(text).toContain("workspace scoped");
+		expect(text).not.toContain("Always use invoice mode.");
 		expect(text).toContain('"rollover": true');
 		expect(text).toContain('"id": "enterprise"');
 		expect(text).toContain('"type": "boolean"');
+	});
+
+	test("separates custom instructions from preloaded context", async () => {
+		const { logger } = createLogger();
+		const context = await loadAutumnOrgContext({
+			env: AppEnv.Sandbox,
+			executeTool: (async ({ toolName }: { toolName: string }) =>
+				toolName === "getAgentRules"
+					? { entity_rules: {}, notes: "Always use invoice mode." }
+					: []) as never,
+			logger: logger as never,
+			token: "test",
+		});
+
+		expect(context?.instructions).toBe("Always use invoice mode.");
+		expect(context?.text).not.toContain("Always use invoice mode.");
 	});
 
 	test("preloads rules, plans, and features in parallel and keeps partial context", async () => {


### PR DESCRIPTION
## Summary

- inject preloaded org notes as dynamic Eve system instructions
- keep custom instructions out of user-role org context
- reuse the existing session preload, with no model tool call

## Verification

- `bun --filter @autumn/leaf ts`
- focused Leaf unit tests: 7 passed
- `bunx eve build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects organization “notes” from `getAgentRules` as Eve system instructions instead of user-role org context. Previously notes were embedded in the preloaded org context; now they are sent via auth and injected on session start, so the system prompt reflects org rules while the user context stays clean. No change when notes are empty.

- Splits `notes` from `getAgentRules` in `orgContextService`; `formatAutumnOrgContext` omits them and `loadAutumnOrgContext` returns `instructions` separately.
- Extends `EveAuthContext` with optional `orgInstructions`; `eve/client` encodes them into the `x-leaf-org-instructions` header (base64url), and the Eve channel decodes into auth attributes.
- Adds dynamic instructions (`agent/instructions/org.ts`) to inject on `session.started`; reuses session preload, no model tool call.
- `runAgentTurn` forwards preloaded org instructions; tests verify notes are excluded from context and included as system instructions.

<sup>Written for commit a87d3a3d4e3fefaf96afb8812f0826b2ff5de0b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR separates organization notes from user-role context and injects them as Eve system instructions when a session starts.

- **Improvements:** Extracts custom organization notes from the preloaded rules response while retaining the remaining rules, plans, and features as ordinary context.
- **Improvements:** Passes the extracted notes through Eve authentication attributes and registers them as dynamic session instructions.
- **Improvements:** Adds focused coverage for separating notes from the organization context.
</details>

<h3>Confidence Score: 4/5</h3>

The unrestricted organization-instructions header can make valid agent sessions fail and should be replaced with a size-safe transport before merging.

Organization notes have no length limit, but the full base64-expanded value is now sent in one HTTP header, allowing sufficiently long valid notes to cause Eve to reject session creation.

**Files Needing Attention:** apps/leaf/src/internal/agentRuntime/eve/client.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/eve/client.ts | Adds organization instructions to an internal HTTP header, but unrestricted notes can exceed header limits and prevent session creation. |
| apps/leaf/agent/channels/eve.ts | Decodes the authenticated internal instruction header into Eve session attributes. |
| apps/leaf/agent/instructions/org.ts | Registers non-empty organization notes as dynamic instructions when a session starts. |
| apps/leaf/src/internal/autumnMcp/orgContextService.ts | Correctly extracts the documented top-level notes string and removes it from ordinary organization context. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts | Supplies preloaded organization instructions when creating the Eve session. |
| apps/leaf/tests/unit/internal/autumnMcp/orgContextService.test.ts | Verifies that notes are returned separately and excluded from user-role context. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Leaf as Leaf agent runtime
  participant MCP as Autumn MCP
  participant Eve as Eve server
  participant Model as Agent model
  Leaf->>MCP: Preload rules, plans, and features
  MCP-->>Leaf: Rules including organization notes
  Leaf->>Leaf: Separate notes from user-role context
  Leaf->>Eve: Create session with notes in auth header
  Eve->>Eve: Decode notes into auth attributes
  Eve->>Model: Install organization system instructions
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/agentRuntime/eve/client.ts:26-30
**Unbounded instructions exceed header limits**

When an organization saves sufficiently long custom instructions, this code base64url-encodes the unrestricted value into one HTTP header, causing Eve to reject the session request before the agent runs. For example, saving a long operating guide can make every new chat fail instead of applying the guide.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 inject org rules into system pr..."](https://github.com/useautumn/autumn/commit/a87d3a3d4e3fefaf96afb8812f0826b2ff5de0b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54082071)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Leaf: Autumn's AI Agent Service](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/leaf-agent-app.md)

<!-- /greptile_comment -->