### PR TITLE
fix(dashboard): hide idempotency_key in event details

### DIFF
--- a/vite/src/views/customers/customer/analytics/components/RowClickDialog.tsx
+++ b/vite/src/views/customers/customer/analytics/components/RowClickDialog.tsx
@@ -10,6 +10,9 @@ export function RowClickDialog({
 	isOpen: boolean;
 	setIsOpen: (isOpen: boolean) => void;
 }) {
+	// Always null: idempotency keys live on the Idempotency-Key header, not the event row.
+	const { idempotency_key: _idempotencyKey, ...eventData } = event;
+
 	return (
 		<Dialog open={isOpen} onOpenChange={setIsOpen}>
 			<DialogContent
@@ -19,7 +22,7 @@ export function RowClickDialog({
 				<CopyablePre
 					text={JSON.stringify(
 						{
-							...event,
+							...eventData,
 							properties: JSON.parse(event.properties),
 						},
 						null,

--- a/vite/src/views/customers2/components/table/customer-usage-analytics/EventDetailsDialog.tsx
+++ b/vite/src/views/customers2/components/table/customer-usage-analytics/EventDetailsDialog.tsx
@@ -24,8 +24,11 @@ export function EventDetailsDialog({
 			? JSON.parse(event.properties)
 			: event.properties;
 
+	// Always null: idempotency keys live on the Idempotency-Key header, not the event row.
+	const { idempotency_key: _idempotencyKey, ...rest } = event;
+
 	const eventData = {
-		...event,
+		...rest,
 		properties,
 	};
 


### PR DESCRIPTION
Follow-up to #2892.

`idempotency_key` renders as `null` on every event in the dashboard's event-details preview, which is what prompted the original Slack report. The key is claimed from the `Idempotency-Key` header and never written to the event row, so the field is noise.

Omits it from both previews:
- `RowClickDialog` (customer analytics)
- `EventDetailsDialog` (customers2)

The field stays on the `Event` type and the Tinybird pipe — removing it end-to-end belongs with the server-side deprecation of the `idempotency_key` body param, which is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide `idempotency_key` from dashboard event details because it is always null. Previously the previews showed a `null` field; now the UI omits it to reduce noise.

- Applies to `RowClickDialog` (customer analytics) and `EventDetailsDialog` (customers2); the copyable JSON no longer includes `idempotency_key`.
- No API, database, or Tinybird changes; the `Event` type still includes the field. End-to-end removal follows server-side deprecation of the `idempotency_key` body param.
- UI-only change; no migration needed.

<sup>Written for commit 92cab7988f57a3bd436c6082f49afb6847be630f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR removes the consistently empty `idempotency_key` field from both dashboard event-detail previews while preserving it in the underlying event model.
- **[Bug fixes]** Omits `idempotency_key` from customer analytics event details.
- **[Bug fixes]** Omits `idempotency_key` from the customers2 event-details dialog.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

Both dialogs use object-rest destructuring to omit only `idempotency_key`; all other event fields and the existing property normalization behavior remain intact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| vite/src/views/customers/customer/analytics/components/RowClickDialog.tsx | Removes only `idempotency_key` from the rendered event object while retaining the existing properties parsing and all other fields. |
| vite/src/views/customers2/components/table/customer-usage-analytics/EventDetailsDialog.tsx | Excludes `idempotency_key` from the preview while preserving the dialog’s handling of string and object property values. |

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): hide idempotency\_key in ..."](https://github.com/useautumn/autumn/commit/92cab7988f57a3bd436c6082f49afb6847be630f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54739774)</sub>

<!-- /greptile_comment -->