### PR TITLE
fix(cloud): install bun on the default Cloud image

### DIFF
--- a/CURSOR.md
+++ b/CURSOR.md
@@ -6,7 +6,8 @@ file is specific to the Cursor Cloud environment.
 
 Config lives in `.cursor/environment.json` (install / start / terminals). Do
 **not** pin a VM snapshot — `snapshot-20260629` makes Cloud builds crash in
-Cursor's VNC/exec-daemon overlay before `install.sh` runs. `install` runs
+Cursor's VNC/exec-daemon overlay before `install.sh` runs. The default Cloud
+image has no bun. `install` installs bun from `.bun-version`, then runs
 `agent-bootstrap.sh` so Postgres 18, Redis Stack, ClickHouse, JRE, and
 ElasticMQ are created on the current Cloud image.
 

--- a/scripts/setup/agent-services.sh
+++ b/scripts/setup/agent-services.sh
@@ -124,9 +124,11 @@ bun scripts/setup/writeAgentEnv.ts
 log "Running migrations"
 # `bun db:migrate` is not a package.json script — the CLI is `bun db migrate`.
 # loadLocalEnv from /workspace does not pick up server/.env, so pass DATABASE_URL.
+# Fresh agent DBs have no tables; without --bootstrap, migrate refuses CREATE INDEX
+# that is not CONCURRENTLY (72 statements in the historical SQL).
 export AUTUMN_DB_DIRECT=1
 export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/autumn}"
 bun db generate >/dev/null 2>&1 || true
-bun db migrate
+bun db migrate --bootstrap
 
 log "All services ready"

--- a/scripts/setup/cursor-cloud/cursor-ai.test.sh
+++ b/scripts/setup/cursor-cloud/cursor-ai.test.sh
@@ -124,6 +124,8 @@ fi
 if grep -q 'ai/src/cli.ts sync' "$ROOT/scripts/setup/cursor-cloud/start.sh"; then
 	fail "start.sh must not sync skills — install.sh owns bun ai sync --copy"
 fi
+grep -q 'db migrate --bootstrap' "$ROOT/scripts/setup/agent-services.sh" \
+	|| fail "agent-services.sh must bun db migrate --bootstrap on a fresh local DB"
 grep -q 'scripts/dw/index.ts" start' "$ROOT/scripts/setup/cursor-cloud/start.sh" \
 	|| grep -q 'scripts/dw/index.ts start' "$ROOT/scripts/setup/cursor-cloud/start.sh" \
 	|| fail "start.sh must run bun scripts/dw/index.ts start"

--- a/scripts/setup/cursor-cloud/cursor-ai.test.sh
+++ b/scripts/setup/cursor-cloud/cursor-ai.test.sh
@@ -89,7 +89,14 @@ if grep -q '"snapshot"' "$ROOT/.cursor/environment.json"; then
 fi
 grep -q 'agent-bootstrap.sh' "$ROOT/scripts/setup/cursor-cloud/install.sh" \
 	|| fail "install.sh must bootstrap system packages instead of relying on a VM snapshot"
-pass "environment.json has no snapshot; install bootstraps packages"
+grep -q 'bun.sh/install' "$ROOT/scripts/setup/cursor-cloud/install.sh" \
+	|| fail "install.sh must install bun — the default Cloud image has none"
+if grep -qE 'BUN="\$\(command -v bun\)"' \
+	"$ROOT/scripts/setup/cursor-cloud/install.sh" \
+	"$ROOT/scripts/setup/cursor-cloud/start.sh"; then
+	fail "command -v bun must be guarded — set -e exits when bun is missing"
+fi
+pass "environment.json has no snapshot; install bootstraps bun + packages"
 
 # --- persist-env writes rc files without embedding the Infisical token ------
 bun "$CLOUD" --root "$tmp/repo" --home "$tmp/home" persist-env

--- a/scripts/setup/cursor-cloud/install.sh
+++ b/scripts/setup/cursor-cloud/install.sh
@@ -11,10 +11,31 @@ log() { echo "[cursor-cloud-install] $*"; }
 export CLOUD_AGENT=1
 export DW_HEADLESS=1
 
+# Default Cloud image has no bun. `command -v bun` exits 1 under set -e.
 BUN="${HOME}/.bun/bin/bun"
 if [ ! -x "$BUN" ]; then
-	BUN="$(command -v bun)"
+	BUN="$(command -v bun 2>/dev/null || true)"
 fi
+if [ ! -x "$BUN" ]; then
+	bun_ver="$(tr -d '[:space:]' < .bun-version 2>/dev/null || true)"
+	log "installing bun ${bun_ver:-latest} (default Cloud image has none)"
+	if [ -n "$bun_ver" ]; then
+		curl -fsSL https://bun.sh/install | bash -s "bun-v${bun_ver}"
+	else
+		curl -fsSL https://bun.sh/install | bash
+	fi
+	BUN="${HOME}/.bun/bin/bun"
+fi
+if [ ! -x "$BUN" ]; then
+	log "ERROR: bun is not executable after install"
+	exit 1
+fi
+export PATH="$(dirname "$BUN"):${PATH}"
+if [ ! -x /usr/local/bin/bun ]; then
+	sudo ln -sf "$BUN" /usr/local/bin/bun
+	sudo ln -sf "$(dirname "$BUN")/bunx" /usr/local/bin/bunx || true
+fi
+log "bun $($BUN --version) at $BUN"
 
 log "init ai submodule (skills + MCP sync source)"
 git submodule update --init --recursive

--- a/scripts/setup/cursor-cloud/start.sh
+++ b/scripts/setup/cursor-cloud/start.sh
@@ -12,7 +12,11 @@ export PATH="$ROOT/node_modules/.bin:/usr/local/bin:$HOME/.bun/bin:$PATH"
 
 BUN="${HOME}/.bun/bin/bun"
 if [ ! -x "$BUN" ]; then
-	BUN="$(command -v bun)"
+	BUN="$(command -v bun 2>/dev/null || true)"
+fi
+if [ ! -x "$BUN" ]; then
+	echo "[cursor-cloud-start] bun missing — install.sh did not finish" >&2
+	exit 1
 fi
 
 if [ -n "${INFISICAL_TOKEN:-}" ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #2883 dropped `snapshot-20260629`, Cloud Agents boot the default image. That image has **no bun**.

`install.sh` ran `BUN="$(command -v bun)"` under `set -euo pipefail`. That exits 1 when bun is missing, so install died in ~140ms with no `[cursor-cloud-install]` logs. JIT agents and draft builds reported `INSTALL_FAILED`.

Once bun was installed, `start.sh` still failed: `agent-services.sh` ran `bun db migrate` on an empty local Postgres. The CLI refused 72 historical `CREATE INDEX` statements that are not `CONCURRENTLY`. Infra was up; schema and the Cloudflare public URL were not.

## Fix

1. Install bun from `.bun-version` (1.3.14) when missing; guard `command -v bun`; symlink onto `/usr/local/bin`.
2. `start.sh` errors clearly if install did not finish.
3. `agent-services.sh` uses `bun db migrate --bootstrap` for the fresh local agent DB.

## Validation

- Local `install.sh` on the default Cloud image: exit 0, bun 1.3.14, 72 skills including `/tdd` with `environments: [cloud]`
- `cursor-ai.test.sh`: all boot contract tests passed
- Draft build [bld-20260819-dea15e69-cb26-42d4-be0b-44b0b8bc9aa8](https://cursor.com/dashboard/cloud-agents/builds/bld-20260819-dea15e69-cb26-42d4-be0b-44b0b8bc9aa8): **SUCCEEDED**
- Fresh agent booted from that build: snapshot artifacts present; start then succeeded after `--bootstrap` (64 migrations, public `autumn-wt1-*.autumnworktree.com`)
- Same start result on this verification VM: `START_EXIT:0`

[Verification notes](https://cursor.com/agents/bc-9de1a9a7-72b6-48ba-95a0-982cf87f69f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloud_agent_verification.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9de1a9a7-72b6-48ba-95a0-982cf87f69f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9de1a9a7-72b6-48ba-95a0-982cf87f69f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs `bun` during Cloud setup and bootstraps a fresh local Postgres on start to prevent silent exits and migration stalls on the default image. Previously the default image had no `bun` and `command -v bun` under `set -e` aborted install; migrations on empty DBs failed without `--bootstrap`.

- `install.sh` installs `bun` from `.bun-version` when missing, guards `command -v bun`, updates `PATH`, and symlinks to `/usr/local/bin`.
- `start.sh` fails fast with a clear error if install did not finish.
- `agent-services.sh` runs `bun db migrate --bootstrap` to initialize empty local DBs.
- Updates tests to assert `bun` install/guard logic and `--bootstrap`; documents default-image behavior in `CURSOR.md`.

<sup>Written for commit f10a530460966043636bff940808b33b08036532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

