### PR TITLE
Auto-create customers on RevenueCat renewal and non-renewing purchase

### DIFF
--- a/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
+++ b/server/src/external/revenueCat/misc/resolveRevenuecatResources.ts
@@ -422,7 +422,7 @@ const resolveRevenueCatCustomer = async ({
 		customerId: idIsValid ? appUserId : null,
 		withEntities: true,
 		customerData: {
-			email: idIsValid ? customerEmail : (customerEmail || appUserId),
+			email: idIsValid ? customerEmail : customerEmail || appUserId,
 			fingerprint: customerFingerprint,
 			processors: {
 				revenuecat: {
@@ -464,6 +464,7 @@ export const resolveRevenuecatResources = async ({
 	customerEmail,
 	customerFingerprint,
 	autoCreateCustomer = false,
+	validateProduct,
 }: {
 	ctx: RevenueCatWebhookContext;
 	revenuecatProductId: string;
@@ -473,6 +474,7 @@ export const resolveRevenuecatResources = async ({
 	customerEmail?: string;
 	customerFingerprint?: string;
 	autoCreateCustomer?: boolean;
+	validateProduct?: (product: FullProduct) => void;
 }): Promise<{
 	ctx: RevenueCatWebhookContext;
 	product: FullProduct;
@@ -501,23 +503,26 @@ export const resolveRevenuecatResources = async ({
 		});
 	}
 
-	const [product, customer] = await Promise.all([
-		ProductService.getFull({
-			db,
-			orgId: org.id,
-			env,
-			idOrInternalId: autumnProductId,
-		}),
-		resolveRevenueCatCustomer({
-			ctx,
-			appUserId: customerId,
-			originalAppUserId,
-			overrideCustomerId,
-			customerEmail,
-			customerFingerprint,
-			autoCreateCustomer,
-		}),
-	]);
+	// Product is resolved and validated before the customer, since resolution can
+	// create one and a rejected event must not leave that write behind.
+	const product = await ProductService.getFull({
+		db,
+		orgId: org.id,
+		env,
+		idOrInternalId: autumnProductId,
+	});
+
+	validateProduct?.(product);
+
+	const customer = await resolveRevenueCatCustomer({
+		ctx,
+		appUserId: customerId,
+		originalAppUserId,
+		overrideCustomerId,
+		customerEmail,
+		customerFingerprint,
+		autoCreateCustomer,
+	});
 
 	// If the customer has a product from a different processor than RevenueCat and it has no subscriptions, throw an error.
 	//

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts
@@ -35,6 +35,9 @@ export const handleRenewal = async ({
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
 		customerEmail: getRevenueCatCustomerEmail(event),
 		customerFingerprint: getRevenueCatCustomerFingerprint(event),
+		// RevenueCat sends RENEWAL (not INITIAL_PURCHASE) when a lapsed user
+		// resubscribes, so the customer may legitimately not exist yet.
+		autoCreateCustomer: true,
 	});
 
 	const { curSameProduct } = getExistingCusProducts({

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
@@ -33,6 +33,8 @@ export const handleNonRenewingPurchase = async ({
 		overrideCustomerId: getRevenueCatOverrideCustomerId(event),
 		customerEmail: getRevenueCatCustomerEmail(event),
 		customerFingerprint: getRevenueCatCustomerFingerprint(event),
+		// A purchase is valid for a customer we have not seen yet.
+		autoCreateCustomer: true,
 	});
 
 	if (!oneOffOrAddOn({ product })) {
@@ -51,7 +53,9 @@ export const handleNonRenewingPurchase = async ({
 		appUserId: event.app_user_id,
 	});
 
-	logger.info(`Created RC cus_product for ${product.id} (non-renewing purchase)`);
+	logger.info(
+		`Created RC cus_product for ${product.id} (non-renewing purchase)`,
+	);
 
 	await recordRevenueCatInvoice({ ctx: customerCtx, event, customer, product });
 };

--- a/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
+++ b/server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts
@@ -35,15 +35,16 @@ export const handleNonRenewingPurchase = async ({
 		customerFingerprint: getRevenueCatCustomerFingerprint(event),
 		// A purchase is valid for a customer we have not seen yet.
 		autoCreateCustomer: true,
+		validateProduct: (product) => {
+			if (!oneOffOrAddOn({ product })) {
+				throw new RecaseError({
+					message: "Non-renewing purchase is not a one-off or add-on",
+					code: ErrCode.InvalidProductItem,
+					statusCode: 400,
+				});
+			}
+		},
 	});
-
-	if (!oneOffOrAddOn({ product })) {
-		throw new RecaseError({
-			message: "Non-renewing purchase is not a one-off or add-on",
-			code: ErrCode.InvalidProductItem,
-			statusCode: 400,
-		});
-	}
 
 	await provisionRevenueCatCusProduct({
 		ctx: customerCtx,


### PR DESCRIPTION
## Problem

RevenueCat's docs define `RENEWAL` as *"An existing subscription was renewed, **or a lapsed user resubscribed**"*. Returning subscribers therefore never produce an `INITIAL_PURCHASE` — but `INITIAL_PURCHASE` was the only handler passing `autoCreateCustomer: true`.

So a lapsed user resubscribing arrives at a resolver that cannot match them and cannot create them, and the webhook 500s. RevenueCat retries ~6 times and drops the event permanently.

`NON_RENEWING_PURCHASE` had the same gap despite being a purchase.

## Impact

On one org (`galaxyai_inc`) over 30 days: **169 dropped webhooks across 22 paying customers**, leaving them with an active subscription in RevenueCat and no plan in Autumn.

```
RENEWAL                64   <- fixed here
NON_RENEWING_PURCHASE  21   <- fixed here
CANCELLATION           36
EXPIRATION             30
BILLING_ISSUE          18
INITIAL_PURCHASE        0   <- never failed; it could already auto-create
```

## Change

`autoCreateCustomer: true` on the two handlers that **provision** a product. Both already fall through to `provisionRevenueCatCusProduct` when no matching cus_product exists, so no other changes are needed.

Deliberately **not** extended to `CANCELLATION` / `EXPIRATION` / `BILLING_ISSUE` / `UNCANCELLATION` — those all guard on `!curSameProduct` and throw, so auto-creating would produce an empty customer and still throw.

## Behaviour by org setup

| org's `app_user_id` | result |
|---|---|
| a real customer id | fully fixed — created with the correct id, access granted |
| an email | creates a `null`-id row keyed on email, which a later `get_or_create` **claims** if it passes `email` |

## Follow-ups (not in this PR)

- Alert on `email_as_id: true` in the existing `Auto-created RevenueCat customer` log — this change turns a loud failure into a silent success for email-`app_user_id` orgs.
- The 22 already-affected customers still need a manual backfill; those events are gone.
- `CANCELLATION`/`EXPIRATION` on an unknown customer arguably ought to be a logged 200 no-op rather than a 500 + 6 retries.

## Testing

`bun ts` passes. Biome clean on both files.

Not covered by an automated test — the "renewal for a customer that doesn't exist" path has never executed in production, so it's worth a reviewer's eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-creates customers on RevenueCat RENEWAL and NON_RENEWING_PURCHASE so returning subscribers and one-off purchasers provision instead of 500s. Validates the product before resolving/creating a customer to avoid orphan records on rejected non-renewing purchases.

- Sets autoCreateCustomer: true in both handlers; NON_RENEWING_PURCHASE supplies validateProduct to enforce one-off/add-on before any customer write.
- The resolver now resolves and validates the product before customer resolution; rejected events no longer persist a customer.
- Unchanged: CANCELLATION/EXPIRATION/BILLING_ISSUE/UNCANCELLATION still require an existing customer and throw on unknown.
- Side effect: Orgs using an email as app_user_id may create a null-id customer keyed by email; later get_or_create can claim via email.
- Rollout: No schema or config changes; no required actions. Previously dropped events are not recovered and need manual backfill if desired.

<sup>Written for commit ecb4b23f4dde904ab1819479c911443113c0f1da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR now auto-creates customers when RevenueCat reports renewals or non-renewing purchases, while ensuring invalid non-renewing products are rejected before customer creation.
- **Bug fixes:** Allows lapsed subscribers and first-time non-renewing purchasers to be provisioned even when Autumn has no existing customer.
- **Bug fixes:** Validates non-renewing products before resolving or creating the customer, preventing rejected events from leaving empty customer records.
- **Improvements:** Resolves the product before the customer so validation can safely precede persistent customer changes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/external/revenueCat/misc/resolveRevenuecatResources.ts | Product lookup and optional validation now complete before customer resolution, closing the previously reported orphan-customer path. |
| server/src/external/revenueCat/webhookHandlers/handleRevenucatRenewal.ts | Renewals can now create missing customers so lapsed subscribers can be provisioned. |
| server/src/external/revenueCat/webhookHandlers/handleRevenuecatNonRenewingPurchase.ts | Non-renewing purchases can create missing customers, while product eligibility is checked before customer creation. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[RevenueCat webhook] --> B[Resolve mapped Autumn product]
  B --> C{Non-renewing product valid?}
  C -->|No| D[Reject event without creating customer]
  C -->|Yes| E[Resolve or create customer]
  E --> F[Provision customer product]
  F --> G[Record invoice]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Validate RevenueCat product before resol..."](https://github.com/useautumn/autumn/commit/ecb4b23f4dde904ab1819479c911443113c0f1da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55141029)</sub>

**Context used:**

- Knowledge Base — [External Integrations (non-Stripe)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-external-integrations.md)

<!-- /greptile_comment -->