### PR TITLE
ci: check out before the leaf evals paths filter

### DIFF
--- a/.github/workflows/leaf-evals.yml
+++ b/.github/workflows/leaf-evals.yml
@@ -20,6 +20,10 @@ jobs:
     outputs:
       leaf: ${{ steps.filter.outputs.leaf }}
     steps:
+      # paths-filter diffs via the API on pull_request but needs a local repo on push.
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Check changed files
         id: filter
         uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050


### PR DESCRIPTION
The `Leaf Evals` workflow's `changes` job ran `dorny/paths-filter` without a checkout. On `pull_request` the action diffs via the GitHub API, but on `push` (the `dev` baseline run) it needs a local repo, so it failed with `fatal: not a git repository` — the failing check on the dev → main PR (#2901).

Adds the checkout step before the filter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checks out the repo before running `dorny/paths-filter` in the `Leaf Evals` workflow’s `changes` job. Previously the job ran the filter without a checkout, which works on `pull_request` (API diff) but fails on `push` (needs local git), causing the dev baseline run to error with “fatal: not a git repository.” Now `push` runs succeed; `pull_request` behavior is unchanged.

<sup>Written for commit 4c3c090cb1c2d4f518320ed36e75064ff16bba60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the Leaf Evals workflow by checking out the repository before its changed-path filter runs on push events.
- **Bug fixes:** Add a checkout step so push-based path filtering has a local Git repository.
- **Improvements:** Document why checkout is required before the filter.
</details>

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking supply-chain hardening issue in the new checkout step.

The checkout fixes push-based path filtering as intended, while pinning its action to an immutable commit would prevent future upstream tag changes from altering CI behavior.

**Files Needing Attention:** .github/workflows/leaf-evals.yml

<details open><summary><h3>Security Review</h3></summary>

The new checkout dependency uses a mutable version tag. Pinning it to a full commit SHA would prevent upstream tag changes from silently changing the code executed by CI.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/leaf-evals.yml | Correctly adds the checkout required for push filtering, but references the action through a mutable version tag. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/leaf-evals.yml:25
**Mutable checkout action reference**

If the upstream `v4` tag is reassigned or compromised, this job executes unreviewed action code with read access to repository and pull-request data, and change detection can be disrupted. Pin `actions/checkout` to a full commit SHA to make the CI dependency immutable.

**How this was verified:** The added step references the mutable `actions/checkout@v4` tag and runs with `contents: read` and `pull-requests: read` permissions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: check out before the leaf evals path..."](https://github.com/useautumn/autumn/commit/4c3c090cb1c2d4f518320ed36e75064ff16bba60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54812708)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->