### PR TITLE
fix: persist grouped-step previews on the approval row

### DIFF
--- a/apps/leaf/src/internal/approvals/actions/createApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/createApproval.ts
@@ -133,8 +133,7 @@ export const createApproval = async ({
 		return undefined;
 	}
 
-	const toolArgs = publicToolArgs(approval.toolArgs);
-	const request = toolRequestFromArgs(toolArgs);
+	const request = toolRequestFromArgs(publicToolArgs(approval.toolArgs));
 	const resolvedPreview = await resolveApprovalPreview({
 		env,
 		getToken,
@@ -150,11 +149,14 @@ export const createApproval = async ({
 		request,
 	});
 	const preview = withApprovalDisplay({ display, preview: resolvedPreview });
-	const groupedToolArgs = await withGroupedWritePreviews({
+	// Enrich the raw args so the stored row keeps both the harness transport
+	// keys (approve/deny ids, sibling ids) and the backfilled step previews;
+	// every later card render reads from the row.
+	const storedToolArgs = await withGroupedWritePreviews({
 		env,
 		getToken,
 		logger,
-		toolArgs,
+		toolArgs: approval.toolArgs,
 	});
 
 	const approvalId = await chatApprovalRepo.insert({
@@ -168,7 +170,7 @@ export const createApproval = async ({
 			provider,
 			providerUserId,
 			runId: turn.sessionId,
-			toolArgs: approval.toolArgs,
+			toolArgs: storedToolArgs,
 			toolCallId: approval.toolCallId,
 			toolName: approval.toolName,
 			workspaceId,
@@ -184,7 +186,7 @@ export const createApproval = async ({
 		approvalId,
 		params: request,
 		preview,
-		toolArgs: groupedToolArgs,
+		toolArgs: publicToolArgs(storedToolArgs),
 		toolName: approval.toolName,
 	} as const;
 };

--- a/apps/leaf/tests/unit/approvals/createApprovalPersistsGroup.test.ts
+++ b/apps/leaf/tests/unit/approvals/createApprovalPersistsGroup.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/env.js", () => ({ env: {} }));
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+const inserted: Array<Record<string, unknown>> = [];
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/repos/chatApprovalRepo.js",
+	factory: () => ({
+		chatApprovalRepo: {
+			insert: async ({ data }: { data: Record<string, unknown> }) => {
+				inserted.push(data);
+				return "chat_app_1";
+			},
+		},
+	}),
+});
+
+const previewFor = (customerId: string) => ({
+	content: [
+		{
+			type: "text",
+			text: JSON.stringify({
+				currency: "usd",
+				customer_id: customerId,
+				line_items: [],
+				total: 2400,
+			}),
+		},
+	],
+});
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/utils/fetchApprovalPreview.js",
+	factory: () => ({
+		FAILED_APPROVAL_PREVIEW: { failed: true },
+		fetchApprovalPreview: async ({
+			request,
+		}: {
+			request: { customer_id: string };
+		}) => previewFor(request.customer_id),
+		isFailedApprovalPreview: () => false,
+		shouldRefreshApprovalPreview: () => true,
+	}),
+});
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/utils/approvalDisplay.js",
+	factory: () => ({
+		resolveApprovalDisplay: async () => ({}),
+		withApprovalDisplay: ({ preview }: { preview: unknown }) => preview,
+	}),
+});
+
+const { createApproval } = await import(
+	"../../../src/internal/approvals/actions/createApproval.js"
+);
+
+// Every card after the first post — running, resolved, superseded, and the
+// dashboard poll — renders from the stored row, so the step previews backfilled
+// for the pending card must be persisted, not only returned.
+describe("createApproval persists the grouped-step previews", () => {
+	test("the stored tool_args carry a preview for every grouped write", async () => {
+		inserted.length = 0;
+		await createApproval({
+			channelId: "C1",
+			env: AppEnv.Sandbox,
+			getToken: async () => "tok",
+			logger: { error: () => {}, info: () => {}, warn: () => {} } as never,
+			orgId: "org_1",
+			provider: "slack",
+			providerUserId: "U1",
+			turn: {
+				approval: {
+					toolArgs: {
+						_eveApproveOptionId: "approve",
+						_eveDenyOptionId: "deny",
+						_eveSiblingRequestIds: ["req_leaf-0002", "req_leaf-0003"],
+						_eveWithheldWrites: ["leaf-0002", "leaf-0003"].map(
+							(customerId) => ({
+								input: {
+									request: {
+										customer_id: customerId,
+										plan_id: "security_pack",
+									},
+								},
+								requestId: `req_${customerId}`,
+								toolName: "autumn__attach",
+							}),
+						),
+						request: { customer_id: "leaf-0001", plan_id: "security_pack" },
+					},
+					toolCallId: "req_1",
+					toolName: "autumn__attach",
+				},
+				sessionId: "eve_1",
+			} as never,
+			workspaceId: "T1",
+		});
+
+		const stored = inserted[0]?.toolArgs as {
+			_eveApproveOptionId?: string;
+			_eveSiblingRequestIds?: string[];
+			_eveWithheldWrites: Array<{ preview?: unknown }>;
+		};
+		expect(stored._eveWithheldWrites).toHaveLength(2);
+		for (const step of stored._eveWithheldWrites) {
+			expect(step.preview).toBeDefined();
+		}
+		// The approve click reads these off the row; enriching must not strip them.
+		expect(stored._eveApproveOptionId).toBe("approve");
+		expect(stored._eveSiblingRequestIds).toEqual([
+			"req_leaf-0002",
+			"req_leaf-0003",
+		]);
+	});
+});

--- a/packages/mcp/tests/unit/tools/client.test.ts
+++ b/packages/mcp/tests/unit/tools/client.test.ts
@@ -26,7 +26,7 @@ describe("callAutumn", () => {
 				),
 			)
 			.mockResolvedValueOnce(Response.json({ id: "customer" }));
-		globalThis.fetch = fetch as typeof globalThis.fetch;
+		globalThis.fetch = fetch as unknown as typeof globalThis.fetch;
 
 		expect(
 			await callAutumn({
@@ -46,7 +46,7 @@ describe("callAutumn", () => {
 				{ status: 500 },
 			),
 		);
-		globalThis.fetch = fetch as typeof globalThis.fetch;
+		globalThis.fetch = fetch as unknown as typeof globalThis.fetch;
 
 		await expect(
 			callAutumn({


### PR DESCRIPTION
## Summary

Three fixes on top of #2874 — the last two unblock the `dev → main` release (#2876).

### Grouped previews were lost after the first card post
`createApproval` backfilled a preview for every grouped write but stored the **raw** args and only returned the enriched ones. Every card rendered from the row after the initial post — running, resolved, superseded, and the dashboard poll — lost the step previews. Visible as a four-customer fan-out reading `$2,400` per row while pending, then `$2,400 / $0 / $0 / $0` the moment it was approved.

The naive fix (store the enriched public args) would have stripped the harness transport keys the approve click reads off the row (`_eveApproveOptionId`, `_eveSiblingRequestIds`) and broken resume. So: enrich the **raw** args, store that, derive the public form from it. Test guards both the previews and the transport keys.

### Release type check
`packages/mcp/tests/unit/tools/client.test.ts` cast a Bun `Mock` straight to `typeof fetch` (TS2352). Routed through `unknown`, matching the existing leaf tests. Zero mcp type errors; the test still passes.

### Release Docker build
`package.json` declares a `patchedDependencies` entry for `@chat-adapter/slack`, but the Dockerfile's deps layer only copied `package.json` + lockfiles, so `bun install` failed with `Couldn't find patch file`. `patches/` is now copied alongside the other install inputs. Verified by building the `deps` stage locally — `bun install` completes.

## Test plan

- [x] 311 leaf unit tests green, `bun ts` clean
- [x] `packages/mcp` typecheck: 0 errors
- [x] `docker build --target deps` succeeds locally (the exact CI step that failed)
- [x] Live matrix (`multiWriteMatrix.e2e.ts "fan-out"`): fan-out and per-customer customize fully green against real customer state, previews intact after approve