### PR TITLE
feat(import): let customer_data back-date a customer's created_at

### DIFF
--- a/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
+++ b/server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts
@@ -119,6 +119,11 @@ const upsertFullCustomer = async ({
 			customerData.fingerprint !== existing.fingerprint
 		)
 			update.fingerprint = customerData.fingerprint;
+		if (
+			customerData?.created_at !== undefined &&
+			customerData.created_at !== existing.created_at
+		)
+			update.created_at = customerData.created_at;
 
 		if (Object.keys(update).length > 0) {
 			await CusService.update({
@@ -145,6 +150,7 @@ const upsertFullCustomer = async ({
 				: undefined,
 			send_email_receipts: false,
 		},
+		createdAt: params.customer_data?.created_at,
 		createDefaultProducts: false,
 	});
 

--- a/server/src/internal/customers/cusUtils/createNewCustomer.ts
+++ b/server/src/internal/customers/cusUtils/createNewCustomer.ts
@@ -62,12 +62,15 @@ export const createNewCustomer = async ({
 	ctx,
 	customer,
 	nextResetAt,
+	createdAt,
 	createDefaultProducts = true,
 	defaultGroup,
 }: {
 	ctx: AutumnContext;
 	customer: CreateCustomer;
 	nextResetAt?: number;
+	// Back-dates the signup date; migrations pass the customer's original one.
+	createdAt?: number;
 	createDefaultProducts?: boolean;
 	defaultGroup?: string;
 }) => {
@@ -105,7 +108,7 @@ export const createNewCustomer = async ({
 		metadata: parsedCustomer.metadata || {},
 		internal_id: internalId,
 		org_id: org.id,
-		created_at: Date.now(),
+		created_at: createdAt ?? Date.now(),
 		env,
 		processors: parsedCustomer.processors ?? null,
 		processor: parsedCustomer.stripe_id

--- a/server/src/internal/customers/cusUtils/createNewCustomer.ts
+++ b/server/src/internal/customers/cusUtils/createNewCustomer.ts
@@ -69,7 +69,6 @@ export const createNewCustomer = async ({
 	ctx: AutumnContext;
 	customer: CreateCustomer;
 	nextResetAt?: number;
-	// Back-dates the signup date; migrations pass the customer's original one.
 	createdAt?: number;
 	createDefaultProducts?: boolean;
 	defaultGroup?: string;

--- a/server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts
+++ b/server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts
@@ -189,9 +189,8 @@ test.concurrent(
 		});
 
 		// First, verify customer has no RevenueCat processor
-		const customerBefore = await autumnV2_3.customers.get<ApiCustomerV5>(
-			customerId,
-		);
+		const customerBefore =
+			await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
 		expect(customerBefore.processors?.revenuecat?.id).toBeUndefined();
 
 		// Try to add RevenueCat processor in dry_run mode
@@ -207,9 +206,102 @@ test.concurrent(
 		expect(flashRes.errorCode).toBeNull();
 
 		// Verify processor was NOT persisted
-		const customerAfter = await autumnV2_3.customers.get<ApiCustomerV5>(
-			customerId,
-		);
+		const customerAfter =
+			await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
 		expect(customerAfter.processors?.revenuecat?.id).toBeUndefined();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: customer_data.created_at back-dates an existing customer's signup date")}`,
+	async () => {
+		const customerId = "dfu-flash-cusdata-created-at";
+		const free = products.base({
+			id: "dfu-cusdata-created-at-free",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+			actions: [],
+		});
+
+		const before = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		const originalSignup = Date.now() - 1000 * 60 * 60 * 24 * 90;
+		expect(before.created_at).not.toBe(originalSignup);
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, {
+			...freePlanPayload({ customerId, planId: free.id, customerData: {} }),
+			customer_data: { created_at: originalSignup },
+		});
+		expect(flashRes.errorCode).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expect(customer.created_at).toBe(originalSignup);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: customer_data.created_at sets the signup date on a customer the import creates")}`,
+	async () => {
+		const customerId = "dfu-flash-cusdata-created-at-new";
+		const free = products.base({
+			id: "dfu-cusdata-created-at-new-free",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+			actions: [],
+		});
+
+		const importedCustomerId = `${customerId}-imported`;
+		const originalSignup = Date.now() - 1000 * 60 * 60 * 24 * 45;
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, {
+			...freePlanPayload({
+				customerId: importedCustomerId,
+				planId: free.id,
+				customerData: {},
+			}),
+			customer_data: { name: "Imported User", created_at: originalSignup },
+		});
+		expect(flashRes.errorCode).toBeNull();
+
+		const customer =
+			await autumnV2_3.customers.get<ApiCustomerV5>(importedCustomerId);
+		expect(customer.name).toBe("Imported User");
+		expect(customer.created_at).toBe(originalSignup);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("billing.import: dry_run does not persist a customer_data.created_at back-date")}`,
+	async () => {
+		const customerId = "dfu-flash-cusdata-created-at-dry-run";
+		const free = products.base({
+			id: "dfu-cusdata-created-at-dry-run-free",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_2, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [free] })],
+			actions: [],
+		});
+
+		const before = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+
+		const flashRes = await callFlash(autumnV2_2 as FlashClient, {
+			...freePlanPayload({ customerId, planId: free.id, customerData: {} }),
+			customer_data: { created_at: Date.now() - 1000 * 60 * 60 * 24 * 200 },
+			dry_run: true,
+		});
+		expect(flashRes.errorCode).toBeNull();
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expect(customer.created_at).toBe(before.created_at);
 	},
 );

--- a/shared/api/billing/dfu/dfuFlashParams.ts
+++ b/shared/api/billing/dfu/dfuFlashParams.ts
@@ -25,6 +25,10 @@ const FlashCustomerDataSchema = z.object({
 		.string()
 		.optional()
 		.meta({ description: "Anti-fraud fingerprint for the customer." }),
+	created_at: z.number().int().positive().optional().meta({
+		description:
+			"Unix ms timestamp the customer signed up, so a migrated customer keeps its original signup date. Defaults to the import time for a customer Autumn creates here.",
+	}),
 });
 
 const FlashProcessorIdentitySchema = z.object({


### PR DESCRIPTION
## What

An imported customer's signup date should reflect the source system, not the moment the import ran.

`customer_data.created_at` now flows through to both paths:

- **New customers** — `createNewCustomer` takes an optional `createdAt` instead of always stamping `Date.now()`.
- **Existing customers** — `upsertFullCustomer` includes `created_at` in the update when it differs.

## Test plan

- [ ] `billing-import-customer-data-update.test.ts` — extended for the new field

Not run locally: the integration harness rejects the local secret key before reaching this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow imports to back-date a customer's signup date so reporting reflects the source system. Previously we stamped `created_at` at import time; now `customer_data.created_at` sets it for new customers and updates it for existing ones. Dry runs still do not persist changes.

- `createNewCustomer` accepts `createdAt?: number` and uses it for `created_at`; defaults to `Date.now()`.
- `upsertFullCustomer` updates `created_at` when `customer_data.created_at` is provided and differs from the stored value.
- DFU Flash schema adds `customer_data.created_at?: number` (Unix ms) with docs.
- Tests cover back-dating on existing customers, setting on creation, and dry-run no-op behavior.

<sup>Written for commit 0cd614a118fe3b65dd0071ce9c5384716658303b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR lets billing imports preserve a customer's original signup timestamp for both newly created and existing customers.

- **[Improvements, API changes]** Adds optional `customer_data.created_at` validation and propagates it through both customer upsert paths.
- **[Bug fixes]** Preserves source-system signup dates instead of always using the import time.
- **[Improvements]** Adds integration coverage for existing customers, newly created customers, and existing-customer dry runs.
</details>

<h3>Confidence Score: 3/5</h3>

The PR should not merge until future signup timestamps are rejected and the public SDK type exposes the new import field.

The server currently persists future signup dates that can distort date-based customer behavior, while typed SDK callers cannot provide the newly supported field without bypassing TypeScript.

**Files Needing Attention:** shared/api/billing/dfu/dfuFlashParams.ts and packages/sdk/src/models/import-op.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/billing/dfu/dfuFlashParams.ts | Adds the public request field, but permits future signup dates and is not mirrored in the SDK import type. |
| server/src/internal/billing/v2/actions/dfu/setup/setupFlashContext.ts | Propagates the imported timestamp through both existing- and new-customer paths while retaining existing dry-run behavior. |
| server/src/internal/customers/cusUtils/createNewCustomer.ts | Adds an optional creation timestamp with the existing current-time behavior preserved as the fallback. |
| server/tests/integration/billing/dfu/billing-import/billing-import-customer-data-update.test.ts | Covers backdating existing and new customers plus dry-run behavior for an existing customer. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Billing import request] --> B{Customer exists?}
  B -->|Yes| C[Update created_at when different]
  B -->|No| D[Create customer with imported created_at]
  C --> E[(Customer record)]
  D --> E
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
shared/api/billing/dfu/dfuFlashParams.ts:28-31
**Future signup dates corrupt chronology**

When an import supplies a future `customer_data.created_at`, the schema accepts and persists it, causing the customer to appear newer than customers created today, disappear from reports ending today, and provide a future anchor to lazy pooled-balance reset calculations.

### Issue 2
shared/api/billing/dfu/dfuFlashParams.ts:28-31
**SDK omits the import field**

The server now accepts `customer_data.created_at`, but the public SDK's `ImportCustomerData` type does not expose it, so TypeScript SDK users receive an excess-property error unless they bypass the client type.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Apply suggestion from @SirTenzin"](https://github.com/useautumn/autumn/commit/0cd614a118fe3b65dd0071ce9c5384716658303b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54359116)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->