### PR TITLE
fix: coerce null entity Lua balance and seed Cloud test org

### DIFF
--- a/scripts/dw/commands/start.ts
+++ b/scripts/dw/commands/start.ts
@@ -1,3 +1,4 @@
+import { isCloudAgent } from "@autumn/env";
 import { ensurePublicAccess } from "../helpers/cloudflare.ts";
 import { ensureLocalInfra } from "../helpers/localInfra.ts";
 import {
@@ -5,6 +6,7 @@ import {
 	registerCurrentWorktree,
 	saveRegistry,
 } from "../helpers/registry.ts";
+import { autoEnsureLocalTestOrg } from "../helpers/setup.ts";
 import { fatal, log } from "../helpers/shell.ts";
 import type { RegistryEntry } from "../types.ts";
 
@@ -20,6 +22,9 @@ export async function cmdStart(): Promise<RegistryEntry> {
 	);
 
 	ensureLocalInfra();
+	if (isCloudAgent()) {
+		await autoEnsureLocalTestOrg();
+	}
 	const entry = await ensurePublicAccess(entry0);
 	const registry = loadRegistry();
 	registry[entry.path] = entry;

--- a/scripts/dw/constants.ts
+++ b/scripts/dw/constants.ts
@@ -15,6 +15,10 @@ export const MAX_WORKTREE = 50;
 export const BRANCH_NAME_RE = /^(?:dw-wt-\d+|capy)-[a-f0-9]+$/;
 export const INACTIVITY_MS = 7 * 24 * 60 * 60 * 1000;
 
+/** Cloud / agent-services local Postgres. Never inherit Infisical DATABASE_URL. */
+export const LOCAL_DATABASE_URL =
+	"postgresql://postgres:postgres@localhost:5432/autumn";
+
 export const NEON_PROJECT_ID = "weathered-morning-43833874";
 export const NEON_TEMPLATE_BRANCH = "dw-template";
 export const NEON_PARENT_BRANCH = "production";

--- a/scripts/dw/helpers/localTestOrg.test.ts
+++ b/scripts/dw/helpers/localTestOrg.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { LOCAL_DATABASE_URL } from "../constants.ts";
+import { localTestOrgEnv } from "./setup.ts";
+
+describe("localTestOrgEnv", () => {
+	const prevUrl = process.env.DATABASE_URL;
+	const prevCritical = process.env.DATABASE_CRITICAL_URL;
+	const prevDirect = process.env.AUTUMN_DB_DIRECT;
+
+	afterEach(() => {
+		if (prevUrl === undefined) delete process.env.DATABASE_URL;
+		else process.env.DATABASE_URL = prevUrl;
+		if (prevCritical === undefined) delete process.env.DATABASE_CRITICAL_URL;
+		else process.env.DATABASE_CRITICAL_URL = prevCritical;
+		if (prevDirect === undefined) delete process.env.AUTUMN_DB_DIRECT;
+		else process.env.AUTUMN_DB_DIRECT = prevDirect;
+	});
+
+	test("pins local postgres even when Infisical already set DATABASE_URL", () => {
+		process.env.DATABASE_URL =
+			"postgresql://user:pass@aws-eu-west-2-1.pg.psdb.cloud:6432/autumn";
+		process.env.DATABASE_CRITICAL_URL = process.env.DATABASE_URL;
+		delete process.env.AUTUMN_DB_DIRECT;
+
+		const env = localTestOrgEnv();
+		expect(env.DATABASE_URL).toBe(LOCAL_DATABASE_URL);
+		expect(env.DATABASE_CRITICAL_URL).toBe(LOCAL_DATABASE_URL);
+		expect(env.AUTUMN_DB_DIRECT).toBe("1");
+	});
+});

--- a/scripts/dw/helpers/setup.ts
+++ b/scripts/dw/helpers/setup.ts
@@ -1,4 +1,8 @@
-import { NEON_TEMPLATE_BRANCH, PROJECT_ROOT } from "../constants.ts";
+import {
+	LOCAL_DATABASE_URL,
+	NEON_TEMPLATE_BRANCH,
+	PROJECT_ROOT,
+} from "../constants.ts";
 import type { RegistryEntry } from "../types.ts";
 import {
 	applyCommittedMigrations,
@@ -63,6 +67,35 @@ export async function setupAgentWorktree(
 	registry[entry.path] = next;
 	saveRegistry(registry);
 	return { entry: next, created: true };
+}
+
+/** Cloud-agent local Postgres — Infisical's DATABASE_URL must not leak in. */
+export function localTestOrgEnv(): Record<string, string> {
+	return {
+		...(process.env as Record<string, string>),
+		DATABASE_URL: LOCAL_DATABASE_URL,
+		DATABASE_CRITICAL_URL: LOCAL_DATABASE_URL,
+		AUTUMN_DB_DIRECT: "1",
+	};
+}
+
+/**
+ * Idempotent Cloud seed: create unit-test-org if missing, otherwise only
+ * ensure the Infisical API key hash. Does not clear an existing org.
+ */
+export async function autoEnsureLocalTestOrg(): Promise<void> {
+	log("ensuring unit-test-org in local postgres");
+	const code = shInherit(
+		"bun",
+		["scripts/setup/setup-test.ts", "--ensure"],
+		{
+			cwd: PROJECT_ROOT,
+			env: localTestOrgEnv(),
+		},
+	);
+	if (code !== 0) {
+		fatal(`setup-test --ensure exited with code ${code}`);
+	}
 }
 
 function worktreeDbEnv(entry: RegistryEntry): Record<string, string> {

--- a/scripts/dw/helpers/start.ts
+++ b/scripts/dw/helpers/start.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { isCloudAgent } from "@autumn/env";
-import { PROJECT_ROOT } from "../constants.ts";
+import { LOCAL_DATABASE_URL, PROJECT_ROOT } from "../constants.ts";
 import type { RegistryEntry } from "../types.ts";
 import { startPublicAccess } from "./cloudflare.ts";
 import { emulateGoogleUrl } from "./emulate.ts";
@@ -19,9 +19,6 @@ import {
 import { fatal, log } from "./shell.ts";
 import { spawnDevInTmux, tmuxSessionName } from "./tmux.ts";
 import { rewriteDbEnv } from "./url.ts";
-
-const LOCAL_DATABASE_URL =
-	"postgresql://postgres:postgres@localhost:5432/autumn";
 
 const HEADLESS_UNSET = [
 	"NEON_WORKTREE_API_KEY",

--- a/scripts/setup/agent-services.sh
+++ b/scripts/setup/agent-services.sh
@@ -122,10 +122,12 @@ bun scripts/setup/writeAgentEnv.ts
 # 5. DB migrations
 # =============================================================
 log "Running migrations"
-# Pass DATABASE_URL — loadLocalEnv from /workspace misses server/.env.
+# Always local postgres. `bun dw` is wrapped in `infisical run`, so an inherited
+# DATABASE_URL would migrate PlanetScale instead of this box.
 # --bootstrap: empty Cloud postgres has 72 CREATE INDEX without CONCURRENTLY.
 export AUTUMN_DB_DIRECT=1
-export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/autumn}"
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/autumn"
+export DATABASE_CRITICAL_URL="$DATABASE_URL"
 bun db generate >/dev/null 2>&1 || true
 bun db migrate --bootstrap
 

--- a/scripts/setup/cursor-cloud/cursor-ai.test.sh
+++ b/scripts/setup/cursor-cloud/cursor-ai.test.sh
@@ -137,6 +137,18 @@ fi
 if grep -q 'bun", \["install"\]' "$ROOT/scripts/dw/commands/start.ts"; then
 	fail "dw start must not run bun install"
 fi
+grep -q 'autoEnsureLocalTestOrg' "$ROOT/scripts/dw/commands/start.ts" \
+	|| fail "dw start must seed unit-test-org on Cloud agents"
+grep -q 'unit-test-org' "$ROOT/scripts/setup/cursor-cloud/cursorCloud.ts" \
+	|| fail "Cloud AGENTS.md section must mention unit-test-org seed"
+grep -q 'setup-test.ts", "--ensure"' "$ROOT/scripts/dw/helpers/setup.ts" \
+	|| fail "Cloud seed must call setup-test --ensure"
+if grep -q 'DATABASE_URL="${DATABASE_URL:-' "$ROOT/scripts/setup/agent-services.sh"; then
+	fail "agent-services.sh must not inherit Infisical DATABASE_URL"
+fi
+grep -q 'postgresql://postgres:postgres@localhost:5432/autumn' \
+	"$ROOT/scripts/setup/agent-services.sh" \
+	|| fail "agent-services.sh must pin migrate to local postgres"
 pass "start.sh runs dw start, not bun dw setup"
 
 if grep -q 'cursor_ai.py' "$ROOT/scripts/setup/cursor-cloud/install.sh" \
@@ -228,6 +240,7 @@ UNIT_TESTS=1 env -u TESTS_ORG bun test \
 	"$ROOT/scripts/dw/helpers/ngrok.test.ts" \
 	"$ROOT/scripts/dw/helpers/machineId.test.ts" \
 	"$ROOT/scripts/dw/helpers/registry.test.ts" \
+	"$ROOT/scripts/dw/helpers/localTestOrg.test.ts" \
 	"$ROOT/scripts/dw/helpers/cloudflare.test.ts" \
 	"$ROOT/scripts/dw/devProxy/cloudflareConfig.test.ts" \
 	|| fail "dw unit tests failed"

--- a/scripts/setup/cursor-cloud/cursorCloud.ts
+++ b/scripts/setup/cursor-cloud/cursorCloud.ts
@@ -30,9 +30,10 @@ and writes the Bearer header into \`.cursor/mcp.json\`. Do not try interactive
 OAuth. If executor tools are missing, say so rather than substituting
 Axiom/PlanetScale OAuth servers.
 
-Boot starts local infra (Postgres/Redis/ClickHouse/ElasticMQ) and the
-Cloudflare public URL via \`bun scripts/dw/index.ts start\`. It does
-**not** start the app. Run \`bun dw\` when the task needs Vite/API.
+Boot starts local infra (Postgres/Redis/ClickHouse/ElasticMQ), seeds
+\`unit-test-org\`, and the Cloudflare public URL via
+\`bun scripts/dw/index.ts start\`. It does **not** start the app.
+Run \`bun dw\` when the task needs Vite/API.
 The in-IDE Browser tab stays blank (Cursor bug, any URL) — open the
 public \`autumn-wt1-<hash>.autumnworktree.com\` URL from \`bun dw identify\`,
 or \`http://localhost:3000\` from Ports.

--- a/scripts/setup/setup-test.ts
+++ b/scripts/setup/setup-test.ts
@@ -137,12 +137,38 @@ async function runFullSetup({ yes }: { yes: boolean }): Promise<void> {
 	console.log(chalk.whiteBright(`  key:  ${autumnSecretKey}\n`));
 }
 
+/** Create unit-test-org if missing; if present, only ensure the API key. */
+async function runEnsure(): Promise<void> {
+	const { db } = await import("@server/db/initDrizzle.js");
+	const { organizations } = await import("@autumn/shared");
+	const { eq } = await import("drizzle-orm");
+	const existing = await db.query.organizations.findFirst({
+		where: eq(organizations.id, TEST_ORG_CONFIG.id),
+	});
+	if (!existing) {
+		await runFullSetup({ yes: true });
+		return;
+	}
+	if (process.env.UNIT_TEST_AUTUMN_SECRET_KEY?.trim()) {
+		await runEnsureKey();
+		return;
+	}
+	console.log(
+		chalk.cyan(
+			`[setup-test] ${TEST_ORG_CONFIG.slug} already present; UNIT_TEST_AUTUMN_SECRET_KEY unset — skipping key ensure`,
+		),
+	);
+}
+
 async function main() {
 	const yes = process.argv.includes("--yes");
 	const ensureKeyOnly = process.argv.includes("--ensure-key");
+	const ensure = process.argv.includes("--ensure");
 
 	try {
-		if (ensureKeyOnly) {
+		if (ensure) {
+			await runEnsure();
+		} else if (ensureKeyOnly) {
 			await runEnsureKey();
 		} else {
 			await runFullSetup({ yes });

--- a/scripts/setup/writeAgentEnv.ts
+++ b/scripts/setup/writeAgentEnv.ts
@@ -63,6 +63,8 @@ const ISOLATION: Record<string, string> = {
 	STRIPE_WEBHOOK_SKIP_VERIFY: "true",
 	NODE_ENV: "development",
 	INFISICAL_ENVIRONMENT: "dev",
+	TESTS_ORG: "unit-test-org",
+	TESTS_ORG_ID: "org_2sWv2S8LJ9iaTjLI6UtNsfL88Kt",
 };
 
 const HEADER = `# -----------------------------------------------------------------------

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/contextUtilsV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/contextUtilsV2.lua
@@ -142,14 +142,14 @@ local function update_in_memory_customer_entitlement_mutation(params)
     end
 
     target[entity_id].balance =
-      (target[entity_id].balance or 0) + balance_delta
+      safe_number(target[entity_id].balance) + balance_delta
     target[entity_id].adjustment =
-      (target[entity_id].adjustment or 0) + adjustment_delta
+      safe_number(target[entity_id].adjustment) + adjustment_delta
     return
   end
 
-  target.balance = (target.balance or 0) + balance_delta
-  target.adjustment = (target.adjustment or 0) + adjustment_delta
+  target.balance = safe_number(target.balance) + balance_delta
+  target.adjustment = safe_number(target.adjustment) + adjustment_delta
 
   if target.subject_balance then
     target.subject_balance.balance = target.balance

--- a/server/tests/balances/track/unlimited-deduction/track-unlimited-null-entity-balance.test.ts
+++ b/server/tests/balances/track/unlimited-deduction/track-unlimited-null-entity-balance.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Entity-scoped unlimited cusEnts can store entities[id].balance = null
+ * (legacy unlimited slot). Track Lua write path uses (balance or 0);
+ * cjson.null is truthy so the add crashes and track fail-opens to SQS.
+ *
+ * Red (current):  track against a seeded null entity slot returns a queued
+ *                 response (no unlimited mask) and the raw entity balance
+ *                 never becomes -1.
+ * Green (after):  track succeeds (unlimited: true) and the raw entity
+ *                 balance becomes -1.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	fullCustomerToCustomerEntitlements,
+	type ProductItem,
+	type TrackResponseV3,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { pollUntil } from "@tests/utils/genUtils.js";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { CusService } from "@/internal/customers/CusService.js";
+import { constructFeatureItem } from "@/utils/scriptUtils/constructItem.js";
+import { findCustomerEntitlement } from "../../utils/findCustomerEntitlement.js";
+import { seedLegacyNullEntityBalance } from "./unlimitedDeductionTestUtils.js";
+
+const POLL_TIMEOUT_MS = 30_000;
+const ENTITY_ID = "ent-1";
+
+const entityScopedUnlimitedMessages = (): ProductItem => ({
+	...constructFeatureItem({
+		featureId: TestFeature.Messages,
+		unlimited: true,
+	}),
+	entity_feature_id: TestFeature.Users,
+});
+
+const expectEntityRawBalance = async ({
+	ctx,
+	customerId,
+	expectedBalance,
+	unlimitedOnly = false,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	expectedBalance: number;
+	unlimitedOnly?: boolean;
+}) => {
+	const balances = await pollUntil({
+		fetch: async () => {
+			const fullCustomer = await CusService.getFull({
+				ctx,
+				idOrInternalId: customerId,
+			});
+			const cusEnts = fullCustomerToCustomerEntitlements({
+				fullCustomer,
+				featureId: TestFeature.Messages,
+			});
+			const cusEnt = unlimitedOnly
+				? cusEnts.find((row) => row.unlimited)
+				: cusEnts[0];
+			return Object.values(cusEnt?.entities ?? {}).map(
+				(entityBalance) => entityBalance.balance,
+			);
+		},
+		until: (entityBalances) =>
+			entityBalances.some((balance) => balance === expectedBalance),
+		timeoutMs: POLL_TIMEOUT_MS,
+	});
+
+	expect(balances).toContain(expectedBalance);
+};
+
+test.concurrent(
+	`${chalk.yellowBright("unlimited-null-entity: track on legacy balance:null entity slot deducts instead of fail-opening")}`,
+	async () => {
+		const customerId = "unlim-null-entity";
+
+		const product = products.base({
+			id: "unlim-null-entity-prod",
+			items: [entityScopedUnlimitedMessages()],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [s.attach({ productId: product.id })],
+		});
+
+		await autumnV2_3.customers.get(customerId);
+
+		const cusEnt = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(cusEnt?.id).toBeDefined();
+		expect(cusEnt?.unlimited).toBe(true);
+
+		await seedLegacyNullEntityBalance({
+			ctx,
+			customerId,
+			customerEntitlementId: cusEnt!.id,
+			entityId: ENTITY_ID,
+			featureId: TestFeature.Messages,
+		});
+
+		const track = (await autumnV2_3.track({
+			customer_id: customerId,
+			entity_id: ENTITY_ID,
+			feature_id: TestFeature.Messages,
+			value: 1,
+		})) as TrackResponseV3;
+
+		expect(track.balance?.unlimited).toBe(true);
+
+		await expectEntityRawBalance({
+			ctx,
+			customerId,
+			expectedBalance: -1,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("unlimited-null-entity: mixed unlimited+finite still absorbs on the null unlimited slot")}`,
+	async () => {
+		const customerId = "unlim-null-mixed";
+
+		const unlimitedProd = products.base({
+			id: "unlim-null-mixed-unlim",
+			items: [entityScopedUnlimitedMessages()],
+		});
+		const limitedProd = products.base({
+			id: "unlim-null-mixed-lim",
+			items: [items.monthlyMessages({ includedUsage: 150 })],
+			isAddOn: true,
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [unlimitedProd, limitedProd] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [
+				s.attach({ productId: limitedProd.id }),
+				s.attach({ productId: unlimitedProd.id }),
+			],
+		});
+
+		await autumnV2_3.customers.get(customerId);
+
+		const fullCustomer = await CusService.getFull({
+			ctx,
+			idOrInternalId: customerId,
+		});
+		const cusEnts = fullCustomerToCustomerEntitlements({
+			fullCustomer,
+			featureId: TestFeature.Messages,
+		});
+		const unlimitedCusEnt = cusEnts.find((row) => row.unlimited);
+		const limitedCusEnt = cusEnts.find((row) => !row.unlimited);
+		expect(unlimitedCusEnt?.id).toBeDefined();
+		expect(limitedCusEnt?.id).toBeDefined();
+
+		await seedLegacyNullEntityBalance({
+			ctx,
+			customerId,
+			customerEntitlementId: unlimitedCusEnt!.id,
+			entityId: ENTITY_ID,
+			featureId: TestFeature.Messages,
+		});
+
+		const track = (await autumnV2_3.track({
+			customer_id: customerId,
+			entity_id: ENTITY_ID,
+			feature_id: TestFeature.Messages,
+			value: 1,
+		})) as TrackResponseV3;
+
+		expect(track.balance?.unlimited).toBe(true);
+
+		await expectEntityRawBalance({
+			ctx,
+			customerId,
+			expectedBalance: -1,
+			unlimitedOnly: true,
+		});
+
+		const limitedRow = await pollUntil({
+			fetch: async () => {
+				const [row] = await ctx.db
+					.select({ balance: customerEntitlements.balance })
+					.from(customerEntitlements)
+					.where(eq(customerEntitlements.id, limitedCusEnt!.id));
+				return row?.balance ?? null;
+			},
+			until: (balance) => balance === 150,
+			timeoutMs: POLL_TIMEOUT_MS,
+		});
+		expect(limitedRow).toBe(150);
+	},
+);

--- a/server/tests/balances/track/unlimited-deduction/unlimitedDeductionTestUtils.ts
+++ b/server/tests/balances/track/unlimited-deduction/unlimitedDeductionTestUtils.ts
@@ -1,6 +1,8 @@
 import { customerEntitlements } from "@autumn/shared";
-import { eq } from "drizzle-orm";
+import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
+import { eq, sql } from "drizzle-orm";
 import { db } from "@/db/initDrizzle.js";
+import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
 
 export interface RawCusEntRow {
 	id: string;
@@ -59,5 +61,75 @@ export const pollRawCusEntBalance = async ({
 		if (row && row.balance === expectedBalance) return row;
 		if (Date.now() >= deadline) return row;
 		await sleep(POLL_INTERVAL_MS);
+	}
+};
+
+/**
+ * Seeds the Semory-shaped unlimited entity slot: the entity key already
+ * exists in both Postgres and the Redis subject-balance hash, with
+ * `balance: null`. Lua `(balance or 0)` does not coerce cjson.null.
+ */
+export const seedLegacyNullEntityBalance = async ({
+	ctx,
+	customerId,
+	customerEntitlementId,
+	entityId,
+	featureId,
+}: {
+	ctx: TestContext;
+	customerId: string;
+	customerEntitlementId: string;
+	entityId: string;
+	featureId: string;
+}): Promise<void> => {
+	const nullSlot = { id: entityId, balance: null, adjustment: 0 };
+
+	await ctx.db.execute(sql`
+		UPDATE customer_entitlements
+		SET entities = COALESCE(entities, '{}'::jsonb) || ${JSON.stringify({ [entityId]: nullSlot })}::jsonb
+		WHERE id = ${customerEntitlementId}
+	`);
+
+	const balanceKey = buildSharedFullSubjectBalanceKey({
+		orgId: ctx.org.id,
+		env: ctx.env,
+		customerId,
+		featureId,
+	});
+
+	const deadline = Date.now() + 10_000;
+	let raw: string | null = null;
+	for (;;) {
+		raw = await ctx.redisV2.hget(balanceKey, customerEntitlementId);
+		if (raw || Date.now() >= deadline) break;
+		await sleep(200);
+	}
+	if (!raw) {
+		throw new Error(
+			`subject balance missing for ${customerEntitlementId} at ${balanceKey}`,
+		);
+	}
+
+	const subjectBalance = JSON.parse(raw) as {
+		entities?: Record<string, { id?: string; balance?: number | null; adjustment?: number }>;
+	};
+	subjectBalance.entities = {
+		...(subjectBalance.entities ?? {}),
+		[entityId]: nullSlot,
+	};
+
+	await ctx.redisV2.hset(
+		balanceKey,
+		customerEntitlementId,
+		JSON.stringify(subjectBalance),
+	);
+
+	const seeded = JSON.parse(
+		(await ctx.redisV2.hget(balanceKey, customerEntitlementId)) ?? "{}",
+	) as { entities?: Record<string, { balance?: number | null }> };
+	if (seeded.entities?.[entityId]?.balance !== null) {
+		throw new Error(
+			`failed to seed Redis entities[${entityId}].balance=null`,
+		);
 	}
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two related Cloud/prod issues from the same Semory track investigation.

### 1. Redis Lua crash on null entity balance

Semory track (`documents` +1 on entity `I. C. Amedeo Moscati`) crashed Redis Lua with `attempt to perform arithmetic on a userdata value`. Redis itself was up; the write path treated `cjson.null` as truthy, so `(balance or 0) + delta` became `null + -1`.

That was mis-tagged as `RedisUnavailableError` and fail-opened to SQS (HTTP 202), then retried into the DLQ.

The unlimited `documents` cusEnt had a legacy entity slot:

```json
"K1u5wqGoRJWwrqur1nPM4TgG6COVjKyA": { "balance": null, "adjustment": 0 }
```

Read path already uses `safe_number()` (`nil` / `cjson.null` → 0). Write path did not.

### 2. Cloud `bun dw start` left an empty local DB

Cloud `bun dw start` (the boot path) migrated local Postgres but never ran `setup-test`. This box had **0 orgs / 0 features**. `bun t` then failed at `initScenario` with `products_org_id_fkey`.

Laptop/Neon `bun dw setup` seeds via `autoSetupTestOrg`. Cloud skips Neon (`wantsCanonicalProvision = false`) and only calls `cmdStart` → `ensureLocalInfra()`.

A second leak: `agent-services.sh` used `${DATABASE_URL:-localhost}`. When `bun dw` is wrapped in `infisical run`, that inherits PlanetScale.

## Fix

### Lua

In `update_in_memory_customer_entitlement_mutation`, use `safe_number()` for entity and top-level balance/adjustment before adding the delta. First successful track heals the slot to a number.

Left alone (out of scope unless they crash the same way):

- `update_in_memory_rollover_mutation` (`or 0`)
- unwind injection in `deductFromSubjectBalances.lua`
- `roundSubjectBalance` still skips entity `balance: null` on cache write

### Cloud seed

- `cmdStart` calls `autoEnsureLocalTestOrg()` on Cloud agents
- `setup-test --ensure` creates `unit-test-org` if missing; if present, only ensures the API key (does not `clearOrg`)
- `agent-services.sh` always migrates `postgresql://postgres:postgres@localhost:5432/autumn`
- Isolation overlay pins `TESTS_ORG=unit-test-org`

## Tests

- `track-unlimited-null-entity-balance.test.ts` seeds `entities[ent-1].balance = null` in Postgres + Redis, then tracks +1. Red: `track.balance?.unlimited` is `undefined` (queued fail-open). Green: `unlimited: true` and raw entity balance is `-1`. Mixed unlimited (null slot) + finite 150 still absorbs on the unlimited cusEnt.
- `scripts/dw/helpers/localTestOrg.test.ts` — Infisical PlanetScale URL is overwritten
- `cursor-ai.test.sh` — `dw start` must call `--ensure`; agent-services must not inherit `DATABASE_URL`

## Note

Supersedes https://github.com/useautumn/autumn/pull/2887 (cloud seed commit cherry-picked here; that PR is closed).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f80d9ba-6c22-4033-a4b8-d32b5ec5f394?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f80d9ba-6c22-4033-a4b8-d32b5ec5f394&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Redis Lua arithmetic errors when tracking against entity-scoped unlimited slots with `balance: null` by coercing nulls with `safe_number()` on the write path. Also seeds `unit-test-org` and pins Cloud agent migrations to local Postgres to unblock integration tests.

- In `update_in_memory_customer_entitlement_mutation`, use `safe_number()` for entity and top-level `balance`/`adjustment` before applying deltas; the first successful track normalizes the entity slot to a number.
- Tests: adds `track-unlimited-null-entity-balance.test.ts` and helpers that seed a legacy `balance: null` entity; verifies successful track (`unlimited: true`) and entity balance becomes `-1`, with mixed unlimited + finite leaving the finite balance intact at 150.
- Cloud agent setup: `dw start` idempotently seeds `unit-test-org` via `setup-test --ensure`; `agent-services.sh` forces migrations/seeds to local Postgres (`DATABASE_URL`/`DATABASE_CRITICAL_URL`) to avoid inheriting Infisical; exports `TESTS_ORG`/`TESTS_ORG_ID`.
- Out of scope: `update_in_memory_rollover_mutation` and unwind injection remain unchanged; `roundSubjectBalance` still skips `balance: null` on cache write.
- Rollout: no migration required; legacy null slots self-correct on the first successful track. Cloud agents need a fresh `dw start` to seed the test org.

<sup>Written for commit ae503790f9b8aaad841766ccc3637050e95c8520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes null-balance arithmetic in Redis and adds automatic Cloud test-organization setup, but the existing-organization path can still finish without a usable test key.

- **Bug fixes:** Coerces null or invalid Lua balance and adjustment values to numbers before applying entitlement mutations.
- **Improvements, Bug fixes:** Pins Cloud database setup to local Postgres and seeds `unit-test-org` during Cloud startup.
- **Improvements:** Adds regression coverage for legacy null entity balances and Cloud setup configuration.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until Cloud startup can recover or clearly fail when an existing test organization has no available API key.

The Lua correction and local-database pinning are sound, but the new ensure path can report success without satisfying the test credential required by integration-test initialization.

**Files Needing Attention:** scripts/setup/setup-test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/_luaScriptsV2/fullSubjectDeduction/contextUtilsV2.lua | Safely normalizes null entity and top-level balance fields before arithmetic, matching the existing read-path behavior. |
| scripts/setup/setup-test.ts | Adds an idempotent ensure mode, but silently leaves an existing organization without a recoverable API key when the key environment variable is absent. |
| scripts/dw/commands/start.ts | Adds Cloud-only test-organization setup after local infrastructure initialization. |
| scripts/dw/helpers/setup.ts | Pins the seed subprocess to local Postgres and treats setup failures as fatal. |
| scripts/setup/agent-services.sh | Prevents inherited remote database URLs from redirecting Cloud migrations away from local Postgres. |
| server/tests/balances/track/unlimited-deduction/track-unlimited-null-entity-balance.test.ts | Covers null entity balances for unlimited and mixed entitlement deductions. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Cloud dw start] --> B[Start and migrate local infrastructure]
  B --> C[setup-test --ensure]
  C --> D{unit-test-org exists?}
  D -- No --> E[Create org and persist new key]
  D -- Yes --> F{Secret key available?}
  F -- Yes --> G[Ensure key hash]
  F -- No --> H[Skip key ensure]
  H --> I[Integration test context fails]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/setup/setup-test.ts:152-159
**Existing organization skips key recovery**

If local Postgres retains `unit-test-org` while `UNIT_TEST_AUTUMN_SECRET_KEY` and `server/.env.local` are absent, `--ensure` returns successfully without restoring a key, causing integration-test context initialization to fail with no secret key.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): seed unit-test-org on dw sta..."](https://github.com/useautumn/autumn/commit/ae503790f9b8aaad841766ccc3637050e95c8520) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54724510)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->