### PR TITLE
fix: keep license links in plan responses for API ≤ 2.1.0

### DIFF
--- a/server/tests/unit/shared/planVersionChanges.licenses.test.ts
+++ b/server/tests/unit/shared/planVersionChanges.licenses.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AffectedResource,
+	type ApiPlanExpandedV1,
+	ApiVersion,
+	ApiVersionClass,
+	AppEnv,
+	AttachAction,
+	applyResponseVersionChanges,
+	EligibilityStatus,
+	type SharedContext,
+} from "@autumn/shared";
+
+const ctx = {} as SharedContext;
+
+const buildPlan = (): ApiPlanExpandedV1 => ({
+	id: "pro",
+	name: "Pro Plan",
+	description: null,
+	group: null,
+	version: 1,
+	add_on: false,
+	auto_enable: false,
+	price: null,
+	items: [],
+	created_at: 1771513979217,
+	env: AppEnv.Sandbox,
+	archived: false,
+	base_variant_id: null,
+	config: { ignore_past_due: false },
+	metadata: {},
+	customer_eligibility: {
+		attach_action: AttachAction.Upgrade,
+		trial_available: true,
+		status: EligibilityStatus.Active,
+		canceling: false,
+		trialing: false,
+	},
+	licenses: [
+		{
+			license_plan_id: "seat",
+			version: 2,
+			included: 5,
+			prepaid_only: true,
+		},
+	],
+});
+
+const downgradePlan = ({ to }: { to: ApiVersion }) =>
+	applyResponseVersionChanges<ApiPlanExpandedV1>({
+		input: buildPlan(),
+		targetVersion: new ApiVersionClass(to),
+		resource: AffectedResource.Product,
+		ctx,
+	});
+
+describe("plan response version changes: licenses", () => {
+	test("V2.1 responses keep the plan's license links", () => {
+		const plan = downgradePlan({ to: ApiVersion.V2_1 });
+
+		expect(plan.licenses).toEqual([
+			{
+				license_plan_id: "seat",
+				version: 2,
+				included: 5,
+				prepaid_only: true,
+			},
+		]);
+	});
+
+	test("V2.1 responses still strip V2.2 customer_eligibility fields", () => {
+		const plan = downgradePlan({ to: ApiVersion.V2_1 });
+
+		expect(plan.customer_eligibility?.attach_action).toBe(AttachAction.Upgrade);
+		expect(plan.customer_eligibility?.trial_available).toBe(true);
+		expect(plan.customer_eligibility?.status).toBeUndefined();
+		expect(plan.customer_eligibility?.canceling).toBeUndefined();
+		expect(plan.customer_eligibility?.trialing).toBeUndefined();
+	});
+
+	test("V2.2 responses keep the plan's license links", () => {
+		const plan = downgradePlan({ to: ApiVersion.V2_2 });
+
+		expect(plan.licenses).toHaveLength(1);
+	});
+
+	test("plans without licenses stay without the field at V2.1", () => {
+		const { licenses: _licenses, ...planWithoutLicenses } = buildPlan();
+
+		const plan = applyResponseVersionChanges<ApiPlanExpandedV1>({
+			input: planWithoutLicenses,
+			targetVersion: new ApiVersionClass(ApiVersion.V2_1),
+			resource: AffectedResource.Product,
+			ctx,
+		});
+
+		expect(plan.licenses).toBeUndefined();
+	});
+});

--- a/shared/api/products/changes/V2.1_PlanChanges.ts
+++ b/shared/api/products/changes/V2.1_PlanChanges.ts
@@ -1,4 +1,7 @@
-import { type ApiPlanV1, ApiPlanV1Schema } from "@api/products/apiPlanV1.js";
+import {
+	type ApiPlanExpandedV1,
+	ApiPlanExpandedV1Schema,
+} from "@api/products/apiPlanV1.js";
 import { ApiVersion } from "@api/versionUtils/ApiVersion.js";
 import {
 	AffectedResource,
@@ -13,6 +16,10 @@ import {
  * - customer_eligibility.scenario removed from public response (internal only)
  *
  * For V2.1 clients, we strip the new fields and restore scenario.
+ *
+ * Schemas use the expanded plan shape: the transform output is re-parsed with
+ * `oldSchema`, and the plain ApiPlanV1Schema would silently strip the plan's
+ * `licenses` / `variants` edges from V2.1 responses.
  */
 export const V2_1_PlanChanges = defineVersionChange({
 	newVersion: ApiVersion.V2_2,
@@ -22,13 +29,17 @@ export const V2_1_PlanChanges = defineVersionChange({
 		"customer_eligibility: scenario kept for V2.1 backward compat",
 	],
 	affectedResources: [AffectedResource.Product],
-	newSchema: ApiPlanV1Schema,
-	oldSchema: ApiPlanV1Schema,
+	newSchema: ApiPlanExpandedV1Schema,
+	oldSchema: ApiPlanExpandedV1Schema,
 
 	affectsRequest: false,
 	affectsResponse: true,
 
-	transformResponse: ({ input }: { input: ApiPlanV1 }): ApiPlanV1 => {
+	transformResponse: ({
+		input,
+	}: {
+		input: ApiPlanExpandedV1;
+	}): ApiPlanExpandedV1 => {
 		if (!input.customer_eligibility) return input;
 
 		return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the regression Remy reported: `POST /v1/plans.list` stopped returning the `licenses` field for clients pinning `X-API-Version: 2.1.0` (like the `atmn` CLI, which pins `2.1.0` in `packages/atmn/src/lib/api/client.ts`). This broke `atmn pull` round-tripping of plan→license links and caused phantom drift in pull-based CI checks.

## Root cause

The V2.2 `customer_eligibility` change added a `V2_1_PlanChanges` downgrade transform (`shared/api/products/changes/V2.1_PlanChanges.ts`) that runs for every Product response served to clients at ≤ 2.1.0.

`defineVersionChange` re-parses each transform's output with the change's `oldSchema` (`oldSchema.safeParse(result)` in `shared/api/versionUtils/versionChangeUtils/VersionChange.ts`), and successful parses **strip unknown keys**. The transform was declared with `ApiPlanV1Schema`, but `licenses` (and `variants`) only exist on `ApiPlanExpandedV1Schema` — so the re-parse silently dropped them. Clients at ≥ 2.2.0 never run this transform, which is why the field still appeared there.

## Fix

Declare `V2_1_PlanChanges` with `ApiPlanExpandedV1Schema` as both `newSchema` and `oldSchema`, so the schema re-parse keeps the plan's `licenses` / `variants` edges while still downgrading `customer_eligibility` (stripping `status`, `canceling`, `trialing`) exactly as before. This restores the pre-regression 2.1.0 behavior, where expanded plan responses included license links.

## Testing

Added `server/tests/unit/shared/planVersionChanges.licenses.test.ts`, which exercises `applyResponseVersionChanges` the same way `handleListPlansV2` does:

- V2.1 responses keep the plan's license links (fails on the old code, passes with the fix)
- V2.1 responses still strip the V2.2 `customer_eligibility` fields
- V2.2 responses keep license links (unchanged behavior)
- Plans without licenses stay without the field at V2.1

Full `bun test:unit` run: 3370 passed / 4 failed — the same 4 failures occur on a clean checkout of `dev` (environment-related Redis shard failures on this VM), so no regressions from this change. `bunx biome check` is clean on the changed files; the `bun ts` failures are pre-existing missing optional modules in untouched `motherduck` files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d23b9c6c-b37d-4a66-aedc-b52d926c46bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d23b9c6c-b37d-4a66-aedc-b52d926c46bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps license links in plan responses for API ≤ 2.1.0. Old: 2.1 responses dropped the `licenses` field; New: 2.1 responses keep `licenses` (and `variants`) while still stripping v2.2-only `customer_eligibility` fields; ≥ 2.2 unchanged.

- Uses `ApiPlanExpandedV1Schema` for both `newSchema` and `oldSchema` in `V2_1_PlanChanges` to prevent re-parse from removing `licenses`/`variants`.
- Adds unit tests for `applyResponseVersionChanges` verifying: 2.1 keeps `licenses`, still strips `customer_eligibility.status/canceling/trialing`; 2.2 unchanged; plans without `licenses` remain without the field.
- No migrations or client changes required.

<sup>Written for commit 74f278bcd8af723def1b9ae419e848b1423e28f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores license links in plan responses for clients using API version 2.1 or earlier while retaining the existing eligibility-field downgrade.

- **Bug fixes, API changes:** Uses the expanded plan schema during the V2.1 response transform so license and variant links are not discarded.
- **Improvements:** Adds focused tests for preserving license links, stripping newer eligibility fields, retaining V2.2 behavior, and handling plans without licenses.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the changed response transform or its tests.

The expanded schema accepts every prior plan shape while preserving optional license and variant fields, and current transformed response paths do not expose incompatible nested data.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| shared/api/products/changes/V2.1_PlanChanges.ts | Widens the response transform schema to preserve optional expanded plan edges without changing the eligibility downgrade behavior. |
| server/tests/unit/shared/planVersionChanges.licenses.test.ts | Covers the reported V2.1 license-link regression and verifies the surrounding version-specific behavior. |

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into cursor/restore-..."](https://github.com/useautumn/autumn/commit/74f278bcd8af723def1b9ae419e848b1423e28f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54920818)</sub>

<!-- /greptile_comment -->