### PR TITLE
fix: persist additional plan currencies

### DIFF
--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/claimCurrentRows/claimBasePrice.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/claimCurrentRows/claimBasePrice.ts
@@ -1,4 +1,8 @@
-import { type Price, pricesAreSame } from "@autumn/shared";
+import {
+	type Price,
+	priceCurrencyDefinitionsAreSame,
+	pricesAreSame,
+} from "@autumn/shared";
 import type { ClaimedBasePrice } from "../types/claimResult";
 
 /** Claim the sole base pair only when definitions match. */
@@ -11,6 +15,9 @@ export const claimBasePrice = ({
 }): ClaimedBasePrice | undefined => {
 	if (!desiredBasePrice || !currentBasePrice) return undefined;
 	if (!pricesAreSame(desiredBasePrice, currentBasePrice)) return undefined;
+	if (!priceCurrencyDefinitionsAreSame(desiredBasePrice, currentBasePrice)) {
+		return undefined;
+	}
 
 	return {
 		desired: desiredBasePrice,

--- a/server/src/internal/products/actions/computeEntitlementPricesPlan/claimCurrentRows/claimEntitlementPrices.ts
+++ b/server/src/internal/products/actions/computeEntitlementPricesPlan/claimCurrentRows/claimEntitlementPrices.ts
@@ -2,6 +2,7 @@ import {
 	type EntitlementPrice,
 	EntitlementPriceMatchPrecision,
 	findEntitlementPriceSuccessor,
+	priceCurrencyDefinitionsAreSame,
 } from "@autumn/shared";
 import type { ClaimedEntitlementPrice } from "../types/claimResult";
 
@@ -20,7 +21,16 @@ export const claimEntitlementPrices = ({
 		const desired = findEntitlementPriceSuccessor({
 			sourceEntitlementPrice: current,
 			candidateEntitlementPrices: desiredEntitlementPrices.filter(
-				(candidate) => !claimedDesiredEntIds.has(candidate.entitlement.id),
+				(candidate) => {
+					if (claimedDesiredEntIds.has(candidate.entitlement.id)) return false;
+					if (!current.price || !candidate.price) {
+						return !current.price && !candidate.price;
+					}
+					return priceCurrencyDefinitionsAreSame(
+						current.price,
+						candidate.price,
+					);
+				},
 			),
 			matchPrecisions: [
 				EntitlementPriceMatchPrecision.EntitlementAndPriceDefinition,

--- a/server/tests/unit/products/computeEntitlementPricesPlan/computeEntitlementPricesPlan.test.ts
+++ b/server/tests/unit/products/computeEntitlementPricesPlan/computeEntitlementPricesPlan.test.ts
@@ -50,6 +50,14 @@ const ctx = contexts.create({
 	} as never,
 });
 
+const multiCurrencyCtx = contexts.create({
+	features: [messagesFeature, seatsFeature],
+	org: {
+		...ctx.org,
+		config: { ...ctx.org.config, multi_currency: true },
+	} as never,
+});
+
 const freeMessagesItem = (
 	overrides: Partial<CreatePlanItemParamsV1> = {},
 ): CreatePlanItemParamsV1 => ({
@@ -262,6 +270,73 @@ describe("computeEntitlementPricesPlan", () => {
 		expect(plan.prices.new).toHaveLength(1);
 		expect(plan.entitlements.new).toHaveLength(1);
 		expect(plan.prices.new[0].id).not.toBe("pr_messages");
+	});
+
+	test("3c. adding catalog currencies replaces base and feature prices", () => {
+		const currentEnt = entitlements.buildWithFeature({
+			id: "ent_messages",
+			internal_feature_id: messagesFeature.internal_id,
+			feature_id: messagesFeature.id,
+			feature: messagesFeature,
+			allowance: 100,
+			interval: EntInterval.Month,
+		});
+		const currentPrice = prices.buildUsage({
+			overrides: { id: "pr_messages", entitlement_id: "ent_messages" },
+		});
+		const currentBase = prices.buildFixed({
+			overrides: { id: "pr_base" },
+			configOverrides: { amount: 50 },
+		});
+
+		const plan = computeEntitlementPricesPlan({
+			ctx: multiCurrencyCtx,
+			params: {
+				mode: { type: "update", protectReferencedRows: false },
+				product,
+				customize: {
+					price: {
+						...basePrice,
+						additional_currencies: [{ currency: "eur", amount: 45 }],
+					},
+					items: [
+						pricedMessagesItem({
+							price: {
+								amount: 1,
+								additional_currencies: [{ currency: "eur", amount: 0.9 }],
+								interval: BillingInterval.Month,
+								billing_units: 1,
+								billing_method: BillingMethod.UsageBased,
+							},
+						}),
+					],
+				},
+				currentRows: {
+					prices: [currentBase, currentPrice],
+					entitlements: [currentEnt],
+				},
+			},
+		});
+
+		expect(plan.prices.same).toEqual([]);
+		expect(plan.prices.deleted.map((price) => price.id).sort()).toEqual([
+			"pr_base",
+			"pr_messages",
+		]);
+		expect(
+			plan.prices.new.find((price) => price.config.type === "fixed")?.config
+				.currencies,
+		).toEqual({ eur: { amount: 45 } });
+		expect(
+			plan.prices.new.find((price) => price.config.type === "usage")?.config
+				.currencies,
+		).toEqual({
+			eur: { usage_tiers: [{ amount: 0.9, to: "inf" }] },
+		});
+		expect(plan.prices.new.map((price) => price.config.base_currency)).toEqual([
+			"usd",
+			"usd",
+		]);
 	});
 
 	test("4. PUT remove feature → deleted / retired", () => {

--- a/shared/utils/productUtils/priceUtils/comparePrice/pricesAreSame.ts
+++ b/shared/utils/productUtils/priceUtils/comparePrice/pricesAreSame.ts
@@ -56,6 +56,27 @@ const currenciesAreCompatible = (
 	return true;
 };
 
+const currenciesHaveSameDefinition = (
+	currencies1: Record<string, PriceCurrencyConfig> | null | undefined,
+	currencies2: Record<string, PriceCurrencyConfig> | null | undefined,
+) => {
+	const keys1 = Object.keys(currencies1 ?? {});
+	const keys2 = Object.keys(currencies2 ?? {});
+	if (keys1.length !== keys2.length) return false;
+	return (
+		currenciesAreCompatible(currencies1, currencies2) &&
+		keys1.every((key) => currencies2?.[key] !== undefined)
+	);
+};
+
+export const priceCurrencyDefinitionsAreSame = (price1: Price, price2: Price) =>
+	(price1.config.base_currency ?? null) ===
+		(price2.config.base_currency ?? null) &&
+	currenciesHaveSameDefinition(
+		price1.config.currencies,
+		price2.config.currencies,
+	);
+
 // base_currency is FX bookkeeping — it appears/disappears with the currencies
 // map. Only treat a mismatch as a change when both sides already carry FX.
 const baseCurrenciesAreCompatible = ({
@@ -126,8 +147,7 @@ export const pricesAreSame = (
 			(usageConfig1.billing_units ?? 1) !== (usageConfig2.billing_units ?? 1),
 		interval: usageConfig1.interval !== usageConfig2.interval,
 		intervalCount:
-			(usageConfig1.interval_count ?? 1) !==
-			(usageConfig2.interval_count ?? 1),
+			(usageConfig1.interval_count ?? 1) !== (usageConfig2.interval_count ?? 1),
 		internalFeatureId:
 			usageConfig1.internal_feature_id !== usageConfig2.internal_feature_id,
 		featureId: usageConfig1.feature_id !== usageConfig2.feature_id,


### PR DESCRIPTION
Fix plan editor saves that reported success while discarding newly added or removed currencies.

`pricesAreSame` intentionally treats currency-key additions and removals as compatible for customer snapshot matching. The catalog persistence planner reused that compatibility check to claim database prices as unchanged, so it skipped writing the updated currency definition. Catalog row claims now additionally require exact currency definitions for both base and feature prices, without changing the broader snapshot compatibility behavior.

Adds planner coverage proving base and feature prices are replaced with their new currency maps and base currency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plan editor saves that reported success while discarding added or removed currencies. We now require exact currency definitions when claiming existing catalog prices, so currency changes persist.

- Introduces `priceCurrencyDefinitionsAreSame` in `@autumn/shared` and applies it when claiming base and entitlement prices; candidates must match base currency and currency keys.
- Keeps snapshot compatibility logic in `pricesAreSame` unchanged; only claim decisions are stricter for currencies.
- Planner now replaces base and usage prices when the currency map changes; tests cover multi-currency cases and verify new currency maps and base currency are written.
- No migrations. Note that changing currencies will retire and recreate price rows; do not assume stable price IDs across currency changes.

<sup>Written for commit 3467f46fafd6857603fbafae6a4896197da97ef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes catalog saves that previously reported success without persisting added or removed plan currencies.

- **Bug fixes:** Requires exact currency definitions before claiming existing base and feature prices as unchanged.
- **Improvements:** Keeps the broader compatibility behavior used for customer snapshot matching unchanged.
- **Improvements:** Adds planner coverage for replacing base and feature prices with updated currency maps and base currency.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the currency persistence fix aligned across base-price and feature-price planning.

Exact currency-definition checks now prevent changed prices from being incorrectly claimed as unchanged, while focused planner coverage verifies the resulting replacement rows contain the requested currencies and base currency.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/products/actions/computeEntitlementPricesPlan/claimCurrentRows/claimBasePrice.ts | Prevents an existing base price from being reused when its base currency or additional-currency definition differs. |
| server/src/internal/products/actions/computeEntitlementPricesPlan/claimCurrentRows/claimEntitlementPrices.ts | Filters feature-price successor candidates by exact currency definitions so currency edits produce replacement rows. |
| shared/utils/productUtils/priceUtils/comparePrice/pricesAreSame.ts | Adds a focused exact currency-definition comparator without changing the existing compatibility comparator. |
| server/tests/unit/products/computeEntitlementPricesPlan/computeEntitlementPricesPlan.test.ts | Verifies that adding currencies replaces both base and feature prices and preserves the requested currency values. |

<sub>Reviews (1): Last reviewed commit: ["fix: persist additional plan currencies"](https://github.com/useautumn/autumn/commit/3467f46fafd6857603fbafae6a4896197da97ef6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54946452)</sub>

<!-- /greptile_comment -->