### PR TITLE
fix(cloud): seed unit-test-org on dw start

### DIFF
--- a/scripts/dw/commands/start.ts
+++ b/scripts/dw/commands/start.ts
@@ -1,3 +1,4 @@
+import { isCloudAgent } from "@autumn/env";
 import { ensurePublicAccess } from "../helpers/cloudflare.ts";
 import { ensureLocalInfra } from "../helpers/localInfra.ts";
 import {
@@ -5,6 +6,7 @@ import {
 	registerCurrentWorktree,
 	saveRegistry,
 } from "../helpers/registry.ts";
+import { autoEnsureLocalTestOrg } from "../helpers/setup.ts";
 import { fatal, log } from "../helpers/shell.ts";
 import type { RegistryEntry } from "../types.ts";
 
@@ -20,6 +22,9 @@ export async function cmdStart(): Promise<RegistryEntry> {
 	);
 
 	ensureLocalInfra();
+	if (isCloudAgent()) {
+		await autoEnsureLocalTestOrg();
+	}
 	const entry = await ensurePublicAccess(entry0);
 	const registry = loadRegistry();
 	registry[entry.path] = entry;

--- a/scripts/dw/constants.ts
+++ b/scripts/dw/constants.ts
@@ -15,6 +15,10 @@ export const MAX_WORKTREE = 50;
 export const BRANCH_NAME_RE = /^(?:dw-wt-\d+|capy)-[a-f0-9]+$/;
 export const INACTIVITY_MS = 7 * 24 * 60 * 60 * 1000;
 
+/** Cloud / agent-services local Postgres. Never inherit Infisical DATABASE_URL. */
+export const LOCAL_DATABASE_URL =
+	"postgresql://postgres:postgres@localhost:5432/autumn";
+
 export const NEON_PROJECT_ID = "weathered-morning-43833874";
 export const NEON_TEMPLATE_BRANCH = "dw-template";
 export const NEON_PARENT_BRANCH = "production";

--- a/scripts/dw/helpers/localTestOrg.test.ts
+++ b/scripts/dw/helpers/localTestOrg.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { LOCAL_DATABASE_URL } from "../constants.ts";
+import { localTestOrgEnv } from "./setup.ts";
+
+describe("localTestOrgEnv", () => {
+	const prevUrl = process.env.DATABASE_URL;
+	const prevCritical = process.env.DATABASE_CRITICAL_URL;
+	const prevDirect = process.env.AUTUMN_DB_DIRECT;
+
+	afterEach(() => {
+		if (prevUrl === undefined) delete process.env.DATABASE_URL;
+		else process.env.DATABASE_URL = prevUrl;
+		if (prevCritical === undefined) delete process.env.DATABASE_CRITICAL_URL;
+		else process.env.DATABASE_CRITICAL_URL = prevCritical;
+		if (prevDirect === undefined) delete process.env.AUTUMN_DB_DIRECT;
+		else process.env.AUTUMN_DB_DIRECT = prevDirect;
+	});
+
+	test("pins local postgres even when Infisical already set DATABASE_URL", () => {
+		process.env.DATABASE_URL =
+			"postgresql://user:pass@aws-eu-west-2-1.pg.psdb.cloud:6432/autumn";
+		process.env.DATABASE_CRITICAL_URL = process.env.DATABASE_URL;
+		delete process.env.AUTUMN_DB_DIRECT;
+
+		const env = localTestOrgEnv();
+		expect(env.DATABASE_URL).toBe(LOCAL_DATABASE_URL);
+		expect(env.DATABASE_CRITICAL_URL).toBe(LOCAL_DATABASE_URL);
+		expect(env.AUTUMN_DB_DIRECT).toBe("1");
+	});
+});

--- a/scripts/dw/helpers/setup.ts
+++ b/scripts/dw/helpers/setup.ts
@@ -1,4 +1,8 @@
-import { NEON_TEMPLATE_BRANCH, PROJECT_ROOT } from "../constants.ts";
+import {
+	LOCAL_DATABASE_URL,
+	NEON_TEMPLATE_BRANCH,
+	PROJECT_ROOT,
+} from "../constants.ts";
 import type { RegistryEntry } from "../types.ts";
 import {
 	applyCommittedMigrations,
@@ -63,6 +67,35 @@ export async function setupAgentWorktree(
 	registry[entry.path] = next;
 	saveRegistry(registry);
 	return { entry: next, created: true };
+}
+
+/** Cloud-agent local Postgres — Infisical's DATABASE_URL must not leak in. */
+export function localTestOrgEnv(): Record<string, string> {
+	return {
+		...(process.env as Record<string, string>),
+		DATABASE_URL: LOCAL_DATABASE_URL,
+		DATABASE_CRITICAL_URL: LOCAL_DATABASE_URL,
+		AUTUMN_DB_DIRECT: "1",
+	};
+}
+
+/**
+ * Idempotent Cloud seed: create unit-test-org if missing, otherwise only
+ * ensure the Infisical API key hash. Does not clear an existing org.
+ */
+export async function autoEnsureLocalTestOrg(): Promise<void> {
+	log("ensuring unit-test-org in local postgres");
+	const code = shInherit(
+		"bun",
+		["scripts/setup/setup-test.ts", "--ensure"],
+		{
+			cwd: PROJECT_ROOT,
+			env: localTestOrgEnv(),
+		},
+	);
+	if (code !== 0) {
+		fatal(`setup-test --ensure exited with code ${code}`);
+	}
 }
 
 function worktreeDbEnv(entry: RegistryEntry): Record<string, string> {

--- a/scripts/dw/helpers/start.ts
+++ b/scripts/dw/helpers/start.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { isCloudAgent } from "@autumn/env";
-import { PROJECT_ROOT } from "../constants.ts";
+import { LOCAL_DATABASE_URL, PROJECT_ROOT } from "../constants.ts";
 import type { RegistryEntry } from "../types.ts";
 import { startPublicAccess } from "./cloudflare.ts";
 import { emulateGoogleUrl } from "./emulate.ts";
@@ -19,9 +19,6 @@ import {
 import { fatal, log } from "./shell.ts";
 import { spawnDevInTmux, tmuxSessionName } from "./tmux.ts";
 import { rewriteDbEnv } from "./url.ts";
-
-const LOCAL_DATABASE_URL =
-	"postgresql://postgres:postgres@localhost:5432/autumn";
 
 const HEADLESS_UNSET = [
 	"NEON_WORKTREE_API_KEY",

--- a/scripts/setup/agent-services.sh
+++ b/scripts/setup/agent-services.sh
@@ -122,10 +122,12 @@ bun scripts/setup/writeAgentEnv.ts
 # 5. DB migrations
 # =============================================================
 log "Running migrations"
-# Pass DATABASE_URL — loadLocalEnv from /workspace misses server/.env.
+# Always local postgres. `bun dw` is wrapped in `infisical run`, so an inherited
+# DATABASE_URL would migrate PlanetScale instead of this box.
 # --bootstrap: empty Cloud postgres has 72 CREATE INDEX without CONCURRENTLY.
 export AUTUMN_DB_DIRECT=1
-export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/autumn}"
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/autumn"
+export DATABASE_CRITICAL_URL="$DATABASE_URL"
 bun db generate >/dev/null 2>&1 || true
 bun db migrate --bootstrap
 

--- a/scripts/setup/cursor-cloud/cursor-ai.test.sh
+++ b/scripts/setup/cursor-cloud/cursor-ai.test.sh
@@ -137,6 +137,18 @@ fi
 if grep -q 'bun", \["install"\]' "$ROOT/scripts/dw/commands/start.ts"; then
 	fail "dw start must not run bun install"
 fi
+grep -q 'autoEnsureLocalTestOrg' "$ROOT/scripts/dw/commands/start.ts" \
+	|| fail "dw start must seed unit-test-org on Cloud agents"
+grep -q 'unit-test-org' "$ROOT/scripts/setup/cursor-cloud/cursorCloud.ts" \
+	|| fail "Cloud AGENTS.md section must mention unit-test-org seed"
+grep -q 'setup-test.ts", "--ensure"' "$ROOT/scripts/dw/helpers/setup.ts" \
+	|| fail "Cloud seed must call setup-test --ensure"
+if grep -q 'DATABASE_URL="${DATABASE_URL:-' "$ROOT/scripts/setup/agent-services.sh"; then
+	fail "agent-services.sh must not inherit Infisical DATABASE_URL"
+fi
+grep -q 'postgresql://postgres:postgres@localhost:5432/autumn' \
+	"$ROOT/scripts/setup/agent-services.sh" \
+	|| fail "agent-services.sh must pin migrate to local postgres"
 pass "start.sh runs dw start, not bun dw setup"
 
 if grep -q 'cursor_ai.py' "$ROOT/scripts/setup/cursor-cloud/install.sh" \
@@ -228,6 +240,7 @@ UNIT_TESTS=1 env -u TESTS_ORG bun test \
 	"$ROOT/scripts/dw/helpers/ngrok.test.ts" \
 	"$ROOT/scripts/dw/helpers/machineId.test.ts" \
 	"$ROOT/scripts/dw/helpers/registry.test.ts" \
+	"$ROOT/scripts/dw/helpers/localTestOrg.test.ts" \
 	"$ROOT/scripts/dw/helpers/cloudflare.test.ts" \
 	"$ROOT/scripts/dw/devProxy/cloudflareConfig.test.ts" \
 	|| fail "dw unit tests failed"

--- a/scripts/setup/cursor-cloud/cursorCloud.ts
+++ b/scripts/setup/cursor-cloud/cursorCloud.ts
@@ -30,9 +30,10 @@ and writes the Bearer header into \`.cursor/mcp.json\`. Do not try interactive
 OAuth. If executor tools are missing, say so rather than substituting
 Axiom/PlanetScale OAuth servers.
 
-Boot starts local infra (Postgres/Redis/ClickHouse/ElasticMQ) and the
-Cloudflare public URL via \`bun scripts/dw/index.ts start\`. It does
-**not** start the app. Run \`bun dw\` when the task needs Vite/API.
+Boot starts local infra (Postgres/Redis/ClickHouse/ElasticMQ), seeds
+\`unit-test-org\`, and the Cloudflare public URL via
+\`bun scripts/dw/index.ts start\`. It does **not** start the app.
+Run \`bun dw\` when the task needs Vite/API.
 The in-IDE Browser tab stays blank (Cursor bug, any URL) — open the
 public \`autumn-wt1-<hash>.autumnworktree.com\` URL from \`bun dw identify\`,
 or \`http://localhost:3000\` from Ports.

--- a/scripts/setup/setup-test.ts
+++ b/scripts/setup/setup-test.ts
@@ -137,12 +137,38 @@ async function runFullSetup({ yes }: { yes: boolean }): Promise<void> {
 	console.log(chalk.whiteBright(`  key:  ${autumnSecretKey}\n`));
 }
 
+/** Create unit-test-org if missing; if present, only ensure the API key. */
+async function runEnsure(): Promise<void> {
+	const { db } = await import("@server/db/initDrizzle.js");
+	const { organizations } = await import("@autumn/shared");
+	const { eq } = await import("drizzle-orm");
+	const existing = await db.query.organizations.findFirst({
+		where: eq(organizations.id, TEST_ORG_CONFIG.id),
+	});
+	if (!existing) {
+		await runFullSetup({ yes: true });
+		return;
+	}
+	if (process.env.UNIT_TEST_AUTUMN_SECRET_KEY?.trim()) {
+		await runEnsureKey();
+		return;
+	}
+	console.log(
+		chalk.cyan(
+			`[setup-test] ${TEST_ORG_CONFIG.slug} already present; UNIT_TEST_AUTUMN_SECRET_KEY unset — skipping key ensure`,
+		),
+	);
+}
+
 async function main() {
 	const yes = process.argv.includes("--yes");
 	const ensureKeyOnly = process.argv.includes("--ensure-key");
+	const ensure = process.argv.includes("--ensure");
 
 	try {
-		if (ensureKeyOnly) {
+		if (ensure) {
+			await runEnsure();
+		} else if (ensureKeyOnly) {
 			await runEnsureKey();
 		} else {
 			await runFullSetup({ yes });

--- a/scripts/setup/writeAgentEnv.ts
+++ b/scripts/setup/writeAgentEnv.ts
@@ -63,6 +63,8 @@ const ISOLATION: Record<string, string> = {
 	STRIPE_WEBHOOK_SKIP_VERIFY: "true",
 	NODE_ENV: "development",
 	INFISICAL_ENVIRONMENT: "dev",
+	TESTS_ORG: "unit-test-org",
+	TESTS_ORG_ID: "org_2sWv2S8LJ9iaTjLI6UtNsfL88Kt",
 };
 
 const HEADER = `# -----------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cloud `bun dw start` (the boot path) migrated local Postgres but never ran `setup-test`. This box had **0 orgs / 0 features**. `bun t` then failed at `initScenario` with `products_org_id_fkey`.

Laptop/Neon `bun dw setup` seeds via `autoSetupTestOrg`. Cloud skips Neon (`wantsCanonicalProvision = false`) and only calls `cmdStart` → `ensureLocalInfra()`.

A second leak: `agent-services.sh` used `${DATABASE_URL:-localhost}`. When `bun dw` is wrapped in `infisical run`, that inherits PlanetScale (`aws-eu-west-2-1.pg.psdb.cloud:6432`).

## Fix

- `cmdStart` calls `autoEnsureLocalTestOrg()` on Cloud agents
- `setup-test --ensure` creates `unit-test-org` if missing; if present, only ensures the API key (does not `clearOrg`)
- `agent-services.sh` always migrates `postgresql://postgres:postgres@localhost:5432/autumn`
- Isolation overlay pins `TESTS_ORG=unit-test-org`
- Cloud AGENTS.md section now says boot seeds `unit-test-org`

## Tests

- `scripts/dw/helpers/localTestOrg.test.ts` — Infisical PlanetScale URL is overwritten
- `cursor-ai.test.sh` — `dw start` must call `--ensure`; agent-services must not inherit `DATABASE_URL`

Verified on this box: `unit-test-org` + 18 features in local Postgres. A second `--ensure` does not wipe the org.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f80d9ba-6c22-4033-a4b8-d32b5ec5f394?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f80d9ba-6c22-4033-a4b8-d32b5ec5f394&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds unit-test-org during Cloud bun dw start and pins DB migrations to local Postgres to prevent Infisical/PlanetScale leakage. Previously, Cloud start skipped setup-test and ran against an empty DB, causing products_org_id_fkey failures; seeding is now idempotent and does not wipe existing data.

- Cloud agents: cmdStart calls autoEnsureLocalTestOrg(), which runs scripts/setup/setup-test.ts --ensure to create unit-test-org if missing, or only ensure the API key when present.
- DB safety: agent-services.sh always migrates postgresql://postgres:postgres@localhost:5432/autumn, sets AUTUMN_DB_DIRECT=1 and DATABASE_CRITICAL_URL, and never inherits DATABASE_URL.
- Env/overlay: isolation pins TESTS_ORG=unit-test-org and TESTS_ORG_ID; new LOCAL_DATABASE_URL constant centralizes the local connection string.
- Tests/docs: adds unit tests to confirm Infisical URLs are overridden; shell test enforces seeding and local DB pin; Cloud boot docs mention seeding unit-test-org.

<sup>Written for commit e562851cf440a12d71a60b33e75d6edf6f41b38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

