### PR TITLE
ci: run vite build with bun

### DIFF
--- a/.github/workflows/vite-build.yml
+++ b/.github/workflows/vite-build.yml
@@ -50,4 +50,4 @@ jobs:
         run: cd vite && bunx tsc --noEmit
 
       - name: Build Vite
-        run: cd vite && bunx vite build
+        run: cd vite && bunx --bun vite build


### PR DESCRIPTION
## Summary

- run the Vite CI build with Bun so TypeScript workspace config imports load correctly
- align the workflow with the existing `build:bun` script

## Verification

- `CI=1 bunx --bun vite build`
- `bunx tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Vite build step in CI with Bun to match the local `build:bun` script and fix TypeScript workspace config import resolution. Previously CI used `bunx vite build` (Node runner); now it uses `bunx --bun vite build`.

- Scope: CI only; updates `.github/workflows/vite-build.yml` build step.
- Keeps `bunx tsc --noEmit` unchanged.
- No app behavior change; resolves workspace import failures seen in CI.

<sup>Written for commit d61633f05005565161ae3e864dd8013621f6aa3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the Vite CI workflow with the repository’s existing Bun-based build path.
- **[Bug fixes]** Runs Vite through Bun so TypeScript workspace configuration imports load under the intended runtime.
- **[Improvements]** Makes the CI build command consistent with the existing `build:bun` script.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The workflow now uses the repository’s established Bun-powered Vite build command, while retaining the separate TypeScript check and the existing pinned Bun CI environment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/vite-build.yml | Changes the Vite build step to use Bun explicitly, matching the existing application build command without introducing an actionable issue. |

<sub>Reviews (1): Last reviewed commit: ["ci: 🎡 run vite build with bun"](https://github.com/useautumn/autumn/commit/d61633f05005565161ae3e864dd8013621f6aa3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54311488)</sub>

<!-- /greptile_comment -->