### PR TITLE
fix: handle active Postgres client errors

### DIFF
--- a/server/src/db/pgPoolMonitor.ts
+++ b/server/src/db/pgPoolMonitor.ts
@@ -165,6 +165,11 @@ export const attachPoolErrorHandlers = ({
 	pool: Pool;
 	name: string;
 }): void => {
+	const activeClientErrorHandlers = new WeakMap<
+		PoolClient,
+		(error: Error & { code?: string }) => void
+	>();
+
 	pool.on("error", (err: Error & { code?: string }) => {
 		logger.warn("pg_pool_error", {
 			type: "pg_pool_error",
@@ -175,6 +180,31 @@ export const attachPoolErrorHandlers = ({
 			error_name: err.name,
 			error_message: err.message,
 		});
+	});
+
+	pool.on("acquire", (client) => {
+		const handleError = (err: Error & { code?: string }) => {
+			logger.warn("pg_client_error", {
+				type: "pg_client_error",
+				pool: name,
+				pid: process.pid,
+				role: getRole(),
+				error_code: err.code,
+				error_name: err.name,
+				error_message: err.message,
+			});
+		};
+
+		activeClientErrorHandlers.set(client, handleError);
+		client.on("error", handleError);
+	});
+
+	pool.on("release", (_error, client) => {
+		const handleError = activeClientErrorHandlers.get(client);
+		if (!handleError) return;
+
+		client.off("error", handleError);
+		activeClientErrorHandlers.delete(client);
 	});
 };
 

--- a/server/tests/unit/db/pg-pool-monitor.test.ts
+++ b/server/tests/unit/db/pg-pool-monitor.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Active Postgres connection drops must stay inside the pool instead of killing the process.
+ * Red: acquired errors are unhandled. Green: they are logged until release.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import type { Pool, PoolClient } from "pg";
+
+const warn = mock((..._args: unknown[]) => {});
+mock.module("@/external/logtail/logtailUtils.js", () => ({
+	logger: {
+		info: mock(() => {}),
+		warn,
+		error: mock(() => {}),
+		debug: mock(() => {}),
+		child: () => ({}),
+	},
+}));
+
+const { attachPoolErrorHandlers } = await import("@/db/pgPoolMonitor.js");
+
+const createPool = () => new EventEmitter() as unknown as Pool;
+const createClient = () => new EventEmitter() as unknown as PoolClient;
+
+describe("attachPoolErrorHandlers", () => {
+	test("handles an acquired client connection drop without an uncaught error", () => {
+		const pool = createPool();
+		const client = createClient();
+		attachPoolErrorHandlers({ pool, name: "general" });
+
+		pool.emit("acquire", client);
+		expect(() =>
+			client.emit("error", new Error("Connection terminated unexpectedly")),
+		).not.toThrow();
+
+		expect(warn).toHaveBeenCalledWith(
+			"pg_client_error",
+			expect.objectContaining({
+				pool: "general",
+				error_message: "Connection terminated unexpectedly",
+			}),
+		);
+	});
+
+	test("removes the active client listener when the client is released", () => {
+		const pool = createPool();
+		const client = createClient();
+		attachPoolErrorHandlers({ pool, name: "general" });
+
+		pool.emit("acquire", client);
+		expect(client.listenerCount("error")).toBe(1);
+
+		pool.emit("release", undefined, client);
+		expect(client.listenerCount("error")).toBe(0);
+	});
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents active PostgreSQL client errors from becoming unhandled process errors and adds focused lifecycle coverage.
- **[Bug fixes]** Listen for errors while a PostgreSQL client is checked out and log connection failures with pool and process context.
- **[Improvements]** Remove each client-specific listener when the client returns to the pool.
- **[Improvements]** Add unit tests covering active-client errors and listener cleanup.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/db/pgPoolMonitor.ts | Adds scoped error listeners for checked-out PostgreSQL clients and removes them on release; no blocking issue was established. |
| server/tests/unit/db/pg-pool-monitor.test.ts | Adds focused tests confirming active connection errors are handled and listeners are cleaned up. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into og/fix/pg-clien..."](https://github.com/useautumn/autumn/commit/b24dae0a3859fd25f611b729afa80efb3b053e8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54875839)</sub>

<!-- /greptile_comment -->