### PR TITLE
fix: preserve MotherDuck semi join qualification

### DIFF
--- a/server/src/internal/customers/resolveByFeatureBalanceSort.ts
+++ b/server/src/internal/customers/resolveByFeatureBalanceSort.ts
@@ -369,7 +369,7 @@ export const nominationQuery = ({
 	const customerScopeJoin = hasCreatedAtRange
 		? sql`
 			SEMI JOIN main.customers c
-				ON c.internal_id = internal_customer_id
+				ON c.internal_id = ce_balance_totals.internal_customer_id
 				AND c.org_id = ${orgId}
 				AND c.env = ${env}
 				${

--- a/server/tests/unit/customers/feature-balance-nomination-query.test.ts
+++ b/server/tests/unit/customers/feature-balance-nomination-query.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { AppEnv } from "@autumn/shared";
-import { PgDialect } from "drizzle-orm/pg-core";
+import { drizzle } from "@duckdbfan/drizzle-duckdb";
 import { nominationQuery } from "@/internal/customers/resolveByFeatureBalanceSort.js";
 
-const dialect = new PgDialect();
+const dialect = drizzle({ client: {} as never }).dialect;
 const normalize = (value: string) => value.replace(/\s+/g, " ").trim();
 
 const render = (createdAtRange?: { start?: number; end?: number }) =>
@@ -31,7 +31,10 @@ describe("feature balance nomination query", () => {
 		const query = normalize(sql);
 
 		expect(query).toContain("SEMI JOIN main.customers c");
-		expect(query).toContain("c.internal_id = internal_customer_id");
+		expect(query).toContain(
+			"c.internal_id = ce_balance_totals.internal_customer_id",
+		);
+		expect(query).not.toContain('"main"."c"');
 		expect(query).toContain("c.org_id = $1");
 		expect(query).toContain("c.env = $2");
 		expect(query).toContain("c.created_at >= $3");


### PR DESCRIPTION
Fixes feature-balance customer queries with a `created_at_range` filter.

The DuckDB Drizzle dialect rewrote the unqualified join operand as `main.c.internal_customer_id`, producing a binder error. The nomination query now explicitly qualifies that operand against `ce_balance_totals`, which prevents the dialect's join transformer from corrupting the `SEMI JOIN`.

The regression test now renders through the production DuckDB dialect and asserts that the malformed `main.c` qualifier is absent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes feature-balance nomination queries with a `created_at_range` by preserving `SEMI JOIN` qualification in DuckDB/MotherDuck. Previously the DuckDB Drizzle dialect rewrote an unqualified operand to `main.c.internal_customer_id`, causing a binder error; we now qualify it as `ce_balance_totals.internal_customer_id`. No change to results, only prevents the dialect from corrupting the join.

- Qualifies the join in `nominationQuery` against `ce_balance_totals.internal_customer_id`.
- Updates the regression test to render via the production DuckDB dialect (`@duckdbfan/drizzle-duckdb`) and asserts that the malformed `"main"."c"` qualifier is absent.

<sup>Written for commit 3095e44bfd49c91c5741e60d3fdd9fa3cce78bea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes feature-balance customer queries that include a creation-date filter by preserving the correct MotherDuck table qualification.
- **Bug fixes:** Qualifies the semi-join operand with `ce_balance_totals`, preventing the DuckDB dialect from rewriting it as the invalid `main.c` reference.
- **Improvements:** Renders the regression test through the production DuckDB dialect and verifies both the correct qualification and absence of the malformed one.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The changed qualification matches the query’s unaliased `ce_balance_totals` source, and the regression test now checks the SQL produced by the relevant dialect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/resolveByFeatureBalanceSort.ts | Correctly qualifies the balance table’s customer identifier in the date-filtered semi join; the source table is visible under this name in every applicable branch. |
| server/tests/unit/customers/feature-balance-nomination-query.test.ts | Switches SQL rendering to the production DuckDB dialect and adds focused assertions for the corrected qualification. |

<sub>Reviews (1): Last reviewed commit: ["fix: preserve MotherDuck semi join quali..."](https://github.com/useautumn/autumn/commit/3095e44bfd49c91c5741e60d3fdd9fa3cce78bea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54422950)</sub>

<!-- /greptile_comment -->