### PR TITLE
ci: post first available PR summary to Slack

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -17,10 +17,12 @@ jobs:
     name: Notify shipped
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(github.event.pull_request.body || '', '<!-- This is an auto-generated description by cubic. -->') &&
+      (contains(github.event.pull_request.body || '', '<!-- This is an auto-generated description by cubic. -->') ||
+      contains(github.event.pull_request.body || '', '<!-- greptile_comment -->')) &&
       (github.event.action == 'opened' ||
       (github.event.changes.body &&
-      !contains(github.event.changes.body.from || '', '<!-- This is an auto-generated description by cubic. -->')))
+      !contains(github.event.changes.body.from || '', '<!-- This is an auto-generated description by cubic. -->') &&
+      !contains(github.event.changes.body.from || '', '<!-- greptile_comment -->')))
     runs-on: ubuntu-latest
 
     steps:
@@ -47,16 +49,30 @@ jobs:
             route_label="$slack_head_ref → main"
           fi
 
-          start_marker="## Summary by cubic"
-          end_marker="<sup>"
-          summary="${PR_BODY#*"$start_marker"}"
+          cubic_start_marker="## Summary by cubic"
+          cubic_end_marker="<sup>"
+          greptile_start_marker="<!-- greptile_comment -->"
+          greptile_summary_marker="</summary>"
+          greptile_end_marker="</details>"
+          cubic_prefix="${PR_BODY%%"$cubic_start_marker"*}"
+          greptile_prefix="${PR_BODY%%"$greptile_start_marker"*}"
 
-          if [ "$summary" = "$PR_BODY" ]; then
-            echo "::error::Cubic summary heading was not found"
-            exit 1
+          if [ "$cubic_prefix" != "$PR_BODY" ] &&
+            { [ "$greptile_prefix" = "$PR_BODY" ] || [ "${#cubic_prefix}" -lt "${#greptile_prefix}" ]; }; then
+            summary="${PR_BODY#*"$cubic_start_marker"}"
+            summary="${summary%%"$cubic_end_marker"*}"
+          else
+            greptile_summary="${PR_BODY#*"$greptile_start_marker"}"
+            summary="${greptile_summary#*"$greptile_summary_marker"}"
+
+            if [ "$summary" = "$greptile_summary" ]; then
+              echo "::error::Greptile summary heading was not found"
+              exit 1
+            fi
+
+            summary="${summary%%"$greptile_end_marker"*}"
           fi
 
-          summary="${summary%%"$end_marker"*}"
           slack_summary=$(printf '%s' "$summary" | sed -E \
             -e '1{/^$/d;}' \
             -e 's/\*\*([^*]+)\*\*/\*\1\*/g' \


### PR DESCRIPTION
Posts the first available Cubic or Greptile PR summary to #shipped, without duplicate parent messages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts the first available PR summary from Cubic or Greptile to `#shipped` so we announce as soon as one provider is ready. Previously we only posted Cubic summaries; now we support Greptile and choose whichever appears first in the PR body. Existing behavior to avoid duplicate parent messages is unchanged.

- Trigger updates: the workflow now runs when the PR body contains either the Cubic marker (`<!-- This is an auto-generated description by cubic. -->`) or the Greptile marker (`<!-- greptile_comment -->`) on open or body edits.
- Summary selection: parses the PR body to pick the earliest provider and extract its summary using provider-specific markers (Cubic: `## Summary by cubic` … `<sup>`, Greptile: `<!-- greptile_comment -->` … `</summary>` … `</details>`). Fails with a clear error if expected Greptile markers are missing.
- Slack payload/formatting and route labels remain the same.

<sup>Written for commit 20af741e5c4d835896fffa85f5d60de22155203b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This workflow now sends whichever supported PR summary becomes available first while avoiding ordinary duplicate marker transitions.
- **Improvements:** Recognizes both Cubic and Greptile summaries and extracts the earlier summary when both are present.
- **Bug fixes:** Extends the immediate previous-body duplicate guard to both summary providers, but marker removal followed by regeneration can still create duplicate Slack parent messages.
</details>

<h3>Confidence Score: 4/5</h3>

The workflow should not merge until duplicate prevention survives removal and regeneration of a Greptile summary block.

The new Greptile path posts whenever the immediately previous body lacks both markers, so removing a previously posted summary and later regenerating it sends another parent Slack message.

**Files Needing Attention:** .github/workflows/post-cubic-summary.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/post-cubic-summary.yml | Adds Greptile triggering and parsing alongside Cubic, but the event-local duplicate guard can repost after a summary block is removed and regenerated. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/post-cubic-summary.yml:23-25
**Duplicate state resets after removal**

When a posted Greptile block is removed and later regenerated, these checks only inspect the immediately previous marker-free body, so the regeneration posts a second parent Slack message for the same pull request.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: post first available PR summary to S..."](https://github.com/useautumn/autumn/commit/20af741e5c4d835896fffa85f5d60de22155203b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55144303)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->