### PR TITLE
fix(trigger): bake bun patches and retry dropped batch pages

### DIFF
--- a/server/src/internal/migrations/v2/batchOperations/execute/runBatchMigrationChunk.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/runBatchMigrationChunk.ts
@@ -12,16 +12,22 @@ import type { BatchMigrationExecutionPlan } from "../types/index.js";
 import { claimNextBatchMigrationPage } from "./claim/index.js";
 import { executeBatchMigrationPage } from "./executeBatchMigrationPage.js";
 import { finalizeBatchMigrationPage } from "./finalize/finalizeBatchMigrationPage.js";
-import type { BatchMigrationChunkResult } from "./types/batchMigrationExecutionTypes.js";
+import type {
+	BatchMigrationChunkResult,
+	BatchMigrationPageResult,
+} from "./types/batchMigrationExecutionTypes.js";
 import {
 	BATCH_MIGRATION_MAX_PAGES,
 	BATCH_MIGRATION_PAGE_SIZE,
+	BATCH_MIGRATION_TRANSIENT_DB_PAGE_ATTEMPTS,
+	BATCH_MIGRATION_TRANSIENT_DB_RETRY_DELAY_MS,
 } from "./utils/batchMigrationExecutionConstants.js";
 import { createDeferredSideEffects } from "./utils/deferredSideEffects.js";
 import {
 	type BatchMigrationPagePhases,
 	timePhase,
 } from "./utils/pagePhaseTimings.js";
+import { runWithTransientDbRetry } from "./utils/runWithTransientDbRetry.js";
 
 /**
  * Runs one batch chunk: pages from `afterInternalId` until the filter is
@@ -111,64 +117,149 @@ export const runBatchMigrationChunk = async ({
 					`batch-migration: exceeded ${BATCH_MIGRATION_MAX_PAGES} pages — aborting run`,
 				);
 
-			const pagePhases: BatchMigrationPagePhases = {};
-			const page = await claimNextBatchMigrationPage({
-				ctx,
-				migration,
-				migrationInternalId,
-				migrationRunId,
-				afterInternalId: cursor ?? undefined,
-				limit: BATCH_MIGRATION_PAGE_SIZE,
-				controls,
-				phases: pagePhases,
-			});
-			if (page.selectedCount === 0) return await finish("exhausted");
-			cursor = page.cursor ?? cursor;
-
-			if (page.customers.length === 0) continue;
-			const pageResult = await executeBatchMigrationPage({
-				ctx,
-				migrationInternalId,
-				migrationRunId,
-				plan,
-				customers: page.customers,
-				phases: pagePhases,
-			});
-			await timePhase({
-				phases: pagePhases,
-				phase: "finalize",
+			const pageAfterInternalId = cursor ?? undefined;
+			const outcome = await runWithTransientDbRetry({
+				maxAttempts: BATCH_MIGRATION_TRANSIENT_DB_PAGE_ATTEMPTS,
+				delayMs: BATCH_MIGRATION_TRANSIENT_DB_RETRY_DELAY_MS,
+				onRetry: ({ error, attempt, maxAttempts }) => {
+					ctx.logger.warn(
+						"batch-migration: retrying page after transient db error",
+						{
+							data: {
+								migrationRunId,
+								cursor,
+								attempt,
+								maxAttempts,
+								error:
+									error instanceof Error ? error.message : String(error),
+							},
+						},
+					);
+				},
 				run: () =>
-					finalizeBatchMigrationPage({
+					runNextBatchMigrationPage({
 						ctx,
+						migration,
 						migrationInternalId,
 						migrationRunId,
 						plan,
-						pageResult,
+						afterInternalId: pageAfterInternalId,
+						controls,
 						webhooks,
-						phases: pagePhases,
-						deferEvents: events.defer,
-						deferCaches: caches.defer,
+						eventsDefer: events.defer,
+						cachesDefer: caches.defer,
+						settle: () => Promise.all([caches.settle(), events.settle()]),
 					}),
 			});
-			await Promise.all([caches.settle(), events.settle()]);
+			if (outcome.kind === "exhausted") return await finish("exhausted");
+			cursor = outcome.cursor ?? cursor;
+			if (outcome.kind === "advanced") continue;
 
 			summary.pages += 1;
-			summary.succeeded += pageResult.succeeded.length;
-			summary.skipped += pageResult.skipped.length;
-			for (const [phase, ms] of Object.entries(pagePhases)) {
+			summary.succeeded += outcome.pageResult.succeeded.length;
+			summary.skipped += outcome.pageResult.skipped.length;
+			for (const [phase, ms] of Object.entries(outcome.pagePhases)) {
 				chunkPhases[phase] = (chunkPhases[phase] ?? 0) + ms;
 			}
 			ctx.logger.info("batch-migration: page executed", {
 				data: {
 					migrationRunId,
 					page: summary.pages,
-					succeeded: pageResult.succeeded.length,
-					skipped: pageResult.skipped.length,
-					...pagePhases,
+					succeeded: outcome.pageResult.succeeded.length,
+					skipped: outcome.pageResult.skipped.length,
+					...outcome.pagePhases,
 				},
 			});
 		}
 	} finally {
 		await Promise.all([caches.drain(), events.drain()]);
 	}
+};
+
+type NextPageOutcome =
+	| { kind: "exhausted" }
+	| { kind: "advanced"; cursor: string | null }
+	| {
+			kind: "executed";
+			cursor: string | null;
+			pageResult: BatchMigrationPageResult;
+			pagePhases: BatchMigrationPagePhases;
+	  };
+
+/** One claim → execute → finalize. Cursor is only returned on success so a
+ * retry restarts from the same keyset after a dropped socket. */
+const runNextBatchMigrationPage = async ({
+	ctx,
+	migration,
+	migrationInternalId,
+	migrationRunId,
+	plan,
+	afterInternalId,
+	controls,
+	webhooks,
+	eventsDefer,
+	cachesDefer,
+	settle,
+}: {
+	ctx: AutumnContext;
+	migration: MigrationRuntimeWithEventId;
+	migrationInternalId: string;
+	migrationRunId: string;
+	plan: BatchMigrationExecutionPlan;
+	afterInternalId?: string;
+	controls?: MigrationRunControls;
+	webhooks?: MigrationWebhookControls;
+	eventsDefer: (run: () => Promise<unknown>) => void;
+	cachesDefer: (run: () => Promise<unknown>) => void;
+	settle: () => Promise<unknown>;
+}): Promise<NextPageOutcome> => {
+	const pagePhases: BatchMigrationPagePhases = {};
+	const page = await claimNextBatchMigrationPage({
+		ctx,
+		migration,
+		migrationInternalId,
+		migrationRunId,
+		afterInternalId,
+		limit: BATCH_MIGRATION_PAGE_SIZE,
+		controls,
+		phases: pagePhases,
+	});
+	if (page.selectedCount === 0) return { kind: "exhausted" };
+	const nextCursor = page.cursor ?? afterInternalId ?? null;
+	if (page.customers.length === 0) {
+		return { kind: "advanced", cursor: nextCursor };
+	}
+
+	const pageResult = await executeBatchMigrationPage({
+		ctx,
+		migrationInternalId,
+		migrationRunId,
+		plan,
+		customers: page.customers,
+		phases: pagePhases,
+	});
+	await timePhase({
+		phases: pagePhases,
+		phase: "finalize",
+		run: () =>
+			finalizeBatchMigrationPage({
+				ctx,
+				migrationInternalId,
+				migrationRunId,
+				plan,
+				pageResult,
+				webhooks,
+				phases: pagePhases,
+				deferEvents: eventsDefer,
+				deferCaches: cachesDefer,
+			}),
+	});
+	await settle();
+
+	return {
+		kind: "executed",
+		cursor: nextCursor,
+		pageResult,
+		pagePhases,
+	};
 };

--- a/server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts
@@ -39,3 +39,9 @@ export const BATCH_MIGRATION_CACHE_BUST_CONCURRENCY = 20;
 
 /** Pages whose post-commit side effects may be in flight at once. */
 export const BATCH_MIGRATION_DEFERRED_INFLIGHT = 3;
+
+/** Claim+execute+finalize attempts per page when Postgres drops or times out. */
+export const BATCH_MIGRATION_TRANSIENT_DB_PAGE_ATTEMPTS = 3;
+
+/** Pause between those page attempts. */
+export const BATCH_MIGRATION_TRANSIENT_DB_RETRY_DELAY_MS = 1_000;

--- a/server/src/internal/migrations/v2/batchOperations/execute/utils/runWithTransientDbRetry.ts
+++ b/server/src/internal/migrations/v2/batchOperations/execute/utils/runWithTransientDbRetry.ts
@@ -1,0 +1,39 @@
+import { isTransientDbError } from "@/db/dbUtils.js";
+
+const sleep = ({ ms }: { ms: number }): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Retries `run` when Postgres drops the socket or times out the statement.
+ * Claim/execute are replay-idempotent, so a failed page can start over.
+ */
+export const runWithTransientDbRetry = async <T>({
+	run,
+	maxAttempts,
+	delayMs,
+	onRetry,
+}: {
+	run: () => Promise<T>;
+	maxAttempts: number;
+	delayMs: number;
+	onRetry?: (args: {
+		error: unknown;
+		attempt: number;
+		maxAttempts: number;
+	}) => void;
+}): Promise<T> => {
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			return await run();
+		} catch (error) {
+			lastError = error;
+			const canRetry =
+				attempt < maxAttempts && isTransientDbError({ error });
+			if (!canRetry) throw error;
+			onRetry?.({ error, attempt, maxAttempts });
+			await sleep({ ms: delayMs });
+		}
+	}
+	throw lastError;
+};

--- a/server/tests/unit/migrations-v2/batch-operations/run-with-transient-db-retry.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/run-with-transient-db-retry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { runWithTransientDbRetry } from "@/internal/migrations/v2/batchOperations/execute/utils/runWithTransientDbRetry.js";
+
+const connectionDropped = () =>
+	new Error("Connection terminated unexpectedly");
+
+describe("runWithTransientDbRetry", () => {
+	test("returns the first success without retrying", async () => {
+		let calls = 0;
+		const result = await runWithTransientDbRetry({
+			maxAttempts: 3,
+			delayMs: 0,
+			run: async () => {
+				calls++;
+				return "ok";
+			},
+		});
+		expect(result).toBe("ok");
+		expect(calls).toBe(1);
+	});
+
+	test("retries a dropped connection then succeeds", async () => {
+		let calls = 0;
+		const retries: number[] = [];
+		const result = await runWithTransientDbRetry({
+			maxAttempts: 3,
+			delayMs: 0,
+			onRetry: ({ attempt }) => {
+				retries.push(attempt);
+			},
+			run: async () => {
+				calls++;
+				if (calls === 1) throw connectionDropped();
+				return "recovered";
+			},
+		});
+		expect(result).toBe("recovered");
+		expect(calls).toBe(2);
+		expect(retries).toEqual([1]);
+	});
+
+	test("does not retry an application error", async () => {
+		let calls = 0;
+		const attempt = runWithTransientDbRetry({
+			maxAttempts: 3,
+			delayMs: 0,
+			run: async () => {
+				calls++;
+				throw new Error("unique constraint");
+			},
+		});
+		expect(attempt).rejects.toThrow("unique constraint");
+		await attempt.catch(() => {});
+		expect(calls).toBe(1);
+	});
+
+	test("throws the last transient error after maxAttempts", async () => {
+		let calls = 0;
+		const attempt = runWithTransientDbRetry({
+			maxAttempts: 3,
+			delayMs: 0,
+			run: async () => {
+				calls++;
+				throw connectionDropped();
+			},
+		});
+		expect(attempt).rejects.toThrow("Connection terminated unexpectedly");
+		await attempt.catch(() => {});
+		expect(calls).toBe(3);
+	});
+});

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -46,6 +46,24 @@ const workspacePackageStubs = workspacePackageDirs.map((dir) => {
 	};
 });
 
+const listFilesRecursive = ({ dir }: { dir: string }): string[] => {
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const path = `${dir}/${entry.name}`;
+		if (entry.isDirectory()) return listFilesRecursive({ dir: path });
+		return entry.isFile() ? [path] : [];
+	});
+};
+
+// Trigger copies patchedDependencies in package.json but only COPY package.json
+// before bun install, so the patch files must already exist in the base image.
+const bunPatchInstallCommands = listFilesRecursive({ dir: "patches" }).map(
+	(path) => {
+		const encoded = readFileSync(path).toString("base64");
+		return `mkdir -p "$(dirname -- '${path}')" && printf '%s' '${encoded}' | base64 -d > '${path}'`;
+	},
+);
+
 export default defineConfig({
 	project: "proj_cwiutfmpdzfcshxevkok",
 	runtime: "bun",
@@ -100,6 +118,17 @@ export default defineConfig({
 							],
 						},
 					});
+					if (bunPatchInstallCommands.length > 0) {
+						context.addLayer({
+							id: "bun-patched-dependencies",
+							image: {
+								instructions: [
+									"WORKDIR /app",
+									`RUN ${bunPatchInstallCommands.join(" && ")} && chown -R bun:bun /app/patches`,
+								],
+							},
+						});
+					}
 				},
 			},
 			// Server runtime imports `*.lua` as raw text via Bun's loader. esbuild


### PR DESCRIPTION
## Summary
- Prod Trigger deploys since #2876 fail at image build: Trigger copies `patchedDependencies` in `package.json` but only `COPY`s that file before `bun install`. Bake `patches/` into the base image.
- Retry each batch-migration page on transient DB errors (`Connection terminated unexpectedly`) instead of failing the Trigger chunk.

## Test plan
- [ ] Trigger prod deploy after merge reaches Deployed
- [ ] Resend (or any long batch run) survives a dropped socket on a page

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Trigger image builds and expands migration, database, Tinybird, and customer-coupon behavior. Two migration execution paths need correction before merge.

- **[Bug fixes]** Copies Bun patch files into the Trigger deploy image and corrects the migration “not run” filter.
- **[Improvements]** Adds cached migration counts, a dedicated slow replica lane, concurrent feature operations, transient database retries, and compressed/chunked Tinybird ingestion.
- **[API changes]** Adds a customer coupon-removal endpoint and corresponding dashboard controls.
- **[Improvements]** Makes reward and promotion selectors searchable and improves product-status tooltips.
</details>


<h3>Confidence Score: 3/5</h3>

This PR should not merge until migration retries preserve post-commit finalization and invalid concurrency configuration can no longer crash migration pages.

A dropped database response after migration marks commit can omit cache, event, and webhook finalization, while a non-numeric concurrency override deterministically crashes pages containing feature operations.

**Files Needing Attention:** server/src/internal/migrations/v2/batchOperations/execute/runBatchMigrationChunk.ts; server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts; server/src/internal/migrations/v2/batchOperations/execute/utils/mapWithConcurrency.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/migrations/v2/batchOperations/execute/runBatchMigrationChunk.ts | Adds whole-page transient retries, but an ambiguous marks commit can make the retry exit without required finalization. |
| server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts | Adds an environment-controlled concurrency value without validating non-numeric configuration. |
| server/src/internal/migrations/v2/batchOperations/execute/executeBatchMigrationPage.ts | Parallelizes feature operations by type while preserving remove/replace/add ordering, but assumes every concurrency worker populated a result. |
| server/src/internal/migrations/v2/handlers/handlePreviewMigrationFilter.ts | Moves expensive migration counts behind a short Redis cache and retains separate row retrieval. |
| server/src/external/tinybird/gzipTinybirdEventsFetch.ts | Adds gzip compression specifically for Tinybird event POST bodies. |
| server/src/internal/customers/handlers/handleRemoveCouponFromCusV2.ts | Adds a scoped Stripe customer-discount removal endpoint whose dashboard caller refreshes the live discount source. |
| trigger.config.ts | Bakes repository patch files into the Trigger base image before Bun installs patched dependencies. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Claim migration page] --> B[Apply entitlement operations]
  B --> C[Commit item-run marks]
  C --> D[Finalize caches, events, and webhooks]
  B -. transient DB error .-> R[Retry whole page]
  C -. ambiguous commit response .-> R
  R --> A
  A -->|Already marked, no rows reclaimed| E[Return exhausted]
  E --> F[Finalization can be skipped]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts`, line 33-35 ([link](https://github.com/useautumn/autumn/blob/b7e2130215da9731807c16397f35c237ece2bd5c/server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts#L33-L35)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Invalid concurrency creates no workers**

   If `BATCH_MIGRATION_FEATURE_OP_CONCURRENCY` contains non-numeric text, `Number` produces `NaN`, so `mapWithConcurrency` creates no workers and returns unpopulated results; the first remove, replace, or add operation then throws while dereferencing `undefined`, aborting the migration page.

   **Knowledge Base Used:** [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts
   Line: 33-35
   
   Comment:
   **Invalid concurrency creates no workers**
   
   If `BATCH_MIGRATION_FEATURE_OP_CONCURRENCY` contains non-numeric text, `Number` produces `NaN`, so `mapWithConcurrency` creates no workers and returns unpopulated results; the first remove, replace, or add operation then throws while dereferencing `undefined`, aborting the migration page.
   
   
   
   **Knowledge Base Used:** [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/migrations/v2/batchOperations/execute/runBatchMigrationChunk.ts:121-153
**Retry skips page finalization**

If Postgres commits the item-run marks but drops the connection before acknowledging the commit, this retry cannot reclaim the already-marked customers and exits as exhausted without finalizing the page, leaving customer caches stale and dropping the corresponding migration events and webhooks.

### Issue 2
server/src/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.ts:33-35
**Invalid concurrency creates no workers**

If `BATCH_MIGRATION_FEATURE_OP_CONCURRENCY` contains non-numeric text, `Number` produces `NaN`, so `mapWithConcurrency` creates no workers and returns unpopulated results; the first remove, replace, or add operation then throws while dereferencing `undefined`, aborting the migration page.

```suggestion
const configuredFeatureOpConcurrency = Number(
	process.env.BATCH_MIGRATION_FEATURE_OP_CONCURRENCY ?? 3,
);
export const BATCH_MIGRATION_FEATURE_OP_CONCURRENCY = Number.isFinite(
	configuredFeatureOpConcurrency,
)
	? Math.max(1, Math.floor(configuredFeatureOpConcurrency))
	: 3;
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(migrations): retry batch pages on tr..."](https://github.com/useautumn/autumn/commit/b7e2130215da9731807c16397f35c237ece2bd5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54702761)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Server API Routing: Request Lifecycle](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-api-routers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)
- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)
</details>


<!-- /greptile_comment -->