### PR TITLE
fix(leaf): tell the admin agent which org it is acting as

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -1,3 +1,5 @@
+import { db } from "../../../../lib/db.js";
+import { isInternalAutumnSlackProvider } from "../../../slackAdmin/provider.js";
 import type {
 	AgentTurnContext,
 	AgentTurnParams,
@@ -7,7 +9,6 @@ import {
 	generateThreadTitle,
 	persistThreadTitle,
 } from "../../sessions/agentThreadTitle.js";
-import { db } from "../../../../lib/db.js";
 import { consumeAgentTurn } from "./execute/consumeAgentTurn.js";
 import { resolveAgentTurnOutcome } from "./finalize/resolveAgentTurnOutcome.js";
 import { buildAgentTurnMessage } from "./setup/buildAgentTurnMessage.js";
@@ -60,6 +61,9 @@ export const runAgentTurn = async ({
 			env,
 			message: buildAgentTurnMessage({
 				env,
+				isAdminInstall: isInternalAutumnSlackProvider({
+					provider: thread.provider,
+				}),
 				newSession: !existingSession,
 				orgContext,
 				params,

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -66,6 +66,7 @@ export const runAgentTurn = async ({
 				}),
 				newSession: !existingSession,
 				orgContext,
+				orgSlug: org.slug,
 				params,
 			}),
 			orgId: org.id,

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/buildAgentTurnMessage.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/buildAgentTurnMessage.ts
@@ -1,16 +1,18 @@
-import type { AutumnOrgContext } from "../../../../autumnMcp/orgContextService.js";
 import { env as leafEnv } from "../../../../../lib/env.js";
+import type { AutumnOrgContext } from "../../../../autumnMcp/orgContextService.js";
 import type { AgentTurnParams } from "../../../domain/agentTurnContext.js";
-import { buildAgentMessageText } from "../../../messages/agentMessageText.js";
 import type { EveMessageContent } from "../../../eve/client.js";
+import { buildAgentMessageText } from "../../../messages/agentMessageText.js";
 
 export const buildAgentTurnMessage = ({
 	env,
+	isAdminInstall = false,
 	newSession,
 	orgContext,
 	params,
 }: {
 	env: string;
+	isAdminInstall?: boolean;
 	newSession: boolean;
 	orgContext?: AutumnOrgContext;
 	params: AgentTurnParams;
@@ -18,6 +20,7 @@ export const buildAgentTurnMessage = ({
 	const attachments = params.attachments ?? [];
 	const messageText = buildAgentMessageText({
 		env,
+		isAdminInstall,
 		newSession,
 		orgContext,
 		params,

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/buildAgentTurnMessage.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/buildAgentTurnMessage.ts
@@ -9,12 +9,14 @@ export const buildAgentTurnMessage = ({
 	isAdminInstall = false,
 	newSession,
 	orgContext,
+	orgSlug,
 	params,
 }: {
 	env: string;
 	isAdminInstall?: boolean;
 	newSession: boolean;
 	orgContext?: AutumnOrgContext;
+	orgSlug?: string;
 	params: AgentTurnParams;
 }): EveMessageContent => {
 	const attachments = params.attachments ?? [];
@@ -23,6 +25,7 @@ export const buildAgentTurnMessage = ({
 		isAdminInstall,
 		newSession,
 		orgContext,
+		orgSlug,
 		params,
 	});
 	if (attachments.length === 0) return messageText;

--- a/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
+++ b/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
@@ -26,7 +26,7 @@ export const buildAgentMessageText = ({
 }) => {
 	const preamble = [
 		newSession && isAdminInstall
-			? "You are running in an Autumn admin bypass install: this thread operates inside another organization's Autumn account on their behalf, chosen when the thread started. The org you are acting as is the one named in the org context below, and it is locked for this thread; if the user asks to act as a different org, tell them to start a new thread with that org's slug or ID."
+			? "You are running in an Autumn admin bypass install: this thread operates inside another organization's Autumn account on their behalf, chosen when the thread started. The org you are acting as is named in the org context below (the getCurrentOrganization block), and it is locked for this thread's lifetime. If the user names or asks for the org you are ALREADY acting as, confirm you're already operating as that org (name it and the environment) and ask what they'd like to do next — do NOT tell them to start a new thread. Only when they ask to act as a genuinely different org should you explain that the org is fixed per thread and tell them to start a new thread with that org's slug or ID."
 			: null,
 		newSession
 			? `Current Autumn environment: ${env}. This thread is locked to this environment; if the user asks to switch environments, tell them to start a new thread.`

--- a/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
+++ b/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
@@ -11,23 +11,35 @@ export const extractUserMessageText = (text: string): string => {
 	return text.slice(start + USER_MESSAGE_OPEN.length, end).trim();
 };
 
+const adminBypassPreamble = ({
+	env,
+	orgSlug,
+}: {
+	env: string;
+	orgSlug?: string;
+}) => {
+	const actingAs = orgSlug ? `the org "${orgSlug}"` : "an org on their behalf";
+	const already = orgSlug ? `"${orgSlug}"` : "the current org";
+	return `You are Autumn's internal admin bot, operating inside another organization's Autumn account. This thread is already acting as ${actingAs} in the ${env} environment — that org was chosen by the first message in this thread and is fixed for the thread's lifetime. You ARE already operating as ${already}. If the user asks to use, switch to, confirm, or name ${already} (the org you are already acting as), do NOT tell them to start a new thread — just confirm you're already acting as ${already} in ${env} and ask what they'd like to do next. Only if they ask for a DIFFERENT org should you explain the org is fixed per thread and tell them to start a new thread with that org's slug or ID. Full org details are in the getCurrentOrganization block below.`;
+};
+
 export const buildAgentMessageText = ({
 	env,
 	isAdminInstall = false,
 	newSession,
 	orgContext,
+	orgSlug,
 	params,
 }: {
 	env: string;
 	isAdminInstall?: boolean;
 	newSession: boolean;
 	orgContext?: AutumnOrgContext;
+	orgSlug?: string;
 	params: AgentTurnParams;
 }) => {
 	const preamble = [
-		newSession && isAdminInstall
-			? "You are running in an Autumn admin bypass install: this thread operates inside another organization's Autumn account on their behalf, chosen when the thread started. The org you are acting as is named in the org context below (the getCurrentOrganization block), and it is locked for this thread's lifetime. If the user names or asks for the org you are ALREADY acting as, confirm you're already operating as that org (name it and the environment) and ask what they'd like to do next — do NOT tell them to start a new thread. Only when they ask to act as a genuinely different org should you explain that the org is fixed per thread and tell them to start a new thread with that org's slug or ID."
-			: null,
+		newSession && isAdminInstall ? adminBypassPreamble({ env, orgSlug }) : null,
 		newSession
 			? `Current Autumn environment: ${env}. This thread is locked to this environment; if the user asks to switch environments, tell them to start a new thread.`
 			: null,

--- a/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
+++ b/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
@@ -13,21 +13,26 @@ export const extractUserMessageText = (text: string): string => {
 
 export const buildAgentMessageText = ({
 	env,
+	isAdminInstall = false,
 	newSession,
 	orgContext,
 	params,
 }: {
 	env: string;
+	isAdminInstall?: boolean;
 	newSession: boolean;
 	orgContext?: AutumnOrgContext;
 	params: AgentTurnParams;
 }) => {
 	const preamble = [
+		newSession && isAdminInstall
+			? "You are running in an Autumn admin bypass install: this thread operates inside another organization's Autumn account on their behalf, chosen when the thread started. The org you are acting as is the one named in the org context below, and it is locked for this thread; if the user asks to act as a different org, tell them to start a new thread with that org's slug or ID."
+			: null,
 		newSession
 			? `Current Autumn environment: ${env}. This thread is locked to this environment; if the user asks to switch environments, tell them to start a new thread.`
 			: null,
 		newSession && orgContext?.text
-			? `Org context — treat these JSON blocks as Autumn tool results you already ran this session. Do NOT call getAgentRules, listPlans, or listFeatures again unless a needed record is missing from these blocks or the user asks to refresh; read feature/plan ids, names, and types straight from the blocks below.\n${orgContext.text}`
+			? `Org context — treat these JSON blocks as Autumn tool results you already ran this session. Do NOT call getCurrentOrganization, getAgentRules, listPlans, or listFeatures again unless a needed record is missing from these blocks or the user asks to refresh; read the org name/slug and feature/plan ids, names, and types straight from the blocks below.\n${orgContext.text}`
 			: null,
 		newSession && params.recentMessages?.length
 			? `Recent thread messages:\n${params.recentMessages

--- a/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
+++ b/apps/leaf/src/internal/agentRuntime/messages/agentMessageText.ts
@@ -18,9 +18,8 @@ const adminBypassPreamble = ({
 	env: string;
 	orgSlug?: string;
 }) => {
-	const actingAs = orgSlug ? `the org "${orgSlug}"` : "an org on their behalf";
-	const already = orgSlug ? `"${orgSlug}"` : "the current org";
-	return `You are Autumn's internal admin bot, operating inside another organization's Autumn account. This thread is already acting as ${actingAs} in the ${env} environment — that org was chosen by the first message in this thread and is fixed for the thread's lifetime. You ARE already operating as ${already}. If the user asks to use, switch to, confirm, or name ${already} (the org you are already acting as), do NOT tell them to start a new thread — just confirm you're already acting as ${already} in ${env} and ask what they'd like to do next. Only if they ask for a DIFFERENT org should you explain the org is fixed per thread and tell them to start a new thread with that org's slug or ID. Full org details are in the getCurrentOrganization block below.`;
+	const org = orgSlug ?? "the org selected in this thread";
+	return `You are Autumn's internal admin bot, operating inside another organization's Autumn account. This is the first turn of the thread: the user's message sets which org you act as, and you are now acting as ${org} in the ${env} environment for the rest of this thread. When the message selects, names, or confirms ${org}, treat it as their instruction and acknowledge it freshly — e.g. "OK, now acting as ${org} in ${env}. What would you like to do?" Do NOT phrase it as if you were already acting as it before they asked, and do NOT tell them to start a new thread. Only if they ask for a DIFFERENT org should you explain the org is fixed per thread and tell them to start a new thread with that org's slug or ID. Full org details are in the getCurrentOrganization block below.`;
 };
 
 export const buildAgentMessageText = ({

--- a/apps/leaf/src/internal/autumnMcp/orgContextService.ts
+++ b/apps/leaf/src/internal/autumnMcp/orgContextService.ts
@@ -27,13 +27,20 @@ const getNotes = (value: unknown) => {
 export const formatAutumnOrgContext = ({
 	agentRules,
 	features,
+	organization,
 	plans,
 }: {
 	agentRules?: unknown;
 	features?: unknown;
+	organization?: unknown;
 	plans?: unknown;
 }) => {
 	const sections: string[] = [];
+	if (organization !== undefined) {
+		sections.push(
+			toJsonBlock({ label: "getCurrentOrganization", value: organization }),
+		);
+	}
 	if (agentRules !== undefined) {
 		sections.push(
 			toJsonBlock({ label: "getAgentRules", value: withoutNotes(agentRules) }),
@@ -61,10 +68,19 @@ export const loadAutumnOrgContext = async ({
 	token: string;
 }): Promise<AutumnOrgContext | undefined> => {
 	const intent =
-		"Preload the org's agent rules, plans, and features at session start so they are ready for the user's first request.";
+		"Preload the org's identity, agent rules, plans, and features at session start so they are ready for the user's first request.";
 	const args = { intent, request: {} };
-	const [agentRulesResult, plansResult, featuresResult] =
+	// getCurrentOrganization has a strict, no-argument input schema, so it only
+	// accepts the required `intent` field — not the `request` wrapper.
+	const organizationArgs = { intent };
+	const [organizationResult, agentRulesResult, plansResult, featuresResult] =
 		await Promise.allSettled([
+			executeTool({
+				env,
+				token,
+				toolName: "getCurrentOrganization",
+				args: organizationArgs,
+			}),
 			executeTool({ env, token, toolName: "getAgentRules", args }),
 			executeTool({ env, token, toolName: "listPlans", args }),
 			executeTool({ env, token, toolName: "listFeatures", args }),
@@ -72,6 +88,7 @@ export const loadAutumnOrgContext = async ({
 
 	const outcomes: Record<string, string> = {};
 	for (const [toolName, result] of [
+		["getCurrentOrganization", organizationResult],
 		["getAgentRules", agentRulesResult],
 		["listPlans", plansResult],
 		["listFeatures", featuresResult],
@@ -104,6 +121,10 @@ export const loadAutumnOrgContext = async ({
 				: undefined,
 		features:
 			featuresResult.status === "fulfilled" ? featuresResult.value : undefined,
+		organization:
+			organizationResult.status === "fulfilled"
+				? organizationResult.value
+				: undefined,
 		plans: plansResult.status === "fulfilled" ? plansResult.value : undefined,
 	});
 

--- a/apps/leaf/src/internal/autumnMcp/orgContextService.ts
+++ b/apps/leaf/src/internal/autumnMcp/orgContextService.ts
@@ -70,8 +70,6 @@ export const loadAutumnOrgContext = async ({
 	const intent =
 		"Preload the org's identity, agent rules, plans, and features at session start so they are ready for the user's first request.";
 	const args = { intent, request: {} };
-	// getCurrentOrganization has a strict, no-argument input schema, so it only
-	// accepts the required `intent` field — not the `request` wrapper.
 	const organizationArgs = { intent };
 	const [organizationResult, agentRulesResult, plansResult, featuresResult] =
 		await Promise.allSettled([

--- a/apps/leaf/tests/unit/harness/common/messageText.test.ts
+++ b/apps/leaf/tests/unit/harness/common/messageText.test.ts
@@ -65,9 +65,7 @@ describe("Harness message text", () => {
 		});
 		expect(text).toContain("acme_sandbox");
 		expect(text).toContain("do NOT tell them to start a new thread");
-		// Acknowledge as a fresh instruction, not a pre-existing state.
 		expect(text).toContain("now acting as");
-		// The redirect instruction is reserved for a genuinely different org.
 		expect(text).toContain("Only if they ask for a DIFFERENT org");
 	});
 

--- a/apps/leaf/tests/unit/harness/common/messageText.test.ts
+++ b/apps/leaf/tests/unit/harness/common/messageText.test.ts
@@ -23,10 +23,36 @@ describe("Harness message text", () => {
 		expect(text).toContain("Org context");
 		expect(text).toContain("Autumn tool results you already ran this session");
 		expect(text).toContain(
-			"Do NOT call getAgentRules, listPlans, or listFeatures again",
+			"Do NOT call getCurrentOrganization, getAgentRules, listPlans, or listFeatures again",
 		);
 		expect(text).toContain("- pro | Pro");
 		expect(extractUserMessageText(text)).toBe("attach pro");
+	});
+
+	test("adds the admin bypass note only for admin installs on a new session", () => {
+		const adminText = buildAgentMessageText({
+			env: "sandbox",
+			isAdminInstall: true,
+			newSession: true,
+			params: { text: "who am I acting as" },
+		});
+		expect(adminText).toContain("admin bypass install");
+
+		const nonAdminText = buildAgentMessageText({
+			env: "sandbox",
+			isAdminInstall: false,
+			newSession: true,
+			params: { text: "who am I acting as" },
+		});
+		expect(nonAdminText).not.toContain("admin bypass install");
+
+		const resumedAdminText = buildAgentMessageText({
+			env: "sandbox",
+			isAdminInstall: true,
+			newSession: false,
+			params: { text: "who am I acting as" },
+		});
+		expect(resumedAdminText).not.toContain("admin bypass install");
 	});
 
 	test("does not inject org context on resumed sessions", () => {

--- a/apps/leaf/tests/unit/harness/common/messageText.test.ts
+++ b/apps/leaf/tests/unit/harness/common/messageText.test.ts
@@ -29,14 +29,14 @@ describe("Harness message text", () => {
 		expect(extractUserMessageText(text)).toBe("attach pro");
 	});
 
-	test("adds the admin bypass note only for admin installs on a new session", () => {
+	test("adds the admin note only for admin installs on a new session", () => {
 		const adminText = buildAgentMessageText({
 			env: "sandbox",
 			isAdminInstall: true,
 			newSession: true,
 			params: { text: "who am I acting as" },
 		});
-		expect(adminText).toContain("admin bypass install");
+		expect(adminText).toContain("internal admin bot");
 
 		const nonAdminText = buildAgentMessageText({
 			env: "sandbox",
@@ -44,7 +44,7 @@ describe("Harness message text", () => {
 			newSession: true,
 			params: { text: "who am I acting as" },
 		});
-		expect(nonAdminText).not.toContain("admin bypass install");
+		expect(nonAdminText).not.toContain("internal admin bot");
 
 		const resumedAdminText = buildAgentMessageText({
 			env: "sandbox",
@@ -52,7 +52,21 @@ describe("Harness message text", () => {
 			newSession: false,
 			params: { text: "who am I acting as" },
 		});
-		expect(resumedAdminText).not.toContain("admin bypass install");
+		expect(resumedAdminText).not.toContain("internal admin bot");
+	});
+
+	test("interpolates the acting-as org slug into the admin note and won't redirect for the current org", () => {
+		const text = buildAgentMessageText({
+			env: "sandbox",
+			isAdminInstall: true,
+			newSession: true,
+			orgSlug: "acme_sandbox",
+			params: { text: 'use "acme_sandbox" org' },
+		});
+		expect(text).toContain('"acme_sandbox"');
+		expect(text).toContain("do NOT tell them to start a new thread");
+		// The redirect instruction is reserved for a genuinely different org.
+		expect(text).toContain("Only if they ask for a DIFFERENT org");
 	});
 
 	test("does not inject org context on resumed sessions", () => {

--- a/apps/leaf/tests/unit/harness/common/messageText.test.ts
+++ b/apps/leaf/tests/unit/harness/common/messageText.test.ts
@@ -63,8 +63,10 @@ describe("Harness message text", () => {
 			orgSlug: "acme_sandbox",
 			params: { text: 'use "acme_sandbox" org' },
 		});
-		expect(text).toContain('"acme_sandbox"');
+		expect(text).toContain("acme_sandbox");
 		expect(text).toContain("do NOT tell them to start a new thread");
+		// Acknowledge as a fresh instruction, not a pre-existing state.
+		expect(text).toContain("now acting as");
 		// The redirect instruction is reserved for a genuinely different org.
 		expect(text).toContain("Only if they ask for a DIFFERENT org");
 	});

--- a/apps/leaf/tests/unit/internal/autumnMcp/orgContextService.test.ts
+++ b/apps/leaf/tests/unit/internal/autumnMcp/orgContextService.test.ts
@@ -79,12 +79,15 @@ describe("Autumn org context service", () => {
 		expect(context?.text).not.toContain("Always use invoice mode.");
 	});
 
-	test("preloads rules, plans, and features in parallel and keeps partial context", async () => {
+	test("preloads org identity, rules, plans, and features in parallel and keeps partial context", async () => {
 		const calls: string[] = [];
 		const { logger, warnings } = createLogger();
 		const executeTool = async ({ toolName }: { toolName: string }) => {
 			calls.push(toolName);
 			if (toolName === "getAgentRules") throw new Error("rules unavailable");
+			if (toolName === "getCurrentOrganization") {
+				return { id: "org_123", name: "Resend", slug: "resend" };
+			}
 			return [{ id: "launch", name: "Launch" }];
 		};
 
@@ -97,9 +100,12 @@ describe("Autumn org context service", () => {
 
 		expect(calls.sort()).toEqual([
 			"getAgentRules",
+			"getCurrentOrganization",
 			"listFeatures",
 			"listPlans",
 		]);
+		expect(context?.text).toContain("getCurrentOrganization:");
+		expect(context?.text).toContain('"slug": "resend"');
 		expect(context?.text).toContain('"id": "launch"');
 		expect(warnings).toHaveLength(1);
 	});


### PR DESCRIPTION
The Slack admin bypass agent was never given the impersonated org's identity or any admin-mode framing, so it narrated a normal single-org install: refusing to switch orgs and claiming it could not see the org name, even while the plumbing had correctly locked the thread onto the target org.

Preload getCurrentOrganization into the session org context alongside agent rules, plans, and features so the agent can name the org it is acting as. On a new session for an admin install, add a preamble line stating it is an admin bypass install operating inside another org's account, mirroring the existing environment-lock note.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack admin bypass sessions that lacked org identity and misled users about org switching. Previously the agent behaved like a single‑org install and redirected on any “act as <org>” request; now we preload org identity, name the acting‑as org/environment, acknowledge the selection as fresh (“now acting as <slug>”), and only redirect for a different org.

- Review notes:
  - orgContextService: preloads getCurrentOrganization with getAgentRules, listPlans, and listFeatures; includes all results in the formatted context; preserves partial context and logs warnings on failures.
  - buildAgentMessageText: on new admin sessions, adds an admin‑bypass preamble that names the current org/environment, instructs confirm‑vs‑redirect for org requests, and tells the agent not to re‑call getCurrentOrganization/getAgentRules/listPlans/listFeatures unless needed.
  - runAgentTurn: detects admin installs via isInternalAutumnSlackProvider, sets isAdminInstall, and passes orgSlug for preamble interpolation.
  - Tests cover the admin preamble, org identity block, slug interpolation, “now acting as” wording, and confirm‑instead‑of‑redirect behavior.

- Rollout:
  - Non‑admin installs are unchanged.
  - Adds one tool call at session start; failures degrade gracefully.

<sup>Written for commit 61724391bcef8e0ba943257099fc655fec29928c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

