### PR TITLE
feat(website): raise free plan limits on the pricing page

### DIFF
--- a/apps/website/components/pricing.tsx
+++ b/apps/website/components/pricing.tsx
@@ -37,8 +37,8 @@ const plans: Plan[] = [
 		description: "Perfect while finding PMF. Everything you need to start.",
 		features: [
 			{ label: "8K monthly billing volume" },
-			{ label: "3,000 customers and entities" },
-			{ label: "1M API requests included" },
+			{ label: "10,000 customers and entities" },
+			{ label: "10M API requests included" },
 			{ label: "CLI and MCP" },
 			{ label: "Community support" },
 		],


### PR DESCRIPTION
Bumps the Free plan's advertised limits on `/pricing`:

- 3,000 → **10,000** customers and entities
- 1M → **10M** API requests included

`bun run build` and `tsc --noEmit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Free plan limits shown on the pricing page to match the current offering. Previously: 3,000 customers/entities and 1M API requests; now: 10,000 customers/entities and 10M API requests. This is a website-only copy change; it does not affect billing or rate limits.

**Review notes**
- Change is limited to apps/website/components/pricing.tsx; no backend or config updates.
- Verify the Free plan feature list on /pricing shows the new numbers at all breakpoints.
- No migrations or rollout steps required.

<sup>Written for commit b194e46374e5dbb70fb005ee5319721918f601b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the public pricing page to advertise higher Free-plan capacity.
- **[Improvements]** Raises the advertised customer and entity limit from 3,000 to 10,000.
- **[Improvements]** Raises the advertised included API requests from 1 million to 10 million.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only updates the intended pricing-page labels and introduces no identified code failure.

The modified strings render directly as Free-plan marketing copy, and no conflicting in-repository pricing value, runtime dependency, or behavioral regression was found.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/website/components/pricing.tsx | Updates two static Free-plan feature labels; no concrete defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["feat(website): raise free plan limits on..."](https://github.com/useautumn/autumn/commit/b194e46374e5dbb70fb005ee5319721918f601b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54810984)</sub>

**Context used:**

- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)

<!-- /greptile_comment -->