### PR TITLE
fix: copy patches into the docker install layer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,9 @@ WORKDIR /app
 # all (add a line here when a workspace is added). Source is copied later, so this
 # layer caches until a package.json or the lockfile changes.
 COPY package.json bun.lock bunfig.toml ./
+# patchedDependencies in package.json are applied during install, so the
+# patch files must be present before it runs.
+COPY patches/ patches/
 COPY server/package.json server/
 COPY shared/package.json shared/
 COPY vite/package.json vite/


### PR DESCRIPTION
## Summary

Unblocks the `dev → main` release (#2876), which fails at **Build and Push Docker Image** with:

```
error: Couldn't find patch file: 'patches/@chat-adapter%2Fslack@4.37.0.patch'
```

`package.json` declares a `patchedDependencies` entry for `@chat-adapter/slack` (added in #2873), but the Dockerfile's deps layer only copied `package.json` + lockfiles before `bun install`. Bun applies patches during install, so the file has to be present in that layer. One `COPY patches/ patches/` alongside the other install inputs.

This was meant to ship in #2877 but that PR merged before the commit landed on it.

## Test plan

- [x] `docker build --target deps` on current `dev` — `bun install` completes, no patch error (the exact CI step that fails)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copies the `patches/` directory into the Docker deps layer so `bun install` can apply `patchedDependencies` for `@chat-adapter/slack`. Previously the deps layer only copied `package.json` and lockfiles, causing the release build to fail with “Couldn't find patch file.” This unblocks the `dev → main` image build; no runtime behavior changes.

- Adds `COPY patches/ patches/` to the deps stage in `docker/Dockerfile`. Docker caching now also keys on patch files.
- To verify locally: `docker build --target deps` should complete `bun install` without the patch error.

<sup>Written for commit c67df3121646b26066355a96e9eb3323d4a0c14f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Docker dependency installation by copying Bun dependency patches into the image before `bun install`.
- **[Bug fixes]** Adds the `patches/` directory to the dependency layer so Bun can apply the declared `@chat-adapter/slack` patch.
- **[Improvements]** Keeps patch files alongside other dependency-install inputs, allowing patch changes to invalidate the cached install layer correctly.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge and directly fixes the Docker dependency installation failure.

The patch directory exists, is included in the repository-root Docker build context, is not excluded by `.dockerignore`, and is copied to the relative path expected by Bun before installation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/Dockerfile | Correctly copies repository patch files before dependency installation; known builds use a compatible repository-root context. |

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 copy patches into the docker ins..."](https://github.com/useautumn/autumn/commit/c67df3121646b26066355a96e9eb3323d4a0c14f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54488613)</sub>

<!-- /greptile_comment -->