### PR TITLE
refactor: shared add/remove model for customize diffs across Slack and dashboard

### DIFF
--- a/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
+++ b/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
@@ -8,6 +8,9 @@ const text = (value: unknown) =>
 const record = (value: unknown) =>
 	value && typeof value === "object" ? (value as Record<string, unknown>) : {};
 
+const getArray = (value: unknown): unknown[] =>
+	Array.isArray(value) ? value : [];
+
 const planNameFromPreview = ({
 	planId,
 	preview,
@@ -124,6 +127,7 @@ export const resolveApprovalDisplay = async ({
 		customerId
 			? fetchRecord("getCustomer", {
 					customer_id: customerId,
+					expand: ["subscriptions.plan"],
 					with_autumn_id: false,
 				})
 			: null,
@@ -139,10 +143,22 @@ export const resolveApprovalDisplay = async ({
 	const planRecords = Object.fromEntries(
 		plans.map(([id, value]) => [id, record(value.plan ?? value)]),
 	);
+	// A remove_items filter names a feature; the quantity being removed is what
+	// the customer currently holds, which a customized subscription can set
+	// differently from the catalog plan. Prefer the live subscription's items.
+	const subscriptionItemsByPlan = Object.fromEntries(
+		getArray(customerRecord.subscriptions).flatMap((subscription) => {
+			const entry = record(subscription);
+			const planId = text(entry.plan_id);
+			const items = record(entry.plan).items;
+			return planId && Array.isArray(items) ? [[planId, items]] : [];
+		}),
+	);
 	const basePlanItemsByPlan = Object.fromEntries(
-		Object.entries(planRecords).flatMap(([id, value]) =>
-			Array.isArray(value.items) ? [[id, value.items]] : [],
-		),
+		Object.entries(planRecords).flatMap(([id, value]) => {
+			const items = subscriptionItemsByPlan[id] ?? value.items;
+			return Array.isArray(items) ? [[id, items]] : [];
+		}),
 	);
 	const fetchedPlanNames = Object.fromEntries(
 		Object.entries(planRecords).flatMap(([id, value]) => {

--- a/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
+++ b/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
@@ -143,22 +143,27 @@ export const resolveApprovalDisplay = async ({
 	const planRecords = Object.fromEntries(
 		plans.map(([id, value]) => [id, record(value.plan ?? value)]),
 	);
-	// A remove_items filter names a feature; the quantity being removed is what
-	// the customer currently holds, which a customized subscription can set
-	// differently from the catalog plan. Prefer the live subscription's items.
-	const subscriptionItemsByPlan = Object.fromEntries(
+	// The plan a change is diffed against is what the customer currently holds.
+	// A customized subscription can differ from the catalog (price and items),
+	// so the live subscription's plan wins and the catalog is the fallback.
+	const subscriptionPlanByPlan = Object.fromEntries(
 		getArray(customerRecord.subscriptions).flatMap((subscription) => {
 			const entry = record(subscription);
 			const planId = text(entry.plan_id);
-			const items = record(entry.plan).items;
-			return planId && Array.isArray(items) ? [[planId, items]] : [];
+			const plan = record(entry.plan);
+			return planId && Object.keys(plan).length ? [[planId, plan]] : [];
 		}),
 	);
+	const currentPlanByPlan = Object.fromEntries(
+		Object.entries(planRecords).map(([id, value]) => [
+			id,
+			subscriptionPlanByPlan[id] ?? value,
+		]),
+	);
 	const basePlanItemsByPlan = Object.fromEntries(
-		Object.entries(planRecords).flatMap(([id, value]) => {
-			const items = subscriptionItemsByPlan[id] ?? value.items;
-			return Array.isArray(items) ? [[id, items]] : [];
-		}),
+		Object.entries(currentPlanByPlan).flatMap(([id, value]) =>
+			Array.isArray(value.items) ? [[id, value.items]] : [],
+		),
 	);
 	const fetchedPlanNames = Object.fromEntries(
 		Object.entries(planRecords).flatMap(([id, value]) => {
@@ -190,6 +195,8 @@ export const resolveApprovalDisplay = async ({
 	return {
 		basePlanItems: planId ? (basePlanItemsByPlan[planId] ?? null) : null,
 		...(Object.keys(basePlanItemsByPlan).length ? { basePlanItemsByPlan } : {}),
+		currentPlan: planId ? (currentPlanByPlan[planId] ?? null) : null,
+		...(Object.keys(currentPlanByPlan).length ? { currentPlanByPlan } : {}),
 		customerEmail: text(customerRecord.email),
 		customerName: text(customerRecord.name),
 		...(Object.keys(featureNames).length ? { featureNames } : {}),

--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -1,7 +1,9 @@
 import {
 	type BillingChangeDisplay,
 	buildBillingPreviewDisplay,
+	buildCustomizeChanges,
 	buildPlanItemChangeDisplay,
+	customPriceText,
 	formatCount,
 	formatMoney,
 	parsePreviewPayload,
@@ -39,6 +41,7 @@ import {
 	changeTableRow,
 	fanOutTable,
 	planItemChangeTableRow,
+	sortByChangeKind,
 	stepOutcomeTable,
 } from "./changeTable.js";
 import {
@@ -771,10 +774,20 @@ const catalogApprovalBlocks = ({
 	];
 	const tables = [
 		...(catalogRows.length
-			? [changeTable({ caption: "Catalog changes", rows: catalogRows })]
+			? [
+					changeTable({
+						caption: "Catalog changes",
+						rows: sortByChangeKind(catalogRows),
+					}),
+				]
 			: []),
 		...(planRows.length
-			? [changeTable({ caption: "Plan changes", rows: planRows })]
+			? [
+					changeTable({
+						caption: "Plan changes",
+						rows: sortByChangeKind(planRows),
+					}),
+				]
 			: []),
 	];
 	if (tables.length) return tables;
@@ -1002,9 +1015,6 @@ const approvalPreviewBlocks = ({
 	);
 	const resolvedFeatureNames = getRecord(approvalDisplay.featureNames);
 	const display = buildBillingPreviewDisplay({
-		basePlanItems: Array.isArray(approvalDisplay.basePlanItems)
-			? approvalDisplay.basePlanItems
-			: null,
 		params: request ?? null,
 		planNames: resolvedPlanNames,
 		preview: parsePreviewPayload(preview),
@@ -1016,40 +1026,42 @@ const approvalPreviewBlocks = ({
 	if (changeSummary) {
 		blocks.push(CardText(changeSummary));
 	}
+	// Every customize row is an add or a remove against the customer's current
+	// plan — the same diff the dashboard renders, so the two surfaces agree.
 	const customizeRows = ({
+		currentPlan,
 		customize,
 		plan,
 	}: {
-		customize: typeof display.customize;
+		currentPlan: unknown;
+		customize: unknown;
 		plan?: string;
 	}) => {
 		const details = (value: string) => (plan ? `${plan} · ${value}` : value);
-		return [
-			...(customize?.priceText
-				? [
+		return buildCustomizeChanges({ currentPlan, customize }).flatMap(
+			(change) => {
+				const verb = change.kind === "add" ? "Add" : "Remove";
+				if (change.subject === "price") {
+					return [
 						changeTableRow({
-							change: "Update",
+							change: verb,
 							details: details("Base price"),
-							pricing: customize.priceText,
+							pricing: customPriceText(change.price) ?? "—",
 						}),
-					]
-				: []),
-			...(customize?.freeTrialText
-				? [
-						changeTableRow({
-							change: "Update",
-							details: details(`Free trial · ${customize.freeTrialText}`),
-						}),
-					]
-				: []),
-			...(customize?.itemChanges.map((change) => {
+					];
+				}
+				const itemDisplay = buildPlanItemChangeDisplay({
+					change: verb,
+					item: change.item,
+				});
+				if (!itemDisplay) return [];
 				const row = planItemChangeTableRow({
-					change,
+					change: itemDisplay,
 					featureNames: resolvedFeatureNames,
 				});
-				return { ...row, details: details(row.details) };
-			}) ?? []),
-		];
+				return [{ ...row, details: details(row.details) }];
+			},
+		);
 	};
 	const schedulePlans = [
 		...(Array.isArray(request?.phases)
@@ -1068,18 +1080,32 @@ const approvalPreviewBlocks = ({
 			({ name, planId }) => [planId, name] as const,
 		),
 	]);
+	// Display data resolved before this change carries only the plan's items;
+	// newer rows carry the whole plan. Accept either so stored cards still diff.
+	const currentPlanByPlan = getRecord(approvalDisplay.currentPlanByPlan);
 	const basePlanItemsByPlan = getRecord(approvalDisplay.basePlanItemsByPlan);
+	const currentPlanFor = (planId: string | null) => {
+		if (!planId) return approvalDisplay.currentPlan ?? null;
+		const whole = currentPlanByPlan[planId];
+		if (whole) return whole;
+		const items = basePlanItemsByPlan[planId];
+		return Array.isArray(items) ? { items } : null;
+	};
+	const primaryCurrentPlan =
+		approvalDisplay.currentPlan ??
+		(Array.isArray(approvalDisplay.basePlanItems)
+			? { items: approvalDisplay.basePlanItems }
+			: null);
 	const changeRows = [
-		...customizeRows({ customize: display.customize }),
+		...customizeRows({
+			currentPlan: primaryCurrentPlan,
+			customize: request?.customize,
+		}),
 		...schedulePlans.flatMap((plan) => {
 			const planId = getString(plan.plan_id) ?? "Plan";
-			const basePlanItems = basePlanItemsByPlan[planId];
-			const nested = buildBillingPreviewDisplay({
-				basePlanItems: Array.isArray(basePlanItems) ? basePlanItems : null,
-				params: plan,
-			});
 			return customizeRows({
-				customize: nested.customize,
+				currentPlan: currentPlanFor(planId),
+				customize: plan.customize,
 				plan: planNames.get(planId) ?? planId,
 			});
 		}),

--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -6,6 +6,7 @@ import {
 	customPriceText,
 	formatCount,
 	formatMoney,
+	freeTrialText,
 	parsePreviewPayload,
 } from "@autumn/render";
 import type { AppEnv } from "@autumn/shared";
@@ -1047,6 +1048,14 @@ const approvalPreviewBlocks = ({
 							change: verb,
 							details: details("Base price"),
 							pricing: customPriceText(change.price) ?? "—",
+						}),
+					];
+				}
+				if (change.subject === "free_trial") {
+					return [
+						changeTableRow({
+							change: verb,
+							details: details(freeTrialText(change.trial) ?? "Free trial"),
 						}),
 					];
 				}

--- a/apps/leaf/src/ui/changeTable.ts
+++ b/apps/leaf/src/ui/changeTable.ts
@@ -93,6 +93,8 @@ export const planItemChangeTableRow = ({
 	});
 };
 
+/** Rows render in the order given — ordering is the caller's concern, since
+ * a catalog listing and a before/after diff want different orders. */
 export const changeTable = ({
 	caption,
 	rows,
@@ -104,17 +106,18 @@ export const changeTable = ({
 		align: ["left", "left", "left"],
 		caption,
 		headers: ["Change", "Details", "Pricing"],
-		rows: [...rows]
-			.sort(
-				(left, right) =>
-					changes[left.change].order - changes[right.change].order,
-			)
-			.map(({ change, details, pricing }) => [
-				changes[change].label,
-				details,
-				pricing,
-			]),
+		rows: rows.map(({ change, details, pricing }) => [
+			changes[change].label,
+			details,
+			pricing,
+		]),
 	});
+
+/** Catalog listings group by operation: adds, then updates, then removes. */
+export const sortByChangeKind = (rows: ReturnType<typeof changeTableRow>[]) =>
+	[...rows].sort(
+		(left, right) => changes[left.change].order - changes[right.change].order,
+	);
 
 const stepStatusLabels = {
 	applied: "🟢 Applied",

--- a/apps/leaf/tests/unit/approvals/approvalDisplay.test.ts
+++ b/apps/leaf/tests/unit/approvals/approvalDisplay.test.ts
@@ -42,6 +42,7 @@ describe("resolveApprovalDisplay", () => {
 			{
 				request: {
 					customer_id: "kp-customer-1000",
+					expand: ["subscriptions.plan"],
 					with_autumn_id: false,
 				},
 				toolName: "getCustomer",
@@ -244,5 +245,86 @@ describe("resolveApprovalDisplay", () => {
 			pro: [{ feature_id: "messages", included: 800 }],
 		});
 		expect(display.planNames).toEqual({ pro: "Pro" });
+	});
+});
+
+// remove_items is a filter; the quantity being removed is what the customer
+// currently holds. A customized subscription can differ from the catalog
+// plan, so the customer's live items must take precedence when present.
+describe("base items prefer the customer's live subscription", () => {
+	test("uses the subscription's customized items over the catalog plan", async () => {
+		const display = await resolveApprovalDisplay({
+			env: AppEnv.Sandbox,
+			executeTool: async ({ toolName }) => ({
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify(
+							toolName === "getPlan"
+								? {
+										items: [{ feature_id: "contacts", included: 0 }],
+										name: "Enterprise",
+									}
+								: {
+										email: "ops@atlas.example",
+										name: "Atlas Management Group",
+										subscriptions: [
+											{
+												plan: {
+													id: "enterprise",
+													items: [
+														{ feature_id: "contacts", included: 250_000 },
+													],
+													name: "Enterprise",
+												},
+												plan_id: "enterprise",
+											},
+										],
+									},
+						),
+					},
+				],
+			}),
+			getToken: async () => "token",
+			preview: undefined,
+			request: {
+				customer_id: "cus_atlas",
+				customize: { remove_items: [{ feature_id: "contacts" }] },
+				plan_id: "enterprise",
+			},
+		});
+
+		expect(display.basePlanItems).toEqual([
+			{ feature_id: "contacts", included: 250_000 },
+		]);
+	});
+
+	test("falls back to the catalog plan when the customer has no such subscription", async () => {
+		const display = await resolveApprovalDisplay({
+			env: AppEnv.Sandbox,
+			executeTool: async ({ toolName }) => ({
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify(
+							toolName === "getPlan"
+								? { items: [{ feature_id: "seats", included: 5 }], name: "Pro" }
+								: {
+										email: "new@example.com",
+										name: "Newco",
+										subscriptions: [],
+									},
+						),
+					},
+				],
+			}),
+			getToken: async () => "token",
+			preview: undefined,
+			request: { customer_id: "cus_new", plan_id: "pro" },
+		});
+
+		expect(display.basePlanItems).toEqual([
+			{ feature_id: "seats", included: 5 },
+		]);
 	});
 });

--- a/apps/leaf/tests/unit/approvals/approvalDisplay.test.ts
+++ b/apps/leaf/tests/unit/approvals/approvalDisplay.test.ts
@@ -33,6 +33,7 @@ describe("resolveApprovalDisplay", () => {
 
 		expect(display).toEqual({
 			basePlanItems: null,
+			currentPlan: null,
 			customerEmail: "billing@key-people.example",
 			customerName: "Key People",
 			planName: "Enterprise",
@@ -73,11 +74,15 @@ describe("resolveApprovalDisplay", () => {
 			request: { customer_id: "cus_1", plan_id: "growth" },
 		});
 
+		const growth = {
+			items: [{ feature_id: "messages", included: 800 }],
+			name: "Growth",
+		};
 		expect(display).toEqual({
-			basePlanItems: [{ feature_id: "messages", included: 800 }],
-			basePlanItemsByPlan: {
-				growth: [{ feature_id: "messages", included: 800 }],
-			},
+			basePlanItems: growth.items,
+			basePlanItemsByPlan: { growth: growth.items },
+			currentPlan: growth,
+			currentPlanByPlan: { growth },
 			customerEmail: "billing@example.com",
 			customerName: null,
 			planName: "Growth",

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -1518,3 +1518,54 @@ describe("grouped steps follow the card state", () => {
 		expect(rendered).toContain("Attaching");
 	});
 });
+
+// A remove_items filter names a feature, not a quantity. The quantity being
+// removed is whatever the customer CURRENTLY has, which can differ from the
+// catalog plan — showing the catalog's included count (often 0) is wrong.
+describe("remove rows show the customer's current quantity", () => {
+	test("removes 250,000 contacts the customer has, not the catalog's 0", () => {
+		const card = approvalCard({
+			id: "u1",
+			env: AppEnv.Sandbox,
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "cus_atlas",
+					customize: {
+						add_items: [{ feature_id: "contacts", included: 500_000 }],
+						remove_items: [{ feature_id: "contacts" }],
+					},
+					plan_id: "enterprise",
+				},
+			},
+			preview: wrapMcpResult({
+				_display: {
+					// resolveApprovalDisplay already prefers the customer's live
+					// subscription items over the catalog's; the card must render
+					// that quantity rather than re-deriving from the filter.
+					basePlanItems: [{ feature_id: "contacts", included: 250_000 }],
+					customerName: "Atlas Management Group",
+					featureNames: {
+						contacts: {
+							name: "contacts",
+							plural: "contacts",
+							singular: "contact",
+						},
+					},
+					planName: "Enterprise",
+				},
+				preview: {
+					currency: "usd",
+					customer_id: "cus_atlas",
+					line_items: [],
+					total: 189.1,
+				},
+			}),
+		});
+
+		const rendered = JSON.stringify(cardToBlockKit(card));
+		expect(rendered).toContain("250,000 contacts");
+		// Anchor on the cell boundary: "500,000 contacts" also contains "0 contacts".
+		expect(rendered).not.toContain('"0 contacts"');
+	});
+});

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -1666,3 +1666,53 @@ describe("update-subscription card, end to end from a real preview shape", () =>
 		expect(json).not.toContain("🟠 Update");
 	});
 });
+
+// A free-trial override is a billing term the reviewer is authorizing; it
+// must appear on the card as an add/remove like price, not vanish.
+describe("free trial on the approval card", () => {
+	test("renders a new trial as an add with its real duration", () => {
+		const card = approvalCard({
+			id: "t1",
+			env: AppEnv.Sandbox,
+			toolName: "attach",
+			toolArgs: {
+				request: {
+					customer_id: "cus_1",
+					customize: {
+						free_trial: { duration_length: 14, duration_type: "day" },
+					},
+					plan_id: "pro",
+				},
+			},
+		});
+		expect(JSON.stringify(card)).toContain(
+			'["🟢 Add","14-day free trial","—"]',
+		);
+	});
+
+	test("renders removing a trial as a remove", () => {
+		const card = approvalCard({
+			id: "t2",
+			env: AppEnv.Sandbox,
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "cus_1",
+					customize: { free_trial: null },
+					plan_id: "pro",
+				},
+			},
+			preview: wrapMcpResult({
+				_display: {
+					currentPlan: {
+						free_trial: { duration_length: 1, duration_type: "month" },
+					},
+				},
+				preview: { currency: "usd", line_items: [], total: 0 },
+			}),
+		});
+		expect(JSON.stringify(card)).toContain(
+			'["🔴 Remove","1-month free trial","—"]',
+		);
+	});
+});

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -123,9 +123,40 @@ describe("approval card", () => {
 		const json = JSON.stringify(card);
 		expect(json).toContain("Update **charlie**'s subscription to **pro**?");
 		expect(json).toContain('"caption":"Plan changes"');
-		expect(json).toContain('["🟠 Update","Base price","$200.00 per month"]');
+		// No current plan in the preview, so setting a price is an add.
+		expect(json).toContain('["🟢 Add","Base price","$200.00 per month"]');
+		expect(json).not.toContain('Update","Base price');
 		expect(json).not.toContain("custom");
 		expect(json).not.toContain('"customize"');
+	});
+
+	// Changing the base price is a remove of the old and an add of the new —
+	// the same diff the dashboard renders, never a hardcoded "Update".
+	test("shows a base price change as a remove and an add", () => {
+		const card = approvalCard({
+			id: "approval_1",
+			env: AppEnv.Sandbox,
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "cus_1",
+					customize: { price: { amount: 200, interval: "month" } },
+					plan_id: "pro",
+				},
+			},
+			preview: wrapMcpResult({
+				_display: {
+					currentPlan: { price: { amount: 150, interval: "month" } },
+					customerName: "charlie",
+					planName: "pro",
+				},
+				preview: { currency: "usd", line_items: [], total: 50 },
+			}),
+		});
+		const json = JSON.stringify(card);
+		expect(json).toContain('["🔴 Remove","Base price","$150.00 per month"]');
+		expect(json).toContain('["🟢 Add","Base price","$200.00 per month"]');
+		expect(json).not.toContain("🟠 Update");
 	});
 
 	test("omits badges and money facts when nothing was set", () => {
@@ -377,8 +408,9 @@ describe("approval card", () => {
 		expect(json).toContain('["🔴 Remove","1,000 credits","$0.05 / unit"]');
 		expect(json).toContain('["🔴 Remove","10 audit logs","—"]');
 		expect(json).toContain('["🔴 Remove","50 annual tokens","—"]');
-		expect(json.indexOf('["🟢 Add","5,000 credits"')).toBeLessThan(
-			json.indexOf('["🔴 Remove","10 audit logs"'),
+		// A diff reads old → new: what the customer loses before what they gain.
+		expect(json.indexOf('["🔴 Remove","10 audit logs"')).toBeLessThan(
+			json.indexOf('["🟢 Add","5,000 credits"'),
 		);
 	});
 
@@ -425,11 +457,11 @@ describe("approval card", () => {
 		expect(json).toContain('["🟢 Add","5,000 words","—"]');
 		expect(json).toContain('["🔴 Remove","4,000 words","—"]');
 		expect(json).toContain('["🔴 Remove","800 messages","$6.00 / 100"]');
-		expect(json.indexOf('["🟢 Add","100 gigabytes"')).toBeLessThan(
-			json.indexOf('["🔴 Remove","4,000 words"'),
+		expect(json.indexOf('["🔴 Remove","4,000 words"')).toBeLessThan(
+			json.indexOf('["🟢 Add","100 gigabytes"'),
 		);
-		expect(json.indexOf('["🟢 Add","5,000 words"')).toBeLessThan(
-			json.indexOf('["🔴 Remove","800 messages"'),
+		expect(json.indexOf('["🔴 Remove","800 messages"')).toBeLessThan(
+			json.indexOf('["🟢 Add","5,000 words"'),
 		);
 		expect(json).not.toContain("Replace");
 		expect(json).not.toContain('["workflows"');
@@ -1567,5 +1599,70 @@ describe("remove rows show the customer's current quantity", () => {
 		expect(rendered).toContain("250,000 contacts");
 		// Anchor on the cell boundary: "500,000 contacts" also contains "0 contacts".
 		expect(rendered).not.toContain('"0 contacts"');
+	});
+});
+
+// Ayush's report end to end through the real pipeline: a customer whose
+// subscription holds 250,000 contacts, updated to 500,000 at a new base price.
+// Every row must be an add or a remove derived from the current plan.
+describe("update-subscription card, end to end from a real preview shape", () => {
+	test("renders the customer's current plan diff as adds and removes", () => {
+		const card = approvalCard({
+			id: "u_atlas",
+			env: AppEnv.Sandbox,
+			toolName: "updateSubscription",
+			toolArgs: {
+				request: {
+					customer_id: "cus_atlas",
+					customize: {
+						add_items: [{ feature_id: "contacts", included: 500_000 }],
+						price: { amount: 1600, interval: "month" },
+						remove_items: [{ feature_id: "contacts" }],
+					},
+					plan_id: "enterprise",
+				},
+			},
+			preview: wrapMcpResult({
+				_display: {
+					currentPlan: {
+						id: "enterprise",
+						items: [{ feature_id: "contacts", included: 250_000 }],
+						name: "Enterprise",
+						price: { amount: 1500, interval: "month" },
+					},
+					customerName: "Atlas Management Group",
+					featureNames: {
+						contacts: {
+							name: "contacts",
+							plural: "contacts",
+							singular: "contact",
+						},
+					},
+					planName: "Enterprise",
+				},
+				preview: {
+					currency: "usd",
+					customer_id: "cus_atlas",
+					line_items: [
+						{ amount: -315.16, description: "Unused Enterprise - Base Price" },
+						{ amount: 504.26, description: "Enterprise - Base Price" },
+					],
+					total: 189.1,
+				},
+			}),
+		});
+
+		const json = JSON.stringify(card);
+		const rows = (
+			json.match(/\["(🟢 Add|🔴 Remove|🟠 Update)","[^"]*","[^"]*"\]/g) ?? []
+		).map((row) => JSON.parse(row) as [string, string, string]);
+
+		expect(rows).toEqual([
+			["🔴 Remove", "Base price", "$1,500.00 per month"],
+			["🔴 Remove", "250,000 contacts", "—"],
+			["🟢 Add", "Base price", "$1,600.00 per month"],
+			["🟢 Add", "500,000 contacts", "—"],
+		]);
+		expect(json).not.toContain("🟠 Update");
 	});
 });

--- a/packages/render/src/billing/customizeChanges.ts
+++ b/packages/render/src/billing/customizeChanges.ts
@@ -1,0 +1,135 @@
+import { formatMoney } from "../format.js";
+import { asRecord, getArray, getNumber, getString } from "../records.js";
+import { itemMatchesFilter } from "./itemMatchesFilter.js";
+
+type PriceShape = Record<string, unknown>;
+type ItemShape = Record<string, unknown>;
+
+/** One customer-specific change to a plan. Every change is an add or a
+ * remove: the verb is a property of the diff against the current plan, never
+ * a label chosen by a surface. Removes carry what is actually being removed. */
+export type CustomizeChange =
+	| { kind: "add" | "remove"; subject: "price"; price: PriceShape }
+	| { kind: "add" | "remove"; subject: "item"; item: ItemShape };
+
+const currentItems = (currentPlan: unknown): ItemShape[] =>
+	getArray(asRecord(currentPlan)?.items).flatMap((item) => {
+		const record = asRecord(item);
+		return record ? [record] : [];
+	});
+
+const priceChanges = ({
+	currentPlan,
+	customize,
+}: {
+	currentPlan: unknown;
+	customize: Record<string, unknown>;
+}): CustomizeChange[] => {
+	if (!("price" in customize)) return [];
+	const currentPrice = asRecord(asRecord(currentPlan)?.price);
+	const nextPrice = asRecord(customize.price);
+	return [
+		...(currentPrice
+			? [
+					{
+						kind: "remove" as const,
+						subject: "price" as const,
+						price: currentPrice,
+					},
+				]
+			: []),
+		...(nextPrice
+			? [{ kind: "add" as const, subject: "price" as const, price: nextPrice }]
+			: []),
+	];
+};
+
+/** `remove_items` entries are filters; each resolves to the current items it
+ * matches so the row shows the quantity being removed. An unmatched filter
+ * still names its feature rather than vanishing. */
+const removedItems = ({
+	currentPlan,
+	filters,
+}: {
+	currentPlan: unknown;
+	filters: unknown;
+}): ItemShape[] =>
+	getArray(filters).flatMap((filter) => {
+		const matches = currentItems(currentPlan).filter((item) =>
+			itemMatchesFilter({ filter, item }),
+		);
+		if (matches.length) return matches;
+		const filterRecord = asRecord(filter);
+		return filterRecord ? [filterRecord] : [];
+	});
+
+const addedItems = (value: unknown): ItemShape[] =>
+	getArray(value).flatMap((item) => {
+		const record = asRecord(item);
+		return record ? [record] : [];
+	});
+
+const itemChanges = ({
+	currentPlan,
+	customize,
+}: {
+	currentPlan: unknown;
+	customize: Record<string, unknown>;
+}): CustomizeChange[] => {
+	// `items` is PUT-style: the new list replaces every current item.
+	const replacing = Array.isArray(customize.items);
+	const removed = replacing
+		? currentItems(currentPlan)
+		: removedItems({ currentPlan, filters: customize.remove_items });
+	const added = replacing
+		? addedItems(customize.items)
+		: addedItems(customize.add_items);
+	return [
+		...removed.map((item) => ({
+			kind: "remove" as const,
+			subject: "item" as const,
+			item,
+		})),
+		...added.map((item) => ({
+			kind: "add" as const,
+			subject: "item" as const,
+			item,
+		})),
+	];
+};
+
+/** The customer-specific terms of a billing action as adds and removes
+ * against the current plan. Removes precede adds so a table reads old → new. */
+export const buildCustomizeChanges = ({
+	currentPlan,
+	customize,
+}: {
+	/** The plan being changed (`outgoing[].plan` or the live subscription),
+	 * or null for a fresh attach where nothing is current. */
+	currentPlan: unknown;
+	customize: unknown;
+}): CustomizeChange[] => {
+	const patch = asRecord(customize);
+	if (!patch) return [];
+	const price = priceChanges({ currentPlan, customize: patch });
+	const items = itemChanges({ currentPlan, customize: patch });
+	return [
+		...price.filter((change) => change.kind === "remove"),
+		...items.filter((change) => change.kind === "remove"),
+		...price.filter((change) => change.kind === "add"),
+		...items.filter((change) => change.kind === "add"),
+	];
+};
+
+/** "$80.00 per month" for a base-price shape, or null when there is no amount. */
+export const customPriceText = (value: unknown): string | null => {
+	const price = asRecord(value);
+	const amount = getNumber(price?.amount);
+	if (price === null || amount === null) return null;
+	const interval = getString(price.interval);
+	const intervalCount = getNumber(price.interval_count);
+	const cadence = interval
+		? ` per ${intervalCount && intervalCount > 1 ? `${intervalCount} ${interval}s` : interval}`
+		: "";
+	return `${formatMoney({ amount, currency: getString(price.currency) })}${cadence}`;
+};

--- a/packages/render/src/billing/customizeChanges.ts
+++ b/packages/render/src/billing/customizeChanges.ts
@@ -2,45 +2,47 @@ import { formatMoney } from "../format.js";
 import { asRecord, getArray, getNumber, getString } from "../records.js";
 import { itemMatchesFilter } from "./itemMatchesFilter.js";
 
-type PriceShape = Record<string, unknown>;
-type ItemShape = Record<string, unknown>;
+type Shape = Record<string, unknown>;
 
 /** One customer-specific change to a plan. Every change is an add or a
  * remove: the verb is a property of the diff against the current plan, never
  * a label chosen by a surface. Removes carry what is actually being removed. */
 export type CustomizeChange =
-	| { kind: "add" | "remove"; subject: "price"; price: PriceShape }
-	| { kind: "add" | "remove"; subject: "item"; item: ItemShape };
+	| { kind: "add" | "remove"; subject: "price"; price: Shape }
+	| { kind: "add" | "remove"; subject: "free_trial"; trial: Shape }
+	| { kind: "add" | "remove"; subject: "item"; item: Shape };
 
-const currentItems = (currentPlan: unknown): ItemShape[] =>
-	getArray(asRecord(currentPlan)?.items).flatMap((item) => {
-		const record = asRecord(item);
+type ChangeKind = CustomizeChange["kind"];
+
+const records = (value: unknown): Shape[] =>
+	getArray(value).flatMap((entry) => {
+		const record = asRecord(entry);
 		return record ? [record] : [];
 	});
 
-const priceChanges = ({
+const currentItems = (currentPlan: unknown): Shape[] =>
+	records(asRecord(currentPlan)?.items);
+
+/** A single-valued override (price, free trial): present in the request means
+ * "set to this", null means "remove". Diffed against the current plan's value
+ * so a change reads as a remove of the old and an add of the new. */
+const overrideChanges = ({
 	currentPlan,
 	customize,
+	field,
+	toChange,
 }: {
 	currentPlan: unknown;
-	customize: Record<string, unknown>;
+	customize: Shape;
+	field: string;
+	toChange: (kind: ChangeKind, value: Shape) => CustomizeChange;
 }): CustomizeChange[] => {
-	if (!("price" in customize)) return [];
-	const currentPrice = asRecord(asRecord(currentPlan)?.price);
-	const nextPrice = asRecord(customize.price);
+	if (!(field in customize)) return [];
+	const current = asRecord(asRecord(currentPlan)?.[field]);
+	const next = asRecord(customize[field]);
 	return [
-		...(currentPrice
-			? [
-					{
-						kind: "remove" as const,
-						subject: "price" as const,
-						price: currentPrice,
-					},
-				]
-			: []),
-		...(nextPrice
-			? [{ kind: "add" as const, subject: "price" as const, price: nextPrice }]
-			: []),
+		...(current ? [toChange("remove", current)] : []),
+		...(next ? [toChange("add", next)] : []),
 	];
 };
 
@@ -53,7 +55,7 @@ const removedItems = ({
 }: {
 	currentPlan: unknown;
 	filters: unknown;
-}): ItemShape[] =>
+}): Shape[] =>
 	getArray(filters).flatMap((filter) => {
 		const matches = currentItems(currentPlan).filter((item) =>
 			itemMatchesFilter({ filter, item }),
@@ -63,27 +65,19 @@ const removedItems = ({
 		return filterRecord ? [filterRecord] : [];
 	});
 
-const addedItems = (value: unknown): ItemShape[] =>
-	getArray(value).flatMap((item) => {
-		const record = asRecord(item);
-		return record ? [record] : [];
-	});
-
 const itemChanges = ({
 	currentPlan,
 	customize,
 }: {
 	currentPlan: unknown;
-	customize: Record<string, unknown>;
+	customize: Shape;
 }): CustomizeChange[] => {
 	// `items` is PUT-style: the new list replaces every current item.
 	const replacing = Array.isArray(customize.items);
 	const removed = replacing
 		? currentItems(currentPlan)
 		: removedItems({ currentPlan, filters: customize.remove_items });
-	const added = replacing
-		? addedItems(customize.items)
-		: addedItems(customize.add_items);
+	const added = records(replacing ? customize.items : customize.add_items);
 	return [
 		...removed.map((item) => ({
 			kind: "remove" as const,
@@ -111,13 +105,28 @@ export const buildCustomizeChanges = ({
 }): CustomizeChange[] => {
 	const patch = asRecord(customize);
 	if (!patch) return [];
-	const price = priceChanges({ currentPlan, customize: patch });
+	const overrides = [
+		...overrideChanges({
+			currentPlan,
+			customize: patch,
+			field: "price",
+			toChange: (kind, price) => ({ kind, subject: "price", price }),
+		}),
+		...overrideChanges({
+			currentPlan,
+			customize: patch,
+			field: "free_trial",
+			toChange: (kind, trial) => ({ kind, subject: "free_trial", trial }),
+		}),
+	];
 	const items = itemChanges({ currentPlan, customize: patch });
+	const only = (kind: ChangeKind) => (change: CustomizeChange) =>
+		change.kind === kind;
 	return [
-		...price.filter((change) => change.kind === "remove"),
-		...items.filter((change) => change.kind === "remove"),
-		...price.filter((change) => change.kind === "add"),
-		...items.filter((change) => change.kind === "add"),
+		...overrides.filter(only("remove")),
+		...items.filter(only("remove")),
+		...overrides.filter(only("add")),
+		...items.filter(only("add")),
 	];
 };
 
@@ -132,4 +141,13 @@ export const customPriceText = (value: unknown): string | null => {
 		? ` per ${intervalCount && intervalCount > 1 ? `${intervalCount} ${interval}s` : interval}`
 		: "";
 	return `${formatMoney({ amount, currency: getString(price.currency) })}${cadence}`;
+};
+
+/** "14-day free trial" for a trial shape, or null when there is no length. */
+export const freeTrialText = (value: unknown): string | null => {
+	const trial = asRecord(value);
+	const length = getNumber(trial?.duration_length);
+	if (trial === null || length === null) return null;
+	const unit = getString(trial.duration_type) ?? "month";
+	return `${length}-${unit} free trial`;
 };

--- a/packages/render/src/billing/itemMatchesFilter.ts
+++ b/packages/render/src/billing/itemMatchesFilter.ts
@@ -20,7 +20,8 @@ export const itemMatchesFilter = ({
 		[filterRecord.interval, price?.interval ?? reset?.interval],
 		[
 			filterRecord.interval_count,
-			price?.interval_count ?? reset?.interval_count,
+			// An item that omits interval_count means 1, so a filter saying 1 matches.
+			price?.interval_count ?? reset?.interval_count ?? 1,
 		],
 	].every(
 		([expected, actual]) => expected === undefined || expected === actual,

--- a/packages/render/src/billing/itemMatchesFilter.ts
+++ b/packages/render/src/billing/itemMatchesFilter.ts
@@ -1,0 +1,28 @@
+import { asRecord } from "../records.js";
+
+/** Whether a plan item satisfies a `remove_items` filter. Every field the
+ * filter names must match; fields it omits are wildcards. */
+export const itemMatchesFilter = ({
+	filter,
+	item,
+}: {
+	filter: unknown;
+	item: unknown;
+}): boolean => {
+	const itemRecord = asRecord(item);
+	const filterRecord = asRecord(filter);
+	if (!(itemRecord && filterRecord)) return false;
+	const price = asRecord(itemRecord.price);
+	const reset = asRecord(itemRecord.reset);
+	return [
+		[filterRecord.feature_id, itemRecord.feature_id],
+		[filterRecord.billing_method, price?.billing_method],
+		[filterRecord.interval, price?.interval ?? reset?.interval],
+		[
+			filterRecord.interval_count,
+			price?.interval_count ?? reset?.interval_count,
+		],
+	].every(
+		([expected, actual]) => expected === undefined || expected === actual,
+	);
+};

--- a/packages/render/src/billing/previewDisplay.ts
+++ b/packages/render/src/billing/previewDisplay.ts
@@ -40,21 +40,8 @@ type PlanItemChangeDisplay = {
 	pricingText: string | null;
 };
 
-const ITEM_CHANGE_ORDER: Record<PlanItemChangeDisplay["change"], number> = {
-	Add: 0,
-	Update: 1,
-	Remove: 2,
-	Replace: 3,
-};
-
 /** The write's plan customizations, dashboard-style: what the custom plan
  * grants/loses relative to the base plan. */
-export type CustomizeDisplay = {
-	freeTrialText: string | null;
-	itemChanges: PlanItemChangeDisplay[];
-	/** "$200.00 per year" */
-	priceText: string | null;
-};
 
 /** Surface-neutral billing action facts shared by every renderer. */
 export type BillingPreviewDisplay = {
@@ -73,7 +60,6 @@ export type BillingPreviewDisplay = {
 	/** Negative total: the customer gets money back, not a charge. */
 	isCredit: boolean;
 	lineItems: LineItemDisplay[];
-	customize: CustomizeDisplay | null;
 	prepaid: PrepaidQuantityDisplay[];
 	nextCycle: (MoneyDisplay & { startsAtText: string | null }) | null;
 	phases: SchedulePhaseDisplay[];
@@ -249,215 +235,6 @@ export const buildPlanItemChangeDisplay = ({
 	};
 };
 
-const filteredItemDisplay = ({
-	change,
-	value,
-}: {
-	change: PlanItemChangeDisplay["change"];
-	value: unknown;
-}): PlanItemChangeDisplay | null => {
-	const filter = asRecord(value);
-	if (!filter) return null;
-	return {
-		change,
-		featureId: getString(filter.feature_id),
-		includedText: null,
-		pricingText: null,
-	};
-};
-
-const itemMatchesFilter = ({
-	item,
-	filter,
-}: {
-	item: unknown;
-	filter: unknown;
-}) => {
-	const itemRecord = asRecord(item);
-	const filterRecord = asRecord(filter);
-	if (!(itemRecord && filterRecord)) return false;
-	const price = asRecord(itemRecord.price);
-	const reset = asRecord(itemRecord.reset);
-	return [
-		[filterRecord.feature_id, itemRecord.feature_id],
-		[filterRecord.billing_method, price?.billing_method],
-		[filterRecord.interval, price?.interval ?? reset?.interval],
-		[
-			filterRecord.interval_count,
-			price?.interval_count ?? reset?.interval_count ?? 1,
-		],
-	].every(
-		([expected, actual]) => expected === undefined || expected === actual,
-	);
-};
-
-const removedItemDisplays = ({
-	baseItems,
-	filters,
-}: {
-	baseItems?: unknown[] | null;
-	filters: unknown;
-}) =>
-	getArray(filters).flatMap((filter) => {
-		const matches =
-			baseItems?.filter((item) => itemMatchesFilter({ filter, item })) ?? [];
-		return matches.length
-			? matches.flatMap(
-					(item) =>
-						buildPlanItemChangeDisplay({ change: "Remove", item }) ?? [],
-				)
-			: (filteredItemDisplay({ change: "Remove", value: filter }) ?? []);
-	});
-
-const itemSignature = (value: unknown) => {
-	const item = asRecord(value);
-	const price = asRecord(item?.price);
-	const reset = asRecord(item?.reset);
-	return JSON.stringify([
-		getString(item?.feature_id),
-		item?.unlimited === true,
-		getNumber(item?.included),
-		getString(reset?.interval),
-		getNumber(price?.amount),
-		getNumber(price?.billing_units) ?? 1,
-		getString(price?.billing_method),
-		getString(price?.interval),
-		getString(price?.tier_behavior),
-		getArray(price?.tiers).map((tierValue) => {
-			const tier = asRecord(tierValue);
-			return [tier?.to, getNumber(tier?.amount), getNumber(tier?.flat_amount)];
-		}),
-	]);
-};
-
-const replacementItemChanges = ({
-	baseItems,
-	items,
-}: {
-	baseItems: unknown[];
-	items: unknown[];
-}) => {
-	const entries = (values: unknown[]) =>
-		values.flatMap((value) => {
-			const display = buildPlanItemChangeDisplay({
-				change: "Update",
-				item: value,
-			});
-			return display
-				? [
-						{
-							display,
-							signature: itemSignature(value),
-						},
-					]
-				: [];
-		});
-	const base = entries(baseItems);
-	const incoming = entries(items);
-	const baseSignatures = new Set(base.map(({ signature }) => signature));
-	const incomingSignatures = new Set(
-		incoming.map(({ signature }) => signature),
-	);
-	return [
-		...incoming
-			.filter(({ signature }) => !baseSignatures.has(signature))
-			.map(({ display }) => ({ ...display, change: "Add" as const })),
-		...base
-			.filter(({ signature }) => !incomingSignatures.has(signature))
-			.map(({ display }) => ({
-				...display,
-				change: "Remove" as const,
-			})),
-	];
-};
-
-const customPriceText = (value: unknown): string | null => {
-	const price = asRecord(value);
-	const amount = getNumber(price?.amount);
-	if (price === null || amount === null) return null;
-	const interval = getString(price.interval);
-	const intervalCount = getNumber(price.interval_count);
-	const cadence = interval
-		? ` per ${intervalCount && intervalCount > 1 ? `${intervalCount} ${interval}s` : interval}`
-		: "";
-	return `${formatMoney({ amount, currency: getString(price.currency) })}${cadence}`;
-};
-
-const freeTrialText = (value: unknown): string | null => {
-	if (value === true) return "free trial";
-	const trial = asRecord(value);
-	if (!trial) return null;
-	const days = getNumber(trial.duration_days ?? trial.days ?? trial.length);
-	return days !== null ? `${formatCount(days)}-day free trial` : "free trial";
-};
-
-const customizeDisplay = ({
-	basePlanItems,
-	params,
-}: {
-	basePlanItems?: unknown[] | null;
-	params?: Record<string, unknown> | null;
-}): CustomizeDisplay | null => {
-	const customize = asRecord(params?.customize);
-	if (!customize) return null;
-	const collect = (
-		value: unknown,
-		render: (entry: unknown) => PlanItemChangeDisplay | null,
-	) =>
-		getArray(value).flatMap((entry) => {
-			const rendered = render(entry);
-			return rendered ? [rendered] : [];
-		});
-	const added = collect(customize.add_items, (value) =>
-		buildPlanItemChangeDisplay({ change: "Add", item: value }),
-	);
-	const removed = removedItemDisplays({
-		baseItems: basePlanItems,
-		filters: customize.remove_items,
-	});
-	const itemChanges = [
-		...(Array.isArray(customize.items) && basePlanItems
-			? replacementItemChanges({
-					baseItems: basePlanItems,
-					items: customize.items,
-				})
-			: collect(customize.items, (value) =>
-					buildPlanItemChangeDisplay({ change: "Replace", item: value }),
-				)),
-		...added,
-		...removed,
-		...collect(customize.update_items, (value) => {
-			const update = asRecord(value);
-			const filter = asRecord(update?.filter);
-			const display = filteredItemDisplay({
-				change: "Update",
-				value: filter ?? value,
-			});
-			const included = getNumber(update?.included);
-			return display
-				? {
-						...display,
-						includedText: included === null ? null : formatCount(included),
-					}
-				: null;
-		}),
-	].sort(
-		(left, right) =>
-			ITEM_CHANGE_ORDER[left.change] - ITEM_CHANGE_ORDER[right.change],
-	);
-	const display: CustomizeDisplay = {
-		freeTrialText: freeTrialText(customize.free_trial),
-		itemChanges,
-		priceText: customPriceText(customize.price),
-	};
-	const hasContent =
-		display.itemChanges.length > 0 ||
-		display.priceText !== null ||
-		display.freeTrialText !== null;
-	return hasContent ? display : null;
-};
-
-/** A prepaid item and its requested quantity; null means the API defaults to 0. */
 export type PrepaidQuantityDisplay = {
 	featureId: string;
 	includedDefault: number | null;
@@ -520,12 +297,10 @@ const money = ({
 
 /** Accepts typed previews or loose output from `parsePreviewPayload`. */
 export const buildBillingPreviewDisplay = ({
-	basePlanItems,
 	params,
 	planNames: knownPlanNames,
 	preview,
 }: {
-	basePlanItems?: unknown[] | null;
 	params?: Record<string, unknown> | null;
 	planNames?: Readonly<Record<string, string>>;
 	preview?: Record<string, unknown> | null;
@@ -571,7 +346,6 @@ export const buildBillingPreviewDisplay = ({
 		currency,
 		customerId:
 			getString(params?.customer_id) ?? getString(payload.customer_id),
-		customize: customizeDisplay({ basePlanItems, params }),
 		dueNow: money({ amount: total, currency }),
 		entityId: getString(params?.entity_id),
 		intentLabel: intent ? (UPDATE_INTENT_LABELS[intent] ?? null) : null,

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -3,6 +3,7 @@ export {
 	buildCustomizeChanges,
 	type CustomizeChange,
 	customPriceText,
+	freeTrialText,
 } from "./billing/customizeChanges.js";
 export {
 	type BillingChangeDisplay,

--- a/packages/render/src/index.ts
+++ b/packages/render/src/index.ts
@@ -1,10 +1,14 @@
 export { type BillingBadge, billingActionBadges } from "./billing/badges.js";
 export {
+	buildCustomizeChanges,
+	type CustomizeChange,
+	customPriceText,
+} from "./billing/customizeChanges.js";
+export {
 	type BillingChangeDisplay,
 	type BillingPreviewDisplay,
 	buildBillingPreviewDisplay,
 	buildPlanItemChangeDisplay,
-	type CustomizeDisplay,
 	type LineItemDisplay,
 	type MoneyDisplay,
 	type SchedulePhaseDisplay,

--- a/vite/package.json
+++ b/vite/package.json
@@ -22,6 +22,7 @@
 	"dependencies": {
 		"@ai-sdk/react": "^3.0.25",
 		"@autumn/env": "workspace:*",
+		"@autumn/render": "workspace:*",
 		"@autumn/shared": "workspace:*",
 		"@autumn/ui": "workspace:*",
 		"@base-ui/react": "^1.4.1",

--- a/vite/src/views/chat/components/BillingCustomizeDiff.tsx
+++ b/vite/src/views/chat/components/BillingCustomizeDiff.tsx
@@ -1,4 +1,8 @@
-import { buildCustomizeChanges, type CustomizeChange } from "@autumn/render";
+import {
+	buildCustomizeChanges,
+	type CustomizeChange,
+	freeTrialText,
+} from "@autumn/render";
 import {
 	type ApiPlanV1,
 	type CustomizePlanV1,
@@ -38,10 +42,13 @@ const itemLabel = (item: Record<string, unknown>) => {
 	return `${included}${feature}${priced}` || "item";
 };
 
-const changeLabel = (change: CustomizeChange) =>
-	change.subject === "price"
-		? `Base price ${priceText(change.price)}`
-		: itemLabel(change.item);
+const changeLabel = (change: CustomizeChange) => {
+	if (change.subject === "price")
+		return `Base price ${priceText(change.price)}`;
+	if (change.subject === "free_trial")
+		return freeTrialText(change.trial) ?? "Free trial";
+	return itemLabel(change.item);
+};
 
 /** The customer-specific terms of a billing action as adds and removes against
  * the current plan. The diff itself lives in @autumn/render so Slack and the

--- a/vite/src/views/chat/components/BillingCustomizeDiff.tsx
+++ b/vite/src/views/chat/components/BillingCustomizeDiff.tsx
@@ -1,3 +1,4 @@
+import { buildCustomizeChanges, type CustomizeChange } from "@autumn/render";
 import {
 	type ApiPlanV1,
 	type CustomizePlanV1,
@@ -6,13 +7,10 @@ import {
 } from "@autumn/shared";
 import { ItemStatusDot } from "@/components/v2/ItemStatusDot";
 
-const priceText = (price: {
-	amount: number;
-	interval?: string | null;
-	interval_count?: number;
-}) => {
-	const amount = formatAmount({
-		amount: price.amount,
+const priceText = (price: Record<string, unknown>) => {
+	const amount = typeof price.amount === "number" ? price.amount : 0;
+	const formatted = formatAmount({
+		amount,
 		amountFormatOptions: {
 			currencyDisplay: "narrowSymbol",
 			maximumFractionDigits: 10,
@@ -21,13 +19,13 @@ const priceText = (price: {
 	const interval = formatInterval({
 		// biome-ignore lint/suspicious/noExplicitAny: interval unions across param schemas
 		interval: price.interval as any,
-		intervalCount: price.interval_count,
+		intervalCount:
+			typeof price.interval_count === "number"
+				? price.interval_count
+				: undefined,
 	});
-	return interval ? `${amount} ${interval}` : amount;
+	return interval ? `${formatted} ${interval}` : formatted;
 };
-
-const asItems = (value: unknown): Record<string, unknown>[] =>
-	Array.isArray(value) ? (value as Record<string, unknown>[]) : [];
 
 const itemLabel = (item: Record<string, unknown>) => {
 	const feature = typeof item.feature_id === "string" ? item.feature_id : "";
@@ -40,64 +38,44 @@ const itemLabel = (item: Record<string, unknown>) => {
 	return `${included}${feature}${priced}` || "item";
 };
 
-/** The customer-specific terms of a billing action (`params.customize`) as a
- * patch against the catalog plan — price old→new plus added/removed items,
- * mirroring the update-subscription sheet's plan-configuration block. */
+const changeLabel = (change: CustomizeChange) =>
+	change.subject === "price"
+		? `Base price ${priceText(change.price)}`
+		: itemLabel(change.item);
+
+/** The customer-specific terms of a billing action as adds and removes against
+ * the current plan. The diff itself lives in @autumn/render so Slack and the
+ * dashboard render the same changes. */
 export function BillingCustomizeDiff({
 	currentPlan,
 	customize,
 }: {
-	/** The plan being replaced (for the price "from" side), when known. */
+	/** The plan being replaced, when known. */
 	currentPlan?: ApiPlanV1 | null;
 	customize: CustomizePlanV1 | Record<string, unknown>;
 }) {
-	const patch = customize as {
-		add_items?: unknown;
-		price?: { amount: number; interval?: string; interval_count?: number };
-		remove_items?: unknown;
-	};
-	const added = asItems(patch.add_items);
-	const removed = asItems(patch.remove_items);
-	const hasContent = patch.price || added.length > 0 || removed.length > 0;
-	if (!hasContent) return null;
+	const changes = buildCustomizeChanges({ currentPlan, customize });
+	if (changes.length === 0) return null;
 
 	return (
 		<div className="flex flex-col gap-1.5 rounded-lg border border-border bg-card px-3 py-2.5">
 			<span className="font-medium text-tertiary-foreground text-xs">
 				Custom terms
 			</span>
-			{patch.price && (
-				<div className="flex items-center gap-1.5 text-sm">
-					{currentPlan?.price && (
-						<>
-							<span className="text-tertiary-foreground">
-								{priceText(currentPlan.price)}
-							</span>
-							<span className="text-subtle">-&gt;</span>
-						</>
-					)}
-					<span className="font-semibold text-foreground">
-						{priceText(patch.price)}
-					</span>
-				</div>
-			)}
-			{added.map((item, index) => (
+			{changes.map((change, index) => (
 				<div
 					className="flex items-center gap-2 text-xs"
-					key={`added-${itemLabel(item)}-${index}`}
+					key={`${change.kind}-${changeLabel(change)}-${index}`}
 				>
-					<ItemStatusDot state="new" />
-					<span className="text-foreground">{itemLabel(item)}</span>
-				</div>
-			))}
-			{removed.map((item, index) => (
-				<div
-					className="flex items-center gap-2 text-xs"
-					key={`removed-${itemLabel(item)}-${index}`}
-				>
-					<ItemStatusDot state="removed" />
-					<span className="text-tertiary-foreground line-through">
-						{itemLabel(item)}
+					<ItemStatusDot state={change.kind === "add" ? "new" : "removed"} />
+					<span
+						className={
+							change.kind === "add"
+								? "text-foreground"
+								: "text-tertiary-foreground line-through"
+						}
+					>
+						{changeLabel(change)}
 					</span>
 				</div>
 			))}


### PR DESCRIPTION
## Summary

**Stacked on #2882** — depends on its `approvalDisplay` current-plan resolution. Merge that first; this retargets to `dev` automatically.

The Slack approval card's "Plan changes" table was built by a Slack-only transformation layer in `@autumn/render` (~218 lines) that reinterpreted the `customize.*` request field-by-field with hardcoded verbs — `"Update"` for a base price whether or not one existed, `price: null` (remove the base price) silently rendering nothing, `remove_items` showing the catalog's quantity instead of the customer's. The dashboard never imported any of it; it had its own simpler diff. The two surfaces disagreed.

### One shared model
`buildCustomizeChanges({ currentPlan, customize })` → `CustomizeChange[]`. Every change is an **add or a remove** against the plan the customer currently holds — the verb is a property of the diff, never a label a surface chose:

| Request | Current plan | Rows |
|---|---|---|
| `price: 80` | price $50 | 🔴 Remove $50 · 🟢 Add $80 |
| `price: 80` | no price | 🟢 Add $80 |
| `price: null` | price $50 | 🔴 Remove $50 *(previously invisible)* |
| `remove_items: [{feature_id}]` | item 250k | 🔴 Remove 250,000 *(resolved from the live plan)* |
| `items: [...]` (PUT) | any | remove every current, add every new |

Removes precede adds so a table reads old → new. `update_items` is no longer rendered (deprecated in the API; the dashboard never showed it).

### Both surfaces consume it
- **Dashboard** `BillingCustomizeDiff` — now a thin renderer over the model (green/red `ItemStatusDot` per change). `@autumn/render` added as a vite dep.
- **Slack** Plan changes table — maps the same changes to 🟢/🔴 rows. The old `customizeDisplay` pipeline and its verb-assignment are deleted. `changeTable` no longer sorts; ordering is the caller's concern (catalog listings keep adds→updates→removes via `sortByChangeKind`; billing diffs keep old→new).
- `approvalDisplay` now exposes the customer's whole current plan (price + items, live subscription preferred over catalog) so a base-price change can show what it replaces. The Slack card also accepts the older items-only display shape, so approval rows stored before this change still diff correctly.

### Net
`-300 / +82` across render, vite, and leaf.

## Test plan

- [x] `packages/render`: 11 unit tests pinning every row of the table above, incl. ordering; typecheck clean
- [x] `vite`: 0 type errors
- [x] `apps/leaf`: 316 unit tests green, typecheck clean — incl. an end-to-end card test for the reported "Remove 0 contacts" case rendering `🔴 Remove 250,000 contacts · 🟢 Add 500,000 contacts` with `$1,500 → $1,600` as a Remove/Add pair
- [x] Biome clean, no warnings
- [x] Confirmed red with the fix reverted (source test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies customize diffs for Slack and the dashboard behind a shared add/remove model in `@autumn/render` so both surfaces show the same customer-specific changes in remove → add order. Restores rendering for `free_trial` overrides and fixes `remove_items` matching by defaulting missing `interval_count` to 1.

- Adds `buildCustomizeChanges({ currentPlan, customize }): CustomizeChange[]` plus `customPriceText`, `freeTrialText`, and `itemMatchesFilter`. Handles price null as a remove, price changes as remove+add, `remove_items` resolved from the customer’s current plan, and `items` (PUT) as replace-all; removes precede adds.
- Slack “Plan changes” and the dashboard `BillingCustomizeDiff` now render from this model; deletes the old reinterpretation in `previewDisplay` and stops rendering deprecated `update_items`.
- `approvalDisplay` now exposes `currentPlan`/`currentPlanByPlan` (prefers live subscription; falls back to catalog) so base-price and item diffs show what they replace; remains backward compatible with the older items-only shape.
- `changeTable` no longer sorts; adds `sortByChangeKind` for catalog listings while billing diffs pass remove → add order through.
- Adds `@autumn/render` as a `vite` dependency; exports `buildCustomizeChanges`, `CustomizeChange`, `customPriceText`, and `freeTrialText`. Removes `CustomizeDisplay` from `@autumn/render` exports.

**Review and rollout notes**
- If you relied on implicit sorting in `changeTable`, sort explicitly with `sortByChangeKind` or supply ordered rows.
- Consumers of `CustomizeDisplay` must switch to `CustomizeChange[]` from `buildCustomizeChanges`.
- Stored approvals continue to render: older rows (items-only) still diff correctly; newer rows use the full `currentPlan`.

<sup>Written for commit 2380147c4952f2b3fa9ef1af4b34530241cfaead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces separate Slack and dashboard customization-diff implementations with one shared add/remove model, keeping both approval surfaces consistent.
- **[Improvements, Bug fixes]** Resolves removals against the customer’s live plan so displayed quantities and prices represent what the customer currently has.
- **[Improvements, API changes]** Introduces shared customization-change and formatting exports from `@autumn/render`, consumed by both Leaf and Vite.
- **[Bug fixes]** Displays base-price removal, free-trial changes, and old-to-new ordering that were previously missing or inconsistent.
- **[Improvements]** Makes change-table ordering explicit at each caller and adds focused approval-card coverage.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the previously reported paths.

The interval-count matcher now applies the established default of one, and free-trial customizations now produce visible add or remove rows using the current request and plan shapes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/render/src/billing/customizeChanges.ts | Defines the shared add/remove customization model, including current-plan resolution for prices, free trials, and items. |
| packages/render/src/billing/itemMatchesFilter.ts | Matches removal filters against current items while correctly treating an omitted interval count as the default value of one. |
| apps/leaf/src/ui/blocks.ts | Renders shared customization changes in approval cards, including free-trial and base-price add/remove rows. |
| apps/leaf/src/internal/approvals/utils/approvalDisplay.ts | Supplies the customer’s expanded live subscription plan as the preferred baseline for approval diffs. |
| vite/src/views/chat/components/BillingCustomizeDiff.tsx | Replaces the dashboard’s bespoke customization rendering with the shared change model. |
| apps/leaf/src/ui/changeTable.ts | Preserves caller-provided row order and provides explicit operation sorting for catalog tables. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Customize request] --> Model[buildCustomizeChanges]
  Current[Customer current plan] --> Model
  Model --> Changes[Ordered remove/add changes]
  Changes --> Slack[Leaf Slack approval card]
  Changes --> Dashboard[Vite customization diff]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 address review — restore interva..."](https://github.com/useautumn/autumn/commit/2380147c4952f2b3fa9ef1af4b34530241cfaead) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54719642)</sub>

<!-- /greptile_comment -->