### PR TITLE
fix(cloud): install bun on the default Cloud image

### DIFF
--- a/scripts/setup/cursor-cloud/cursor-ai.test.sh
+++ b/scripts/setup/cursor-cloud/cursor-ai.test.sh
@@ -89,7 +89,14 @@ if grep -q '"snapshot"' "$ROOT/.cursor/environment.json"; then
 fi
 grep -q 'agent-bootstrap.sh' "$ROOT/scripts/setup/cursor-cloud/install.sh" \
 	|| fail "install.sh must bootstrap system packages instead of relying on a VM snapshot"
-pass "environment.json has no snapshot; install bootstraps packages"
+grep -q 'bun.sh/install' "$ROOT/scripts/setup/cursor-cloud/install.sh" \
+	|| fail "install.sh must install bun — the default Cloud image has none"
+if grep -qE 'BUN="\$\(command -v bun\)"' \
+	"$ROOT/scripts/setup/cursor-cloud/install.sh" \
+	"$ROOT/scripts/setup/cursor-cloud/start.sh"; then
+	fail "command -v bun must be guarded — set -e exits when bun is missing"
+fi
+pass "environment.json has no snapshot; install bootstraps bun + packages"
 
 # --- persist-env writes rc files without embedding the Infisical token ------
 bun "$CLOUD" --root "$tmp/repo" --home "$tmp/home" persist-env

--- a/scripts/setup/cursor-cloud/install.sh
+++ b/scripts/setup/cursor-cloud/install.sh
@@ -11,10 +11,31 @@ log() { echo "[cursor-cloud-install] $*"; }
 export CLOUD_AGENT=1
 export DW_HEADLESS=1
 
+# Default Cloud image has no bun. Unguarded `command -v bun` exits 1 under set -e.
 BUN="${HOME}/.bun/bin/bun"
 if [ ! -x "$BUN" ]; then
-	BUN="$(command -v bun)"
+	BUN="$(command -v bun 2>/dev/null || true)"
 fi
+if [ ! -x "$BUN" ]; then
+	bun_ver="$(tr -d '[:space:]' < .bun-version 2>/dev/null || true)"
+	log "installing bun ${bun_ver:-latest} (default Cloud image has none)"
+	if [ -n "$bun_ver" ]; then
+		curl -fsSL https://bun.sh/install | bash -s "bun-v${bun_ver}"
+	else
+		curl -fsSL https://bun.sh/install | bash
+	fi
+	BUN="${HOME}/.bun/bin/bun"
+fi
+if [ ! -x "$BUN" ]; then
+	log "ERROR: bun is not executable after install"
+	exit 1
+fi
+export PATH="$(dirname "$BUN"):${PATH}"
+if [ ! -x /usr/local/bin/bun ]; then
+	sudo ln -sf "$BUN" /usr/local/bin/bun
+	sudo ln -sf "$(dirname "$BUN")/bunx" /usr/local/bin/bunx || true
+fi
+log "bun $($BUN --version) at $BUN"
 
 log "init ai submodule (skills + MCP sync source)"
 git submodule update --init --recursive

--- a/scripts/setup/cursor-cloud/start.sh
+++ b/scripts/setup/cursor-cloud/start.sh
@@ -12,7 +12,11 @@ export PATH="$ROOT/node_modules/.bin:/usr/local/bin:$HOME/.bun/bin:$PATH"
 
 BUN="${HOME}/.bun/bin/bun"
 if [ ! -x "$BUN" ]; then
-	BUN="$(command -v bun)"
+	BUN="$(command -v bun 2>/dev/null || true)"
+fi
+if [ ! -x "$BUN" ]; then
+	echo "[cursor-cloud-start] bun missing — install.sh did not finish" >&2
+	exit 1
 fi
 
 if [ -n "${INFISICAL_TOKEN:-}" ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#2883 dropped `snapshot-20260629` so builds could leave Cursor’s June VM. That worked: the next JIT agent reached `install.sh`.

The default Cloud image has **no bun**. `install.sh` did `BUN="$(command -v bun)"` under `set -euo pipefail`. That exits 1 when bun is missing, so install died in ~160ms with no `[cursor-cloud-install]` logs.

```
[2026-08-19T09:29:25.032Z] [INSTALL] Command:  - bash scripts/setup/cursor-cloud/install.sh
[2026-08-19T09:29:25.192Z] [INSTALL] Exit code: 1
```

## Fix

- Install bun from `.bun-version` (`1.3.14`) when missing
- Guard `command -v bun` so `set -e` cannot abort
- Symlink bun onto `/usr/local/bin`
- `start.sh` fails clearly if install did not finish

## Validation

- `bash scripts/setup/cursor-cloud/cursor-ai.test.sh` passed
- Draft [bld-20260819-05db7c9e-a22d-48d0-a1d3-a07f336fe220](https://cursor.com/dashboard/cloud-agents/builds/bld-20260819-05db7c9e-a22d-48d0-a1d3-a07f336fe220) **SUCCEEDED**
  - `[cursor-cloud-install] installing bun 1.3.14`
  - `[cursor-cloud-install] user skills ready at ~/.cursor/skills`
  - `[cursor-cloud-install] install complete` / `Exit code: 0`
- Fresh agent on that build: `bun` 1.3.14 at `/usr/local/bin/bun`, `~/.cursor/skills/tdd/SKILL.md` present, `node_modules` present

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa30820d-fc23-4bb0-892e-978589b18887?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa30820d-fc23-4bb0-892e-978589b18887&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs bun during Cloud setup on the default image to prevent early install failures after removing the VM snapshot. Previously `install.sh` exited immediately under `set -e` when `command -v bun` returned 1; now we install bun and surface clear errors if setup didn’t finish.

- Guard `command -v bun` in `install.sh` and `start.sh` so `set -e` can’t abort.
- Install bun from `.bun-version` (fallback to latest), add it to PATH, and symlink to `/usr/local/bin`.
- `start.sh` exits with a clear message if bun is still missing.
- Update `cursor-ai.test.sh` to assert bun installation and the guarded checks.

<sup>Written for commit 75b9a7f21f4b63a63d5aa18717b310c3566e7c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

