### PR TITLE
fix: approve grouped writes on internal Slack threads and keep re-issued cards visible

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/consumeResumedAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/consumeResumedAgentTurn.ts
@@ -27,6 +27,20 @@ const parsedResultText = (output: unknown): unknown => {
 	}
 };
 
+/** Eve explains a write it did not run — denied, ignored, invalid option —
+ * inside the result payload; surface that or the failure is undiagnosable. */
+const rejectionDetail = (output: unknown) => {
+	const record = output as
+		| { approval?: { status?: string }; code?: string; message?: string }
+		| undefined;
+	if (!record || typeof record !== "object") return undefined;
+	return {
+		approval_status: record.approval?.status,
+		code: record.code,
+		message: record.message,
+	};
+};
+
 const isFailedActionResult = (event: {
 	result?: { output?: unknown };
 	status?: string;
@@ -113,6 +127,7 @@ export const consumeResumedAgentTurn = async ({
 				data: {
 					call_id: event.result?.callId,
 					failed: isFailedActionResult(event),
+					rejection: rejectionDetail(event.result?.output),
 					status: event.status,
 					tool: event.result?.toolName,
 				},

--- a/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
+++ b/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
@@ -12,6 +12,7 @@ import {
 } from "../../agentRuntime/eve/parkedInput.js";
 import { getEveSessionBySessionId } from "../../agentRuntime/eve/repo.js";
 import type { EveAuthContext } from "../../agentRuntime/eve/types.js";
+import { isInternalAutumnSlackProvider } from "../../slackAdmin/provider.js";
 import type { ApprovalRunResult } from "../types.js";
 import { createChainedApproval } from "./createChainedApproval.js";
 
@@ -31,10 +32,11 @@ const approvalAuth = ({
 	workspaceId: approval.workspace_id,
 });
 
-const GROUP_RENDERING_PROVIDERS: ReadonlySet<string> = new Set(["slack"]);
-
+/** Slack cards render every write in a parked batch, so approving the card
+ * approves the group; the dashboard shows the primary write alone. Internal
+ * Slack threads use the `slack_admin:<client>` provider and the same card. */
 const surfaceRendersGroup = (provider: string) =>
-	GROUP_RENDERING_PROVIDERS.has(provider);
+	provider === "slack" || isInternalAutumnSlackProvider({ provider });
 
 export const submitApprovalInput = async ({
 	approval,
@@ -122,6 +124,7 @@ export const submitApprovalInput = async ({
 			data: { session_id: session.sessionId, tool: approval.tool_name },
 		});
 		return {
+			chainedApprovalId,
 			error: true,
 			message: text || ACTION_FAILED_MESSAGE,
 			retryable: false,

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -356,8 +356,10 @@ export const handleApprovalActionWithDeps = async ({
 			}
 		}
 		// The resumed turn can park again (chained write or a question) where
-		// nothing streams — surface those as fresh cards or they stay invisible.
-		if (!failed && event.thread) {
+		// nothing streams — surface those as fresh cards or they stay invisible,
+		// even when an earlier step failed: the re-issued write is how the user
+		// recovers from that failure.
+		if (event.thread) {
 			try {
 				if ("chainedApprovalId" in result && result.chainedApprovalId) {
 					const chained = await deps.getApproval({

--- a/apps/leaf/src/internal/approvals/types.ts
+++ b/apps/leaf/src/internal/approvals/types.ts
@@ -19,6 +19,9 @@ export type ApprovalRunResult =
 	// `retryable` means the write never ran to completion (a session crash /
 	// interruption), so the approval stays pending and the user can re-apply.
 	| {
+			/** A write the resumed turn re-issued after a step failed — it still
+			 * needs its own card, or the session waits on it in silence. */
+			chainedApprovalId?: string;
 			error: true;
 			message: string;
 			retryable?: boolean;

--- a/apps/leaf/src/providers/web/actions/decideWebApproval.ts
+++ b/apps/leaf/src/providers/web/actions/decideWebApproval.ts
@@ -1,6 +1,7 @@
 import { discardApproval } from "../../../internal/approvals/actions/discardApproval.js";
 import { resolveApproval } from "../../../internal/approvals/actions/resolveApproval.js";
 import { chatApprovalRepo } from "../../../internal/approvals/repos/chatApprovalRepo.js";
+import { WEB_CHAT_PROVIDER } from "../../../internal/installations/actions/ensureWebChatAuth.js";
 import { db } from "../../../lib/db.js";
 import { logger } from "../../../lib/logger.js";
 
@@ -21,7 +22,13 @@ export const decideWebApproval = async ({
 	providerUserId: string;
 }): Promise<WebApprovalDecision> => {
 	const approval = await chatApprovalRepo.get({ approvalId, db });
-	if (!approval || approval.org_id !== orgId) {
+	// The dashboard renders only its own approvals (and only a group's primary
+	// write), so it must not decide cards another surface showed.
+	if (
+		!approval ||
+		approval.org_id !== orgId ||
+		approval.provider !== WEB_CHAT_PROVIDER
+	) {
 		return { error: "Approval not found" };
 	}
 	if (approval.status !== "pending") {

--- a/apps/leaf/tests/unit/harness/resume-eve-approval.test.ts
+++ b/apps/leaf/tests/unit/harness/resume-eve-approval.test.ts
@@ -71,6 +71,17 @@ await mockLeafModule({
 	}),
 });
 
+const chainedInserts: { toolName: string }[] = [];
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/actions/createChainedApproval.js",
+	factory: () => ({
+		createChainedApproval: async (input: { chained: { toolName: string } }) => {
+			chainedInserts.push({ toolName: input.chained.toolName });
+			return `chained_${chainedInserts.length}`;
+		},
+	}),
+});
+
 const { discardApproval } = await import(
 	"../../../src/internal/approvals/actions/discardApproval.js"
 );
@@ -476,7 +487,12 @@ describe("same-tool groups attribute each result to its own step", () => {
 			callId,
 			output: failed
 				? {
-						content: [{ type: "text", text: '{"message":"Autumn API request failed (400): boom","code":"invalid_request"}' }],
+						content: [
+							{
+								type: "text",
+								text: '{"message":"Autumn API request failed (400): boom","code":"invalid_request"}',
+							},
+						],
 						isError: true,
 					}
 				: { content: [{ type: "text", text: '{"ok":true}' }] },
@@ -533,7 +549,9 @@ describe("grouped approval is surface-scoped", () => {
 			run_id: "eve_session_1",
 			tool_args: {
 				_eveSiblingRequestIds: ["req_2"],
-				_eveWithheldWrites: [{ requestId: "req_2", toolName: "autumn__attach" }],
+				_eveWithheldWrites: [
+					{ requestId: "req_2", toolName: "autumn__attach" },
+				],
 			},
 			tool_call_id: "req_1",
 			tool_name: "autumn__updateCustomer",
@@ -544,10 +562,21 @@ describe("grouped approval is surface-scoped", () => {
 		streamedEvents = [
 			{ type: "turn.started" },
 			{ type: "step.started" },
-			{ result: { callId: "c1", output: { ok: true }, toolName: "autumn__updateCustomer" }, status: "completed", type: "action.result" },
+			{
+				result: {
+					callId: "c1",
+					output: { ok: true },
+					toolName: "autumn__updateCustomer",
+				},
+				status: "completed",
+				type: "action.result",
+			},
 			{ type: "session.waiting" },
 		];
-		await resumeApproval({ approval: groupedFor("slack"), providerUserId: "U1" });
+		await resumeApproval({
+			approval: groupedFor("slack"),
+			providerUserId: "U1",
+		});
 		expect(postedResponses.at(-1)).toMatchObject({
 			approveSiblings: true,
 			siblingRequestIds: ["req_2"],
@@ -558,10 +587,129 @@ describe("grouped approval is surface-scoped", () => {
 		streamedEvents = [
 			{ type: "turn.started" },
 			{ type: "step.started" },
-			{ result: { callId: "c1", output: { ok: true }, toolName: "autumn__updateCustomer" }, status: "completed", type: "action.result" },
+			{
+				result: {
+					callId: "c1",
+					output: { ok: true },
+					toolName: "autumn__updateCustomer",
+				},
+				status: "completed",
+				type: "action.result",
+			},
 			{ type: "session.waiting" },
 		];
 		await resumeApproval({ approval: groupedFor("web"), providerUserId: "U1" });
 		expect(postedResponses.at(-1)?.approveSiblings).not.toBe(true);
+	});
+});
+
+// Internal Autumn threads run on the `slack_admin:<client>` provider and render
+// the same grouped card, so approving it must approve every write it showed.
+describe("grouped approvals on internal Slack threads", () => {
+	beforeEach(() => {
+		streamedEvents = EMPTY_TURN;
+		postedResponses.length = 0;
+	});
+
+	test("approves the siblings for a slack_admin provider", async () => {
+		await resumeApproval({
+			approval: {
+				...approval({ _eveSiblingRequestIds: ["req_2"] }),
+				provider: "slack_admin:7771931436213.11262719726241",
+			} as ChatApproval,
+			providerUserId: "U1",
+		});
+
+		expect(postedResponses).toEqual([
+			{
+				approveSiblings: true,
+				optionId: "approve",
+				requestId: "req_1",
+				siblingRequestIds: ["req_2"],
+			},
+		]);
+	});
+
+	test("withholds the siblings for the dashboard, which shows one write", async () => {
+		await resumeApproval({
+			approval: {
+				...approval({ _eveSiblingRequestIds: ["req_2"] }),
+				provider: "web",
+			} as ChatApproval,
+			providerUserId: "U1",
+		});
+
+		expect(postedResponses[0]?.approveSiblings).toBe(false);
+	});
+});
+
+// A sibling that eve rejected gets re-issued by the model as its own step; the
+// card for that re-park must still reach the surface even though the approval
+// itself is reported failed — otherwise the session waits on it in silence.
+describe("grouped approvals that fail a step and park again", () => {
+	beforeEach(() => {
+		postedResponses.length = 0;
+		chainedInserts.length = 0;
+	});
+
+	test("returns the chained approval alongside the failure", async () => {
+		streamedEvents = [
+			{ type: "turn.started" },
+			{ type: "step.started" },
+			{
+				result: {
+					callId: "c2",
+					output: {
+						approval: { requestId: "req_2", status: "denied" },
+						code: "TOOL_EXECUTION_DENIED",
+						message: "Tool execution was denied.",
+					},
+					toolName: "autumn__attach",
+				},
+				status: "rejected",
+				type: "action.result",
+			},
+			{
+				result: {
+					callId: "c1",
+					output: { ok: true },
+					toolName: "autumn__updateCustomer",
+				},
+				status: "completed",
+				type: "action.result",
+			},
+			{
+				requests: [
+					{
+						action: {
+							callId: "c3",
+							input: { request: { customer_id: "cus_1", plan_id: "pro" } },
+							toolName: "autumn__attach",
+						},
+						options: [
+							{ id: "approve", label: "Approve" },
+							{ id: "deny", label: "Deny" },
+						],
+						requestId: "req_3",
+					},
+				],
+				type: "input.requested",
+			},
+		];
+
+		const result = await resumeApproval({
+			approval: groupedApproval(),
+			providerUserId: "U1",
+		});
+
+		expect(chainedInserts).toEqual([{ toolName: "autumn__attach" }]);
+		expect(result).toMatchObject({
+			chainedApprovalId: "chained_1",
+			error: true,
+			steps: [
+				{ status: "applied", toolName: "autumn__updateCustomer" },
+				{ status: "failed", toolName: "autumn__attach" },
+			],
+		});
 	});
 });

--- a/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
+++ b/server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts
@@ -13,6 +13,27 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusService } from "@/internal/customers/CusService";
 
+/** The caller's customer may be a snapshot taken before a concurrent
+ * customers.update committed; pushing its email to Stripe would echo the stale
+ * value back through the customer.updated webhook and overwrite the new one. */
+const latestCustomerEmail = async ({
+	ctx,
+	customer,
+}: {
+	ctx: AutumnContext;
+	customer: Customer;
+}) => {
+	const idOrInternalId = customer.id || customer.internal_id;
+	if (!idOrInternalId) return customer.email;
+	const current = await CusService.get({
+		db: ctx.db,
+		env: ctx.env,
+		idOrInternalId,
+		orgId: ctx.org.id,
+	});
+	return current?.email ?? customer.email;
+};
+
 export const getOrCreateStripeCustomer = async ({
 	ctx,
 	customer,
@@ -38,18 +59,19 @@ export const getOrCreateStripeCustomer = async ({
 	});
 
 	if (currentStripeCustomer) {
+		const email = await latestCustomerEmail({ ctx, customer });
 		if (
-			customer.email &&
-			currentStripeCustomer.email !== customer.email &&
+			email &&
+			currentStripeCustomer.email !== email &&
 			!orgDisableStripeWrites({ ctx })
 		) {
 			const stripeCli = createStripeCli({ org: ctx.org, env: ctx.env });
 			await stripeCli.customers.update(
 				currentStripeCustomer.id,
-				{ email: customer.email },
+				{ email },
 				autumnStripeRequestOptions({ source: "customer.update" }),
 			);
-			return { ...currentStripeCustomer, email: customer.email };
+			return { ...currentStripeCustomer, email };
 		}
 
 		return currentStripeCustomer;

--- a/server/src/external/stripe/webhookHandlers/handleStripeCustomerUpdated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCustomerUpdated.ts
@@ -1,5 +1,6 @@
 import { notNullish } from "@autumn/shared";
 import type Stripe from "stripe";
+import { isAutumnOriginatedStripeEvent } from "@/external/stripe/common/autumnStripeIdempotency.js";
 import { CusService } from "@/internal/customers/CusService.js";
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer.js";
 import type { StripeWebhookContext } from "../webhookMiddlewares/stripeWebhookContext.js";
@@ -21,6 +22,10 @@ export async function handleStripeCustomerUpdated({
 }) {
 	const { logger, fullCustomer } = ctx;
 	if (!fullCustomer) return;
+	// Autumn's own pushes are never news, and one made from a stale customer
+	// snapshot (e.g. an attach racing a customers.update) would overwrite the
+	// newer value if it were synced back.
+	if (isAutumnOriginatedStripeEvent({ event })) return;
 
 	const stripeCustomer = event.data.object;
 	const update: { name?: string; email?: string } = {};


### PR DESCRIPTION
## Summary
Root-causes the Slack thread where a grouped "update email + attach transactional_pro" card applied the email, showed the attach as denied, then went silent.

Three stacked bugs (Axiom + prod DB rows + local repro):

1. **Grouped sibling denied on internal Slack threads** — `surfaceRendersGroup` only matched provider `"slack"`; that thread runs on `slack_admin:<client>`, so the sibling attach was answered `deny` (Eve reported it rejected before anything ran). Now any Slack provider (`slack`, `slack_admin:*`) approves the group it rendered.
2. **Thread goes silent after a failed step** — the re-issued attach's approval row was created (`chat_app_c4a798…`) but the failure result dropped its id, so no card was posted and the session waited on it. The failure result now carries `chainedApprovalId` and Slack surfaces it regardless of step outcome.
3. **Server lost update** (found while reproducing): `customers.update` racing `billing.attach` — the attach pushed its stale email snapshot to Stripe and the `customer.updated` webhook synced it back over the new value (lost 5/6 locally). `getOrCreateStripeCustomer` now re-reads the current email before pushing, and the webhook ignores Autumn-originated echoes (8/8 after).

Resumed tool results now log Eve's rejection reason (`approval_status`/`code`) so this is diagnosable next time.

## Test plan
- Unit: slack_admin provider approves siblings; web withholds; failed step + re-park still returns chainedApprovalId.
- Live: grouped email+attach via leaf → Eve → MCP → sandbox API, 3/3 grouped runs keep the email and attach.
- API race: parallel update+attach 8/8 keep the new email.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes grouped approvals on internal Slack threads, scopes dashboard decisions to dashboard-only, and prevents silent waits after a failed step. Previously, `slack_admin:*` threads denied grouped siblings and a re-issued write stayed invisible; the web endpoint could decide non-web approvals. Now Slack threads approve the full group, re-issued cards are always posted, and web can only decide `web` approvals.

- Grouped approvals: treat any Slack provider (`slack`, `slack_admin:*`) as rendering the group; `web` approves only the primary write and only for `web` approvals.
- Failed step recovery: return `chainedApprovalId` from failed approvals and always fetch/render that card on Slack threads, even when an earlier step failed.
- Observability: include `approval_status`, `code`, and `message` from Eve in resumed tool result logs.
- Stripe lost update guard: `getOrCreateStripeCustomer` re-reads the latest customer email before writing to Stripe; `handleStripeCustomerUpdated` ignores Autumn-originated events to prevent echoing stale emails over newer values.

<sup>Written for commit cefe07f9a47376b762a3a9f1d11a208c6ce8ef25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes grouped approval handling in internal Slack threads, restores visibility for re-issued approval cards, and reduces stale-email feedback from Stripe.
- **Bug fixes:** Internal Slack approvals now authorize all writes displayed in a grouped card, while dashboard approvals are restricted to dashboard-owned records.
- **Bug fixes:** Failed resumed turns retain the chained approval ID so Slack can show the next approval card instead of leaving the session waiting silently.
- **Improvements:** Resumed tool logs now include rejection status, code, and message.
- **Bug fixes:** Stripe synchronization re-reads customer email before writing and ignores Autumn-originated webhook echoes, although the previously reported read-to-write race remains.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a concurrent customer update can still leave Stripe with an older email.

The new email re-read and subsequent Stripe update are separate unlocked operations, so another update can commit between them; the stale Autumn-originated Stripe webhook is then ignored and does not repair the mismatch.

**Files Needing Attention:** server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts; server/src/external/stripe/webhookHandlers/handleStripeCustomerUpdated.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts | Extends grouped approval authorization to internal Slack providers and preserves chained approval IDs on failed turns. |
| apps/leaf/src/internal/approvals/surfaces/slack/decide.ts | Displays chained approval cards even when an earlier resumed step failed. |
| apps/leaf/src/providers/web/actions/decideWebApproval.ts | Restricts dashboard decisions to approvals created for the web provider, closing the previously reported cross-surface bypass. |
| server/src/external/stripe/customers/operations/getOrCreateStripeCustomer.ts | Re-reads the customer email before updating Stripe, but a concurrent update can still commit between that read and the external write. |
| server/src/external/stripe/webhookHandlers/handleStripeCustomerUpdated.ts | Prevents Autumn-originated Stripe events from echoing customer fields back into Autumn. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Slack
    participant Leaf
    participant Eve
    participant DB
    User->>Slack: Approve grouped card
    Slack->>Leaf: Submit approval
    Leaf->>Eve: Approve primary and displayed siblings
    Eve-->>Leaf: Step failure plus re-issued write
    Leaf->>DB: Store chained approval
    Leaf-->>Slack: Post new approval card
    Slack-->>User: Show recovery action
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: dashboard approval decisions only a..."](https://github.com/useautumn/autumn/commit/cefe07f9a47376b762a3a9f1d11a208c6ce8ef25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54808158)</sub>

<!-- /greptile_comment -->