### PR TITLE
perf(catalog-v2): bound versioning usage queries

### DIFF
--- a/server/experiments/explainVersioningCustomerProducts.ts
+++ b/server/experiments/explainVersioningCustomerProducts.ts
@@ -1,0 +1,81 @@
+import { AppEnv } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { initDrizzle } from "../src/db/initDrizzle";
+import {
+	buildBoundedVersioningCustomerProductsQuery,
+	buildVersioningCustomerProductsQuery,
+} from "../src/internal/customers/cusProducts/repos/getVersioningUsage";
+
+const STATEMENT_TIMEOUT_MS = 30_000;
+const STAGING_BRANCH_ID = "zg829hpzvvkc";
+
+const requireEnv = ({ key }: { key: string }) => {
+	const value = process.env[key];
+	if (!value) throw new Error(`${key} env var is required`);
+	return value;
+};
+
+const dbUrl = requireEnv({ key: "EXPLAIN_DATABASE_URL" });
+if (!dbUrl.includes(STAGING_BRANCH_ID)) {
+	throw new Error("EXPLAIN_DATABASE_URL is not the prod-copy staging branch");
+}
+
+const orgId = requireEnv({ key: "EXPLAIN_ORG_ID" });
+const planId = requireEnv({ key: "EXPLAIN_PLAN_ID" });
+const env = requireEnv({ key: "EXPLAIN_ENV" }) as AppEnv;
+const analyze = process.argv.includes("--analyze");
+const bounded = process.argv.includes("--bounded");
+const { db, client } = initDrizzle({ databaseUrl: dbUrl, maxConnections: 2 });
+
+const withStatementTimeout = async <T>({
+	run,
+}: {
+	run: (tx: typeof db) => Promise<T>;
+}) =>
+	db.transaction(async (tx) => {
+		await tx.execute(
+			sql.raw(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`),
+		);
+		return run(tx as unknown as typeof db);
+	});
+
+const main = async () => {
+	const products = await withStatementTimeout({
+		run: (tx) =>
+			tx.execute<{ internal_id: string }>(sql`
+				SELECT internal_id
+				FROM products
+				WHERE org_id = ${orgId}
+					AND env = ${env}
+					AND id = ${planId}
+				ORDER BY version
+			`),
+	});
+	const internalProductIds = products.map((product) => product.internal_id);
+	if (internalProductIds.length === 0) {
+		throw new Error("No staging product versions matched the supplied plan");
+	}
+	console.log(`product versions: ${internalProductIds.length}`);
+
+	const query = bounded
+		? buildBoundedVersioningCustomerProductsQuery({ internalProductIds })
+		: buildVersioningCustomerProductsQuery({
+				db,
+				internalProductIds,
+			}).getSQL();
+	console.log(`mode: ${bounded ? "bounded" : "exact"}`);
+	const plan = await withStatementTimeout({
+		run: (tx) =>
+			tx.execute(
+				analyze
+					? sql`EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT TEXT) ${query}`
+					: sql`EXPLAIN (VERBOSE, FORMAT TEXT) ${query}`,
+			),
+	});
+
+	for (const row of plan) {
+		console.log((row as Record<string, unknown>)["QUERY PLAN"]);
+	}
+};
+
+await main().finally(() => client.end());

--- a/server/experiments/explainVersioningRowRefs.ts
+++ b/server/experiments/explainVersioningRowRefs.ts
@@ -1,0 +1,152 @@
+import type { AppEnv } from "@autumn/shared";
+import { sql, type SQL } from "drizzle-orm";
+import { buildBoundedVersionableRowRefsQuery } from "../src/internal/customers/cusProducts/repos/getBoundedVersionableRowRefs";
+import {
+	buildVersionableEntitlementRefsQuery,
+	buildVersionablePriceRefsQuery,
+} from "../src/internal/customers/cusProducts/repos/getVersioningUsage";
+import { initDrizzle } from "../src/db/initDrizzle";
+
+const STATEMENT_TIMEOUT_MS = 30_000;
+const STAGING_BRANCH_ID = "zg829hpzvvkc";
+
+const requireEnv = ({ key }: { key: string }) => {
+	const value = process.env[key];
+	if (!value) throw new Error(`${key} env var is required`);
+	return value;
+};
+
+const dbUrl = requireEnv({ key: "EXPLAIN_DATABASE_URL" });
+if (!dbUrl.includes(STAGING_BRANCH_ID)) {
+	throw new Error("EXPLAIN_DATABASE_URL is not the prod-copy staging branch");
+}
+
+const analyze = process.argv.includes("--analyze");
+const unionProbes = process.argv.includes("--union-probes");
+const orgId = requireEnv({ key: "EXPLAIN_ORG_ID" });
+const planId = requireEnv({ key: "EXPLAIN_PLAN_ID" });
+const env = requireEnv({ key: "EXPLAIN_ENV" }) as AppEnv;
+const { db, client } = initDrizzle({ databaseUrl: dbUrl, maxConnections: 2 });
+
+const withStatementTimeout = async <T>({
+	run,
+}: {
+	run: (tx: typeof db) => Promise<T>;
+}) =>
+	db.transaction(async (tx) => {
+		await tx.execute(
+			sql.raw(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`),
+		);
+		return run(tx as unknown as typeof db);
+	});
+
+const explain = async ({ query }: { query: SQL }) =>
+	withStatementTimeout({
+		run: (tx) =>
+			tx.execute(
+				analyze
+					? sql`EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT TEXT) ${query}`
+					: sql`EXPLAIN (VERBOSE, FORMAT TEXT) ${query}`,
+			),
+	});
+
+const printPlan = ({
+	title,
+	rows,
+}: {
+	title: string;
+	rows: Array<Record<string, unknown>>;
+}) => {
+	console.log(`=== ${title} ===`);
+	for (const row of rows) console.log(row["QUERY PLAN"]);
+};
+
+const buildUnionProbe = ({
+	targets,
+	table,
+	targetColumn,
+}: {
+	targets: Array<{ id: string; internal_product_id: string }>;
+	table: "customer_entitlements" | "customer_prices";
+	targetColumn: "entitlement_id" | "price_id";
+}) =>
+	buildBoundedVersionableRowRefsQuery({
+		targets,
+		refTable: table,
+		targetColumn,
+	});
+
+const main = async () => {
+	const products = await withStatementTimeout({
+		run: (tx) =>
+			tx.execute<{ internal_id: string }>(sql`
+				SELECT p.internal_id
+				FROM products p
+				WHERE p.org_id = ${orgId}
+					AND p.env = ${env}
+					AND p.id = ${planId}
+				ORDER BY p.version
+			`),
+	});
+	const internalProductIds = products.map((product) => product.internal_id);
+	if (internalProductIds.length === 0) {
+		throw new Error("No staging product versions matched the supplied plan");
+	}
+	console.log(`product versions: ${internalProductIds.length}`);
+
+	if (unionProbes) {
+		const entitlementTargets = await withStatementTimeout({
+			run: (tx) =>
+				tx.execute<{ id: string; internal_product_id: string }>(sql`
+					SELECT id, internal_product_id
+					FROM entitlements
+					WHERE internal_product_id = ANY(${sql.param(internalProductIds)}::text[])
+				`),
+		});
+		const priceTargets = await withStatementTimeout({
+			run: (tx) =>
+				tx.execute<{ id: string; internal_product_id: string }>(sql`
+					SELECT id, internal_product_id
+					FROM prices
+					WHERE internal_product_id = ANY(${sql.param(internalProductIds)}::text[])
+				`),
+		});
+		const entitlementPlan = await explain({
+			query: buildUnionProbe({
+				targets: entitlementTargets,
+				table: "customer_entitlements",
+				targetColumn: "entitlement_id",
+			}),
+		});
+		const pricePlan = await explain({
+			query: buildUnionProbe({
+				targets: priceTargets,
+				table: "customer_prices",
+				targetColumn: "price_id",
+			}),
+		});
+		printPlan({ title: "entitlement refs", rows: entitlementPlan });
+		printPlan({ title: "price refs", rows: pricePlan });
+		return;
+	}
+
+	const entitlementPlan = await explain({
+		query: buildVersionableEntitlementRefsQuery({
+			internalProductIds,
+			orgId,
+			env,
+		}),
+	});
+	const pricePlan = await explain({
+		query: buildVersionablePriceRefsQuery({
+			internalProductIds,
+			orgId,
+			env,
+		}),
+	});
+
+	printPlan({ title: "entitlement refs", rows: entitlementPlan });
+	printPlan({ title: "price refs", rows: pricePlan });
+};
+
+await main().finally(() => client.end());

--- a/server/src/internal/catalog/actions/previewUpdateCatalog/setupPreviewCatalogContext.ts
+++ b/server/src/internal/catalog/actions/previewUpdateCatalog/setupPreviewCatalogContext.ts
@@ -69,6 +69,8 @@ export const setupPreviewCatalogContext = async ({
 	const usageByProduct = await customerProductRepo.getVersioningUsage({
 		db,
 		internalProductIds,
+		orgId: org.id,
+		env,
 	});
 	const withCustomers = new Set(
 		internalProductIds.filter(

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext.ts
@@ -1,6 +1,10 @@
 import type { UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import {
+	type CatalogPhases,
+	timeCatalogPhase,
+} from "@/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase";
+import {
 	emptyProductStatesContext,
 	type ProductStatesContext,
 } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -8,7 +12,8 @@ import { buildProductStatesContext } from "@/internal/catalogV2/actions/updateCa
 import { collectProductStateRows } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/collectProductStateRows";
 import { groupProductsByPlanId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/groupProductsByPlanId";
 import { indexRewardProgramsByPlanId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/indexRewardProgramsByPlanId";
-import { getVersioningUsage } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
+import type { VersioningRowRefTargets } from "@/internal/customers/cusProducts/repos/getBoundedVersionableRowRefs.js";
+import { getVersioningFlags } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { rewardProgramRepo } from "@/internal/rewards/repos/index.js";
 
@@ -37,21 +42,29 @@ const payloadPlanIds = ({
 export const setupProductStatesContext = async ({
 	ctx,
 	params,
+	phases,
 }: {
 	ctx: AutumnContext;
 	params: UpdateCatalogParams;
+	phases: CatalogPhases;
 }): Promise<ProductStatesContext> => {
 	const { db, org, env } = ctx;
 	const loadedPlanIds = payloadPlanIds({ params });
 	if (loadedPlanIds.length === 0) return emptyProductStatesContext();
 
-	const payloadVersions = await ProductService.listFull({
-		db,
-		orgId: org.id,
-		env,
-		inIds: loadedPlanIds,
-		returnAll: true,
-		skipCache: true,
+	const payloadVersions = await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "list_full",
+		run: () =>
+			ProductService.listFull({
+				db,
+				orgId: org.id,
+				env,
+				inIds: loadedPlanIds,
+				returnAll: true,
+				skipCache: true,
+			}),
 	});
 	const allVersions = collectProductStateRows({
 		products: payloadVersions,
@@ -60,17 +73,40 @@ export const setupProductStatesContext = async ({
 	const allPlanIds = [
 		...new Set([...loadedPlanIds, ...allVersions.map((product) => product.id)]),
 	];
+	const rowRefTargets = {
+		entitlements: allVersions.flatMap((product) =>
+			product.entitlements.map((entitlement) => ({
+				id: entitlement.id,
+				internal_product_id: product.internal_id,
+			})),
+		),
+		prices: allVersions.flatMap((product) =>
+			product.prices.map((price) => ({
+				id: price.id,
+				internal_product_id: product.internal_id,
+			})),
+		),
+	} satisfies VersioningRowRefTargets;
 
 	const [usageByInternalId, rewardPrograms] = await Promise.all([
-		getVersioningUsage({
+		getVersioningFlags({
 			db,
 			internalProductIds: allVersions.map((product) => product.internal_id),
+			rowRefTargets,
+			timePhase: ({ phase, run }) =>
+				timeCatalogPhase({ ctx, phases, phase, run }),
 		}),
-		rewardProgramRepo.getByProductId({
-			db,
-			productIds: allPlanIds,
-			orgId: org.id,
-			env,
+		timeCatalogPhase({
+			ctx,
+			phases,
+			phase: "reward_programs",
+			run: () =>
+				rewardProgramRepo.getByProductId({
+					db,
+					productIds: allPlanIds,
+					orgId: org.id,
+					env,
+				}),
 		}),
 	]);
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext.ts
@@ -5,29 +5,58 @@ import { setupPlanUsagePersisted } from "@/internal/catalogV2/actions/updateCata
 import { setupFeatureStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupFeatureStatesContext";
 import { setupLicenseStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupLicenseStatesContext";
 import { setupProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext";
+import {
+	type CatalogPhases,
+	timeCatalogPhase,
+} from "@/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 
 export const setupUpdateCatalogContext = async ({
 	ctx,
 	params,
 	preview = false,
+	phases,
 }: {
 	ctx: AutumnContext;
 	params: UpdateCatalogParams;
 	preview?: boolean;
+	phases: CatalogPhases;
 }): Promise<UpdateCatalogContext> => {
 	const [featureStatesContext, productStatesContext, featureUsagePersisted] =
 		await Promise.all([
-			setupFeatureStatesContext({ ctx, params }),
-			setupProductStatesContext({ ctx, params }),
-			preview ? setupFeatureUsagePersisted({ ctx, params }) : undefined,
+			timeCatalogPhase({
+				ctx,
+				phases,
+				phase: "feature_states",
+				run: () => setupFeatureStatesContext({ ctx, params }),
+			}),
+			setupProductStatesContext({ ctx, params, phases }),
+			preview
+				? timeCatalogPhase({
+						ctx,
+						phases,
+						phase: "feature_usage",
+						run: () => setupFeatureUsagePersisted({ ctx, params }),
+					})
+				: undefined,
 		]);
 
 	// License refs + plan-usage samples both need loaded product internal ids.
 	const [licenseStatesContext, planUsagePersisted] = await Promise.all([
-		setupLicenseStatesContext({ ctx, productStatesContext }),
+		timeCatalogPhase({
+			ctx,
+			phases,
+			phase: "license_states",
+			run: () => setupLicenseStatesContext({ ctx, productStatesContext }),
+		}),
 		preview
-			? setupPlanUsagePersisted({ ctx, params, productStatesContext })
+			? timeCatalogPhase({
+					ctx,
+					phases,
+					phase: "plan_usage",
+					run: () =>
+						setupPlanUsagePersisted({ ctx, params, productStatesContext }),
+				})
 			: undefined,
 	]);
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase.ts
@@ -1,0 +1,46 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { addToExtraLogs } from "@/utils/logging/addToExtraLogs";
+
+export type CatalogPhases = Record<string, number>;
+
+export const timeCatalogPhase = async <T>({
+	ctx,
+	phases,
+	phase,
+	run,
+}: {
+	ctx: AutumnContext;
+	phases: CatalogPhases;
+	phase: string;
+	run: () => Promise<T>;
+}): Promise<T> => {
+	const started = Date.now();
+	try {
+		return await run();
+	} finally {
+		const ms = Date.now() - started;
+		phases[phase] = (phases[phase] ?? 0) + ms;
+		const existing = ctx.extraLogs.catalogTiming;
+		const catalogTiming =
+			existing && typeof existing === "object" && !Array.isArray(existing)
+				? existing
+				: {};
+		const existingPhases =
+			"phases" in catalogTiming &&
+			catalogTiming.phases &&
+			typeof catalogTiming.phases === "object" &&
+			!Array.isArray(catalogTiming.phases)
+				? catalogTiming.phases
+				: {};
+
+		addToExtraLogs({
+			ctx,
+			extras: {
+				catalogTiming: {
+					...catalogTiming,
+					phases: { ...existingPhases, ...phases },
+				},
+			},
+		});
+	}
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/productStateContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/productStateContext.ts
@@ -1,11 +1,11 @@
 import type { FullProduct, ProductKey, RewardProgram } from "@autumn/shared";
-import type { CustomerProductVersioningUsage } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
+import type { CustomerProductVersioningFlags } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
 
 /** One setup/projected row for a single productKey. */
 export type ProductState = {
 	productKey: ProductKey;
 	currentFullProduct: FullProduct;
-	customerUsage: CustomerProductVersioningUsage;
+	customerUsage: CustomerProductVersioningFlags;
 };
 
 /**

--- a/server/src/internal/catalogV2/actions/updateCatalog/updateCatalogV2.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/updateCatalogV2.ts
@@ -3,12 +3,17 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computeUpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpdateCatalogPlan";
 import { handleUpdateCatalogErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors";
 import { setupUpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext";
+import {
+	type CatalogPhases,
+	timeCatalogPhase,
+} from "@/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 import {
 	type CatalogResult,
 	executeUpdateCatalogPlan,
 } from "@/internal/catalogV2/execute/executeUpdateCatalogPlan";
+import { addToExtraLogs } from "@/utils/logging/addToExtraLogs";
 
 export type UpdateCatalogActionResult = {
 	catalogContext: UpdateCatalogContext;
@@ -26,18 +31,28 @@ export async function updateCatalogV2({
 	params: UpdateCatalogParams;
 	preview?: boolean;
 }): Promise<UpdateCatalogActionResult> {
+	const phases: CatalogPhases = {};
+	const started = Date.now();
+
 	// 1. Setup — all DB reads; preview adds previewContext presentation facts
 	const catalogContext = await setupUpdateCatalogContext({
 		ctx,
 		params,
 		preview,
+		phases,
 	});
 
 	// 2. Compute
-	const updateCatalogPlan = computeUpdateCatalogPlan({
+	const updateCatalogPlan = await timeCatalogPhase({
 		ctx,
-		catalogContext,
-		params,
+		phases,
+		phase: "compute",
+		run: async () =>
+			computeUpdateCatalogPlan({
+				ctx,
+				catalogContext,
+				params,
+			}),
 	});
 
 	// 3. Errors
@@ -49,6 +64,16 @@ export async function updateCatalogV2({
 	});
 
 	if (preview) {
+		addToExtraLogs({
+			ctx,
+			extras: {
+				catalogTiming: {
+					operation: "preview",
+					totalMs: Date.now() - started,
+					phases,
+				},
+			},
+		});
 		return { catalogContext, updateCatalogPlan };
 	}
 
@@ -56,7 +81,18 @@ export async function updateCatalogV2({
 	const catalogResult = await executeUpdateCatalogPlan({
 		ctx,
 		updateCatalogPlan,
+		phases,
 	});
 
+	addToExtraLogs({
+		ctx,
+		extras: {
+			catalogTiming: {
+				operation: "update",
+				totalMs: Date.now() - started,
+				phases,
+			},
+		},
+	});
 	return { catalogContext, updateCatalogPlan, catalogResult };
 }

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/buildProductStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/buildProductStatesContext.ts
@@ -5,8 +5,8 @@ import type {
 	ProductStatesContext,
 } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import {
-	type CustomerProductVersioningUsage,
-	emptyVersioningUsage,
+	type CustomerProductVersioningFlags,
+	emptyVersioningFlags,
 } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
 
 /** One ProductState per existing productKey, plus plan-scoped indexes. */
@@ -18,7 +18,7 @@ export const buildProductStatesContext = ({
 }: {
 	planIds: string[];
 	versionsByPlanId: Map<string, FullProduct[]>;
-	usageByInternalId: Map<string, CustomerProductVersioningUsage>;
+	usageByInternalId: Map<string, CustomerProductVersioningFlags>;
 	rewardProgramsByPlanId: Map<string, RewardProgram[]>;
 }): ProductStatesContext => {
 	const statesByPlanVersion: Record<string, ProductState> = {};
@@ -39,7 +39,7 @@ export const buildProductStatesContext = ({
 				currentFullProduct,
 				customerUsage:
 					usageByInternalId.get(currentFullProduct.internal_id) ??
-					emptyVersioningUsage(),
+					emptyVersioningFlags(),
 			};
 		}
 	}

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState.ts
@@ -5,13 +5,13 @@ import {
 } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import {
-	type CustomerProductVersioningUsage,
-	emptyVersioningUsage,
+	type CustomerProductVersioningFlags,
+	emptyVersioningFlags,
 } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
 
 export type ProductKeyState = {
 	currentFullProduct: FullProduct | null;
-	customerUsage: CustomerProductVersioningUsage;
+	customerUsage: CustomerProductVersioningFlags;
 };
 
 /** Lookup one productKey in productStatesContext; missing → create baseline. */
@@ -30,7 +30,7 @@ export const productKeyToState = ({
 	if (!state) {
 		return {
 			currentFullProduct: null,
-			customerUsage: emptyVersioningUsage(),
+			customerUsage: emptyVersioningFlags(),
 		};
 	}
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/projectProductStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/projectProductStatesContext.ts
@@ -1,7 +1,7 @@
 import type { FullProduct, RewardProgram } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import type { CustomerProductVersioningUsage } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
+import type { CustomerProductVersioningFlags } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
 import { buildProductStatesContext } from "./buildProductStatesContext";
 
 /**
@@ -48,7 +48,7 @@ export const projectProductStatesContext = ({
 		if (!versionsByPlanId.has(planId)) versionsByPlanId.set(planId, []);
 	}
 
-	const usageByInternalId = new Map<string, CustomerProductVersioningUsage>(
+	const usageByInternalId = new Map<string, CustomerProductVersioningFlags>(
 		Object.values(original.statesByPlanVersion).map((state) => [
 			state.currentFullProduct.internal_id,
 			state.customerUsage,

--- a/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
@@ -1,15 +1,19 @@
 import type { CatalogAction, CatalogMigration } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import {
+	type CatalogPhases,
+	timeCatalogPhase,
+} from "@/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 import {
 	coalesceCreditSystemSchemaRewrites,
 	executeCreditSystemSchemaRewrites,
 	executeFeatureReferenceRewrites,
 } from "@/internal/catalogV2/execute/executeFeatureReferenceRewrites";
+import { initStripeResourcesForCatalog } from "@/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog";
 import { executeMigrationDrafts } from "@/internal/catalogV2/execute/executeMigrationDrafts";
 import { executeRemovePlans } from "@/internal/catalogV2/execute/executeRemovePlans";
 import { executeUpsertProducts } from "@/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts";
-import { initStripeResourcesForCatalog } from "@/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog";
 import { queueRewardMigrations } from "@/internal/catalogV2/execute/queueRewardMigrations";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import type { ClearCreditSystemCachePayload } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
@@ -148,24 +152,72 @@ const executeRemoveFeatures = async ({
 export const executeUpdateCatalogPlan = async ({
 	ctx,
 	updateCatalogPlan,
+	phases,
 }: {
 	ctx: AutumnContext;
 	updateCatalogPlan: UpdateCatalogPlan;
+	phases: CatalogPhases;
 }): Promise<CatalogResult> => {
-	await executeInsertFeatures({ ctx, updateCatalogPlan });
-	await executeUpdateFeatures({ ctx, updateCatalogPlan });
-	await executeRemoveFeatures({ ctx, updateCatalogPlan });
-	const plans = await executeUpsertProducts({ ctx, updateCatalogPlan });
-	await executeRemovePlans({ ctx, updateCatalogPlan });
-	await initStripeResourcesForCatalog({ ctx, updateCatalogPlan });
-	await queueRewardMigrations({ ctx, updateCatalogPlan });
-	const migrations = await executeMigrationDrafts({ ctx, updateCatalogPlan });
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.insert_features",
+		run: () => executeInsertFeatures({ ctx, updateCatalogPlan }),
+	});
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.update_features",
+		run: () => executeUpdateFeatures({ ctx, updateCatalogPlan }),
+	});
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.remove_features",
+		run: () => executeRemoveFeatures({ ctx, updateCatalogPlan }),
+	});
+	const plans = await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.upsert_products",
+		run: () => executeUpsertProducts({ ctx, updateCatalogPlan }),
+	});
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.remove_plans",
+		run: () => executeRemovePlans({ ctx, updateCatalogPlan }),
+	});
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.init_stripe",
+		run: () => initStripeResourcesForCatalog({ ctx, updateCatalogPlan }),
+	});
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.queue_reward_migrations",
+		run: () => queueRewardMigrations({ ctx, updateCatalogPlan }),
+	});
+	const migrations = await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.migration_drafts",
+		run: () => executeMigrationDrafts({ ctx, updateCatalogPlan }),
+	});
 
-	await clearOrgCache({
-		db: ctx.db,
-		orgId: ctx.org.id,
-		env: ctx.env,
-		logger: ctx.logger,
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.clear_org_cache",
+		run: () =>
+			clearOrgCache({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				env: ctx.env,
+				logger: ctx.logger,
+			}),
 	});
 
 	return {

--- a/server/src/internal/catalogV2/handlers/handlePreviewUpdateCatalogV2.ts
+++ b/server/src/internal/catalogV2/handlers/handlePreviewUpdateCatalogV2.ts
@@ -7,6 +7,7 @@ import {
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { catalogV2Actions } from "@/internal/catalogV2/actions/index.js";
 import { buildUpdateCatalogPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/buildUpdateCatalogPreview";
+import { timeCatalogPhase } from "@/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase";
 
 /** Resolve a proposed catalog change WITHOUT persisting — same params as catalogV2.update. */
 export const handlePreviewUpdateCatalogV2 = createRoute({
@@ -24,10 +25,16 @@ export const handlePreviewUpdateCatalogV2 = createRoute({
 				preview: true,
 			});
 
-		return c.json(
-			PreviewUpdateCatalogResponseSchema.parse(
-				buildUpdateCatalogPreview({ catalogContext, updateCatalogPlan }),
-			),
-		);
+		const preview = await timeCatalogPhase({
+			ctx,
+			phases: {},
+			phase: "build_preview",
+			run: async () =>
+				PreviewUpdateCatalogResponseSchema.parse(
+					buildUpdateCatalogPreview({ catalogContext, updateCatalogPlan }),
+				),
+		});
+
+		return c.json(preview);
 	},
 });

--- a/server/src/internal/customers/cusProducts/repos/getBoundedVersionableRowRefs.ts
+++ b/server/src/internal/customers/cusProducts/repos/getBoundedVersionableRowRefs.ts
@@ -1,0 +1,179 @@
+import { VERSIONABLE_CUSTOMER_STATUSES } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export type VersioningRowRefTarget = {
+	id: string;
+	internal_product_id: string;
+};
+
+export type VersioningRowRefTargets = {
+	entitlements: VersioningRowRefTarget[];
+	prices: VersioningRowRefTarget[];
+};
+
+type VersioningRowRefSource = {
+	refTable: "customer_entitlements" | "customer_prices";
+	targetColumn: "entitlement_id" | "price_id";
+};
+
+type TimeVersioningPhaseArgs<T> = {
+	phase: string;
+	run: () => Promise<T>;
+};
+
+type TimeVersioningPhase = <T>(args: TimeVersioningPhaseArgs<T>) => Promise<T>;
+
+const BOUNDED_ROW_REF_PROBE_CHUNK_SIZE = 50;
+
+const sqlIn = ({ values }: { values: string[] }) =>
+	sql.join(
+		values.map((value) => sql`${value}`),
+		sql`, `,
+	);
+
+const runUntimed = async <T>({ run }: TimeVersioningPhaseArgs<T>): Promise<T> =>
+	run();
+
+export const buildBoundedVersionableRowRefsQuery = ({
+	targets,
+	refTable,
+	targetColumn,
+}: {
+	targets: VersioningRowRefTarget[];
+	refTable: VersioningRowRefSource["refTable"];
+	targetColumn: VersioningRowRefSource["targetColumn"];
+}) => {
+	if (targets.length === 0) {
+		return sql`SELECT NULL::text AS internal_product_id WHERE false`;
+	}
+
+	const statuses = sqlIn({ values: [...VERSIONABLE_CUSTOMER_STATUSES] });
+	const targetsByProduct = new Map<string, VersioningRowRefTarget[]>();
+	for (const target of targets) {
+		const productTargets =
+			targetsByProduct.get(target.internal_product_id) ?? [];
+		productTargets.push(target);
+		targetsByProduct.set(target.internal_product_id, productTargets);
+	}
+
+	const productProbes = [...targetsByProduct.entries()].map(
+		([internalProductId, productTargets]) => {
+			const rowProbes = productTargets.map(
+				(target) => sql`
+					(
+						SELECT 1 AS found
+						FROM (
+							SELECT ref.customer_product_id
+							FROM ${sql.raw(refTable)} ref
+							WHERE ref.${sql.raw(targetColumn)} = ${target.id}
+							OFFSET 0
+						) ref
+						INNER JOIN LATERAL (
+							SELECT 1
+							FROM (
+								SELECT cp.status
+								FROM customer_products cp
+								WHERE cp.id = ref.customer_product_id
+								LIMIT 1
+							) cp
+							WHERE cp.status IN (${statuses})
+							LIMIT 1
+						) cp ON true
+						LIMIT 1
+					)
+				`,
+			);
+
+			return sql`
+				(
+					SELECT ${internalProductId}::text AS internal_product_id
+					FROM (${sql.join(rowProbes, sql` UNION ALL `)}) refs
+					LIMIT 1
+				)
+			`;
+		},
+	);
+
+	return sql.join(productProbes, sql` UNION ALL `);
+};
+
+const getBoundedVersionableRowRefs = async ({
+	db,
+	targets,
+	source,
+}: {
+	db: DrizzleCli;
+	targets: VersioningRowRefTarget[];
+	source: VersioningRowRefSource;
+}): Promise<Array<{ internal_product_id: string | null }>> => {
+	const refs: Array<{ internal_product_id: string | null }> = [];
+
+	for (
+		let offset = 0;
+		offset < targets.length;
+		offset += BOUNDED_ROW_REF_PROBE_CHUNK_SIZE
+	) {
+		const chunk = targets.slice(
+			offset,
+			offset + BOUNDED_ROW_REF_PROBE_CHUNK_SIZE,
+		);
+		const rows = await db.execute<{ internal_product_id: string | null }>(
+			buildBoundedVersionableRowRefsQuery({
+				targets: chunk,
+				refTable: source.refTable,
+				targetColumn: source.targetColumn,
+			}),
+		);
+		refs.push(...rows);
+	}
+
+	return refs;
+};
+
+export const getBoundedVersionableRowRefIds = async ({
+	db,
+	targets,
+	timePhase,
+}: {
+	db: DrizzleCli;
+	targets: VersioningRowRefTargets;
+	timePhase?: TimeVersioningPhase;
+}): Promise<Set<string>> => {
+	const timed = timePhase ?? runUntimed;
+	const [entitlementRows, priceRows] = await Promise.all([
+		timed({
+			phase: "versioning_usage.entitlement_refs",
+			run: () =>
+				getBoundedVersionableRowRefs({
+					db,
+					targets: targets.entitlements,
+					source: {
+						refTable: "customer_entitlements",
+						targetColumn: "entitlement_id",
+					},
+				}),
+		}),
+		timed({
+			phase: "versioning_usage.price_refs",
+			run: () =>
+				getBoundedVersionableRowRefs({
+					db,
+					targets: targets.prices,
+					source: {
+						refTable: "customer_prices",
+						targetColumn: "price_id",
+					},
+				}),
+		}),
+	]);
+	const referencedProductIds = new Set<string>();
+
+	for (const row of [...entitlementRows, ...priceRows]) {
+		if (row.internal_product_id) {
+			referencedProductIds.add(row.internal_product_id);
+		}
+	}
+
+	return referencedProductIds;
+};

--- a/server/src/internal/customers/cusProducts/repos/getVersioningUsage.ts
+++ b/server/src/internal/customers/cusProducts/repos/getVersioningUsage.ts
@@ -1,122 +1,299 @@
 import {
-	customerEntitlements,
-	customerPrices,
+	type AppEnv,
 	customerProducts,
-	entitlements,
-	prices,
 	VERSIONABLE_CUSTOMER_STATUSES,
 } from "@autumn/shared";
-import { and, countDistinct, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, countDistinct, inArray, isNull, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import {
+	getBoundedVersionableRowRefIds,
+	type VersioningRowRefTargets,
+} from "./getBoundedVersionableRowRefs.js";
 
-export type CustomerProductVersioningUsage = {
+export type CustomerProductVersioningFlags = {
 	hasAnyCustomerProducts: boolean;
 	hasVersionableCustomerProducts: boolean;
 	/** Versionable CPs that are not seat assignments (`customer_license_link_id` null). */
 	hasVersionableDirectCustomerProducts: boolean;
-	versionableCustomerCount: number;
 	/** This version's ent/price ids are referenced by a versionable cus_ent/cus_price. */
 	hasVersionableRowRefs: boolean;
 };
 
-export const emptyVersioningUsage = (): CustomerProductVersioningUsage => ({
+export type CustomerProductVersioningUsage = CustomerProductVersioningFlags & {
+	versionableCustomerCount: number;
+};
+
+export const emptyVersioningFlags = (): CustomerProductVersioningFlags => ({
 	hasAnyCustomerProducts: false,
 	hasVersionableCustomerProducts: false,
 	hasVersionableDirectCustomerProducts: false,
-	versionableCustomerCount: 0,
 	hasVersionableRowRefs: false,
+});
+
+export const emptyVersioningUsage = (): CustomerProductVersioningUsage => ({
+	...emptyVersioningFlags(),
+	versionableCustomerCount: 0,
 });
 
 const emptyUsage = emptyVersioningUsage;
 
-const hasVersionableEntitlementRef = async ({
-	db,
-	internalProductId,
-}: {
-	db: DrizzleCli;
-	internalProductId: string;
-}): Promise<boolean> => {
-	const [row] = await db
-		.select({ internalProductId: entitlements.internal_product_id })
-		.from(customerEntitlements)
-		.innerJoin(
-			entitlements,
-			eq(customerEntitlements.entitlement_id, entitlements.id),
-		)
-		.innerJoin(
-			customerProducts,
-			eq(customerEntitlements.customer_product_id, customerProducts.id),
-		)
-		.where(
-			and(
-				eq(entitlements.internal_product_id, internalProductId),
-				inArray(customerProducts.status, VERSIONABLE_CUSTOMER_STATUSES),
-			),
-		)
-		.limit(1);
+const sqlIn = ({ values }: { values: string[] }) =>
+	sql.join(
+		values.map((value) => sql`${value}`),
+		sql`, `,
+	);
 
-	return row != null;
+const collectInternalProductIds = ({
+	rows,
+}: {
+	rows: Array<{ internal_product_id: string | null }>;
+}): string[] =>
+	rows.flatMap((row) =>
+		row.internal_product_id ? [row.internal_product_id] : [],
+	);
+
+type TimeVersioningPhaseArgs<T> = {
+	phase: string;
+	run: () => Promise<T>;
 };
 
-const hasVersionablePriceRef = async ({
-	db,
-	internalProductId,
-}: {
-	db: DrizzleCli;
-	internalProductId: string;
-}): Promise<boolean> => {
-	const [row] = await db
-		.select({ internalProductId: prices.internal_product_id })
-		.from(customerPrices)
-		.innerJoin(prices, eq(customerPrices.price_id, prices.id))
-		.innerJoin(
-			customerProducts,
-			eq(customerPrices.customer_product_id, customerProducts.id),
-		)
-		.where(
-			and(
-				eq(prices.internal_product_id, internalProductId),
-				inArray(customerProducts.status, VERSIONABLE_CUSTOMER_STATUSES),
-			),
-		)
-		.limit(1);
+type TimeVersioningPhase = <T>(args: TimeVersioningPhaseArgs<T>) => Promise<T>;
 
-	return row != null;
+const runUntimed = async <T>({ run }: TimeVersioningPhaseArgs<T>): Promise<T> =>
+	run();
+
+export const buildVersionableEntitlementRefsQuery = ({
+	internalProductIds,
+	orgId,
+	env,
+}: {
+	internalProductIds: string[];
+	orgId: string;
+	env: AppEnv;
+}) => {
+	const productIds = sqlIn({ values: internalProductIds });
+	const statuses = sqlIn({ values: [...VERSIONABLE_CUSTOMER_STATUSES] });
+
+	return sql`
+		SELECT DISTINCT t.internal_product_id
+		FROM entitlements t
+		INNER JOIN customer_entitlements ce
+			ON ce.entitlement_id = t.id
+		INNER JOIN customer_products cp
+			ON ce.customer_product_id COLLATE "C" = cp.id
+		INNER JOIN products p
+			ON p.internal_id = cp.internal_product_id
+		WHERE t.internal_product_id IN (${productIds})
+			AND cp.status IN (${statuses})
+			AND p.org_id = ${orgId}
+			AND p.env = ${env}
+	`;
 };
 
-/** Product versions whose entitlement/price rows are still referenced by a versionable customer. */
+export const buildVersionablePriceRefsQuery = ({
+	internalProductIds,
+	orgId,
+	env,
+}: {
+	internalProductIds: string[];
+	orgId: string;
+	env: AppEnv;
+}) => {
+	const productIds = sqlIn({ values: internalProductIds });
+	const statuses = sqlIn({ values: [...VERSIONABLE_CUSTOMER_STATUSES] });
+
+	return sql`
+		SELECT DISTINCT t.internal_product_id
+		FROM prices t
+		INNER JOIN customer_prices cpr
+			ON cpr.price_id = t.id
+		INNER JOIN customer_products cp
+			ON cpr.customer_product_id COLLATE "C" = cp.id
+		INNER JOIN products p
+			ON p.internal_id = cp.internal_product_id
+		WHERE t.internal_product_id IN (${productIds})
+			AND cp.status IN (${statuses})
+			AND p.org_id = ${orgId}
+			AND p.env = ${env}
+	`;
+};
+
 const internalProductIdsWithVersionableRowRefs = async ({
 	db,
 	internalProductIds,
+	orgId,
+	env,
+	timePhase,
 }: {
 	db: DrizzleCli;
 	internalProductIds: string[];
+	orgId: string;
+	env: AppEnv;
+	timePhase?: TimeVersioningPhase;
 }): Promise<Set<string>> => {
-	const hits = await Promise.all(
-		internalProductIds.map(async (internalProductId) => {
-			if (await hasVersionableEntitlementRef({ db, internalProductId })) {
-				return internalProductId;
-			}
-			if (await hasVersionablePriceRef({ db, internalProductId })) {
-				return internalProductId;
-			}
-			return null;
-		}),
-	);
+	const timed = timePhase ?? runUntimed;
 
-	return new Set(hits.filter((id) => id != null));
+	const [entitlementRows, priceRows] = await Promise.all([
+		timed({
+			phase: "versioning_usage.entitlement_refs",
+			run: () =>
+				db.execute<{ internal_product_id: string | null }>(
+					buildVersionableEntitlementRefsQuery({
+						internalProductIds,
+						orgId,
+						env,
+					}),
+				),
+		}),
+		timed({
+			phase: "versioning_usage.price_refs",
+			run: () =>
+				db.execute<{ internal_product_id: string | null }>(
+					buildVersionablePriceRefsQuery({ internalProductIds, orgId, env }),
+				),
+		}),
+	]);
+
+	return new Set([
+		...collectInternalProductIds({ rows: [...entitlementRows] }),
+		...collectInternalProductIds({ rows: [...priceRows] }),
+	]);
 };
 
-export const getVersioningUsage = async ({
+export const buildBoundedVersioningCustomerProductsQuery = ({
+	internalProductIds,
+}: {
+	internalProductIds: string[];
+}) => {
+	const statuses = sqlIn({ values: [...VERSIONABLE_CUSTOMER_STATUSES] });
+
+	return sql`
+		SELECT
+			candidate.internal_product_id,
+			EXISTS (
+				SELECT 1
+				FROM customer_products cp
+				WHERE cp.internal_product_id = candidate.internal_product_id
+				LIMIT 1
+			) AS has_any_customer_products,
+			EXISTS (
+				SELECT 1
+				FROM customer_products cp
+				WHERE cp.internal_product_id = candidate.internal_product_id
+					AND cp.status IN (${statuses})
+				LIMIT 1
+			) AS has_versionable_customer_products,
+			EXISTS (
+				SELECT 1
+				FROM customer_products cp
+				WHERE cp.internal_product_id = candidate.internal_product_id
+					AND cp.status IN (${statuses})
+					AND cp.customer_license_link_id IS NULL
+				LIMIT 1
+			) AS has_versionable_direct_customer_products
+		FROM unnest(${sql.param(internalProductIds)}::text[])
+			AS candidate(internal_product_id)
+	`;
+};
+
+export const getVersioningFlags = async ({
+	db,
+	internalProductIds,
+	rowRefTargets,
+	timePhase,
+}: {
+	db: DrizzleCli;
+	internalProductIds: string[];
+	rowRefTargets: VersioningRowRefTargets;
+	timePhase?: TimeVersioningPhase;
+}): Promise<Map<string, CustomerProductVersioningFlags>> => {
+	const flags = new Map(
+		internalProductIds.map((internalProductId) => [
+			internalProductId,
+			emptyVersioningFlags(),
+		]),
+	);
+	if (internalProductIds.length === 0) return flags;
+
+	const timed = timePhase ?? runUntimed;
+	const [rows, rowRefIds] = await Promise.all([
+		timed({
+			phase: "versioning_usage.customer_products",
+			run: () =>
+				db.execute<{
+					internal_product_id: string;
+					has_any_customer_products: boolean;
+					has_versionable_customer_products: boolean;
+					has_versionable_direct_customer_products: boolean;
+				}>(buildBoundedVersioningCustomerProductsQuery({ internalProductIds })),
+		}),
+		getBoundedVersionableRowRefIds({
+			db,
+			targets: rowRefTargets,
+			timePhase,
+		}),
+	]);
+
+	for (const row of rows) {
+		flags.set(row.internal_product_id, {
+			hasAnyCustomerProducts: row.has_any_customer_products,
+			hasVersionableCustomerProducts: row.has_versionable_customer_products,
+			hasVersionableDirectCustomerProducts:
+				row.has_versionable_direct_customer_products,
+			hasVersionableRowRefs: rowRefIds.has(row.internal_product_id),
+		});
+	}
+
+	return flags;
+};
+
+export const buildVersioningCustomerProductsQuery = ({
 	db,
 	internalProductIds,
 	excludeLicenseAssignments,
 }: {
 	db: DrizzleCli;
 	internalProductIds: string[];
+	excludeLicenseAssignments?: boolean;
+}) =>
+	db
+		.select({
+			internalProductId: customerProducts.internal_product_id,
+			anyCount: countDistinct(customerProducts.id).as("any_count"),
+			versionableCount: countDistinct(
+				sql`CASE WHEN ${inArray(customerProducts.status, VERSIONABLE_CUSTOMER_STATUSES)} THEN ${customerProducts.id} END`,
+			).as("versionable_count"),
+			versionableDirectCount: countDistinct(
+				sql`CASE WHEN ${inArray(customerProducts.status, VERSIONABLE_CUSTOMER_STATUSES)} AND ${isNull(customerProducts.customer_license_link_id)} THEN ${customerProducts.id} END`,
+			).as("versionable_direct_count"),
+		})
+		.from(customerProducts)
+		.where(
+			and(
+				inArray(customerProducts.internal_product_id, internalProductIds),
+				excludeLicenseAssignments
+					? isNull(customerProducts.customer_license_link_id)
+					: undefined,
+			),
+		)
+		.groupBy(customerProducts.internal_product_id);
+
+export const getVersioningUsage = async ({
+	db,
+	internalProductIds,
+	orgId,
+	env,
+	excludeLicenseAssignments,
+	timePhase,
+}: {
+	db: DrizzleCli;
+	internalProductIds: string[];
+	orgId: string;
+	env: AppEnv;
 	/** Seat assignments live on the license plan but are migrated through the
 	 * parent's upsert_licenses, so a plan-scoped op can never reach them. */
 	excludeLicenseAssignments?: boolean;
+	timePhase?: TimeVersioningPhase;
 }): Promise<Map<string, CustomerProductVersioningUsage>> => {
 	const usage = new Map(
 		internalProductIds.map((internalProductId) => [
@@ -126,29 +303,25 @@ export const getVersioningUsage = async ({
 	);
 	if (internalProductIds.length === 0) return usage;
 
+	const timed = timePhase ?? runUntimed;
+
 	const [result, rowRefIds] = await Promise.all([
-		db
-			.select({
-				internalProductId: customerProducts.internal_product_id,
-				anyCount: countDistinct(customerProducts.id).as("any_count"),
-				versionableCount: countDistinct(
-					sql`CASE WHEN ${inArray(customerProducts.status, VERSIONABLE_CUSTOMER_STATUSES)} THEN ${customerProducts.id} END`,
-				).as("versionable_count"),
-				versionableDirectCount: countDistinct(
-					sql`CASE WHEN ${inArray(customerProducts.status, VERSIONABLE_CUSTOMER_STATUSES)} AND ${isNull(customerProducts.customer_license_link_id)} THEN ${customerProducts.id} END`,
-				).as("versionable_direct_count"),
-			})
-			.from(customerProducts)
-			.where(
-				and(
-					inArray(customerProducts.internal_product_id, internalProductIds),
-					excludeLicenseAssignments
-						? isNull(customerProducts.customer_license_link_id)
-						: undefined,
-				),
-			)
-			.groupBy(customerProducts.internal_product_id),
-		internalProductIdsWithVersionableRowRefs({ db, internalProductIds }),
+		timed({
+			phase: "versioning_usage.customer_products",
+			run: () =>
+				buildVersioningCustomerProductsQuery({
+					db,
+					internalProductIds,
+					excludeLicenseAssignments,
+				}),
+		}),
+		internalProductIdsWithVersionableRowRefs({
+			db,
+			internalProductIds,
+			orgId,
+			env,
+			timePhase,
+		}),
 	]);
 
 	for (const row of result) {
@@ -176,15 +349,21 @@ export const getVersioningUsage = async ({
 export const getVersioningUsageForProduct = async ({
 	db,
 	internalProductId,
+	orgId,
+	env,
 	excludeLicenseAssignments,
 }: {
 	db: DrizzleCli;
 	internalProductId: string;
+	orgId: string;
+	env: AppEnv;
 	excludeLicenseAssignments?: boolean;
 }): Promise<CustomerProductVersioningUsage> => {
 	const usageByProduct = await getVersioningUsage({
 		db,
 		internalProductIds: [internalProductId],
+		orgId,
+		env,
 		excludeLicenseAssignments,
 	});
 

--- a/server/src/internal/licenses/actions/propagation/prepareLicenseParentPropagation.ts
+++ b/server/src/internal/licenses/actions/propagation/prepareLicenseParentPropagation.ts
@@ -50,6 +50,8 @@ export const prepareLicenseParentPropagation = async ({
 	const usageByInternalId = await customerProductRepo.getVersioningUsage({
 		db: ctx.db,
 		internalProductIds: contexts.map(({ parent }) => parent.internal_id),
+		orgId: ctx.org.id,
+		env: ctx.env,
 	});
 	const latestVersionByPlanId = new Map<string, number>();
 	for (const { parent } of contexts) {

--- a/server/src/internal/product/actions/previewUpdatePlan/hasPlanCustomers.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/hasPlanCustomers.ts
@@ -12,6 +12,8 @@ export const getPlanCustomerUsage = async ({
 	const usage = await customerProductRepo.getVersioningUsageForProduct({
 		db: ctx.db,
 		internalProductId: product.internal_id,
+		orgId: ctx.org.id,
+		env: ctx.env,
 	});
 
 	return {

--- a/server/src/internal/product/actions/previewUpdatePlan/previewAffectedLicenseParents.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewAffectedLicenseParents.ts
@@ -82,6 +82,8 @@ export const previewAffectedLicenseParents = async ({
 	const usageByInternalId = await customerProductRepo.getVersioningUsage({
 		db: ctx.db,
 		internalProductIds: parentProducts.map((parent) => parent.internal_id),
+		orgId: ctx.org.id,
+		env: ctx.env,
 	});
 	const selectedTargets = new Set(
 		selectedContexts.map(({ parent }) =>

--- a/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
+++ b/server/src/internal/product/actions/updateProduct/createPlanMigrationDraft.ts
@@ -265,6 +265,8 @@ export const createPlanMigrationDraft = async ({
 		const baseUsage = await customerProductRepo.getVersioningUsageForProduct({
 			db: ctx.db,
 			internalProductId: current.internal_id,
+			orgId: ctx.org.id,
+			env: ctx.env,
 			excludeLicenseAssignments: true,
 		});
 		const targets = [
@@ -297,6 +299,8 @@ export const createPlanMigrationDraft = async ({
 	const usageByProduct = await customerProductRepo.getVersioningUsage({
 		db: ctx.db,
 		internalProductIds: baseVersions.map((product) => product.internal_id),
+		orgId: ctx.org.id,
+		env: ctx.env,
 		excludeLicenseAssignments: true,
 	});
 

--- a/server/src/internal/product/actions/updateProduct/setupUpdateProductContext.ts
+++ b/server/src/internal/product/actions/updateProduct/setupUpdateProductContext.ts
@@ -57,6 +57,8 @@ export const setupUpdateProductContext = async ({
 	const customerUsage = await customerProductRepo.getVersioningUsageForProduct({
 		db,
 		internalProductId: fullProduct.internal_id,
+		orgId: org.id,
+		env,
 	});
 
 	return {

--- a/server/src/internal/products/handlers/handlePlanHasCustomersV2.ts
+++ b/server/src/internal/products/handlers/handlePlanHasCustomersV2.ts
@@ -46,6 +46,8 @@ export const handlePlanHasCustomersV2 = createRoute({
 			await customerProductRepo.getVersioningUsageForProduct({
 				db,
 				internalProductId: product.internal_id,
+				orgId: org.id,
+				env,
 			});
 
 		// V2.0+ (CLI): body is CreatePlanParams, convert to ProductV2


### PR DESCRIPTION
## Summary
- replace unbounded catalog versioning scans with bounded customer-product and row-reference probes
- reuse loaded product rows and short-circuit after the first referenced entitlement or price per plan
- collect catalog preview/update phase timings in request extra logs
- add staging-safe EXPLAIN scripts for the affected query shapes

## Test plan
- [x] Run server TypeScript build
- [x] Run pre-commit knip checks
- [x] EXPLAIN ANALYZE Resend `transactional_free` against the prod-copy staging branch
- [x] Verify bounded entitlement-reference execution drops to 0.66ms database time

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds catalog versioning usage queries and adds phase timing to Catalog V2. Previously we scanned `customer_products`/entitlement/price refs; now we use bounded, org/env‑scoped EXISTS probes and short‑circuit after the first hit, and we record per‑phase timings.

- Replace unbounded scans with:
  - Bounded customer-product flags via unnest + EXISTS.
  - Bounded entitlement/price reference probes per product version; unioned and chunked.
- `ProductState.customerUsage` now carries flags only (no counts). Use repo calls for counts.
- `getVersioningUsage` now requires `orgId` and `env`; queries are scoped. `setupProductStatesContext` uses `getVersioningFlags` with `rowRefTargets` built from loaded products.
- New `timeCatalogPhase` wraps setup/compute/execute steps (and preview build). We log `{ operation, totalMs, phases }` in `ctx.extraLogs.catalogTiming`. Staging EXPLAIN scripts were added under `server/experiments` to validate plans.

**Rollout**
- No schema changes or data migrations.
- Callers of `getVersioningUsage` must pass `orgId` and `env`.
- Monitor `catalogTiming` in request extra logs for preview/update.

<sup>Written for commit c11f3e5432715aa7eecf292602d4947cb9d5cf7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves catalog-versioning performance by replacing broad usage scans with bounded probes and adds request-phase timing diagnostics.

- **Improvements:** Builds bounded customer-product and entitlement/price reference queries, reusing already-loaded product versions and stopping after the first relevant reference.
- **API changes:** Separates boolean-only versioning flags used by catalog V2 from exact usage counts and requires organization/environment scope for exact usage queries.
- **Improvements:** Records setup, planning, execution, and preview timings in catalog request logs.
- **Improvements:** Adds staging-restricted EXPLAIN utilities for validating the affected PostgreSQL query plans.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code failure remains after tracing the bounded probes through catalog planning and execution.

The bounded queries preserve the boolean usage semantics required by catalog V2, their target set matches the rows eligible for planning, and the timing wrappers retain the existing operation order and results.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusProducts/repos/getBoundedVersionableRowRefs.ts | Adds chunked, per-row bounded entitlement and price reference probes that preserve per-product hits. |
| server/src/internal/customers/cusProducts/repos/getVersioningUsage.ts | Introduces boolean-only bounded usage flags while retaining exact scoped usage counts for existing callers. |
| server/src/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext.ts | Reuses loaded full-product rows to construct reference targets and populate catalog product states. |
| server/src/internal/catalogV2/actions/updateCatalog/setup/timeCatalogPhase.ts | Adds cumulative phase timing collection and merges measurements into request extra logs. |
| server/src/internal/catalogV2/actions/updateCatalog/updateCatalogV2.ts | Instruments catalog setup, computation, and total preview/update duration without changing the execution order. |
| server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts | Wraps each existing catalog execution stage with timing while retaining sequential behavior. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Handler as Catalog Handler
  participant Setup as Catalog Setup
  participant Products as ProductService
  participant Usage as Versioning Probes
  participant Planner as Catalog Planner
  participant Executor as Catalog Executor
  participant DB as PostgreSQL

  Handler->>Setup: preview/update request
  Setup->>Products: Load all requested plan versions
  Products-->>Setup: Full product rows
  Setup->>Usage: Probe customer-product flags and row references
  Usage->>DB: Bounded EXISTS and chunked reference probes
  DB-->>Usage: Per-product reference flags
  Usage-->>Setup: Versioning flags
  Setup-->>Planner: Product states
  Planner-->>Handler: Update plan
  opt Persist update
    Handler->>Executor: Execute update plan
    Executor->>DB: Apply catalog changes
  end
  Handler->>Handler: Store phase and total timings
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into john/catalog-v2..."](https://github.com/useautumn/autumn/commit/c11f3e5432715aa7eecf292602d4947cb9d5cf7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54766300)</sub>

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->