### PR TITLE
Fix pooled migration duplicate customer products

### DIFF
--- a/apps/checkout/vite.config.ts
+++ b/apps/checkout/vite.config.ts
@@ -1,10 +1,10 @@
 import { createRequire } from "node:module";
 import path from "node:path";
-import { viteHmrClient } from "@autumn/env/viteDev";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { viteHmrClient } from "../../packages/env/src/viteDev.js";
 
 const require = createRequire(import.meta.url);
 const vitePort = Number.parseInt(process.env.VITE_PORT || "3001", 10);

--- a/server/src/internal/migrations/v2/operations/updatePlan/processUpdatePlan.ts
+++ b/server/src/internal/migrations/v2/operations/updatePlan/processUpdatePlan.ts
@@ -5,6 +5,7 @@ import type {
 import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
 import { computeUpdateSubscriptionPlan } from "@/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.js";
 import { logUpdateSubscriptionContext } from "@/internal/billing/v2/actions/updateSubscription/logs/logUpdateSubscriptionContext.js";
+import { applyAutumnBillingPlanToFullCustomer } from "@/internal/billing/v2/utils/autumnBillingPlanToFinalFullCustomer.js";
 import { logAutumnBillingPlan } from "@/internal/billing/v2/utils/logs/logAutumnBillingPlan.js";
 import { MigrationOperationError } from "../errors/index.js";
 import type { OperationProcessor } from "../types/index.js";
@@ -59,6 +60,7 @@ export const processUpdatePlan = async ({
 		});
 
 	let nextPlan = plan;
+	let nextProjectedFullCustomer = projectedFullCustomer;
 	const billingContexts: UpdateSubscriptionBillingContext[] = [];
 	let matchedCustomerProductCount = matchedCustomerProducts.length;
 
@@ -68,7 +70,7 @@ export const processUpdatePlan = async ({
 			context,
 			op,
 			opIndex,
-			projectedFullCustomer,
+			projectedFullCustomer: nextProjectedFullCustomer,
 			customerProduct,
 		});
 		if (!productContext) {
@@ -117,12 +119,16 @@ export const processUpdatePlan = async ({
 			base: nextPlan,
 			incoming: executablePlan,
 		});
+		nextProjectedFullCustomer = applyAutumnBillingPlanToFullCustomer({
+			fullCustomer: context.fullCustomer,
+			autumnBillingPlan: nextPlan,
+		});
 		billingContexts.push(productContext.billingContext);
 	}
 
 	return {
 		plan: nextPlan,
-		projectedFullCustomer,
+		projectedFullCustomer: nextProjectedFullCustomer,
 		matchedCustomerProducts: matchedCustomerProductCount,
 		billingContexts,
 	};

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/versioning/update-plan-op-version.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/versioning/update-plan-op-version.test.ts
@@ -1,16 +1,18 @@
-/**
- * TDD coverage for update_plan version migrations.
- *
- * Contract under test:
- *   - update_plan can migrate matched customer products to a target plan version.
- *   - Usage/quantity state carries across the version update.
- *   - Migration execution does not create extra invoices.
- */
+/** Pre-fix, multi-entity pooled versioning inserts duplicate pools and leaves duplicate active plans.
+ * Post-fix, planning converges on one shared pool before execution. */
 
 import { test } from "bun:test";
-import type { ApiCustomerV3, ApiCustomerV5 } from "@autumn/shared";
+import {
+	type ApiCustomerV3,
+	type ApiCustomerV5,
+	CusProductStatus,
+	EntInterval,
+	PooledBalanceResetMode,
+} from "@autumn/shared";
+import { expectPooledBalanceCorrect } from "@tests/integration/billing/pooled-balances/utils/expectPooledBalanceCorrect";
 import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
 import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectCustomerProductStatuses } from "@tests/integration/billing/utils/expectCustomerProductStatuses";
 import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
 import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
@@ -210,3 +212,92 @@ test.concurrent(`${chalk.yellowBright("migrations update_plan: prepaid version u
 	});
 	await expectStripeSubscriptionCorrect({ ctx, customerId });
 });
+
+test.concurrent(
+	`${chalk.yellowBright("migrations update_plan: pooled version update coalesces entity products")}`,
+	async () => {
+		const customerId = "migration-update-pooled-entities";
+		const grant = 100;
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: grant })],
+		});
+
+		const { autumnV1, autumnV2_3, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer(),
+				s.entities({ count: 2, featureId: TestFeature.Users }),
+				s.products({ list: [free] }),
+			],
+			actions: [
+				s.billing.attach({ productId: free.id, entityIndex: 0 }),
+				s.billing.attach({ productId: free.id, entityIndex: 1 }),
+			],
+		});
+
+		await autumnV1.products.update(free.id, {
+			items: [
+				{
+					...items.monthlyMessages({ includedUsage: grant }),
+					pooled: true,
+				},
+			],
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: free.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: free.id },
+						version: 2,
+					},
+				],
+			},
+			runOnServer: false,
+		});
+
+		for (const entity of entities) {
+			await expectCustomerProductStatuses({
+				ctx,
+				customerId,
+				productId: free.id,
+				entityId: entity.id,
+				expected: {
+					[CusProductStatus.Active]: 1,
+					[CusProductStatus.Expired]: 1,
+				},
+			});
+		}
+		await expectPooledBalanceCorrect({
+			db: ctx.db,
+			customerId,
+			pool: {
+				balance: grant * entities.length,
+				adjustment: 0,
+				granted: grant * entities.length,
+				interval: EntInterval.Month,
+				nextResetAt: "present",
+				resetCycleAnchor: "present",
+				resetMode: PooledBalanceResetMode.Lazy,
+				stripeSubscriptionId: null,
+			},
+			contributions: {
+				count: entities.length,
+				currentContribution: grant,
+				nextCycleContribution: grant,
+			},
+			sources: {
+				count: entities.length,
+				balance: 0,
+				adjustment: 0,
+			},
+		});
+	},
+);

--- a/server/tests/unit/migrations-v2/process-update-plan.test.ts
+++ b/server/tests/unit/migrations-v2/process-update-plan.test.ts
@@ -1,0 +1,151 @@
+/** Pre-fix, each matched product computes from the same stale pool state and inserts another pool.
+ * Post-fix, every product computes from the projection produced by the previous product. */
+
+import { beforeEach, expect, test } from "bun:test";
+import type {
+	AutumnBillingPlan,
+	FullCusProduct,
+	FullCustomer,
+	FullCustomerEntitlement,
+	UpdateSubscriptionBillingContext,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { MigrateCustomerContext } from "@/internal/migrations/v2/operations/types/index.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const state = {
+	computeCount: 0,
+	projectedCustomers: [] as FullCustomer[],
+};
+
+const emptyPlan = (): AutumnBillingPlan => ({
+	customerId: "customer",
+	insertCustomerProducts: [],
+});
+
+const insertedPoolPlan = ({ id }: { id: string }): AutumnBillingPlan => {
+	const pooledCustomerEntitlement = {
+		id,
+		pooled_balance: { id },
+	} as FullCustomerEntitlement;
+
+	return {
+		...emptyPlan(),
+		pooledBalancePlan: {
+			insertPoolBalances: [pooledCustomerEntitlement],
+			updatePoolBalances: [],
+			expirePoolBalanceCandidates: [],
+			insertPoolRollovers: [],
+			insertPoolContributions: [],
+			updatePoolContributions: [],
+			deletePoolContributions: [],
+		},
+	};
+};
+
+await mockModuleWithRestore(
+	"@/internal/migrations/v2/operations/utils/index.js",
+	() => ({
+		appendMigrationBillingLog: () => undefined,
+		filterCustomerProductsByPlanFilter: ({
+			customerProducts,
+		}: {
+			customerProducts: FullCusProduct[];
+		}) => ({ customerProducts }),
+	}),
+);
+
+await mockModuleWithRestore(
+	"@/internal/migrations/v2/operations/updatePlan/setup/index.js",
+	() => ({
+		setupUpdatePlanProductContext: async ({
+			projectedFullCustomer,
+		}: {
+			projectedFullCustomer: FullCustomer;
+		}) => {
+			state.projectedCustomers.push(projectedFullCustomer);
+			return {
+				billingContext: {
+					fullCustomer: projectedFullCustomer,
+				} as UpdateSubscriptionBillingContext,
+				params: {},
+				preparedIds: {
+					priceIds: new Set<string>(),
+					entitlementIds: new Set<string>(),
+				},
+			};
+		},
+	}),
+);
+
+await mockModuleWithRestore(
+	"@/internal/billing/v2/actions/updateSubscription/compute/computeUpdateSubscriptionPlan.js",
+	() => ({
+		computeUpdateSubscriptionPlan: async ({
+			billingContext,
+		}: {
+			billingContext: UpdateSubscriptionBillingContext;
+		}) => {
+			const hasProjectedPool =
+				billingContext.fullCustomer.pooled_customer_entitlements?.length;
+			if (hasProjectedPool) return emptyPlan();
+
+			state.computeCount += 1;
+			return insertedPoolPlan({ id: `pool-${state.computeCount}` });
+		},
+	}),
+);
+
+import { processUpdatePlan } from "@/internal/migrations/v2/operations/updatePlan/processUpdatePlan.js";
+
+const expectOneProjectedPool = ({
+	result,
+}: {
+	result: Awaited<ReturnType<typeof processUpdatePlan>>;
+}) => {
+	expect(
+		result.plan.pooledBalancePlan?.insertPoolBalances.map(({ id }) => id),
+	).toEqual(["pool-1"]);
+	expect(
+		state.projectedCustomers[1]?.pooled_customer_entitlements?.map(
+			({ id }) => id,
+		),
+	).toEqual(["pool-1"]);
+	expect(
+		result.projectedFullCustomer.pooled_customer_entitlements?.map(
+			({ id }) => id,
+		),
+	).toEqual(["pool-1"]);
+};
+
+beforeEach(() => {
+	state.computeCount = 0;
+	state.projectedCustomers = [];
+});
+
+test("update_plan reuses the projected pool across matched customer products", async () => {
+	const customerProducts = [
+		{ id: "customer-product-1", customer_entitlements: [] },
+		{ id: "customer-product-2", customer_entitlements: [] },
+	] as FullCusProduct[];
+	const fullCustomer = {
+		id: "customer",
+		internal_id: "internal-customer",
+		customer_products: customerProducts,
+		pooled_customer_entitlements: [],
+	} as FullCustomer;
+
+	const result = await processUpdatePlan({
+		ctx: {} as AutumnContext,
+		context: { fullCustomer } as MigrateCustomerContext,
+		op: {
+			type: "update_plan",
+			plan_filter: { plan_id: "plan" },
+		},
+		opIndex: 0,
+		plan: emptyPlan(),
+		projectedFullCustomer: fullCustomer,
+	});
+
+	expectOneProjectedPool({ result });
+});

--- a/server/tests/unit/migrations-v2/process-update-plan.test.ts
+++ b/server/tests/unit/migrations-v2/process-update-plan.test.ts
@@ -11,6 +11,8 @@ import type {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { MigrateCustomerContext } from "@/internal/migrations/v2/operations/types/index.js";
+import { makeFullCusProduct } from "../billing/billing-change-response/helpers/makeFullCusProduct.js";
+import { makeFullCustomer } from "../billing/billing-change-response/helpers/makeFullCustomer.js";
 import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const state = {
@@ -125,15 +127,14 @@ beforeEach(() => {
 
 test("update_plan reuses the projected pool across matched customer products", async () => {
 	const customerProducts = [
-		{ id: "customer-product-1", customer_entitlements: [] },
-		{ id: "customer-product-2", customer_entitlements: [] },
-	] as FullCusProduct[];
-	const fullCustomer = {
+		makeFullCusProduct({ id: "customer-product-1", planId: "plan" }),
+		makeFullCusProduct({ id: "customer-product-2", planId: "plan" }),
+	];
+	const fullCustomer = makeFullCustomer({
 		id: "customer",
-		internal_id: "internal-customer",
-		customer_products: customerProducts,
-		pooled_customer_entitlements: [],
-	} as FullCustomer;
+		customerProducts,
+	});
+	fullCustomer.pooled_customer_entitlements = [];
 
 	const result = await processUpdatePlan({
 		ctx: {} as AutumnContext,

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
 		// and breaks platform-specific binaries (pg, ioredis, etc.).
 		external: [
 			"@aws-sdk/client-s3",
+			"@duckdb/node-api",
 			"@google-cloud/bigquery",
 			"ioredis",
 			"pino",

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
-import { viteHmrClient } from "@autumn/env/viteDev";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { viteHmrClient } from "../packages/env/src/viteDev.js";
 
 // Defaults so the app works when no .env.local is present
 // (e.g. after `bun dw disable`). Real values from .env / infisical /


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reproduce and fix multi-entity pooled plan migrations planning duplicate pooled balances
- project each matched customer product’s billing plan before computing the next product
- assert each entity keeps exactly one active replacement and shares one pooled balance
- externalize DuckDB’s native package from Trigger bundles
- make both Vite configs bundle the shared HMR helper instead of asking Node to import workspace TypeScript

## Testing
- Focused planner regression: red `[pool-1, pool-2]`; green `[pool-1]`
- Vite/checkout config-load and Trigger build verification in progress
- Repository-wide typecheck remains blocked by pre-existing duplicate `better-auth` package types
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5af4594d-f6a1-4dd3-8db7-608c38ad5c1a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5af4594d-f6a1-4dd3-8db7-608c38ad5c1a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate pooled balances and duplicate active entity plans during multi-entity plan version migrations by threading the evolving customer projection across matched products. Previously each product computed from stale pool state and inserted another pool; now each computes against the updated projection, yielding one shared pool and one active replacement per entity with the predecessor expired.

- In `processUpdatePlan`: pass the evolving `projectedFullCustomer` (`nextProjectedFullCustomer`) into each product setup, merge each `executablePlan` into `nextPlan`, update the projection via `applyAutumnBillingPlanToFullCustomer`, and return the final projection.
- Tests: add a unit test confirming the projected pool is reused across products; extend the integration test to assert 1 Active + 1 Expired per entity and a single pooled balance sized to grant × entity count with correct contributions and sources.
- Build: externalize `@duckdb/node-api` in `trigger.config.ts`; make `apps/checkout` and `vite` import the HMR helper from `packages/env/src/viteDev.js` instead of `@autumn/env/viteDev` to bundle it directly.

<sup>Written for commit 10f4117d6b68215736aaaa7fd0617d4c92cf2a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes pooled plan migrations by projecting each matched customer product’s result before planning the next one. It also adjusts Vite config imports and Trigger’s treatment of DuckDB.

- **Bug fixes:** Thread the evolving projected customer through multi-product update-plan planning so entity products reuse one pooled balance.
- **Improvements:** Add focused unit and integration coverage for one active replacement per entity and a single shared pooled balance.
- **Improvements:** Bundle the shared HMR helper directly from workspace source in both Vite configurations.
- **Improvements:** Keep DuckDB’s native package external to Trigger bundles.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed code.

The migration now follows the repository’s cumulative-plan projection model and adds regression coverage for the duplicate pooled-balance scenario; the build configuration changes did not yield a reachable failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/operations/updatePlan/processUpdatePlan.ts | Sequentially applies the cumulative billing plan so later matched products compute from the state projected by earlier products. |
| server/tests/unit/migrations-v2/process-update-plan.test.ts | Adds focused regression coverage proving that the second matched product sees and reuses the first projected pool. |
| server/tests/integration/billing/migrations-v2/update-plan-operation/versioning/update-plan-op-version.test.ts | Verifies pooled entity migration results, including replacement statuses, pooled totals, contributions, and sources. |
| trigger.config.ts | Externalizes DuckDB’s native Node package from Trigger bundles; no concrete runtime regression was established. |
| apps/checkout/vite.config.ts | Imports the shared HMR helper directly from workspace source so Vite bundles it during config loading. |
| vite/vite.config.ts | Applies the same direct HMR-helper import to the main dashboard Vite configuration. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Migration as update_plan migration
  participant Product1 as First entity product
  participant Projection as Projected customer
  participant Product2 as Second entity product
  Migration->>Product1: Compute against initial projection
  Product1-->>Migration: Plan inserting replacement and pooled balance
  Migration->>Projection: Apply cumulative billing plan
  Migration->>Product2: Compute against updated projection
  Product2-->>Migration: Reuse existing pooled balance
  Migration-->>Projection: Return final cumulative projection
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bundle Vite HMR helper from source"](https://github.com/useautumn/autumn/commit/10f4117d6b68215736aaaa7fd0617d4c92cf2a28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54386467)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [Checkout App](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/checkout-app.md)

<!-- /greptile_comment -->