### PR TITLE
fix: support Stripe-only coupons at the customer level

### DIFF
--- a/server/src/internal/customers/handlers/handleAddCouponToCusV2.ts
+++ b/server/src/internal/customers/handlers/handleAddCouponToCusV2.ts
@@ -8,6 +8,7 @@ import {
 } from "@autumn/shared";
 import { z } from "zod/v4";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { resolveCoupon } from "@/external/stripe/coupons";
 import { getOrCreateStripeCustomer } from "@/external/stripe/customers";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { rewardActions } from "@/internal/rewards/actions/index.js";
@@ -45,14 +46,7 @@ export const handleAddCouponToCusV2 = createRoute({
 			throw new CustomerNotFoundError({ customerId: customer_id });
 		}
 
-		if (!coupon) {
-			throw new RecaseError({
-				message: `Coupon ${coupon_id} not found`,
-				statusCode: 404,
-			});
-		}
-
-		if (coupon.type === RewardType.FeatureGrant) {
+		if (coupon?.type === RewardType.FeatureGrant) {
 			if (!promo_code) {
 				throw new RecaseError({
 					message: "Promo code is required for feature grant rewards",
@@ -71,7 +65,14 @@ export const handleAddCouponToCusV2 = createRoute({
 			return c.json({ customer, coupon });
 		}
 
-		const stripeCli = createStripeCli({
+		// Autumn reward ids double as Stripe coupon ids, so a single Stripe
+		// lookup covers both Autumn rewards and Stripe-only coupons.
+		const { source } = await resolveCoupon({
+			stripeCli: createStripeCli({ org, env }),
+			couponId: coupon?.id ?? coupon_id,
+		});
+
+		const legacyStripeCli = createStripeCli({
 			org,
 			env,
 			legacyVersion: true,
@@ -83,14 +84,14 @@ export const handleAddCouponToCusV2 = createRoute({
 		});
 
 		// Attach coupon to customer
-		await stripeCli.rawRequest(
+		await legacyStripeCli.rawRequest(
 			"POST",
 			`/v1/customers/${customer.processor.id}`,
 			{
-				coupon: coupon.id,
+				coupon: source.coupon.id,
 			},
 		);
 
-		return c.json({ customer, coupon });
+		return c.json({ customer, coupon: coupon ?? source.coupon });
 	},
 });

--- a/server/tests/integration/rewards/add-stripe-only-coupon-to-customer.test.ts
+++ b/server/tests/integration/rewards/add-stripe-only-coupon-to-customer.test.ts
@@ -1,0 +1,153 @@
+/**
+ * TDD test for applying Stripe-only coupons at the customer level.
+ *
+ * The product/subscription-level path (resolveParamDiscounts -> resolveCoupon)
+ * resolves a reward_id straight against Stripe, so a coupon that exists only in
+ * Stripe can be attached to a subscription. The customer-level endpoint instead
+ * resolved solely via rewardRepo, so Stripe-only coupons 404'd.
+ *
+ * Contract under test:
+ *   New behaviors:
+ *     - POST /customers/:customer_id/coupons/:coupon_id with a Stripe-only
+ *       coupon id -> 200, discount lands on the Stripe customer
+ *     - coupon id in neither Autumn nor Stripe -> error
+ *     - coupon exists in Stripe but valid === false -> error
+ *   Side effects:
+ *     - Stripe customer carries discount.coupon.id === coupon_id
+ *     - No row inserted into Autumn's rewards table
+ *
+ * Pre-impl red: handleAddCouponToCusV2 throws "Coupon <id> not found" because
+ * rewardRepo.get misses for Stripe-only coupons.
+ * Post-impl green: the handler falls back to resolveCoupon on a rewardRepo miss.
+ */
+
+import { expect, test } from "bun:test";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import { rewardRepo } from "@/internal/rewards/repos/index.js";
+import { createPercentCoupon } from "../billing/utils/discounts/discountTestUtils.js";
+
+/** Legacy Stripe API discounts expand `coupon`; modern ones expose `source.coupon` as an id. */
+type LegacyStripeDiscount = { coupon?: Stripe.Coupon };
+
+/**
+ * The legacy Stripe API returns the customer discount with a fully expanded
+ * `coupon` object; the modern one only returns `source.coupon` as an id.
+ */
+const getStripeCustomerCoupon = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const legacyStripeCli = createStripeCli({
+		org: ctx.org,
+		env: ctx.env,
+		legacyVersion: true,
+	});
+
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+
+	const stripeCustomerId = fullCustomer.processor?.id;
+	if (!stripeCustomerId) throw new Error("Missing Stripe customer ID");
+
+	const stripeCustomer =
+		await legacyStripeCli.customers.retrieve(stripeCustomerId);
+
+	if (stripeCustomer.deleted) throw new Error("Stripe customer was deleted");
+
+	const legacyDiscount = stripeCustomer.discount as LegacyStripeDiscount | null;
+
+	return legacyDiscount?.coupon;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("customer-coupon 1: applies a Stripe-only coupon to the customer")}`,
+	async () => {
+		const customerId = "cus-stripe-only-coupon-v3";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false, paymentMethod: "success" })],
+			actions: [],
+		});
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		const coupon = await createPercentCoupon({ stripeCli, percentOff: 25 });
+
+		// ── Contract assertion 1: the coupon exists only in Stripe ──────────
+		const autumnReward = await rewardRepo.get({
+			db: ctx.db,
+			idOrInternalId: coupon.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(autumnReward).toBeFalsy();
+
+		// ── Contract assertion 2: endpoint accepts the Stripe-only id ───────
+		await autumnV1.post(`/customers/${customerId}/coupons/${coupon.id}`, {});
+
+		// ── Contract assertion 3: discount lands on the Stripe customer ─────
+		const appliedCoupon = await getStripeCustomerCoupon({ customerId });
+		expect(appliedCoupon?.id).toBe(coupon.id);
+		expect(appliedCoupon?.percent_off).toBe(25);
+
+		// ── Contract assertion 4: no reward row was created in Autumn ───────
+		const rewardAfter = await rewardRepo.get({
+			db: ctx.db,
+			idOrInternalId: coupon.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(rewardAfter).toBeFalsy();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer-coupon 2: rejects a coupon id in neither Autumn nor Stripe")}`,
+	async () => {
+		const customerId = "cus-unknown-coupon";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		// ── Contract assertion 5: unknown id is still an error ──────────────
+		await expect(
+			autumnV1.post(
+				`/customers/${customerId}/coupons/coupon_does_not_exist_anywhere`,
+				{},
+			),
+		).rejects.toThrow();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("customer-coupon 3: rejects a deleted Stripe coupon")}`,
+	async () => {
+		const customerId = "cus-deleted-coupon";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		const coupon = await createPercentCoupon({ stripeCli, percentOff: 15 });
+		await stripeCli.coupons.del(coupon.id);
+
+		// ── Contract assertion 6: invalid/deleted coupon is an error ────────
+		await expect(
+			autumnV1.post(`/customers/${customerId}/coupons/${coupon.id}`, {}),
+		).rejects.toThrow();
+	},
+);

--- a/vite/src/views/customers2/customer/components/AddCouponDialog.tsx
+++ b/vite/src/views/customers2/customer/components/AddCouponDialog.tsx
@@ -16,7 +16,12 @@ import {
 } from "@autumn/ui";
 import { useState } from "react";
 import { toast } from "sonner";
+import {
+	rewardToOption,
+	stripeCouponToOption,
+} from "@/components/forms/attach-v2/utils/discountOptionUtils";
 import { useRewardsQuery } from "@/hooks/queries/useRewardsQuery";
+import { useStripeCouponsQuery } from "@/hooks/queries/useStripeCouponsQuery";
 import { CusService } from "@/services/customers/CusService";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
@@ -35,7 +40,7 @@ export const AddCouponDialog = ({
 	const { stripeCus, cusRewardRefetch } = useCusReferralQuery();
 	const { customer, refetch } = useCusQuery();
 
-	const [couponSelected, setCouponSelected] = useState<Reward | null>(null);
+	const [selectedId, setSelectedId] = useState<string | null>(null);
 	const [promoCodeSelected, setPromoCodeSelected] = useState<string | null>(
 		null,
 	);
@@ -43,9 +48,26 @@ export const AddCouponDialog = ({
 	const axiosInstance = useAxiosInstance();
 
 	const { rewards } = useRewardsQuery();
+	const { stripeCoupons } = useStripeCouponsQuery();
+
+	// Stripe coupons are merged in so coupons created outside Autumn are
+	// selectable here, matching the subscription-level discount picker.
+	const rewardOptions = rewards
+		.filter((reward: Reward) => reward.type !== RewardType.FreeProduct)
+		.map(rewardToOption);
+
+	const rewardOptionIds = new Set(rewardOptions.map((option) => option.id));
+	const stripeOnlyOptions = stripeCoupons
+		.filter((coupon) => !rewardOptionIds.has(coupon.id))
+		.map(stripeCouponToOption);
+
+	const discountOptions = [...rewardOptions, ...stripeOnlyOptions];
+
+	const selectedReward = rewards.find((r: Reward) => r.id === selectedId);
+	const requiresPromoCode = selectedReward?.type === RewardType.FeatureGrant;
 
 	const resetSelection = () => {
-		setCouponSelected(null);
+		setSelectedId(null);
 		setPromoCodeSelected(null);
 	};
 
@@ -58,16 +80,15 @@ export const AddCouponDialog = ({
 	};
 
 	const handleAddClicked = async () => {
-		if (!couponSelected) return;
-		if (couponSelected.type === RewardType.FeatureGrant && !promoCodeSelected)
-			return;
+		if (!selectedId) return;
+		if (requiresPromoCode && !promoCodeSelected) return;
 
 		try {
 			setLoading(true);
 			await CusService.addCouponToCustomer({
 				axios: axiosInstance,
 				customer_id: customer.id,
-				coupon_id: couponSelected.internal_id,
+				coupon_id: selectedId,
 				promo_code: promoCodeSelected ?? undefined,
 			});
 			setOpen(false);
@@ -85,17 +106,15 @@ export const AddCouponDialog = ({
 
 	const getExistingCoupon = () => {
 		if (existingDiscount?.coupon?.id) {
-			return rewards.find(
-				(c: Reward) =>
-					c?.internal_id === getOriginalCouponId(existingDiscount.coupon.id),
+			const originalId = getOriginalCouponId(existingDiscount.coupon.id);
+			return discountOptions.find(
+				(option) => option.id === originalId || option.label === originalId,
 			);
 		}
 		return null;
 	};
 
-	if (!rewards) return null;
-
-	const promoCodeOptions = (couponSelected?.promo_codes || []).filter(
+	const promoCodeOptions = (selectedReward?.promo_codes || []).filter(
 		(promoCode) => promoCode.code,
 	);
 
@@ -116,39 +135,25 @@ export const AddCouponDialog = ({
 				)}
 				<div className="space-y-3">
 					<Select
-						value={couponSelected?.internal_id}
+						value={selectedId ?? undefined}
 						onValueChange={(value) => {
-							const coupon = rewards.find(
-								(c: Reward) => c.internal_id === value,
-							);
-
-							if (!coupon) return;
-
-							setCouponSelected(coupon);
+							setSelectedId(value);
 							setPromoCodeSelected(null);
 						}}
 						items={Object.fromEntries(
-							rewards
-								.filter((c: Reward) => c.type !== RewardType.FreeProduct)
-								.map((c: Reward) => [c.internal_id, c.name]),
+							discountOptions.map((option) => [option.id, option.label]),
 						)}
 					>
 						<SelectTrigger className="w-full">
 							<SelectValue placeholder="Select Reward" />
 						</SelectTrigger>
 						<SelectContent>
-							{rewards && rewards.length > 0 ? (
-								rewards.map((coupon: Reward) => {
-									if (coupon.type === RewardType.FreeProduct) return null;
-									return (
-										<SelectItem
-											key={coupon.internal_id}
-											value={coupon.internal_id}
-										>
-											{coupon.name}
-										</SelectItem>
-									);
-								})
+							{discountOptions.length > 0 ? (
+								discountOptions.map((option) => (
+									<SelectItem key={option.id} value={option.id}>
+										{option.label}
+									</SelectItem>
+								))
 							) : (
 								<SelectItem value="none" disabled>
 									No coupons found
@@ -157,7 +162,7 @@ export const AddCouponDialog = ({
 						</SelectContent>
 					</Select>
 
-					{couponSelected?.type === RewardType.FeatureGrant && (
+					{requiresPromoCode && (
 						<Select
 							value={promoCodeSelected || undefined}
 							onValueChange={setPromoCodeSelected}
@@ -191,11 +196,7 @@ export const AddCouponDialog = ({
 					<ShortcutButton
 						variant="primary"
 						onClick={handleAddClicked}
-						disabled={
-							!couponSelected ||
-							(couponSelected.type === RewardType.FeatureGrant &&
-								!promoCodeSelected)
-						}
+						disabled={!selectedId || (requiresPromoCode && !promoCodeSelected)}
 						isLoading={loading}
 						metaShortcut="enter"
 						className="w-full"


### PR DESCRIPTION
Reported in Slack: coupons created directly in Stripe don't show up when adding a reward to a customer — the dropdown reads "No coupons found", and applying one by id fails with `Coupon <id> not found`.

## Cause

The customer-level endpoint resolved `coupon_id` solely against Autumn's `rewards` table and 404'd on a miss.

The subscription-level path never had this problem — it doesn't consult the rewards table at all. `resolveParamDiscounts` passes `reward_id` straight to Stripe via `resolveCoupon`. That covers both sources because `createStripeCoupon` creates the Stripe coupon with `id: reward.id`, so an Autumn reward id *is* its Stripe coupon id.

## Fix

Mirror the subscription behaviour at the customer level:

- `handleAddCouponToCusV2.ts` — the rewards lookup is now only used to route feature-grant rewards, which have no Stripe object. Discount coupons resolve through `resolveCoupon`, so Autumn rewards and Stripe-only coupons both work. Unknown and invalid/deleted coupons still error.
- `AddCouponDialog.tsx` — merges Stripe coupons into the dropdown (deduped by id), matching the subscription-level discount picker. Selection now keys on the public `id` rather than `internal_id`, which is what the endpoint resolves against.

## Tests

New `server/tests/integration/rewards/add-stripe-only-coupon-to-customer.test.ts` (3 passing):

- Stripe-only coupon applies and lands on the Stripe customer at the right percent off
- No reward row is written to Autumn
- Unknown coupon id errors; deleted/invalid Stripe coupon errors

Verified red before the fix (`Coupon <id> not found`) and green after. `rewards-redeem-feature-grant` still passes 7/7, so the promo-code path is unaffected.

## Note

`attach-discounts-basic` test 6 ("upgrade pro to premium with reward") fails on `dev` independently of this change — `previewAttach` returns *"subscription was not created by Autumn"*. It reproduces with a fresh customer id and only touches the subscription path this PR doesn't modify. Not addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports attaching coupons created directly in Stripe at the customer level. Previously, the endpoint and dialog only resolved against Autumn rewards (dropdown showed “No coupons found”; applying by id returned “Coupon <id> not found”); now both Autumn rewards and Stripe-only coupons work, matching subscription behavior.

- Customer endpoint resolves discount coupons via Stripe; feature-grant rewards still require a promo code; unknown/invalid/deleted coupons still error; applying a Stripe-only coupon does not create a reward row.
- Customer “Add Coupon” dialog merges Stripe coupons with Autumn rewards (deduped by id) and selects by public id.
- Added integration tests covering Stripe-only apply success, no Autumn row, and error cases; an unrelated subscription upgrade test already failing on `dev` is unchanged.

<sup>Written for commit 5aff5d04f188535aca1c806424e849cc6b0b782e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR allows Stripe-only coupons to be selected and applied directly to customers while preserving the separate feature-grant flow.

- **[Bug fixes]** Resolves customer-level discount coupons through Stripe when no Autumn reward exists.
- **[Improvements]** Adds Stripe coupons to the customer reward dropdown and deduplicates them against Autumn rewards.
- **[API changes]** Accepts public Stripe coupon or Autumn reward IDs when adding a coupon to a customer.
- **[Bug fixes]** Adds integration coverage for applying Stripe-only coupons and rejecting unknown or deleted coupons.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed paths.

The server preserves feature-grant handling while resolving both Autumn-backed and Stripe-only discounts through valid Stripe coupon IDs, and the dashboard uses query defaults and compatible public identifiers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/handlers/handleAddCouponToCusV2.ts | Routes feature grants through the existing redemption flow and resolves all customer discounts through Stripe before attaching them. |
| server/tests/integration/rewards/add-stripe-only-coupon-to-customer.test.ts | Covers successful Stripe-only coupon application, absence of an Autumn reward row, and rejection of unknown or deleted coupons. |
| vite/src/views/customers2/customer/components/AddCouponDialog.tsx | Merges Autumn rewards with Stripe coupons, deduplicates by public ID, and submits the identifier understood by both repository and Stripe resolution paths. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Customer Dashboard
  participant API as Customer Coupon Endpoint
  participant DB as Autumn Rewards
  participant Stripe

  UI->>API: Add coupon using public coupon ID
  API->>DB: Look up reward by public/internal ID
  alt Feature-grant reward
    DB-->>API: Feature-grant reward
    API->>API: Validate and redeem promo code
  else Discount reward or Stripe-only coupon
    DB-->>API: Discount reward or no row
    API->>Stripe: Resolve coupon by Stripe coupon ID
    Stripe-->>API: Valid coupon
    API->>Stripe: Attach coupon to customer
  end
  API-->>UI: Updated customer/coupon
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: support Stripe-only coupons at the ..."](https://github.com/useautumn/autumn/commit/5aff5d04f188535aca1c806424e849cc6b0b782e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54387159)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->