### PR TITLE
fix: recover a thread whose eve session is gone instead of deadlocking it

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/prepareAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/prepareAgentTurn.ts
@@ -1,8 +1,8 @@
-import { autumnOrgContextService } from "../../../../autumnMcp/orgContextService.js";
 import { db } from "../../../../../lib/db.js";
-import type { AgentTurnContext } from "../../../domain/agentTurnContext.js";
-import { getEveSession } from "../../../eve/repo.js";
 import { withdrawSupersededApprovals } from "../../../../approvals/actions/withdrawSupersededApprovals.js";
+import { autumnOrgContextService } from "../../../../autumnMcp/orgContextService.js";
+import type { AgentTurnContext } from "../../../domain/agentTurnContext.js";
+import { deleteEveSession, getEveSession } from "../../../eve/repo.js";
 import type { EveAuthContext } from "../../../eve/types.js";
 
 export const prepareAgentTurn = async ({
@@ -34,7 +34,7 @@ export const prepareAgentTurn = async ({
 		} as const;
 	}
 
-	await withdrawSupersededApprovals({
+	const { sessionGone } = await withdrawSupersededApprovals({
 		auth,
 		logger,
 		onApprovalsSuperseded,
@@ -43,5 +43,21 @@ export const prepareAgentTurn = async ({
 		session: existingSession,
 		thread,
 	});
+	if (sessionGone) {
+		// Eve lost the session; keeping its row would replay the same dead
+		// resume on every message, so this turn starts a fresh conversation.
+		await deleteEveSession({
+			db,
+			env,
+			orgId: org.id,
+			sessionId: existingSession.sessionId,
+			threadKey: existingSession.threadKey,
+		});
+		await onAction?.("Loading context");
+		return {
+			existingSession: undefined,
+			orgContext: await autumnOrgContextService.load({ env, logger, token }),
+		} as const;
+	}
 	return { existingSession, orgContext: undefined } as const;
 };

--- a/apps/leaf/src/internal/agentRuntime/eve/client.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/client.ts
@@ -32,6 +32,19 @@ const eveHeaders = (auth: EveAuthContext, init?: HeadersInit) => {
 	return headers;
 };
 
+/** Eve no longer has the session behind our continuation token — every
+ * further post to it fails the same way, so callers should drop the session
+ * rather than retry or block on it. */
+export class EveSessionGoneError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveSessionGoneError";
+	}
+}
+
+const SESSION_GONE_PATTERN =
+	/not found via continuation token|session (was )?not found/i;
+
 const parseSessionResponse = async ({
 	existing,
 	response,
@@ -40,7 +53,15 @@ const parseSessionResponse = async ({
 	response: Response;
 }) => {
 	if (!response.ok) {
-		throw new Error(`Eve session request failed: ${response.status}`);
+		const body = await response.text().catch(() => "");
+		if (response.status === 404 || SESSION_GONE_PATTERN.test(body)) {
+			throw new EveSessionGoneError(
+				`Eve session is gone (${response.status}): ${body.slice(0, 200)}`,
+			);
+		}
+		throw new Error(
+			`Eve session request failed: ${response.status}${body ? ` ${body.slice(0, 200)}` : ""}`,
+		);
 	}
 	const body = (await response.json()) as {
 		continuationToken?: string;

--- a/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
@@ -1,10 +1,33 @@
 import type { ChatApproval } from "@autumn/shared";
 import { db } from "../../../lib/db.js";
 import { logger } from "../../../lib/logger.js";
+import { APPROVAL_SESSION_GONE_MESSAGE } from "../../../ui/messages.js";
+import { EveSessionGoneError } from "../../agentRuntime/eve/client.js";
+import {
+	deleteEveSession,
+	getEveSessionBySessionId,
+} from "../../agentRuntime/eve/repo.js";
 import { chatApprovalRepo } from "../repos/chatApprovalRepo.js";
 import type { ApprovalRunResult } from "../types.js";
 import { approvalErrorResult } from "../utils/approvalErrors.js";
 import { resumeApproval } from "./resumeApproval.js";
+
+const dropEveSession = async ({ approval }: { approval: ChatApproval }) => {
+	if (!approval.run_id) return;
+	const session = await getEveSessionBySessionId({
+		db,
+		orgId: approval.org_id,
+		sessionId: approval.run_id,
+	});
+	if (!session) return;
+	await deleteEveSession({
+		db,
+		env: session.env,
+		orgId: approval.org_id,
+		sessionId: session.sessionId,
+		threadKey: session.threadKey,
+	});
+};
 
 const releaseClaim = async ({
 	approval,
@@ -53,6 +76,26 @@ export const resolveApproval = async ({
 			providerUserId,
 		});
 	} catch (error) {
+		if (error instanceof EveSessionGoneError) {
+			// Eve lost the session this card belongs to; no retry can run it, and
+			// leaving it pending would block the thread behind a dead card.
+			logger.error("[chat] Approval session is gone", error, {
+				event: "leaf.approval_session_gone",
+				approval_id: approval.id,
+			});
+			await chatApprovalRepo.finalize({
+				approvalId: approval.id,
+				db,
+				providerUserId,
+				status: "failed",
+			});
+			await dropEveSession({ approval });
+			return {
+				error: true,
+				message: APPROVAL_SESSION_GONE_MESSAGE,
+				retryable: false,
+			};
+		}
 		// A thrown resumer error means the write never ran — release the claim so
 		// the row returns to pending and the card stays clickable.
 		logger.error("[chat] Approval run failed", error, {

--- a/apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts
+++ b/apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts
@@ -5,7 +5,10 @@ import { APPROVAL_STILL_OPEN_MESSAGE } from "../../../ui/messages.js";
 import { drainParkedAgentTurn } from "../../agentRuntime/actions/submitAgentInput/drainParkedAgentTurn.js";
 import type { AgentThreadRef } from "../../agentRuntime/domain/agentTurnContext.js";
 import { adoptPostedEveSession } from "../../agentRuntime/eve/adoptPostedSession.js";
-import { postEveInputResponse } from "../../agentRuntime/eve/client.js";
+import {
+	EveSessionGoneError,
+	postEveInputResponse,
+} from "../../agentRuntime/eve/client.js";
 import { siblingRequestIdsFromToolArgs } from "../../agentRuntime/eve/parkedInput.js";
 import { saveEveSessionState } from "../../agentRuntime/eve/sessionState.js";
 import type {
@@ -23,6 +26,8 @@ const withdrawnNote = (toolName: string) =>
 			: ""
 	})`;
 
+type WithdrawOutcome = "withdrawn" | "undecided" | "session_gone";
+
 const withdrewInEve = async ({
 	approval,
 	auth,
@@ -35,8 +40,8 @@ const withdrewInEve = async ({
 	logger: AutumnLogger;
 	orgId: string;
 	session: EveSessionRef;
-}) => {
-	if (!approval.tool_call_id) return true;
+}): Promise<WithdrawOutcome> => {
+	if (!approval.tool_call_id) return "withdrawn";
 	try {
 		const posted = await postEveInputResponse({
 			auth,
@@ -48,14 +53,24 @@ const withdrewInEve = async ({
 		});
 		adoptPostedEveSession({ posted, session, status: "running" });
 		await drainParkedAgentTurn({ auth, orgId, session });
-		return true;
+		return "withdrawn";
 	} catch (error) {
+		// A session eve has lost can never decide this card; the card is dead
+		// with it, and the thread must not stay blocked on it.
+		if (error instanceof EveSessionGoneError) {
+			logger.warn("Eve session is gone; cancelling its pending approval", {
+				event: "leaf.eve_superseded_approval_session_gone",
+				approval_id: approval.id,
+				data: { error: error.message, session_id: session.sessionId },
+			});
+			return "session_gone";
+		}
 		logger.warn("Could not deny superseded Eve approval", {
 			event: "leaf.eve_superseded_approval_deny_failed",
 			approval_id: approval.id,
 			data: { error: error instanceof Error ? error.message : String(error) },
 		});
-		return false;
+		return "undecided";
 	}
 };
 
@@ -93,7 +108,7 @@ export const withdrawSupersededApprovals = async ({
 	providerUserId: string;
 	session: EveSessionRef;
 	thread: AgentThreadRef;
-}) => {
+}): Promise<{ sessionGone: boolean }> => {
 	const pendingApprovals = await chatApprovalRepo.listPendingForRun({
 		db,
 		channelId: thread.channelId,
@@ -103,15 +118,24 @@ export const withdrawSupersededApprovals = async ({
 		runId: session.sessionId,
 		workspaceId: thread.workspaceId,
 	});
-	if (pendingApprovals.length === 0) return;
+	if (pendingApprovals.length === 0) return { sessionGone: false };
 
 	const cancelledApprovals: ChatApproval[] = [];
 	const undecidedApprovals: ChatApproval[] = [];
+	let sessionGone = false;
 	for (const approval of pendingApprovals) {
-		if (!(await withdrewInEve({ approval, auth, logger, orgId, session }))) {
+		const outcome = await withdrewInEve({
+			approval,
+			auth,
+			logger,
+			orgId,
+			session,
+		});
+		if (outcome === "undecided") {
 			undecidedApprovals.push(approval);
 			continue;
 		}
+		if (outcome === "session_gone") sessionGone = true;
 		const cancelled = await chatApprovalRepo.cancel({
 			approvalId: approval.id,
 			db,
@@ -123,7 +147,7 @@ export const withdrawSupersededApprovals = async ({
 	if (cancelledApprovals.length > 0) {
 		await onApprovalsSuperseded?.(cancelledApprovals);
 	}
-	if (undecidedApprovals.length === 0) return;
+	if (undecidedApprovals.length === 0) return { sessionGone };
 
 	await rehomeUndecidedApprovals({
 		approvals: undecidedApprovals,

--- a/apps/leaf/src/ui/messages.ts
+++ b/apps/leaf/src/ui/messages.ts
@@ -17,6 +17,9 @@ export const CREDENTIAL_WITHHELD_MESSAGE =
 
 // Approvals
 
+export const APPROVAL_SESSION_GONE_MESSAGE =
+	"This conversation's session has ended, so this request can't be applied — send it again and I'll start fresh.";
+
 export const APPROVAL_STILL_OPEN_MESSAGE =
 	"there's still an open approval card on this thread — approve or discard it before sending a new message";
 

--- a/apps/leaf/tests/unit/harness/resume-eve-approval.test.ts
+++ b/apps/leaf/tests/unit/harness/resume-eve-approval.test.ts
@@ -18,6 +18,13 @@ const mockLeafModule = ({
 	specifier: string;
 }) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
 
+class MockEveSessionGoneError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveSessionGoneError";
+	}
+}
+let sessionGone = false;
 let streamedEvents: EveEvent[] = [];
 const postedResponses: {
 	approveSiblings?: boolean;
@@ -29,12 +36,18 @@ let session: EveSessionRef;
 await mockLeafModule({
 	specifier: "../../../src/internal/agentRuntime/eve/client.js",
 	factory: () => ({
+		EveSessionGoneError: MockEveSessionGoneError,
 		postEveInputResponse: async (input: {
 			approveSiblings?: boolean;
 			optionId: string;
 			requestId: string;
 			siblingRequestIds?: string[];
 		}) => {
+			if (sessionGone) {
+				throw new MockEveSessionGoneError(
+					"Eve session is gone (500): target session was not found via continuation token.",
+				);
+			}
 			postedResponses.push({
 				approveSiblings: input.approveSiblings,
 				optionId: input.optionId,
@@ -49,11 +62,37 @@ await mockLeafModule({
 	}),
 });
 
+const deletedSessionIds: string[] = [];
 await mockLeafModule({
 	specifier: "../../../src/internal/agentRuntime/eve/repo.js",
 	factory: () => ({
+		deleteEveSession: async ({ sessionId }: { sessionId: string }) => {
+			deletedSessionIds.push(sessionId);
+		},
 		getEveSessionBySessionId: async () => session,
 		upsertEveSession: async () => undefined,
+	}),
+});
+
+const finalized: Array<{ approvalId: string; status: string }> = [];
+const released: string[] = [];
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/repos/chatApprovalRepo.js",
+	factory: () => ({
+		chatApprovalRepo: {
+			finalize: async ({
+				approvalId,
+				status,
+			}: {
+				approvalId: string;
+				status: string;
+			}) => {
+				finalized.push({ approvalId, status });
+			},
+			release: async ({ approvalId }: { approvalId: string }) => {
+				released.push(approvalId);
+			},
+		},
 	}),
 });
 
@@ -82,6 +121,9 @@ await mockLeafModule({
 	}),
 });
 
+const { resolveApproval } = await import(
+	"../../../src/internal/approvals/actions/resolveApproval.js"
+);
 const { discardApproval } = await import(
 	"../../../src/internal/approvals/actions/discardApproval.js"
 );
@@ -711,5 +753,29 @@ describe("grouped approvals that fail a step and park again", () => {
 				{ status: "failed", toolName: "autumn__attach" },
 			],
 		});
+	});
+});
+
+// Eve has lost the session (its transcript broke terminally). Returning the card
+// to pending would block the thread behind a card nothing can ever run.
+describe("resolveApproval when eve has lost the session", () => {
+	beforeEach(() => {
+		sessionGone = true;
+		finalized.length = 0;
+		released.length = 0;
+		deletedSessionIds.length = 0;
+	});
+
+	test("finalizes the card as failed, drops the session, and does not retry", async () => {
+		const result = await resolveApproval({
+			approval: approval(),
+			providerUserId: "U1",
+		});
+
+		expect(result).toMatchObject({ error: true, retryable: false });
+		expect(finalized).toEqual([{ approvalId: "a_1", status: "failed" }]);
+		expect(released).toEqual([]);
+		expect(deletedSessionIds).toEqual(["eve_session_1"]);
+		sessionGone = false;
 	});
 });

--- a/apps/leaf/tests/unit/harness/withdraw-superseded-eve-approvals.test.ts
+++ b/apps/leaf/tests/unit/harness/withdraw-superseded-eve-approvals.test.ts
@@ -53,12 +53,20 @@ await mockLeafModule({
 	}),
 });
 
+class MockEveSessionGoneError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveSessionGoneError";
+	}
+}
 const failingRequestIds = new Set<string>();
+const goneRequestIds = new Set<string>();
 const postedNotes: string[] = [];
 const postedRequestIds: string[] = [];
 await mockLeafModule({
 	specifier: "../../../src/internal/agentRuntime/eve/client.js",
 	factory: () => ({
+		EveSessionGoneError: MockEveSessionGoneError,
 		postEveInputResponse: async ({
 			note,
 			requestId,
@@ -70,6 +78,11 @@ await mockLeafModule({
 			postedRequestIds.push(requestId);
 			if (failingRequestIds.has(requestId)) {
 				throw new Error("Eve session request failed: 503");
+			}
+			if (goneRequestIds.has(requestId)) {
+				throw new MockEveSessionGoneError(
+					"Eve session is gone (500): Cannot deliver inputResponses — the target session was not found via continuation token.",
+				);
 			}
 			// Eve re-homes on every post here, so a persisted session id proves the
 			// caller saved the ref rather than dropping it.
@@ -154,6 +167,7 @@ describe("withdrawSupersededApprovals", () => {
 	beforeEach(() => {
 		pendingApprovals = [];
 		failingRequestIds.clear();
+		goneRequestIds.clear();
 		cancelledApprovalIds.length = 0;
 		postedRequestIds.length = 0;
 		postedNotes.length = 0;
@@ -276,5 +290,33 @@ describe("withdrawSupersededApprovals", () => {
 		expect(postedRequestIds).toEqual([]);
 		expect(cancelledApprovalIds).toEqual([]);
 		expect(supersededBatches).toEqual([]);
+	});
+});
+
+// Eve has lost the session (its transcript broke terminally): the card can
+// never be decided through it, so blocking the thread on it would deadlock
+// the conversation until the card expires.
+describe("withdrawSupersededApprovals when eve has lost the session", () => {
+	beforeEach(() => {
+		goneRequestIds.clear();
+		cancelledApprovalIds.length = 0;
+		supersededBatches = [];
+	});
+
+	test("cancels the card, does not block the turn, and reports the dead session", async () => {
+		pendingApprovals = [approval("a_1", "tc_1")];
+		goneRequestIds.add("tc_1");
+
+		const result = await withdraw();
+
+		expect(result).toEqual({ sessionGone: true });
+		expect(cancelledApprovalIds).toEqual(["a_1"]);
+		expect(supersededBatches).toHaveLength(1);
+	});
+
+	test("reports a live session when every withdrawal went through", async () => {
+		pendingApprovals = [approval("a_1", "tc_1")];
+
+		expect(await withdraw()).toEqual({ sessionGone: false });
 	});
 });


### PR DESCRIPTION
Triage of https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1787160178581719 (approve → "not executed", then every message → "Message failed").

**Root cause (Axiom leaf + ecs logs):** eve's model call failed terminally right after the approve — Anthropic rejected the session transcript (`messages.44: tool_use ids were found without tool_result blocks … toolu_014E81…`, errorIds `dbbdf007…`/`464619c5…`, session `wrun_01M0DG163DK1DXAY84HGYBJ0Y4`). From then on eve answered `Cannot deliver inputResponses — the target session was not found via continuation token` (500). That upstream transcript bug is eve's; this PR fixes how leaf behaves once it happens.

**Leaf's part:** the approve saw no execution and released the card back to `pending`; the next message tried to deny that card in eve, got the 500, treated it as undecided and aborted with "there's still an open approval card…" — a deadlock until the card expired.

**Fix:**
- `eve/client`: raise `EveSessionGoneError` for 404 / "session not found via continuation token" responses (with the body in the message).
- `resolveApproval`: on a gone session finalize the card as failed (not retryable), drop the eve session row, reply with a clear message.
- `withdrawSupersededApprovals`: on a gone session cancel the card instead of blocking, and report `sessionGone`; `prepareAgentTurn` then deletes the session and starts a fresh conversation for the new message.

**Red/green:** new tests for both paths fail on `dev` and pass here; leaf suite 337/337.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents chat deadlocks when Eve loses a session by detecting “session gone” responses and recovering the thread. Previously, we retried/blocked on a dead approval card; now we finalize/cancel the card, drop the session, and start a fresh conversation.

- Eve client raises EveSessionGoneError on 404 or “not found via continuation token” responses, including response text in the error.
- resolveApproval: finalizes the affected approval as failed (non‑retryable), deletes the Eve session row, and replies with a clear user message.
- withdrawSupersededApprovals: cancels pending cards tied to the dead session, reports sessionGone to the caller, and does not block the turn.
- prepareAgentTurn: if sessionGone, deletes the Eve session and loads context to start a new conversation for the incoming message.
- Adds APPROVAL_SESSION_GONE_MESSAGE and targeted unit tests for both approval resolution and superseded withdrawals.

<sup>Written for commit e4b00e39556ab263653a8291def5fa62c14d984f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows Leaf to recover when Eve no longer recognizes a saved conversation session.
- **Bug fixes:** Classifies Eve's missing-session responses, fails unrecoverable approval cards, and removes dead session records.
- **Improvements:** Cancels superseded approvals tied to a lost session and starts the user's next message in a fresh conversation.
- **Bug fixes:** Adds unit coverage for approval resolution and superseded-approval recovery.
</details>


<h3>Confidence Score: 4/5</h3>

The mixed-outcome approval path should be fixed before merging because it can preserve a session already known to be dead and keep the thread blocked.

The normal lost-session paths recover correctly, but a batch containing both a session-gone response and an ordinary withdrawal failure throws before prepareAgentTurn can delete the dead session.

**Files Needing Attention:** apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts, apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/prepareAgentTurn.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/eve/client.ts | Adds a dedicated error for HTTP responses indicating that Eve no longer has a continuation session. |
| apps/leaf/src/internal/approvals/actions/resolveApproval.ts | Finalizes approvals as failed and removes their saved Eve session when continuation is impossible. |
| apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts | Cancels approvals attached to a lost session, but mixed withdrawal outcomes can discard the session-gone signal and skip recovery. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/prepareAgentTurn.ts | Starts a fresh conversation after a returned session-gone result, though it cannot do so when withdrawal throws first. |
| apps/leaf/tests/unit/harness/resume-eve-approval.test.ts | Covers failing and finalizing an approval when Eve has lost its session. |
| apps/leaf/tests/unit/harness/withdraw-superseded-eve-approvals.test.ts | Covers isolated session-gone recovery but not a batch containing both session-gone and ordinary withdrawal failures. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[New message with pending approvals] --> B[Withdraw each approval in Eve]
  B --> C{Outcome}
  C -->|Withdrawn| D[Cancel local card]
  C -->|Session gone| E[Cancel local card and mark session gone]
  C -->|Other failure| F[Keep card undecided]
  D --> G{Any undecided cards?}
  E --> G
  F --> G
  G -->|No| H[Return session status]
  H -->|Gone| I[Delete saved session and start fresh]
  H -->|Live| J[Continue existing session]
  G -->|Yes| K[Throw open-card error]
  K --> L[Dead session cleanup is skipped]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts`, line 150-157 ([link](https://github.com/useautumn/autumn/blob/e4b00e39556ab263653a8291def5fa62c14d984f/apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts#L150-L157)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mixed outcomes preserve dead sessions**

   When one approval reports that the Eve session is gone and another withdrawal returns an ordinary error, this branch throws and discards the `sessionGone` result, so `prepareAgentTurn` never deletes the known-dead session and later messages can repeatedly fail instead of starting fresh.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts
   Line: 150-157

   Comment:
   **Mixed outcomes preserve dead sessions**

   When one approval reports that the Eve session is gone and another withdrawal returns an ordinary error, this branch throws and discards the `sessionGone` result, so `prepareAgentTurn` never deletes the known-dead session and later messages can repeatedly fail instead of starting fresh.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts:150-157
**Mixed outcomes preserve dead sessions**

When one approval reports that the Eve session is gone and another withdrawal returns an ordinary error, this branch throws and discards the `sessionGone` result, so `prepareAgentTurn` never deletes the known-dead session and later messages can repeatedly fail instead of starting fresh.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: recover a thread whose eve session ..."](https://github.com/useautumn/autumn/commit/e4b00e39556ab263653a8291def5fa62c14d984f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54855051)</sub>

<!-- /greptile_comment -->