### PR TITLE
fix(mcp): accept an optional intent when it is not required

### DIFF
--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -4,7 +4,7 @@ import { claimLatestPendingAction } from "../agent/pending-actions.js";
 import { instrumentToolsWithAnalytics } from "../analytics/index.js";
 import { type AutumnMcpAuth, getAutumnAuth } from "../server/auth/auth.js";
 import { domainModules, toolDomains } from "./domains.js";
-import { orgTools } from "./org.js";
+import { createOrgTools } from "./org.js";
 import { callAutumn } from "./utils/client.js";
 import {
 	dateToEpochMillisecondsTool,
@@ -19,7 +19,7 @@ import {
 	rawLocalPreviewTool,
 	toTools,
 } from "./utils/factories.js";
-import { requireIntentOnTools } from "./utils/intent.js";
+import { attachIntentToTools } from "./utils/intent.js";
 import type { ConfirmedWriteToolName } from "./utils/types.js";
 
 const {
@@ -100,10 +100,10 @@ const createRawAutumnOperationToolset = ({
 		),
 		...toTools(localPreviews, rawLocalPreviewTool),
 		...toTools(confirmedWrites, operationTool),
-		...orgTools,
+		...createOrgTools(),
 	};
 	return {
-		...(requireIntent ? requireIntentOnTools(operationTools) : operationTools),
+		...attachIntentToTools({ required: requireIntent, tools: operationTools }),
 		dateToEpochMilliseconds: dateToEpochMillisecondsTool,
 		epochMillisecondsToDate: epochMillisecondsToDateTool,
 	};
@@ -112,7 +112,8 @@ const createRawAutumnOperationToolset = ({
 /**
  * Build the Autumn MCP toolset. `requireIntent` (default true) forces a
  * one-sentence `intent` on every external tool call for analytics — disable it
- * for our own internal agent, which would otherwise fail when it omits it.
+ * for our own internal agent, which would otherwise fail when it omits it. Every
+ * tool still accepts an intent either way.
  */
 export const createRawAutumnOperationTools = ({
 	requireIntent = true,

--- a/packages/mcp/src/tools/org.ts
+++ b/packages/mcp/src/tools/org.ts
@@ -21,7 +21,8 @@ const organizationMeSchema = z.object({
 const signalOf = (context: { mcp?: { extra?: { signal?: AbortSignal } } }) =>
 	context?.mcp?.extra?.signal;
 
-export const orgTools = {
+/** Built per toolset: the intent and analytics layers mutate tools in place. */
+export const createOrgTools = () => ({
 	getCurrentOrganization: createTool({
 		id: "getCurrentOrganization",
 		description:
@@ -37,4 +38,4 @@ export const orgTools = {
 				}),
 			),
 	}),
-} as const;
+});

--- a/packages/mcp/src/tools/utils/intent.ts
+++ b/packages/mcp/src/tools/utils/intent.ts
@@ -23,15 +23,22 @@ export const getIntent = (input: unknown): string | undefined =>
 		: undefined;
 
 /**
- * Adds a required `intent` field to every tool's input schema, in place, so
- * external MCP clients must declare their goal on every call. Call this once on
- * a fully-built toolset (the intent is captured by the analytics layer).
+ * Adds an `intent` field to every tool's input schema, in place, so MCP clients
+ * declare their goal on every call. Call this once on a fully-built toolset (the
+ * intent is captured by the analytics layer).
+ *
+ * `required: false` still accepts an intent rather than dropping the field: tool
+ * inputs are strict, so a missing field rejects clients that volunteer one.
  *
  * Tools whose input isn't a plain object are left untouched.
  */
-export const requireIntentOnTools = <T extends Record<string, AnyTool>>(
-	tools: T,
-): T => {
+export const attachIntentToTools = <T extends Record<string, AnyTool>>({
+	required,
+	tools,
+}: {
+	required: boolean;
+	tools: T;
+}): T => {
 	for (const tool of Object.values(tools)) {
 		const schema = tool.inputSchema;
 		if (schema instanceof z.ZodObject) {
@@ -39,7 +46,7 @@ export const requireIntentOnTools = <T extends Record<string, AnyTool>>(
 			// JSON-schema-augmented schema (incompatible at the type level only), so
 			// route the reassignment through `unknown`.
 			tool.inputSchema = schema.extend({
-				intent: intentSchema,
+				intent: required ? intentSchema : intentSchema.optional(),
 			}) as unknown as typeof tool.inputSchema;
 		}
 	}

--- a/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/agent/tools.test.ts
@@ -22,6 +22,17 @@ type ExecutableTool = {
 	execute?: (input: unknown, context: unknown) => Promise<unknown>;
 };
 
+const parseToolInput = ({
+	tool,
+	input,
+}: {
+	tool: { inputSchema?: unknown };
+	input: unknown;
+}) => {
+	const schema = tool.inputSchema as { parse: (value: unknown) => unknown };
+	return schema.parse(input);
+};
+
 const auth: AutumnMcpAuth = {
 	apiKey: "sk_test",
 	env: "sandbox",
@@ -66,6 +77,46 @@ describe("Autumn operation tools", () => {
 		expect(tools.previewAttach.description).toContain("Billing resource");
 		expect(tools.attach.description).toContain("Billing resource");
 		expect(tools.getCurrentOrganization.description).toContain("organization");
+	});
+
+	test("external toolset requires an intent on every call", () => {
+		const tools = createRawAutumnOperationTools();
+
+		expect(() =>
+			parseToolInput({ input: { request: {} }, tool: tools.getAgentRules }),
+		).toThrow();
+		expect(() =>
+			parseToolInput({ input: {}, tool: tools.getCurrentOrganization }),
+		).toThrow();
+		expect(
+			parseToolInput({
+				input: { intent: "Check the org's billing rules.", request: {} },
+				tool: tools.getAgentRules,
+			}),
+		).toMatchObject({ request: {} });
+	});
+
+	test("internal toolset accepts a call with or without an intent", () => {
+		const tools = createRawAutumnOperationTools({ requireIntent: false });
+
+		expect(
+			parseToolInput({ input: { request: {} }, tool: tools.getAgentRules }),
+		).toMatchObject({ request: {} });
+		expect(
+			parseToolInput({
+				input: { intent: "Preload org context.", request: {} },
+				tool: tools.getAgentRules,
+			}),
+		).toMatchObject({ intent: "Preload org context." });
+		expect(
+			parseToolInput({ input: {}, tool: tools.getCurrentOrganization }),
+		).toEqual({});
+		expect(
+			parseToolInput({
+				input: { intent: "Preload org context." },
+				tool: tools.getCurrentOrganization,
+			}),
+		).toEqual({ intent: "Preload org context." });
 	});
 
 	test("write tools are annotated as destructive", () => {


### PR DESCRIPTION
Leaf's own MCP router builds the toolset with `requireIntent: false`, which skipped the `intent` field entirely. Tool inputs are strict, so any client that volunteered an intent was rejected with a root `additionalProperties` error -- including leaf's own org-context preload, whose four calls all failed silently and left the agent with no org context.

Attach `intent` either way, optional when it is not required, and drop the fabricated preload intent in leaf. Build the org tools per toolset too: the intent and analytics layers mutate tools in place, so the shared singleton leaked schema changes between servers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts an optional intent in MCP tool inputs when `requireIntent` is false. Previously the internal toolset omitted the field, so calls that included `intent` were rejected and org-context preload failed; now every tool schema includes `intent`, required for external toolsets and optional for internal.

- Attach intent to all tool input schemas with `attachIntentToTools({ required, tools })`; `required: false` marks `intent` optional instead of dropping it.
- Build org tools per toolset with `createOrgTools()` to prevent in-place schema mutation from leaking between servers.
- Add tests confirming external toolset requires `intent` and internal toolset accepts calls with or without it.

<sup>Written for commit 57304aa545de59d959f2cbc2c68adeed06b5ce87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

