### PR TITLE
Skip the subscription ownership gate on default managed Stripe accounts

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts
@@ -9,6 +9,8 @@ const expectedStripeApplicationId = ({ ctx }: { ctx: AutumnContext }) =>
 		? process.env.STRIPE_LIVE_CLIENT_ID
 		: process.env.STRIPE_SANDBOX_CLIENT_ID;
 
+// Only real OAuth-connected accounts can hold foreign subscriptions; the
+// default managed account is Autumn's own, so its subs need no ownership gate.
 const shouldValidateStripeApplicationOwnership = ({
 	ctx,
 }: {
@@ -17,6 +19,7 @@ const shouldValidateStripeApplicationOwnership = ({
 	isStripeConnected({
 		org: ctx.org,
 		env: ctx.env,
+		excludeDefault: true,
 		throughAccountId: true,
 	}) &&
 	!isStripeConnected({

--- a/server/tests/integration/stripe/dual-auth-ownership.test.ts
+++ b/server/tests/integration/stripe/dual-auth-ownership.test.ts
@@ -62,6 +62,25 @@ describe("dual-auth: subscription ownership gate", () => {
 		process.env.STRIPE_SANDBOX_CLIENT_ID = ORIGINAL_CLIENT_ID;
 	});
 
+	// A default_account_id is Autumn's own managed account — nothing foreign
+	// can exist there, so the gate must not reject Autumn's own subscriptions.
+	test("skipped (no throw) when the org only has the default managed account", () => {
+		process.env.STRIPE_SANDBOX_CLIENT_ID = "ca_autumn_platform";
+		const org = buildOrg({
+			test_stripe_connect: { default_account_id: "acct_default_only" },
+		});
+
+		expect(() =>
+			validateStripeSubscriptionActionOwnership({
+				ctx: buildCtx(org),
+				billingContext: buildBillingContext("ca_some_other_platform"),
+				stripeSubscriptionAction: updateAction,
+			}),
+		).not.toThrow();
+
+		process.env.STRIPE_SANDBOX_CLIENT_ID = ORIGINAL_CLIENT_ID;
+	});
+
 	test("active (throws) when only oauth account_id is present and application id mismatches", () => {
 		process.env.STRIPE_SANDBOX_CLIENT_ID = "ca_autumn_platform";
 		const org = buildOrg({


### PR DESCRIPTION
## What

`validateStripeSubscriptionActionOwnership` activates whenever an org is connected `throughAccountId` without a secret key — and `orgToAccountId` counts `default_account_id`. For orgs on Autumn's **default managed account** (standard state after `clearMaster` locally, and any org whose secret key expired/was removed), every `updateSubscription`/cancel gets rejected with *"Cannot update subscription because it was not created by Autumn"* — including subscriptions Autumn itself just created via invoice-mode attach.

Nothing foreign can exist on the managed account, so the gate now requires a real OAuth-connected account (`excludeDefault: true`).

## How this surfaced

The leaf e2e `multiWriteMatrix 'attach + update'` case (cancel at end of cycle) started failing after `bun cm`: the master org's `STRIPE_TEST_KEY` in Infisical has expired, so the re-setup org lands on the default-account-only shape and the gate turned on. Reproduced with direct MCP calls (no agents): invoice-mode attach → `previewUpdateSubscription cancel_end_of_cycle` → 400. Likely also explains prod reports of grouped update+attach approvals where the update applied and the attach/cancel step failed for orgs in this connection shape.

## Verification

- New pinned test: default_account_id-only org + mismatched application id → gate skipped. Existing dual-auth ownership/config tests still green (8 tests, 2 files).
- Live: after the fix, the previously-failing cancel preview returns a real preview, and the leaf `attach + update` e2e passes 2/2 (cancel lands with `canceled_at`).
- `bun ts` clean.

Side note: `STRIPE_TEST_KEY` in Infisical dev is expired and should be rotated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the subscription ownership gate for orgs on Autumn’s default managed Stripe account. Previously the gate counted `default_account_id` as a connected account and rejected updates/cancels as “not created by Autumn”; now it only runs for real OAuth-connected accounts, restoring attach + update flows.

- Updates `validateStripeSubscriptionActionOwnership` to require OAuth by calling `isStripeConnected(..., excludeDefault: true, throughAccountId: true)`.
- Adds an integration test to confirm the gate is skipped when only `default_account_id` is present; existing dual-auth ownership tests remain green.

<sup>Written for commit 581d33e601850dc8fc0b7daa3def769c1b5c8011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR narrows Stripe subscription ownership validation so Autumn-managed default accounts no longer reject legitimate updates or cancellations.
- **Bug fixes:** Skip the application-ownership gate when an organization only uses its dedicated default managed Stripe account.
- **Improvements:** Add coverage for the default-account-only connection shape while preserving OAuth-only and dual-auth behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The production change appears safe to merge; only non-blocking test-isolation cleanup remains.

The default-account bypass preserves validation for real OAuth accounts, while the new regression test can leak its mocked Stripe client ID if its assertion fails.

**Files Needing Attention:** server/tests/integration/stripe/dual-auth-ownership.test.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/connect/validateStripeSubscriptionActionOwnership.ts | Correctly limits application ownership validation to real OAuth-connected accounts without a secret key. |
| server/tests/integration/stripe/dual-auth-ownership.test.ts | Adds the intended regression case, but its process-wide environment mutation should be restored with try/finally to avoid cascading test failures. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/tests/integration/stripe/dual-auth-ownership.test.ts:67-82
**Environment restoration skips failures**

The new test restores `STRIPE_SANDBOX_CLIENT_ID` only after its assertion succeeds. An assertion failure leaves the mocked client ID active for subsequent tests, producing misleading cascading failures; wrapping the assertion in `try`/`finally` guarantees cleanup.

```suggestion
	test("skipped (no throw) when the org only has the default managed account", () => {
		process.env.STRIPE_SANDBOX_CLIENT_ID = "ca_autumn_platform";
		try {
			const org = buildOrg({
				test_stripe_connect: { default_account_id: "acct_default_only" },
			});

			expect(() =>
				validateStripeSubscriptionActionOwnership({
					ctx: buildCtx(org),
					billingContext: buildBillingContext("ca_some_other_platform"),
					stripeSubscriptionAction: updateAction,
				}),
			).not.toThrow();
		} finally {
			process.env.STRIPE_SANDBOX_CLIENT_ID = ORIGINAL_CLIENT_ID;
		}
	});
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 skip the subscription ownership ..."](https://github.com/useautumn/autumn/commit/581d33e601850dc8fc0b7daa3def769c1b5c8011) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55144646)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->