### PR TITLE
Improve Autumn tab identification

### DIFF
--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
 import { useEffect, useRef, useState } from "react";
 import { Outlet } from "react-router";
 import { CustomToaster } from "@/components/general/CustomToaster";
+import { SandboxFavicon } from "@/components/general/SandboxFavicon";
 import { PortalContainerContext } from "@/contexts/PortalContainerContext";
 import { useAutumnFlags } from "@/hooks/common/useAutumnFlags";
 import { useGlobalErrorHandler } from "@/hooks/common/useGlobalErrorHandler";
@@ -84,6 +85,7 @@ const DashboardShell = ({
 
 	return (
 		<>
+			<SandboxFavicon />
 			<div className="hidden sm:flex">
 				<MainSidebar />
 			</div>

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -1,4 +1,4 @@
-import { AppEnv } from "@autumn/shared";
+import { AppEnv, DEFAULT_SANDBOX_COLOR } from "@autumn/shared";
 import { useEffect } from "react";
 import { sandboxColorValue } from "@/hooks/sandbox/sandboxDisplay";
 import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
@@ -15,7 +15,10 @@ const sandboxFaviconHref = (color: string) =>
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
-	const color = env === AppEnv.Sandbox ? activeSandbox?.color : undefined;
+	const color =
+		env === AppEnv.Sandbox
+			? (activeSandbox?.color ?? DEFAULT_SANDBOX_COLOR)
+			: undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -1,0 +1,36 @@
+import { AppEnv } from "@autumn/shared";
+import { useEffect } from "react";
+import { sandboxColorValue } from "@/hooks/sandbox/sandboxDisplay";
+import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
+import { useEnv } from "@/utils/envUtils";
+
+const AUTUMN_MARK =
+	"M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z";
+
+const sandboxFaviconHref = (color: string) =>
+	`data:image/svg+xml,${encodeURIComponent(
+		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="white"/><path d="${AUTUMN_MARK}" fill="${sandboxColorValue(color)}"/></svg>`,
+	)}`;
+
+export const SandboxFavicon = () => {
+	const env = useEnv();
+	const activeSandbox = useActiveSandbox();
+	const color = env === AppEnv.Sandbox ? activeSandbox?.color : undefined;
+
+	useEffect(() => {
+		if (!color) return;
+
+		const favicon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+		if (!favicon) return;
+
+		const originalHref = favicon.getAttribute("href");
+		favicon.href = sandboxFaviconHref(color);
+
+		return () => {
+			if (originalHref) favicon.setAttribute("href", originalHref);
+			else favicon.removeAttribute("href");
+		};
+	}, [color]);
+
+	return null;
+};

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -9,7 +9,7 @@ const AUTUMN_MARK =
 
 const sandboxFaviconHref = (color: string) =>
 	`data:image/svg+xml,${encodeURIComponent(
-		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="white"/><path d="${AUTUMN_MARK}" fill="${sandboxColorValue(color)}"/></svg>`,
+		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
 export const SandboxFavicon = () => {

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -1,4 +1,4 @@
-import { AppEnv, DEFAULT_SANDBOX_COLOR } from "@autumn/shared";
+import { AppEnv } from "@autumn/shared";
 import { useEffect } from "react";
 import { sandboxColorValue } from "@/hooks/sandbox/sandboxDisplay";
 import { useActiveSandbox } from "@/hooks/sandbox/useActiveSandbox";
@@ -16,9 +16,7 @@ export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
 	const color =
-		env === AppEnv.Sandbox
-			? (activeSandbox?.color ?? DEFAULT_SANDBOX_COLOR)
-			: undefined;
+		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/hooks/sandbox/sandboxDisplay.tsx
+++ b/vite/src/hooks/sandbox/sandboxDisplay.tsx
@@ -18,6 +18,15 @@ const COLOR_PILL_MAP: Record<SandboxColor, string> = {
 	pink: "text-pink-500 bg-pink-500/10 border-pink-500",
 };
 
+const COLOR_VALUE_MAP: Record<SandboxColor, string> = {
+	gray: "#6a7282",
+	blue: "#2b7fff",
+	green: "#00c950",
+	amber: "#f0b100",
+	red: "#fb2c36",
+	pink: "#f6339a",
+};
+
 export const sandboxColorClass = (color: string | null | undefined): string =>
 	COLOR_CLASS_MAP[color as SandboxColor] ??
 	COLOR_CLASS_MAP[DEFAULT_SANDBOX_COLOR];
@@ -25,3 +34,7 @@ export const sandboxColorClass = (color: string | null | undefined): string =>
 export const sandboxPillClass = (color: string | null | undefined): string =>
 	COLOR_PILL_MAP[color as SandboxColor] ??
 	COLOR_PILL_MAP[DEFAULT_SANDBOX_COLOR];
+
+export const sandboxColorValue = (color: string | null | undefined): string =>
+	COLOR_VALUE_MAP[color as SandboxColor] ??
+	COLOR_VALUE_MAP[DEFAULT_SANDBOX_COLOR];

--- a/vite/src/views/customers2/customer-plan/CustomerPlanEditor.tsx
+++ b/vite/src/views/customers2/customer-plan/CustomerPlanEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { Link, useParams } from "react-router";
+import { useParams } from "react-router";
 import { CustomToaster } from "@/components/general/CustomToaster";
 import { useOrg } from "@/hooks/common/useOrg";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
@@ -9,33 +9,10 @@ import { useProductSync } from "@/hooks/stores/useProductSync";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
 import { useCusProductQuery } from "@/views/customers/customer/product/hooks/useCusProductQuery";
+import { CustomerPageTitle } from "@/views/customers2/customer/CustomerPageTitle";
 import ErrorScreen from "@/views/general/ErrorScreen";
 import LoadingScreen from "@/views/general/LoadingScreen";
 import { PlanEditor } from "@/views/products/plan/components/PlanEditor";
-
-interface OptionValue {
-	feature_id: string;
-	threshold?: number;
-	quantity?: number;
-}
-
-function getProductUrlParams({
-	version,
-	customer_product_id,
-	entity_id,
-}: {
-	version?: string | null;
-	customer_product_id?: string | null;
-	entity_id?: string | null;
-}) {
-	const params = new URLSearchParams();
-	if (version) params.append("version", version);
-	if (customer_product_id)
-		params.append("customer_product_id", customer_product_id);
-	if (entity_id) params.append("entity_id", entity_id);
-	const str = params.toString();
-	return str ? `?${str}` : "";
-}
 
 export default function CustomerProductView() {
 	const { customer_id, product_id } = useParams();
@@ -53,7 +30,7 @@ export default function CustomerProductView() {
 
 	useProductSync({ product: originalProduct });
 
-	const { isLoading: cusLoading } = useCusQuery();
+	const { customer, isLoading: cusLoading } = useCusQuery();
 
 	if (error) {
 		return (
@@ -74,36 +51,10 @@ export default function CustomerProductView() {
 
 	return (
 		<>
+			<CustomerPageTitle customer={customer} />
 			<CustomToaster />
 
 			<PlanEditor />
 		</>
 	);
 }
-
-const CopyUrl = ({
-	url,
-	isInvoice = false,
-}: {
-	url: string;
-	isInvoice: boolean;
-}) => {
-	return (
-		<div className="flex flex-col gap-2">
-			{!isInvoice && (
-				<p className="text-sm text-gray-500">
-					This link will expire in 24 hours
-				</p>
-			)}
-			<div className="w-full bg-gray-100 p-3 rounded-md">
-				<Link
-					className="text-xs text-muted-foreground break-all hover:underline"
-					to={url}
-					target="_blank"
-				>
-					{url}
-				</Link>
-			</div>
-		</div>
-	);
-};

--- a/vite/src/views/customers2/customer/CustomerPageTitle.tsx
+++ b/vite/src/views/customers2/customer/CustomerPageTitle.tsx
@@ -1,10 +1,8 @@
-import type { FullCustomer } from "@autumn/shared";
 import { useEffect } from "react";
-
-type CustomerTitle = Pick<FullCustomer, "name" | "email" | "id">;
-
-export const getCustomerPageTitle = ({ name, email, id }: CustomerTitle) =>
-	`${name || email || id || "Customer"} – Autumn`;
+import {
+	type CustomerTitle,
+	getCustomerPageTitle,
+} from "./getCustomerPageTitle";
 
 export const CustomerPageTitle = ({
 	customer,

--- a/vite/src/views/customers2/customer/CustomerPageTitle.tsx
+++ b/vite/src/views/customers2/customer/CustomerPageTitle.tsx
@@ -1,0 +1,27 @@
+import type { FullCustomer } from "@autumn/shared";
+import { useEffect } from "react";
+
+type CustomerTitle = Pick<FullCustomer, "name" | "email" | "id">;
+
+export const getCustomerPageTitle = ({ name, email, id }: CustomerTitle) =>
+	`${name || email || id || "Customer"} – Autumn`;
+
+export const CustomerPageTitle = ({
+	customer,
+}: {
+	customer: CustomerTitle | null | undefined;
+}) => {
+	const title = customer ? getCustomerPageTitle(customer) : null;
+
+	useEffect(() => {
+		if (!title) return;
+
+		const previousTitle = document.title;
+		document.title = title;
+		return () => {
+			document.title = previousTitle;
+		};
+	}, [title]);
+
+	return null;
+};

--- a/vite/src/views/customers2/customer/CustomerView2.tsx
+++ b/vite/src/views/customers2/customer/CustomerView2.tsx
@@ -32,6 +32,7 @@ import { CustomerUsageAnalyticsTable } from "../components/table/customer-usage-
 import { CustomerBreadcrumbs } from "./CustomerBreadcrumbs2";
 import { CustomerContext } from "./CustomerContext";
 import { CustomerPageDetails } from "./CustomerPageDetails";
+import { CustomerPageTitle } from "./CustomerPageTitle";
 import { CustomerSheets } from "./CustomerSheets";
 import { CustomerHeaderActions } from "./components/CustomerHeaderActions";
 import { SelectedEntityDetails } from "./components/SelectedEntityDetails";
@@ -40,7 +41,6 @@ import { Workbench } from "./workbench/Workbench";
 export default function CustomerView2() {
 	const {
 		customer,
-		schedule,
 		testClockFrozenTimeMs,
 		isLoading: cusLoading,
 	} = useCusQuery();
@@ -85,6 +85,7 @@ export default function CustomerView2() {
 				setIsInlineEditorOpen,
 			}}
 		>
+			<CustomerPageTitle customer={customer} />
 			<div className="flex w-full h-full overflow-hidden relative">
 				<div className="h-full w-full overflow-hidden absolute inset-0 z-0">
 					<div className="flex flex-col overflow-x-hidden overflow-y-auto absolute inset-0 pb-8">

--- a/vite/src/views/customers2/customer/getCustomerPageTitle.ts
+++ b/vite/src/views/customers2/customer/getCustomerPageTitle.ts
@@ -1,0 +1,6 @@
+import type { FullCustomer } from "@autumn/shared";
+
+export type CustomerTitle = Pick<FullCustomer, "name" | "email" | "id">;
+
+export const getCustomerPageTitle = ({ name, email, id }: CustomerTitle) =>
+	`${name || email || id || "Customer"} – Autumn`;

--- a/vite/tests/hooks/sandbox/sandboxDisplay.test.ts
+++ b/vite/tests/hooks/sandbox/sandboxDisplay.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { sandboxColorValue } from "@/hooks/sandbox/sandboxDisplay";
+
+describe("sandboxColorValue", () => {
+	test("maps sandbox colors to their display values", () => {
+		expect(sandboxColorValue("red")).toBe("#fb2c36");
+	});
+
+	test("falls back to the default sandbox color", () => {
+		expect(sandboxColorValue("unknown")).toBe("#6a7282");
+	});
+});

--- a/vite/tests/views/customers2/customer/customer-page-title.test.ts
+++ b/vite/tests/views/customers2/customer/customer-page-title.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getCustomerPageTitle } from "@/views/customers2/customer/CustomerPageTitle";
+import { getCustomerPageTitle } from "@/views/customers2/customer/getCustomerPageTitle";
 
 describe("getCustomerPageTitle", () => {
 	test("uses the customer name", () => {

--- a/vite/tests/views/customers2/customer/customer-page-title.test.ts
+++ b/vite/tests/views/customers2/customer/customer-page-title.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { getCustomerPageTitle } from "@/views/customers2/customer/CustomerPageTitle";
+
+describe("getCustomerPageTitle", () => {
+	test("uses the customer name", () => {
+		expect(
+			getCustomerPageTitle({ name: "Brian Kerr", email: null, id: "brian" }),
+		).toBe("Brian Kerr – Autumn");
+	});
+
+	test("falls back to the email, then ID", () => {
+		expect(
+			getCustomerPageTitle({
+				name: null,
+				email: "brian@resend.com",
+				id: "brian",
+			}),
+		).toBe("brian@resend.com – Autumn");
+		expect(getCustomerPageTitle({ name: null, email: null, id: "brian" })).toBe(
+			"brian – Autumn",
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Color named-sandbox favicons with the active sandbox color.
- Title customer and customer-plan tabs like `Brian Kerr – Autumn`.
- Fall back to customer email or ID when no name is set.

## Tests

- `bun -F @autumn/vite test:unit` (432 passed)
- `bun -F @autumn/vite ts`
- Biome and React Doctor (no changed-file issues)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes browser tabs easier to distinguish by applying sandbox-specific favicons and customer-specific titles.
- **[Improvements]** Colors the Autumn favicon using the active named sandbox’s configured color.
- **[Improvements]** Titles customer and customer-plan tabs using the customer name, email, or ID.
- **[Improvements]** Adds focused tests for sandbox color values and customer-title fallback behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/components/general/SandboxFavicon.tsx | Adds a dashboard-level effect that applies an allowlisted sandbox color to a generated favicon and restores the previous favicon on cleanup. |
| vite/src/views/customers2/customer/CustomerPageTitle.tsx | Adds a reusable effect that updates the browser title for customer pages and restores the previous title when unmounted. |
| vite/src/views/customers2/customer/getCustomerPageTitle.ts | Formats customer tab titles using the name, email, ID, and generic fallback order. |
| vite/src/views/customers2/customer-plan/CustomerPlanEditor.tsx | Extends customer plan-editor tabs with the same customer-aware title used by customer detail pages. |
| vite/src/hooks/sandbox/sandboxDisplay.tsx | Adds fixed hexadecimal values for the existing sandbox color palette. |

<sub>Reviews (5): Last reviewed commit: ["fix: use blue for sandbox favicon"](https://github.com/useautumn/autumn/commit/7d62c8eb572d8e37b139384fbcf58236ac6242c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54445045)</sub>

<!-- /greptile_comment -->