### PR TITLE
fix: dismiss an approval once when the button is clicked twice

### DIFF
--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -221,7 +221,12 @@ export const handleApprovalActionWithDeps = async ({
 			// and the discarded write can still run later.
 			if (cancelled.harness === "eve") {
 				const discard = deps.discardApproval ?? discardApproval;
-				const denied = await discard({ approval: cancelled, providerUserId });
+				// The row is already cancelled, so a deny eve drops would leave its
+				// turn parked behind a card nobody can click — one retry is cheap.
+				let denied = await discard({ approval: cancelled, providerUserId });
+				if ("error" in denied && denied.error) {
+					denied = await discard({ approval: cancelled, providerUserId });
+				}
 				if ("error" in denied && denied.error) {
 					deps.logger.warn("Could not deny Eve approval on dismiss", {
 						event: "leaf.eve_dismiss_deny_failed",

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -201,11 +201,27 @@ export const handleApprovalActionWithDeps = async ({
 		}
 
 		if (event.actionId === "cancel_billing_action") {
+			// Cancel first so exactly one click wins: the Eve denial below takes
+			// seconds, and a second click in that window would otherwise read the
+			// row as still pending and discard (and reply) all over again.
+			const cancelled = await deps.cancelApproval({
+				approvalId,
+				providerUserId,
+			});
+			if (!cancelled) {
+				deps.logger.warn("Approval cancellation ignored", {
+					event: "leaf.approval_cancel_ignored",
+					approval_id: approvalId,
+				});
+				await editToCurrentStatus();
+				return;
+			}
 			// Eve parks the whole turn on the approval — deny it in the session too,
 			// or it keeps waiting, holds the next message behind the stale approval,
 			// and the discarded write can still run later.
-			if (approval.harness === "eve" && approval.status === "pending") {
-				const denied = await discardApproval({ approval, providerUserId });
+			if (cancelled.harness === "eve") {
+				const discard = deps.discardApproval ?? discardApproval;
+				const denied = await discard({ approval: cancelled, providerUserId });
 				if ("error" in denied && denied.error) {
 					deps.logger.warn("Could not deny Eve approval on dismiss", {
 						event: "leaf.eve_dismiss_deny_failed",
@@ -219,18 +235,6 @@ export const handleApprovalActionWithDeps = async ({
 						// The acknowledgement reply is cosmetic.
 					}
 				}
-			}
-			const cancelled = await deps.cancelApproval({
-				approvalId,
-				providerUserId,
-			});
-			if (!cancelled) {
-				deps.logger.warn("Approval cancellation ignored", {
-					event: "leaf.approval_cancel_ignored",
-					approval_id: approvalId,
-				});
-				await editToCurrentStatus();
-				return;
 			}
 			await deps.editActionMessage({
 				content: approvalStatusCard({

--- a/apps/leaf/src/internal/approvals/types.ts
+++ b/apps/leaf/src/internal/approvals/types.ts
@@ -63,6 +63,10 @@ export type ApprovalActionDeps = {
 		approvalId: string;
 		providerUserId: string;
 	}) => Promise<ChatApproval | undefined>;
+	discardApproval?: (input: {
+		approval: ChatApproval;
+		providerUserId: string;
+	}) => Promise<ApprovalRunResult>;
 	releaseApproval?: (input: {
 		approvalId: string;
 		providerUserId: string;

--- a/apps/leaf/src/providers/web/actions/decideWebApproval.ts
+++ b/apps/leaf/src/providers/web/actions/decideWebApproval.ts
@@ -42,7 +42,13 @@ export const decideWebApproval = async ({
 			db,
 			providerUserId,
 		});
-		if (!cancelled) return { error: "Approval already decided" };
+		if (!cancelled) {
+			// A repeated reject that lost the race still rejected the card.
+			const current = await chatApprovalRepo.get({ approvalId, db });
+			return current?.status === "cancelled"
+				? { status: "rejected" }
+				: { error: "Approval already decided" };
+		}
 		// Deny Eve remotely so discarded writes cannot resume later.
 		let text: string | undefined;
 		if (cancelled.harness === "eve") {

--- a/apps/leaf/src/providers/web/actions/decideWebApproval.ts
+++ b/apps/leaf/src/providers/web/actions/decideWebApproval.ts
@@ -36,12 +36,21 @@ export const decideWebApproval = async ({
 	}
 
 	if (action === "reject") {
+		// Cancel first so a repeated click cannot deny in Eve twice.
+		const cancelled = await chatApprovalRepo.cancel({
+			approvalId,
+			db,
+			providerUserId,
+		});
+		if (!cancelled) return { error: "Approval already decided" };
 		// Deny Eve remotely so discarded writes cannot resume later.
 		let text: string | undefined;
-		if (approval.harness === "eve") {
-			// Always cancel locally even if the remote denial fails.
+		if (cancelled.harness === "eve") {
 			try {
-				const denied = await discardApproval({ approval, providerUserId });
+				const denied = await discardApproval({
+					approval: cancelled,
+					providerUserId,
+				});
 				if ("error" in denied && denied.error) {
 					logger.warn("Could not deny Eve approval on reject", {
 						event: "leaf.eve_reject_deny_failed",
@@ -59,7 +68,6 @@ export const decideWebApproval = async ({
 				});
 			}
 		}
-		await chatApprovalRepo.cancel({ approvalId, db, providerUserId });
 		return { status: "rejected", text };
 	}
 

--- a/apps/leaf/tests/unit/approvals/flow.test.ts
+++ b/apps/leaf/tests/unit/approvals/flow.test.ts
@@ -405,3 +405,69 @@ describe("approval flow", () => {
 		expect(JSON.stringify(edits[0])).toContain("expired");
 	});
 });
+
+describe("dismissing an approval", () => {
+	// A double-click (or a retried Slack interaction) lands the second click
+	// while the first is still denying in Eve. Only the first may discard and
+	// reply; the second must find the row already decided and do nothing.
+	test("a second dismiss click discards and replies only once", async () => {
+		setLeafTestEnv();
+		const { handleApprovalActionWithDeps } = await import(
+			"../../../src/internal/approvals/surfaces/slack/decide.js"
+		);
+		const approval = {
+			env: AppEnv.Sandbox,
+			expires_at: Date.now() + 60_000,
+			harness: "eve",
+			id: "approval_1",
+			status: "pending",
+			tool_name: "attach",
+			tool_args: { request: { customer_id: "cus_1", plan_id: "pro" } },
+		} as unknown as ChatApproval;
+		const event = {
+			actionId: "cancel_billing_action",
+			messageId: "message_1",
+			threadId: "thread_1",
+			user: { userId: "U1" },
+			value: "approval_1",
+		} as unknown as ActionEvent;
+		let cancelWins = 1;
+		const discards: string[] = [];
+		const replies: string[] = [];
+		const deps = {
+			resolveApproval: async () => {
+				throw new Error("should not run");
+			},
+			cancelApproval: async () =>
+				cancelWins-- > 0
+					? ({ ...approval, status: "cancelled" } as ChatApproval)
+					: undefined,
+			claimApproval: async () => undefined,
+			discardApproval: async ({
+				approval: discarded,
+			}: {
+				approval: ChatApproval;
+			}) => {
+				discards.push(discarded.id);
+				return {
+					result: {},
+					text: "Discarded. What would you like different?",
+				};
+			},
+			editActionMessage: async () => {},
+			getApproval: async () => approval,
+			logger: { error: () => {}, info: () => {}, warn: () => {} },
+			postThreadReply: async ({ markdown }: { markdown: string }) => {
+				replies.push(markdown);
+			},
+		};
+
+		await Promise.all([
+			handleApprovalActionWithDeps({ deps, event }),
+			handleApprovalActionWithDeps({ deps, event }),
+		]);
+
+		expect(discards).toEqual(["approval_1"]);
+		expect(replies).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
Triage of https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1787159555495419 — the agent posted "Discarded. What would you like different…" twice.

**Cause (Axiom):** two `approval_action_received` for the same approval from the same user 2s apart (double-click). The dismiss branch denied the write in Eve first (seconds: Eve resumes, model replies) and cancelled the row only afterwards, so the second click still saw `status: pending` and ran the whole discard again.

**Fix:** cancel the row first (`cancel` is an atomic `pending → cancelled`; only one click gets the row), then deny in Eve and reply. Same ordering applied to the dashboard reject path. `discardApproval` is now an injectable dep on the Slack handler so this is unit-testable.

**Red/green:** new test fires two concurrent dismiss clicks and asserts one discard + one reply — fails on `dev`, passes here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double discard and duplicate replies when an approval is dismissed/rejected twice. Previously we denied in Eve before cancelling the DB row, so a second click could re-discard and reply; now we cancel first (atomic pending → cancelled) so only one click wins, then deny in Eve. Repeated dashboard rejects now return success instead of an error, and Slack denial retries once to avoid stranding Eve.

- Slack dismiss path: call `cancelApproval` first; if already decided, warn and update the message; if Eve, call `discardApproval` (with one retry) and then edit the card and reply once.
- Web reject path: cancel-first ordering; if cancellation lost the race, return `{ status: "rejected" }` when the row is already cancelled, otherwise an "already decided" error; deny in Eve only if cancellation succeeded.
- Types: add optional `discardApproval` to `ApprovalActionDeps` so the Slack handler can be unit-tested.
- Tests: new unit test issues two concurrent dismiss clicks and asserts exactly one discard and one reply.

<sup>Written for commit 50214593072b28b975fac67786ba088be31c19d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes dismissal and rejection race-safe by atomically cancelling an approval before notifying Eve.

- **Bug fixes, Improvements:** Makes one Slack dismissal win when a user clicks twice, preventing duplicate discard replies.
- **Bug fixes:** Makes repeated dashboard rejection return the already-completed rejection instead of displaying a false failure.
- **API changes, Improvements:** Adds an injectable discard dependency to support focused concurrency tests.
- **Bug fixes:** Adds a concurrent Slack dismissal test that verifies only one discard and reply occur.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a temporary Eve outage can leave a cancelled approval permanently blocking the agent session.

Cancelling the local row before Eve accepts the denial removes the only actionable approval, while exhausting two immediate denial attempts merely logs the failure and provides no durable retry or reconciliation path.

**Files Needing Attention:** apps/leaf/src/internal/approvals/surfaces/slack/decide.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/approvals/surfaces/slack/decide.ts | Moves cancellation before Eve denial and adds one immediate retry, but failed denial attempts can still leave Eve waiting behind a terminal local approval. |
| apps/leaf/src/providers/web/actions/decideWebApproval.ts | Serializes concurrent rejection through atomic cancellation and treats an already-cancelled approval as successfully rejected. |
| apps/leaf/src/internal/approvals/types.ts | Adds an optional injectable discard dependency without changing the default production implementation. |
| apps/leaf/tests/unit/approvals/flow.test.ts | Verifies that two concurrent Slack dismissals produce only one discard and one reply. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant H as Approval handler
  participant DB as Approval database
  participant E as Eve
  U->>H: Dismiss twice
  par First request
    H->>DB: Cancel pending approval
    DB-->>H: Cancelled approval
    H->>E: Deny approval
    E-->>H: Resume agent turn
  and Second request
    H->>DB: Cancel pending approval
    DB-->>H: No row updated
    H-->>U: Show current status
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: retry the eve denial once on dismis..."](https://github.com/useautumn/autumn/commit/50214593072b28b975fac67786ba088be31c19d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54846125)</sub>

**Context used:**

- Knowledge Base — [Leaf: Autumn's AI Agent Service](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/leaf-agent-app.md)

<!-- /greptile_comment -->