### PR TITLE
feat: remove coupons at the customer and subscription level

### DIFF
--- a/server/src/internal/customers/cusRouter.ts
+++ b/server/src/internal/customers/cusRouter.ts
@@ -17,6 +17,8 @@ import { handleListCustomerProducts } from "./handlers/handleListCustomerProduct
 import { handleListCustomers } from "./handlers/handleListCustomers.js";
 import { handleListCustomersV2 } from "./handlers/handleListCustomersV2.js";
 import { handleRefundInvoice } from "./handlers/handleRefundInvoice/handleRefundInvoice.js";
+import { handleRemoveCouponFromCusV2 } from "./handlers/handleRemoveCouponFromCusV2.js";
+import { handleRemoveCouponFromSubscriptionV2 } from "./handlers/handleRemoveCouponFromSubscriptionV2.js";
 import { handleTransferProductV2 } from "./handlers/handleTransferProductV2.js";
 import { handleUpdateBalancesV2 } from "./handlers/handleUpdateBalancesV2.js";
 import { handleUpdateCustomer } from "./handlers/handleUpdateCustomer/handleUpdateCustomer.js";
@@ -37,6 +39,11 @@ cusRouter.patch("/:customer_id", ...handleUpdateCustomer);
 cusRouter.delete("/:customer_id", ...handleDeleteCustomer);
 
 cusRouter.post("/:customer_id/coupons/:coupon_id", ...handleAddCouponToCusV2);
+cusRouter.delete("/:customer_id/coupons", ...handleRemoveCouponFromCusV2);
+cusRouter.delete(
+	"/:customer_id/subscriptions/:subscription_id/coupons/:coupon_id",
+	...handleRemoveCouponFromSubscriptionV2,
+);
 cusRouter.post("/:customer_id/transfer", ...handleTransferProductV2);
 cusRouter.post(
 	"/:customer_id/invoices/:stripe_invoice_id/refund",

--- a/server/src/internal/customers/handlers/handleRemoveCouponFromCusV2.ts
+++ b/server/src/internal/customers/handlers/handleRemoveCouponFromCusV2.ts
@@ -1,0 +1,46 @@
+import {
+	AffectedResource,
+	CustomerNotFoundError,
+	Scopes,
+} from "@autumn/shared";
+import type Stripe from "stripe";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { CusService } from "../CusService.js";
+
+export const handleRemoveCouponFromCusV2 = createRoute({
+	scopes: [Scopes.Billing.Write],
+	resource: AffectedResource.Customer,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org, env } = ctx;
+		const { customer_id } = c.req.param();
+
+		const customer = await CusService.get({
+			db,
+			idOrInternalId: customer_id,
+			orgId: org.id,
+			env,
+		});
+
+		if (!customer?.id) {
+			throw new CustomerNotFoundError({ customerId: customer_id });
+		}
+
+		const stripeCustomerId = customer.processor?.id;
+		if (!stripeCustomerId) {
+			return c.json({ customer });
+		}
+
+		const stripeCli = createStripeCli({ org, env });
+		const stripeCustomer = (await stripeCli.customers.retrieve(
+			stripeCustomerId,
+		)) as Stripe.Customer;
+
+		if (stripeCustomer.discount) {
+			await stripeCli.customers.deleteDiscount(stripeCustomerId);
+		}
+
+		return c.json({ customer });
+	},
+});

--- a/server/src/internal/customers/handlers/handleRemoveCouponFromSubscriptionV2.ts
+++ b/server/src/internal/customers/handlers/handleRemoveCouponFromSubscriptionV2.ts
@@ -1,0 +1,81 @@
+import {
+	AffectedResource,
+	CustomerNotFoundError,
+	RecaseError,
+	Scopes,
+} from "@autumn/shared";
+import type Stripe from "stripe";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { getOriginalCouponId } from "@/internal/rewards/rewardUtils.js";
+import { CusService } from "../CusService.js";
+
+/** `source.coupon` is a bare id unless `discounts.source.coupon` is expanded. */
+const discountCouponId = (discount: Stripe.Discount) => {
+	const coupon = discount.source?.coupon;
+	return typeof coupon === "string" ? coupon : (coupon?.id ?? "");
+};
+
+export const handleRemoveCouponFromSubscriptionV2 = createRoute({
+	scopes: [Scopes.Billing.Write],
+	resource: AffectedResource.Customer,
+	handler: async (c) => {
+		const ctx = c.get("ctx");
+		const { db, org, env } = ctx;
+		const { customer_id, subscription_id, coupon_id } = c.req.param();
+
+		const customer = await CusService.get({
+			db,
+			idOrInternalId: customer_id,
+			orgId: org.id,
+			env,
+		});
+
+		if (!customer?.id) {
+			throw new CustomerNotFoundError({ customerId: customer_id });
+		}
+
+		const stripeCli = createStripeCli({ org, env });
+		const subscription = await stripeCli.subscriptions.retrieve(
+			subscription_id,
+			{ expand: ["discounts"] },
+		);
+		const discounts = subscription.discounts.filter(
+			(discount): discount is Stripe.Discount => typeof discount !== "string",
+		);
+
+		const subscriptionCustomerId =
+			typeof subscription.customer === "string"
+				? subscription.customer
+				: subscription.customer.id;
+
+		if (subscriptionCustomerId !== customer.processor?.id) {
+			throw new RecaseError({
+				message: `Subscription ${subscription_id} does not belong to customer ${customer_id}`,
+				statusCode: 404,
+			});
+		}
+
+		const targetCouponId = getOriginalCouponId(coupon_id);
+		const matchesTarget = (discount: Stripe.Discount) =>
+			getOriginalCouponId(discountCouponId(discount)) === targetCouponId;
+
+		if (!discounts.some(matchesTarget)) {
+			throw new RecaseError({
+				message: `Coupon ${coupon_id} is not applied to subscription ${subscription_id}`,
+				statusCode: 404,
+			});
+		}
+
+		// Stripe's discounts param is a full replace, so send back the survivors.
+		const remainingDiscounts = discounts
+			.filter((discount) => !matchesTarget(discount))
+			.map((discount) => ({ discount: discount.id }));
+
+		await stripeCli.subscriptions.update(subscription_id, {
+			discounts: remainingDiscounts,
+		});
+
+		return c.json({ customer });
+	},
+});

--- a/server/tests/integration/rewards/remove-coupon-from-customer-and-subscription.test.ts
+++ b/server/tests/integration/rewards/remove-coupon-from-customer-and-subscription.test.ts
@@ -1,0 +1,264 @@
+/**
+ * TDD test for removing coupons at the customer and subscription level.
+ *
+ * Coupons could be added at both levels but never removed: the update
+ * subscription `discounts` param is additive-only (existing discounts are
+ * always merged back in), and no customer-level removal route existed.
+ *
+ * Contract under test:
+ *   New endpoints:
+ *     - DELETE /customers/:customer_id/coupons
+ *         -> 200, removes the customer-level Stripe discount
+ *     - DELETE /customers/:customer_id/subscriptions/:subscription_id/coupons/:coupon_id
+ *         -> 200, removes that coupon's discount from the subscription.
+ *            Matches on the original coupon id so `_roll_` variants match.
+ *   New behaviors:
+ *     - customer has a discount -> removed, Stripe customer.discount is null
+ *     - customer has no discount -> 200 no-op (idempotent)
+ *     - unknown customer -> error
+ *     - sub has the coupon -> removed, coupon absent from sub.discounts
+ *     - sub has other coupons too -> only the targeted one removed
+ *     - coupon not on the sub -> error
+ *     - sub not belonging to the customer -> error
+ *   Side effects:
+ *     - Stripe discount object deleted; no Autumn rows touched
+ *
+ * Pre-impl red: every DELETE 404s because the routes are not registered.
+ * Post-impl green: both handlers resolve the customer and delete the discount.
+ */
+
+import { expect, test } from "bun:test";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { CusService } from "@/internal/customers/CusService.js";
+import {
+	applySubscriptionDiscount,
+	createPercentCoupon,
+	getStripeSubscription,
+} from "../billing/utils/discounts/discountTestUtils.js";
+
+/** Legacy Stripe API discounts expand `coupon`; modern ones expose `source.coupon` as an id. */
+type LegacyStripeDiscount = { coupon?: Stripe.Coupon };
+
+const getStripeCustomerId = async ({ customerId }: { customerId: string }) => {
+	const fullCustomer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+
+	const stripeCustomerId = fullCustomer.processor?.id;
+	if (!stripeCustomerId) throw new Error("Missing Stripe customer ID");
+
+	return stripeCustomerId;
+};
+
+const getStripeCustomerCoupon = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const legacyStripeCli = createStripeCli({
+		org: ctx.org,
+		env: ctx.env,
+		legacyVersion: true,
+	});
+
+	const stripeCustomerId = await getStripeCustomerId({ customerId });
+	const stripeCustomer =
+		await legacyStripeCli.customers.retrieve(stripeCustomerId);
+
+	if (stripeCustomer.deleted) throw new Error("Stripe customer was deleted");
+
+	const legacyDiscount = stripeCustomer.discount as LegacyStripeDiscount | null;
+
+	return legacyDiscount?.coupon;
+};
+
+const applyCustomerCoupon = async ({
+	customerId,
+	couponId,
+}: {
+	customerId: string;
+	couponId: string;
+}) => {
+	const legacyStripeCli = createStripeCli({
+		org: ctx.org,
+		env: ctx.env,
+		legacyVersion: true,
+	});
+
+	const stripeCustomerId = await getStripeCustomerId({ customerId });
+	await legacyStripeCli.rawRequest(
+		"POST",
+		`/v1/customers/${stripeCustomerId}`,
+		{ coupon: couponId },
+	);
+};
+
+const getSubscriptionCouponIds = async ({
+	customerId,
+}: {
+	customerId: string;
+}) => {
+	const { subscription } = await getStripeSubscription({
+		customerId,
+		expand: ["data.discounts"],
+	});
+
+	return subscription.discounts.map((discount) =>
+		typeof discount === "string" ? discount : discount.source.coupon,
+	);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("remove-coupon 1: removes the customer-level discount")}`,
+	async () => {
+		const customerId = "rm-cus-coupon";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false, paymentMethod: "success" })],
+			actions: [],
+		});
+
+		const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
+		const coupon = await createPercentCoupon({ stripeCli, percentOff: 30 });
+		await applyCustomerCoupon({ customerId, couponId: coupon.id });
+
+		const before = await getStripeCustomerCoupon({ customerId });
+		expect(before?.id).toBe(coupon.id);
+
+		// ── Contract assertion 1: DELETE removes the customer discount ─────
+		await autumnV1.delete(`/customers/${customerId}/coupons`);
+
+		const after = await getStripeCustomerCoupon({ customerId });
+		expect(after).toBeFalsy();
+
+		// ── Contract assertion 2: idempotent when nothing is applied ───────
+		await autumnV1.delete(`/customers/${customerId}/coupons`);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("remove-coupon 2: rejects an unknown customer")}`,
+	async () => {
+		const customerId = "rm-cus-coupon-known";
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false })],
+			actions: [],
+		});
+
+		// ── Contract assertion 3: unknown customer is an error ─────────────
+		await expect(
+			autumnV1.delete("/customers/rm-cus-does-not-exist/coupons"),
+		).rejects.toThrow();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("remove-coupon 3: removes only the targeted subscription coupon")}`,
+	async () => {
+		const customerId = "rm-sub-coupon";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const { stripeCli, subscription } = await getStripeSubscription({
+			customerId,
+		});
+		const target = await createPercentCoupon({ stripeCli, percentOff: 10 });
+		const keep = await createPercentCoupon({ stripeCli, percentOff: 5 });
+		await applySubscriptionDiscount({
+			stripeCli,
+			subscriptionId: subscription.id,
+			couponIds: [target.id, keep.id],
+		});
+
+		const before = await getSubscriptionCouponIds({ customerId });
+		expect(before).toContain(target.id);
+		expect(before).toContain(keep.id);
+
+		// ── Contract assertion 4: DELETE removes the targeted coupon ───────
+		await autumnV1.delete(
+			`/customers/${customerId}/subscriptions/${subscription.id}/coupons/${target.id}`,
+		);
+
+		// ── Contract assertion 5: the other coupon is untouched ────────────
+		const after = await getSubscriptionCouponIds({ customerId });
+		expect(after).not.toContain(target.id);
+		expect(after).toContain(keep.id);
+
+		// ── Contract assertion 6: coupon no longer on the sub is an error ──
+		await expect(
+			autumnV1.delete(
+				`/customers/${customerId}/subscriptions/${subscription.id}/coupons/${target.id}`,
+			),
+		).rejects.toThrow();
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("remove-coupon 4: rejects a subscription not owned by the customer")}`,
+	async () => {
+		const customerId = "rm-sub-coupon-owner";
+		const otherCustomerId = "rm-sub-coupon-other";
+
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 500 })],
+		});
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.otherCustomers([{ id: otherCustomerId, paymentMethod: "success" }]),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.billing.attach({ productId: pro.id }),
+				s.billing.attach({ productId: pro.id, customerId: otherCustomerId }),
+			],
+		});
+
+		const { stripeCli, subscription: otherSubscription } =
+			await getStripeSubscription({ customerId: otherCustomerId });
+		const coupon = await createPercentCoupon({ stripeCli, percentOff: 10 });
+		await applySubscriptionDiscount({
+			stripeCli,
+			subscriptionId: otherSubscription.id,
+			couponIds: [coupon.id],
+		});
+
+		// ── Contract assertion 7: another customer's sub is an error ───────
+		await expect(
+			autumnV1.delete(
+				`/customers/${customerId}/subscriptions/${otherSubscription.id}/coupons/${coupon.id}`,
+			),
+		).rejects.toThrow();
+
+		// ── Contract assertion 8: the other customer's coupon survives ────
+		const otherAfter = await getSubscriptionCouponIds({
+			customerId: otherCustomerId,
+		});
+		expect(otherAfter).toContain(coupon.id);
+	},
+);

--- a/vite/src/services/customers/CusService.tsx
+++ b/vite/src/services/customers/CusService.tsx
@@ -85,6 +85,32 @@ export class CusService {
 		);
 	}
 
+	static async removeCouponFromCustomer({
+		axios,
+		customer_id,
+	}: {
+		axios: AxiosInstance;
+		customer_id: string;
+	}) {
+		return await axios.delete(`/v1/customers/${customer_id}/coupons`);
+	}
+
+	static async removeCouponFromSubscription({
+		axios,
+		customer_id,
+		subscription_id,
+		coupon_id,
+	}: {
+		axios: AxiosInstance;
+		customer_id: string;
+		subscription_id: string;
+		coupon_id: string;
+	}) {
+		return await axios.delete(
+			`/v1/customers/${customer_id}/subscriptions/${subscription_id}/coupons/${coupon_id}`,
+		);
+	}
+
 	static async addCouponToCustomer({
 		axios,
 		customer_id,

--- a/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx
@@ -1,11 +1,12 @@
 import {
+	type ApiDiscount,
 	billingControlsFromColumns,
 	CusProductStatus,
 	cp,
 	type Entity,
 	isCustomerProductTrialing,
 } from "@autumn/shared";
-import { Button, CopyButton, InfoRow } from "@autumn/ui";
+import { Button, CopyButton, IconButton, InfoRow } from "@autumn/ui";
 import {
 	CalendarBlankIcon,
 	CreditCardIcon,
@@ -19,9 +20,11 @@ import {
 	TicketIcon,
 	TimerIcon,
 	XCircle,
+	XIcon,
 } from "@phosphor-icons/react";
 import { format } from "date-fns";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
 import {
 	BillingControlsList,
 	hasBillingControls,
@@ -34,8 +37,10 @@ import { useProductVersionQuery } from "@/hooks/queries/useProductVersionQuery";
 import { usePrepaidItems } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useSubscriptionById } from "@/hooks/stores/useSubscriptionStore";
-
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { backendToDisplayQuantity } from "@/utils/billing/prepaidQuantityUtils";
+import { getBackendErr } from "@/utils/genUtils";
 import { getCusProductKind, getPlanKindConfig } from "@/utils/planKind";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { CustomerProductsStatus } from "../table/customer-products/CustomerProductsStatus";
@@ -48,6 +53,59 @@ import { SubscriptionLicenseRow } from "./SubscriptionLicenseRow";
 import { formatDiscountLabel } from "./subscriptionDetailUtils";
 
 const ID_CHIP_INNER_CLASS = "max-w-40 text-tiny-id truncate !font-normal";
+
+const SubscriptionDiscountRow = ({
+	discount,
+	customerId,
+}: {
+	discount: ApiDiscount;
+	customerId: string;
+}) => {
+	const { refetch: refetchRewards } = useCusRewardsQuery();
+	const axiosInstance = useAxiosInstance();
+	const [removing, setRemoving] = useState(false);
+
+	const handleRemove = async () => {
+		if (!discount.subscription_id) return;
+
+		try {
+			setRemoving(true);
+			await CusService.removeCouponFromSubscription({
+				axios: axiosInstance,
+				customer_id: customerId,
+				subscription_id: discount.subscription_id,
+				coupon_id: discount.id,
+			});
+			await refetchRewards();
+			toast.success("Coupon removed from subscription");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to remove coupon"));
+		} finally {
+			setRemoving(false);
+		}
+	};
+
+	return (
+		<InfoRow
+			icon={<TicketIcon size={16} weight="duotone" />}
+			label="Coupon"
+			value={
+				<span className="flex items-center gap-1">
+					<span>{formatDiscountLabel({ discount })}</span>
+					<IconButton
+						variant="muted"
+						size="sm"
+						onClick={handleRemove}
+						disabled={removing}
+						icon={<XIcon size={12} />}
+						aria-label="Remove coupon"
+						className="shrink-0 text-tertiary-foreground hover:text-red-500"
+					/>
+				</span>
+			}
+		/>
+	);
+};
 
 export function SubscriptionDetailSheet() {
 	const { customer, features = [], testClockFrozenTimeMs } = useCusQuery();
@@ -287,11 +345,10 @@ export function SubscriptionDetailSheet() {
 					/>
 
 					{subscriptionDiscounts.map((discount: ApiDiscount) => (
-						<InfoRow
+						<SubscriptionDiscountRow
 							key={discount.id}
-							icon={<TicketIcon size={16} weight="duotone" />}
-							label="Coupon"
-							value={formatDiscountLabel({ discount })}
+							discount={discount}
+							customerId={customer.id}
 						/>
 					))}
 

--- a/vite/src/views/customers2/customer/CustomerPageDetails.tsx
+++ b/vite/src/views/customers2/customer/CustomerPageDetails.tsx
@@ -1,5 +1,10 @@
-import { CopyButton } from "@autumn/ui";
-import { FingerprintIcon, TicketIcon } from "@phosphor-icons/react";
+import { CopyButton, IconButton } from "@autumn/ui";
+import { FingerprintIcon, TicketIcon, XIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { CusService } from "@/services/customers/CusService";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+import { getBackendErr } from "@/utils/genUtils";
 import { useCusReferralQuery } from "@/views/customers/customer/hooks/useCusReferralQuery";
 import { CustomerActions } from "./CustomerActions";
 import { useCustomerContext } from "./CustomerContext";
@@ -8,6 +13,45 @@ const mutedDivClassName =
 	"py-0.5 px-1.5 rounded-lg text-tertiary-foreground text-tiny flex items-center gap-2 h-6 max-w-48 truncate bg-muted text-tiny-id";
 
 const placeholderText = "PENDING";
+
+const AppliedCouponChip = ({ couponId }: { couponId: string }) => {
+	const { customer } = useCustomerContext();
+	const { cusRewardRefetch } = useCusReferralQuery();
+	const axiosInstance = useAxiosInstance();
+	const [removing, setRemoving] = useState(false);
+
+	const handleRemove = async () => {
+		try {
+			setRemoving(true);
+			await CusService.removeCouponFromCustomer({
+				axios: axiosInstance,
+				customer_id: customer.id,
+			});
+			await cusRewardRefetch();
+			toast.success("Coupon removed from customer");
+		} catch (error) {
+			toast.error(getBackendErr(error, "Failed to remove coupon"));
+		} finally {
+			setRemoving(false);
+		}
+	};
+
+	return (
+		<div className={mutedDivClassName} title={couponId}>
+			<TicketIcon size={13} className="shrink-0" />
+			<span className="truncate">{couponId}</span>
+			<IconButton
+				variant="muted"
+				size="sm"
+				onClick={handleRemove}
+				disabled={removing}
+				icon={<XIcon size={10} />}
+				aria-label="Remove coupon"
+				className="shrink-0 -mr-1 text-tertiary-foreground hover:text-red-500"
+			/>
+		</div>
+	);
+};
 
 export const CustomerPageDetails = () => {
 	const { customer } = useCustomerContext();
@@ -47,12 +91,7 @@ export const CustomerPageDetails = () => {
 						</span>
 					</div>
 				)}
-				{appliedCoupon && (
-					<div className={mutedDivClassName} title={appliedCoupon.coupon}>
-						<TicketIcon size={13} className="shrink-0" />
-						<span className="truncate">{appliedCoupon.coupon}</span>
-					</div>
-				)}
+				{appliedCoupon && <AppliedCouponChip couponId={appliedCoupon.coupon} />}
 			</div>
 			<CustomerActions />
 		</div>


### PR DESCRIPTION
Stacked on #2864 (base is that branch so the diff shows only the removal work; retarget to `dev` once #2864 merges).

Coupons could be added at both the customer and subscription level but never removed. The update-subscription `discounts` param is additive-only — `fetchStripeDiscountsForBilling` always merges existing discounts back in — and no customer-level removal route existed.

## API

Two DELETE routes, mirroring the existing `POST /customers/:id/coupons/:coupon_id`:

```
DELETE /v1/customers/:customer_id/coupons
DELETE /v1/customers/:customer_id/subscriptions/:subscription_id/coupons/:coupon_id
```

- **Customer-level** — deletes the customer's Stripe discount. Idempotent: 200 no-op when nothing is applied.
- **Subscription-level** — verifies the Stripe subscription belongs to the customer (404 otherwise), matches the coupon on its *original* id via `getOriginalCouponId` so `_roll_` variants match, and 404s if the coupon isn't on the sub. Because Stripe's `discounts` param is a full replace, it sends back only the surviving `di_` ids so other coupons are untouched.

The sub route takes `:coupon_id` rather than a `di_` discount id because `ApiDiscount.id` (what the dashboard holds) is the coupon id, and it mirrors the add route.

Both use `Scopes.Billing.Write`. Neither touches Autumn rows — Stripe is the source of truth for applied discounts.

## Dashboard

- **Customer page** — the applied-coupon ticket chip gets an X (`AppliedCouponChip`).
- **Subscription detail sheet** — each coupon row gets an X (`SubscriptionDiscountRow`).

Both refetch the relevant query and toast on success/failure. Also fixed a latent missing `ApiDiscount` import in `SubscriptionDetailSheet.tsx` that predates this change.

## Tests

`server/tests/integration/rewards/remove-coupon-from-customer-and-subscription.test.ts` (4 passing):

- customer-level discount removed; second DELETE is a no-op
- unknown customer errors
- with two coupons on a sub, only the targeted one is removed; re-DELETE errors
- another customer's subscription errors, and their coupon survives

Verified red first (routes unregistered → falls through to `Unauthorized - no session found`), then green. `add-stripe-only-coupon-to-customer` (3/3) and `rewards-redeem-feature-grant` (7/7) still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable removing coupons at both the customer and subscription levels to reverse applied discounts. Previously you could add coupons but could not remove them.

- API and behavior
  - DELETE /v1/customers/:customer_id/coupons — deletes the customer’s Stripe discount; idempotent 200 when none is applied.
  - DELETE /v1/customers/:customer_id/subscriptions/:subscription_id/coupons/:coupon_id — validates the subscription belongs to the customer, matches on the original coupon id (handles _roll_ variants), and replaces Stripe discounts with only the survivors so other coupons remain.
  - Requires Scopes.Billing.Write. No Autumn DB changes; Stripe is the source of truth.
  - Integration tests cover success, idempotency, ownership, and not-found cases.

- Dashboard
  - Customer page: remove the applied coupon via an X on the coupon chip; refetches and toasts.
  - Subscription detail: remove a single coupon via an X on each coupon row; preserves other coupons; refetches and toasts.

<sup>Written for commit 1c70875cdd715455214de256e45bfeb0bce04948. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds customer- and subscription-level coupon removal across the API and dashboard, with integration coverage for ownership, idempotency, and preserving other coupons.
- **API changes, Bug fixes:** Adds authenticated DELETE endpoints for removing customer and subscription coupons in Stripe.
- **Improvements:** Adds removal controls and query refreshes to the customer page and subscription detail sheet.
- **Improvements:** Adds integration tests covering successful removal, repeated deletion, unknown customers, subscription ownership, and multiple coupons.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until subscription coupon removal reliably preserves every unrelated Stripe discount.

The new full-replacement update builds its survivor list only from expanded discount objects, so a valid string-valued discount response can cause an unrelated discount to be silently removed.

**Files Needing Attention:** server/src/internal/customers/handlers/handleRemoveCouponFromSubscriptionV2.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusRouter.ts | Registers the two new billing-write coupon-removal routes. |
| server/src/internal/customers/handlers/handleRemoveCouponFromCusV2.ts | Idempotently removes a customer-level Stripe discount after an organization-scoped customer lookup. |
| server/src/internal/customers/handlers/handleRemoveCouponFromSubscriptionV2.ts | Verifies subscription ownership and replaces surviving discounts, but can omit unrelated string-valued discounts. |
| server/tests/integration/rewards/remove-coupon-from-customer-and-subscription.test.ts | Covers primary removal, idempotency, ownership, missing-resource, and multi-coupon behavior, but not mixed expanded/string discount responses. |
| vite/src/services/customers/CusService.tsx | Adds dashboard service methods for both DELETE endpoints. |
| vite/src/views/customers2/components/sheets/SubscriptionDetailSheet.tsx | Adds per-subscription coupon removal with loading state, feedback, and reward-query refresh. |
| vite/src/views/customers2/customer/CustomerPageDetails.tsx | Adds customer-level coupon removal with loading state, feedback, and referral-query refresh. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Dashboard
  participant API as Customer DELETE route
  participant DB as Customer service
  participant Stripe
  UI->>API: Remove coupon
  API->>DB: Resolve customer in org/environment
  DB-->>API: Customer and Stripe customer ID
  API->>Stripe: Retrieve customer or subscription
  API->>API: Verify ownership and locate coupon
  API->>Stripe: Delete customer discount or replace subscription discounts
  Stripe-->>API: Updated billing state
  API-->>UI: Success
  UI->>API: Refetch displayed discounts
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/customers/handlers/handleRemoveCouponFromSubscriptionV2.ts:43-45
**String discounts are discarded**

If Stripe returns an unrelated subscription discount as a string ID, this filter drops it before the full-replacement update, causing removal of the targeted coupon to remove that unrelated discount as well.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: remove coupons at the customer and..."](https://github.com/useautumn/autumn/commit/1c70875cdd715455214de256e45bfeb0bce04948) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54442496)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->