### PR TITLE
fix(migrations): pin batch page ids so replace SELECT cannot scan the product

### DIFF
--- a/server/src/db/withStatementTimeout.ts
+++ b/server/src/db/withStatementTimeout.ts
@@ -12,10 +12,14 @@ export const withStatementTimeout = async <T>(
 	db: DrizzleCli,
 	fn: (tx: DrizzleCli) => Promise<T>,
 	timeoutMs: number = CRON_STATEMENT_TIMEOUT_MS,
+	options?: { forceCustomPlan?: boolean },
 ): Promise<T> =>
 	db.transaction(async (tx) => {
 		await tx.execute(
 			sql.raw(`SET LOCAL statement_timeout = ${Math.floor(timeoutMs)}`),
 		);
+		if (options?.forceCustomPlan) {
+			await tx.execute(sql.raw("SET LOCAL plan_cache_mode = force_custom_plan"));
+		}
 		return fn(tx as unknown as DrizzleCli);
 	});

--- a/server/src/internal/migrations/v2/batchOperations/actions/addCustomerEntitlementsForPage/selectAddCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/addCustomerEntitlementsForPage/selectAddCandidateRows.ts
@@ -8,6 +8,7 @@ import { sql } from "drizzle-orm";
 import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { cycleAnchorSourcesSql } from "@/internal/migrations/v2/batchOperations/actions/utils/cycleAnchorSql.js";
+import { pageCustomerIdsCte } from "@/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.js";
 import {
 	type OperationScope,
 	operationScopeSql,
@@ -74,6 +75,7 @@ export const buildAddCandidateRowsQuery = ({
 	});
 
 	return sql`
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })}
 		SELECT
 			cp.id AS customer_product_id,
 			cp.internal_customer_id,
@@ -88,15 +90,16 @@ export const buildAddCandidateRowsQuery = ({
 			cp.billing_cycle_anchor,
 			${anchors.subscriptionAnchorColumn} AS subscription_cycle_anchor,
 			${anchors.siblingAnchorColumn} AS sibling_reset_cycle_anchor
-		FROM customer_products AS cp
+		FROM page
+		INNER JOIN customer_products AS cp
+			ON cp.internal_customer_id = page.internal_customer_id
 		INNER JOIN customers AS customer
 			ON customer.internal_id = cp.internal_customer_id
 		LEFT JOIN entities AS entity
 			ON entity.internal_id = cp.internal_entity_id
 		${anchors.siblingJoin}
 		${anchors.subscriptionJoin}
-		WHERE cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-			AND ${operationScopeSql({ scope })}
+		WHERE ${operationScopeSql({ scope })}
 			${afterCustomerProductId ? sql`AND cp.id > ${afterCustomerProductId}` : sql``}
 			AND NOT EXISTS (
 				SELECT 1

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/resolveRemovableEntitlementIds.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/resolveRemovableEntitlementIds.ts
@@ -8,6 +8,7 @@ import {
 import { enrichEntitlementsWithFeatures } from "@autumn/shared/utils/productUtils/entUtils/enrichEntitlement.js";
 import { inArray, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { pageCustomerIdsCte } from "@/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.js";
 import { BATCH_MIGRATION_MAX_DISTINCT_ENTITLEMENTS } from "@/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.js";
 import {
 	type OperationScope,
@@ -88,13 +89,15 @@ const selectDistinctLiveEntitlementIds = async ({
 	limit: number;
 }): Promise<string[]> => {
 	const rows = await db.execute<{ id: string }>(sql`
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })}
 		SELECT DISTINCT live.entitlement_id AS id
-		FROM customer_products AS cp
+		FROM page
+		INNER JOIN customer_products AS cp
+			ON cp.internal_customer_id = page.internal_customer_id
 		INNER JOIN customer_entitlements AS live
 			ON live.customer_product_id = cp.id
 			AND live.internal_feature_id = ${internalFeatureId}
-		WHERE cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-			AND ${operationScopeSql({ scope })}
+		WHERE ${operationScopeSql({ scope })}
 		LIMIT ${limit}
 	`);
 	return rows.map((row) => row.id);

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { sqlList } from "@/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.js";
+import { pageCustomerIdsCte } from "@/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.js";
 import { rowIsUnpaidSql } from "@/internal/migrations/v2/batchOperations/actions/utils/rowIsUnpaidSql.js";
 import {
 	type OperationScope,
@@ -51,6 +52,7 @@ export const selectRemoveCandidateRows = async ({
 	if (entitlementIds.length === 0) return [];
 
 	const rows = await db.execute(sql`
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })}
 		SELECT
 			cp.id AS customer_product_id,
 			cp.internal_customer_id,
@@ -60,11 +62,12 @@ export const selectRemoveCandidateRows = async ({
 			cp.canceled_at,
 			cp.ended_at,
 			cp.trial_ends_at
-		FROM customer_products AS cp
+		FROM page
+		INNER JOIN customer_products AS cp
+			ON cp.internal_customer_id = page.internal_customer_id
 		LEFT JOIN entities AS entity
 			ON entity.internal_id = cp.internal_entity_id
-		WHERE cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-			AND ${operationScopeSql({ scope })}
+		WHERE ${operationScopeSql({ scope })}
 			${afterCustomerProductId ? sql`AND cp.id > ${afterCustomerProductId}` : sql``}
 			AND EXISTS (
 				SELECT 1

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeLicenseEntitlementsForPage/removeLicenseEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeLicenseEntitlementsForPage/removeLicenseEntitlementRows.ts
@@ -16,6 +16,7 @@ import {
 	operationScopeSql,
 } from "../../scope/operationScope.js";
 import { canonicalPoolLateralSql } from "../licensePoolSql.js";
+import { pageCustomerIdsCte } from "../utils/pageCustomerIdsSql.js";
 
 /** Pool anchors are excluded because the anchor FK is RESTRICT — deleting one
  * would abort the whole page. */
@@ -64,9 +65,11 @@ export const removeLicenseEntitlementRows = async ({
 		trial_ends_at: string | null;
 		definition: Entitlement;
 	}>(sql`
-		WITH dropped AS (
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })},
+		dropped AS (
 			DELETE FROM customer_entitlements AS target
-			USING entitlements AS definition,
+			USING page,
+				entitlements AS definition,
 				customer_products AS assignment
 				${canonicalPoolLateralSql({ licensePlanId })}
 				JOIN customer_products AS cp
@@ -75,7 +78,7 @@ export const removeLicenseEntitlementRows = async ({
 				AND definition.id = target.entitlement_id
 				AND definition.feature_id = ${filter.feature_id}
 				${intervalCondition}
-				AND assignment.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
+				AND assignment.internal_customer_id = page.internal_customer_id
 				AND assignment.internal_entity_id IS NOT NULL
 				AND assignment.status IN (${sqlList({ values: [...MIGRATABLE_STATUSES] })})
 				AND NOT target.is_pooled_balance

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeLicenseEntitlementsForPage/removeLicenseEntitlementsForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeLicenseEntitlementsForPage/removeLicenseEntitlementsForPage.ts
@@ -46,6 +46,7 @@ export const removeLicenseEntitlementsForPage = async ({
 						features,
 					}),
 				BATCH_MIGRATION_PAGE_STATEMENT_TIMEOUT_MS,
+				{ forceCustomPlan: true },
 			),
 	});
 

--- a/server/src/internal/migrations/v2/batchOperations/actions/replaceCustomerEntitlementsForPage/selectReplaceCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/replaceCustomerEntitlementsForPage/selectReplaceCandidateRows.ts
@@ -8,6 +8,7 @@ import { z } from "zod/v4";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { sqlList } from "@/internal/billing/v2/actions/batchTransition/execute/sql/batchTransitionSqlUtils.js";
 import { cycleAnchorSourcesSql } from "@/internal/migrations/v2/batchOperations/actions/utils/cycleAnchorSql.js";
+import { pageCustomerIdsCte } from "@/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.js";
 import { rowIsUnpaidSql } from "@/internal/migrations/v2/batchOperations/actions/utils/rowIsUnpaidSql.js";
 import {
 	type OperationScope,
@@ -45,19 +46,7 @@ export type ReplaceCandidateRow = CycleEnrichmentCandidate & {
 	liveNextResetAt: number | null;
 };
 
-/** Selects scoped live from-rows and cycle anchors; selecting by from-id
- * makes replay idempotent. */
-export const selectReplaceCandidateRows = async ({
-	db,
-	internalCustomerIds,
-	scope,
-	entitlement,
-	fromEntitlementIds,
-	includeAnchorSources,
-	afterCustomerProductId,
-	limit,
-}: {
-	db: DrizzleCli;
+type SelectReplaceCandidateRowsArgs = {
 	internalCustomerIds: string[];
 	scope: OperationScope;
 	/** The minted to-entitlement; drives the sibling anchor's interval match. */
@@ -66,11 +55,19 @@ export const selectReplaceCandidateRows = async ({
 	includeAnchorSources: boolean;
 	afterCustomerProductId?: string;
 	limit: number;
-}): Promise<ReplaceCandidateRow[]> => {
-	if (internalCustomerIds.length === 0 || fromEntitlementIds.length === 0) {
-		return [];
-	}
+};
 
+/** Selects scoped live from-rows and cycle anchors; selecting by from-id
+ * makes replay idempotent. */
+export const buildReplaceCandidateRowsQuery = ({
+	internalCustomerIds,
+	scope,
+	entitlement,
+	fromEntitlementIds,
+	includeAnchorSources,
+	afterCustomerProductId,
+	limit,
+}: SelectReplaceCandidateRowsArgs) => {
 	const targetInterval = String(entitlement.interval ?? EntInterval.Lifetime);
 	const targetIntervalCount = entitlement.interval_count ?? 1;
 	const anchors = cycleAnchorSourcesSql({
@@ -82,7 +79,8 @@ export const selectReplaceCandidateRows = async ({
 		keepLiveRowAnchor: true,
 	});
 
-	const rows = await db.execute(sql`
+	return sql`
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })}
 		SELECT
 			live.id AS "customerEntitlementId",
 			cp.id AS "customerProductId",
@@ -100,7 +98,9 @@ export const selectReplaceCandidateRows = async ({
 			${anchors.siblingAnchorColumn} AS "siblingResetCycleAnchor",
 			live.balance AS "liveBalance",
 			live.next_reset_at AS "liveNextResetAt"
-		FROM customer_products AS cp
+		FROM page
+		INNER JOIN customer_products AS cp
+			ON cp.internal_customer_id = page.internal_customer_id
 		INNER JOIN customer_entitlements AS live
 			ON live.customer_product_id = cp.id
 			AND live.entitlement_id IN (${sqlList({ values: fromEntitlementIds })})
@@ -110,8 +110,7 @@ export const selectReplaceCandidateRows = async ({
 			ON entity.internal_id = cp.internal_entity_id
 		${anchors.siblingJoin}
 		${anchors.subscriptionJoin}
-		WHERE cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-			AND ${operationScopeSql({ scope })}
+		WHERE ${operationScopeSql({ scope })}
 			AND ${rowIsUnpaidSql({
 				customerProductId: sql`cp.id`,
 				entitlementId: sql`live.entitlement_id`,
@@ -119,7 +118,23 @@ export const selectReplaceCandidateRows = async ({
 			${afterCustomerProductId ? sql`AND cp.id > ${afterCustomerProductId}` : sql``}
 		ORDER BY cp.id
 		LIMIT ${limit}
-	`);
+	`;
+};
+
+export const selectReplaceCandidateRows = async ({
+	db,
+	...args
+}: SelectReplaceCandidateRowsArgs & {
+	db: DrizzleCli;
+}): Promise<ReplaceCandidateRow[]> => {
+	if (
+		args.internalCustomerIds.length === 0 ||
+		args.fromEntitlementIds.length === 0
+	) {
+		return [];
+	}
+
+	const rows = await db.execute(buildReplaceCandidateRowsQuery(args));
 
 	return rows.map((row) => {
 		const parsed = ReplaceCandidateRowSchema.parse(row);

--- a/server/src/internal/migrations/v2/batchOperations/actions/replaceLicenseEntitlementsForPage/listDistinctLicenseEntitlementsForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/replaceLicenseEntitlementsForPage/listDistinctLicenseEntitlementsForPage.ts
@@ -13,6 +13,7 @@ import { BATCH_MIGRATION_MAX_DISTINCT_ENTITLEMENTS } from "../../execute/utils/b
 import type { OperationScope } from "../../scope/operationScope.js";
 import { operationScopeSql } from "../../scope/operationScope.js";
 import { canonicalPoolLateralSql } from "../licensePoolSql.js";
+import { pageCustomerIdsCte } from "../utils/pageCustomerIdsSql.js";
 
 export type DistinctLicenseEntitlementsForPage = {
 	distinct: EntitlementWithFeature[];
@@ -103,16 +104,18 @@ const selectDistinctLiveEntitlementIds = async ({
 	limit: number;
 }): Promise<string[]> => {
 	const idRows = await db.execute<{ id: string }>(sql`
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })}
 		SELECT DISTINCT live.entitlement_id AS id
-		FROM customer_products AS assignment
+		FROM page
+		INNER JOIN customer_products AS assignment
+			ON assignment.internal_customer_id = page.internal_customer_id
 		${canonicalPoolLateralSql({ licensePlanId, columns: sql`pool.*` })}
 		INNER JOIN customer_products AS cp
 			ON cp.id = pool.parent_customer_product_id
 		INNER JOIN customer_entitlements AS live
 			ON live.customer_product_id = assignment.id
 			AND live.internal_feature_id = ${internalFeatureId}
-		WHERE assignment.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-			AND assignment.internal_entity_id IS NOT NULL
+		WHERE assignment.internal_entity_id IS NOT NULL
 			AND assignment.status IN (${sqlList({ values: [...MIGRATABLE_STATUSES] })})
 			AND ${operationScopeSql({ scope })}
 		LIMIT ${limit}

--- a/server/src/internal/migrations/v2/batchOperations/actions/repointCustomerProductsForPage/repointCustomerProductRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/repointCustomerProductsForPage/repointCustomerProductRows.ts
@@ -6,6 +6,7 @@ import {
 	type OperationScope,
 	operationScopeSql,
 } from "../../scope/operationScope.js";
+import { pageCustomerIdsCte } from "../utils/pageCustomerIdsSql.js";
 
 const RepointedCustomerProductRowSchema = z.object({
 	customer_product_id: z.string(),
@@ -41,7 +42,8 @@ export const repointCustomerProductRows = async ({
 	toInternalProductId: string;
 }): Promise<RepointedCustomerProductRow[]> => {
 	const rows = await db.execute(sql`
-		WITH candidate_rows AS MATERIALIZED (
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })},
+		candidate_rows AS MATERIALIZED (
 			SELECT
 				cp.id AS customer_product_id,
 				cp.internal_customer_id,
@@ -51,11 +53,12 @@ export const repointCustomerProductRows = async ({
 				cp.canceled_at,
 				cp.ended_at,
 				cp.trial_ends_at
-			FROM customer_products AS cp
+			FROM page
+			INNER JOIN customer_products AS cp
+				ON cp.internal_customer_id = page.internal_customer_id
 			LEFT JOIN entities AS entity
 				ON entity.internal_id = cp.internal_entity_id
-			WHERE cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-				AND ${operationScopeSql({ scope })}
+			WHERE ${operationScopeSql({ scope })}
 			FOR UPDATE OF cp
 		),
 		updated AS (

--- a/server/src/internal/migrations/v2/batchOperations/actions/repointLicensePoolForPage/repointLicensePoolForPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/repointLicensePoolForPage/repointLicensePoolForPage.ts
@@ -44,6 +44,7 @@ export const repointLicensePoolForPage = async ({
 						licensePlanId: operation.licensePlanId,
 					}),
 				BATCH_MIGRATION_PAGE_STATEMENT_TIMEOUT_MS,
+				{ forceCustomPlan: true },
 			),
 	});
 

--- a/server/src/internal/migrations/v2/batchOperations/actions/repointLicensePoolForPage/repointLicensePoolRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/repointLicensePoolForPage/repointLicensePoolRows.ts
@@ -6,6 +6,7 @@ import {
 	canonicalPoolOrderingSql,
 	poolLicensePlanSql,
 } from "../licensePoolSql.js";
+import { pageCustomerIdsCte } from "../utils/pageCustomerIdsSql.js";
 
 /** Granted stays derived: included moves, paid_quantity is billing-owned. */
 export const repointLicensePoolRows = async ({
@@ -25,6 +26,7 @@ export const repointLicensePoolRows = async ({
 		return { pools: 0, internalCustomerIds: [] };
 
 	const updated = await db.execute<{ internal_customer_id: string }>(sql`
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })}
 		UPDATE customer_licenses AS pool
 		SET
 			plan_license_id = ${planLicenseId},
@@ -32,15 +34,15 @@ export const repointLicensePoolRows = async ({
 			remaining =
 				pool.remaining + ((target.included + pool.paid_quantity) - pool.granted),
 			updated_at = ${Date.now()}
-		FROM customer_products AS cp, plan_license AS target
+		FROM page, customer_products AS cp, plan_license AS target
 		WHERE cp.id = pool.parent_customer_product_id
 			AND target.id = ${planLicenseId}
 			AND ${poolLicensePlanSql({ licensePlanId })}
 			AND pool.plan_license_id IS DISTINCT FROM ${planLicenseId}
 			-- Scoped on the pool as well as the parent: matching the license plan
 			-- alone spans every pool in the org, so the page must drive this scan.
-			AND pool.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-			AND cp.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
+			AND pool.internal_customer_id = page.internal_customer_id
+			AND cp.internal_customer_id = page.internal_customer_id
 			AND ${operationScopeSql({ scope })}
 			AND pool.id = (
 				SELECT live.id

--- a/server/src/internal/migrations/v2/batchOperations/actions/selectLicenseCandidateRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/selectLicenseCandidateRows.ts
@@ -13,6 +13,7 @@ import type { OperationScope } from "../scope/operationScope.js";
 import { operationScopeSql } from "../scope/operationScope.js";
 import { canonicalPoolLateralSql } from "./licensePoolSql.js";
 import { cycleAnchorSourcesSql } from "./utils/cycleAnchorSql.js";
+import { pageCustomerIdsCte } from "./utils/pageCustomerIdsSql.js";
 
 const nullableNumeric = z.preprocess(
 	(value) => (value === null || value === undefined ? null : Number(value)),
@@ -181,6 +182,7 @@ export async function selectLicenseCandidateRows({
 	});
 
 	const rows = await db.execute(sql`
+		WITH ${pageCustomerIdsCte({ internalCustomerIds })}
 		SELECT
 			${matched.customerEntitlementId} AS "customerEntitlementId",
 			assignment.id AS "customerProductId",
@@ -203,7 +205,9 @@ export async function selectLicenseCandidateRows({
 			${anchors.siblingAnchorColumn} AS "siblingResetCycleAnchor",
 			${matched.liveBalance} AS "liveBalance",
 			${matched.liveNextResetAt} AS "liveNextResetAt"
-		FROM customer_products AS assignment
+		FROM page
+		INNER JOIN customer_products AS assignment
+			ON assignment.internal_customer_id = page.internal_customer_id
 		${canonicalPoolLateralSql({ licensePlanId, columns: sql`pool.*` })}
 		INNER JOIN customer_products AS cp
 			ON cp.id = pool.parent_customer_product_id
@@ -214,8 +218,7 @@ export async function selectLicenseCandidateRows({
 			ON entity.internal_id = assignment.internal_entity_id
 		${anchors.siblingJoin}
 		${anchors.subscriptionJoin}
-		WHERE assignment.internal_customer_id = ANY(${sql.param(internalCustomerIds)}::text[])
-			AND assignment.internal_entity_id IS NOT NULL
+		WHERE assignment.internal_entity_id IS NOT NULL
 			AND assignment.status IN (${sqlList({ values: [...MIGRATABLE_STATUSES] })})
 			AND ${operationScopeSql({ scope })}
 			${afterCustomerProductId ? sql`AND assignment.id > ${afterCustomerProductId}` : sql``}

--- a/server/src/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.ts
@@ -1,0 +1,11 @@
+import { type SQL, sql } from "drizzle-orm";
+
+/** Materialize the claimed page's customer ids so the planner cannot
+ * estimate `= ANY($1::text[])` as 1 row and nest-loop the whole product. */
+export const pageCustomerIdsCte = ({
+	internalCustomerIds,
+}: {
+	internalCustomerIds: string[];
+}): SQL => sql`page AS MATERIALIZED (
+	SELECT unnest(${sql.param(internalCustomerIds)}::text[]) AS internal_customer_id
+)`;

--- a/server/src/internal/migrations/v2/batchOperations/execute/customerProductPagination/iterateCustomerProductPages.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/customerProductPagination/iterateCustomerProductPages.ts
@@ -57,6 +57,7 @@ export const iterateCustomerProductPages = async <
 					assertWithinCeiling,
 				}),
 			BATCH_MIGRATION_PAGE_STATEMENT_TIMEOUT_MS,
+			{ forceCustomPlan: true },
 		);
 		if (rows.length === 0) break;
 		rowCount += rows.length;

--- a/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts
@@ -229,6 +229,7 @@ export const executeBatchMigrationPage = async ({
 						skippedInternalCustomerIds: skippedIds,
 					}),
 				BATCH_MIGRATION_PAGE_STATEMENT_TIMEOUT_MS,
+				{ forceCustomPlan: true },
 			),
 	});
 

--- a/server/tests/unit/migrations-v2/batch-operations/page-customer-ids-sql.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/page-customer-ids-sql.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { EntInterval, type EntitlementWithFeature } from "@autumn/shared";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { buildAddCandidateRowsQuery } from "@/internal/migrations/v2/batchOperations/actions/addCustomerEntitlementsForPage/selectAddCandidateRows.js";
+import { buildReplaceCandidateRowsQuery } from "@/internal/migrations/v2/batchOperations/actions/replaceCustomerEntitlementsForPage/selectReplaceCandidateRows.js";
+import { pageCustomerIdsCte } from "@/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.js";
+import { buildOperationScope } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
+
+const dialect = new PgDialect();
+const normalize = (value: string) => value.replace(/\s+/g, " ").trim();
+
+const entitlement = {
+	id: "ent_to",
+	interval: EntInterval.Month,
+	interval_count: 1,
+	internal_feature_id: "feat_internal",
+	feature: { id: "emails", type: "metered" },
+} as EntitlementWithFeature;
+
+const scope = buildOperationScope({
+	internalProductId: "prod_internal",
+	isCustom: false,
+});
+
+const render = (query: Parameters<PgDialect["sqlToQuery"]>[0]) =>
+	normalize(dialect.sqlToQuery(query).sql);
+
+describe("pageCustomerIdsCte", () => {
+	test("materializes unnest so ANY() cannot collapse to 1 row", () => {
+		const sql = render(
+			pageCustomerIdsCte({ internalCustomerIds: ["cus_1", "cus_2"] }),
+		);
+
+		expect(sql).toContain("page AS MATERIALIZED");
+		expect(sql).toContain("unnest($1::text[])");
+		expect(sql).not.toContain("= ANY");
+	});
+});
+
+describe("page-scoped candidate selects", () => {
+	test("replace drives from the page CTE, not ANY(customer ids)", () => {
+		const sql = render(
+			buildReplaceCandidateRowsQuery({
+				internalCustomerIds: ["cus_1", "cus_2"],
+				scope,
+				entitlement,
+				fromEntitlementIds: ["ent_from"],
+				includeAnchorSources: true,
+				limit: 10000,
+			}),
+		);
+
+		expect(sql).toContain("page AS MATERIALIZED");
+		expect(sql).toContain("FROM page");
+		expect(sql).toContain(
+			"INNER JOIN customer_products AS cp ON cp.internal_customer_id = page.internal_customer_id",
+		);
+		expect(sql).not.toMatch(/internal_customer_id = ANY/);
+	});
+
+	test("add drives from the page CTE, not ANY(customer ids)", () => {
+		const sql = render(
+			buildAddCandidateRowsQuery({
+				internalCustomerIds: ["cus_1", "cus_2"],
+				scope,
+				entitlement,
+				includeAnchorSources: true,
+				limit: 10000,
+			}),
+		);
+
+		expect(sql).toContain("page AS MATERIALIZED");
+		expect(sql).toContain("FROM page");
+		expect(sql).not.toMatch(/internal_customer_id = ANY/);
+	});
+});


### PR DESCRIPTION
## Summary
- Materialize the claimed page (`WITH page AS MATERIALIZED (SELECT unnest(...) AS internal_customer_id)`) and `SET LOCAL plan_cache_mode = force_custom_plan` on batch page transactions so the page drives the join.
- Same CTE applied to the other batch page queries that used `ANY(customer ids)` (add/remove/repoint/license). License-add catalog-join rewrite is **not** in this PR.

## Test plan
- [x] `bun test server/tests/unit/migrations-v2/batch-operations/page-customer-ids-sql.test.ts` (3 pass)
- [ ] Deploy to prod, then replay `transactional_free-migrate-all-to-v2-iwi`
- [ ] Confirm pages no longer 60s-timeout on the replace candidate SELECT



Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop batch migration page timeouts by materializing page customer IDs and forcing custom plans. Previously queries filtered with = ANY($1::text[]), which generic plans estimated as 1 row and nest-loop scanned the product; now a MATERIALIZED page CTE drives joins, and page-scoped transactions use force_custom_plan.

- Add `pageCustomerIdsCte` and rewrite page queries to join from `page` (add/remove/replace/repoint customer and license operations, plus license candidate/distinct selects). Semantics are unchanged.
- Extend `withStatementTimeout` with `{ forceCustomPlan }` and enable it for page executions.
- Keep license-add catalog-join rewrite out of scope.
- Add unit tests that render SQL and assert the page CTE drives the join and `ANY()` is not used.

**Rollout**
- Deploy and replay the `transactional_free-migrate-all-to-v2-iwi` job. Verify replace candidate SELECTs no longer hit 60s statement timeouts.

<sup>Written for commit e3afac4d4b264dbe195bbb9cd11c2d0a9772eda5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes migration-page queries to materialize their customer IDs and force PostgreSQL custom query plans, preventing generic plans from scanning far beyond the claimed page.
- **Bug fixes:** Replaces customer-ID `ANY(...)` filters with a materialized page CTE that drives entitlement and license joins.
- **Improvements:** Adds an optional transaction-level custom-plan setting and enables it for batch migration page transactions.
- **Improvements:** Adds SQL-shape tests for the page CTE and the add/replace candidate queries.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness or security regressions identified in the changed migration paths.

The claimed pages provide unique customer IDs, the new transaction setting is applied within top-level page transactions, and the rewritten joins preserve the reviewed customer and license ownership relationships.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/withStatementTimeout.ts | Adds an optional transaction-scoped custom-plan setting without changing existing callers that omit the option. |
| server/src/internal/migrations/v2/batchOperations/actions/utils/pageCustomerIdsSql.ts | Introduces the shared materialized CTE used to make claimed customer IDs drive query planning. |
| server/src/internal/migrations/v2/batchOperations/actions/replaceCustomerEntitlementsForPage/selectReplaceCandidateRows.ts | Rewrites the timed-out replacement candidate query around the materialized page and extracts a query builder for testing. |
| server/src/internal/migrations/v2/batchOperations/actions/repointLicensePoolForPage/repointLicensePoolRows.ts | Scopes pool and parent-product updates through the same page row, consistent with the customer ownership invariant in reviewed creation paths. |
| server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts | Enables custom PostgreSQL plans for the transaction that executes migration-page marking work. |
| server/tests/unit/migrations-v2/batch-operations/page-customer-ids-sql.test.ts | Verifies that the helper and representative candidate queries render a materialized page CTE rather than customer-ID ANY predicates. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Worker as Migration worker
  participant TX as Page transaction
  participant PG as PostgreSQL
  Worker->>TX: Execute claimed customer page
  TX->>PG: SET LOCAL statement_timeout
  TX->>PG: "SET LOCAL plan_cache_mode = force_custom_plan"
  TX->>PG: Materialize page customer IDs
  PG->>PG: Join page IDs to customer products
  PG-->>TX: Return or mutate page-scoped rows
  TX-->>Worker: Commit page result
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): pin batch page customer..."](https://github.com/useautumn/autumn/commit/e3afac4d4b264dbe195bbb9cd11c2d0a9772eda5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54452969)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->