### PR TITLE
fix: show the customer's live quantity on remove rows

### DIFF
--- a/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
+++ b/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
@@ -8,6 +8,9 @@ const text = (value: unknown) =>
 const record = (value: unknown) =>
 	value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 
+const getArray = (value: unknown): unknown[] =>
+	Array.isArray(value) ? value : [];
+
 const planNameFromPreview = ({
 	planId,
 	preview,
@@ -124,6 +127,7 @@ export const resolveApprovalDisplay = async ({
 		customerId
 			? fetchRecord("getCustomer", {
 					customer_id: customerId,
+					expand: ["subscriptions.plan"],
 					with_autumn_id: false,
 				})
 			: null,
@@ -139,10 +143,22 @@ export const resolveApprovalDisplay = async ({
 	const planRecords = Object.fromEntries(
 		plans.map(([id, value]) => [id, record(value.plan ?? value)]),
 	);
+	// A remove_items filter names a feature; the quantity being removed is what
+	// the customer currently holds, which a customized subscription can set
+	// differently from the catalog plan. Prefer the live subscription's items.
+	const subscriptionItemsByPlan = Object.fromEntries(
+		getArray(customerRecord.subscriptions).flatMap((subscription) => {
+			const entry = record(subscription);
+			const planId = text(entry.plan_id);
+			const items = record(entry.plan).items;
+			return planId && Array.isArray(items) ? [[planId, items]] : [];
+		}),
+	);
 	const basePlanItemsByPlan = Object.fromEntries(
-		Object.entries(planRecords).flatMap(([id, value]) =>
-			Array.isArray(value.items) ? [[id, value.items]] : [],
-		),
+		Object.entries(planRecords).flatMap(([id, value]) => {
+			const items = subscriptionItemsByPlan[id] ?? value.items;
+			return Array.isArray(items) ? [[id, items]] : [];
+		}),
 	);
 	const fetchedPlanNames = Object.fromEntries(
 		Object.entries(planRecords).flatMap(([id, value]) => {

--- a/apps/leaf/tests/unit/approvals/approvalDisplay.test.ts
+++ b/apps/leaf/tests/unit/approvals/approvalDisplay.test.ts
@@ -42,6 +42,7 @@ describe("resolveApprovalDisplay", () => {
 			{
 				request: {
 					customer_id: "kp-customer-1000",
+					expand: ["subscriptions.plan"],
 					with_autumn_id: false,
 				},
 				toolName: "getCustomer",
@@ -244,5 +245,86 @@ describe("resolveApprovalDisplay", () => {
 			pro: [{ feature_id: "messages", included: 800 }],
 		});
 		expect(display.planNames).toEqual({ pro: "Pro" });
+	});
+});
+
+// remove_items is a filter; the quantity being removed is what the customer
+// currently holds. A customized subscription can differ from the catalog
+// plan, so the customer's live items must take precedence when present.
+describe("base items prefer the customer's live subscription", () => {
+	test("uses the subscription's customized items over the catalog plan", async () => {
+		const display = await resolveApprovalDisplay({
+			env: AppEnv.Sandbox,
+			executeTool: async ({ toolName }) => ({
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify(
+							toolName === "getPlan"
+								? {
+										items: [{ feature_id: "contacts", included: 0 }],
+										name: "Enterprise",
+									}
+								: {
+										email: "ops@atlas.example",
+										name: "Atlas Management Group",
+										subscriptions: [
+											{
+												plan: {
+													id: "enterprise",
+													items: [
+														{ feature_id: "contacts", included: 250_000 },
+													],
+													name: "Enterprise",
+												},
+												plan_id: "enterprise",
+											},
+										],
+									},
+						),
+					},
+				],
+			}),
+			getToken: async () => "token",
+			preview: undefined,
+			request: {
+				customer_id: "cus_atlas",
+				customize: { remove_items: [{ feature_id: "contacts" }] },
+				plan_id: "enterprise",
+			},
+		});
+
+		expect(display.basePlanItems).toEqual([
+			{ feature_id: "contacts", included: 250_000 },
+		]);
+	});
+
+	test("falls back to the catalog plan when the customer has no such subscription", async () => {
+		const display = await resolveApprovalDisplay({
+			env: AppEnv.Sandbox,
+			executeTool: async ({ toolName }) => ({
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify(
+							toolName === "getPlan"
+								? { items: [{ feature_id: "seats", included: 5 }], name: "Pro" }
+								: {
+										email: "new@example.com",
+										name: "Newco",
+										subscriptions: [],
+									},
+						),
+					},
+				],
+			}),
+			getToken: async () => "token",
+			preview: undefined,
+			request: { customer_id: "cus_new", plan_id: "pro" },
+		});
+
+		expect(display.basePlanItems).toEqual([
+			{ feature_id: "seats", included: 5 },
+		]);
 	});
 });

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -1518,3 +1518,54 @@ describe("grouped steps follow the card state", () => {
 		expect(rendered).toContain("Attaching");
 	});
 });
+
+// A remove_items filter names a feature, not a quantity. The quantity being
+// removed is whatever the customer CURRENTLY has, which can differ from the
+// catalog plan — showing the catalog's included count (often 0) is wrong.
+describe("remove rows show the customer's current quantity", () => {
+	test("removes 250,000 contacts the customer has, not the catalog's 0", () => {
+		const card = approvalCard({
+			id: "u1",
+			env: AppEnv.Sandbox,
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "cus_atlas",
+					customize: {
+						add_items: [{ feature_id: "contacts", included: 500_000 }],
+						remove_items: [{ feature_id: "contacts" }],
+					},
+					plan_id: "enterprise",
+				},
+			},
+			preview: wrapMcpResult({
+				_display: {
+					// resolveApprovalDisplay already prefers the customer's live
+					// subscription items over the catalog's; the card must render
+					// that quantity rather than re-deriving from the filter.
+					basePlanItems: [{ feature_id: "contacts", included: 250_000 }],
+					customerName: "Atlas Management Group",
+					featureNames: {
+						contacts: {
+							name: "contacts",
+							plural: "contacts",
+							singular: "contact",
+						},
+					},
+					planName: "Enterprise",
+				},
+				preview: {
+					currency: "usd",
+					customer_id: "cus_atlas",
+					line_items: [],
+					total: 189.1,
+				},
+			}),
+		});
+
+		const rendered = JSON.stringify(cardToBlockKit(card));
+		expect(rendered).toContain("250,000 contacts");
+		// Anchor on the cell boundary: "500,000 contacts" also contains "0 contacts".
+		expect(rendered).not.toContain('"0 contacts"');
+	});
+});


### PR DESCRIPTION
## Summary

Reported by Ayush: an update-subscription card showed **"Remove 0 contacts"** when the customer actually had **250,000** contacts being removed.

### Root cause
A `remove_items` entry is a **feature filter** (`{ feature_id: "contacts" }`), not a quantity. To show what's being removed, the card matches that filter against the plan's base items and renders the matched item's `included`. Those base items came from `getPlan` — the **catalog** plan — where `contacts` is `0`. But this customer's subscription was **customized** to 250,000. So the card faithfully rendered the catalog's zero.

### Fix
`resolveApprovalDisplay` already calls `getCustomer` for the name. It now also expands `subscriptions.plan` and prefers the customer's **live subscription items** for the plan being changed, falling back to the catalog only when no such subscription exists (e.g. a fresh attach, where there's nothing live yet).

The render package (`removedItemDisplays`) was already correct — given the right base items it produces `250,000`. Only the source of those items was wrong.

## Test plan

- [x] Source test (`approvalDisplay.test.ts`): live subscription items win over catalog; catalog still used when no subscription. Confirmed red with the fix reverted.
- [x] Card test (`blocks.test.ts`): Ayush's exact shape renders `250,000 contacts`
- [x] 314 leaf unit tests green, `bun ts` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes approval cards to show the customer’s current quantity on “remove” rows. Previously we read quantities from the catalog plan and could display “Remove 0 contacts”; now we prefer the customer’s live subscription items for the target plan and fall back to the catalog only when no subscription exists.

- Expands `subscriptions.plan` on `getCustomer` and uses those items to compute `basePlanItems`; rendering code is unchanged.
- Adds unit tests for live-items preference and catalog fallback, plus a card rendering test that reproduces the reported case. No migrations or external API changes.

<sup>Written for commit fb151fc36b286df23a0f4c0221300c062239b030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects approval cards so removed features use quantities from the customer’s customized subscription rather than the catalog plan.

- **Bug fixes:** Expands customer subscription plans and prefers their live item quantities when displaying removals.
- **Bug fixes:** Adds source-level and rendered-card coverage for customized quantities and catalog fallback behavior.
- **Improvements:** Preserves catalog items as the fallback when the customer has no matching subscription.
</details>

<h3>Confidence Score: 4/5</h3>

The duplicate-plan subscription selection should be fixed before merging because an approval card can describe a different subscription from the one being updated.

The new lookup collapses every customer subscription with the same plan ID into one entry and ignores the request’s subscription ID, allowing array order to determine which quantity is displayed.

**Files Needing Attention:** apps/leaf/src/internal/approvals/utils/approvalDisplay.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/approvals/utils/approvalDisplay.ts | Prefers expanded customer subscription items, but selecting solely by plan_id can choose the wrong subscription when that plan appears more than once. |
| apps/leaf/tests/unit/approvals/approvalDisplay.test.ts | Covers customized-item precedence and catalog fallback, but not multiple subscriptions sharing a plan. |
| apps/leaf/tests/unit/ui/blocks.test.ts | Verifies that the approval card renders the customized removal quantity supplied in display data. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Update subscription request] --> B[Fetch catalog plan]
  A --> C[Fetch customer with expanded subscriptions]
  C --> D[Select subscription items by plan ID]
  B --> E{Matching subscription?}
  D --> E
  E -->|Yes| F[Render removal using customer quantity]
  E -->|No| G[Render removal using catalog quantity]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/approvals/utils/approvalDisplay.ts:149-155
**Duplicate plan subscriptions overwrite selection**

When a customer has multiple subscriptions for the same plan and an update targets one with `subscription_id`, this lookup retains only the last subscription for that `plan_id` and ignores the requested subscription, causing the approval card to show a quantity from a different subscription.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 show the customer&#39;s live quantit..."](https://github.com/useautumn/autumn/commit/fb151fc36b286df23a0f4c0221300c062239b030) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54692146)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Leaf: Autumn's AI Agent Service](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/leaf-agent-app.md)

<!-- /greptile_comment -->