### PR TITLE
feat(products): omit-version reads and writes resolve via the active pointer

### DIFF
--- a/server/src/internal/catalog/actions/catalogMappings/getMappings/loadCatalogMappingProducts.ts
+++ b/server/src/internal/catalog/actions/catalogMappings/getMappings/loadCatalogMappingProducts.ts
@@ -1,6 +1,6 @@
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "@/internal/products/ProductService.js";
-import { getLatestProducts } from "@/internal/products/productUtils.js";
+import { getActiveProducts } from "@/internal/products/productUtils.js";
 
 // Derives the latest versions from the all-versions read rather than calling
 // listFull again: that second call hits the 24h products cache, which serves a
@@ -22,7 +22,7 @@ export const loadCatalogMappingProducts = async ({
 
 	// Archived is filtered AFTER picking the latest version, matching
 	// listFull({ archived: false }).
-	const latestProducts = getLatestProducts(everyVersion).filter(
+	const latestProducts = getActiveProducts(everyVersion).filter(
 		(product) => !product.archived,
 	);
 	const allProducts = everyVersion.filter((product) => !product.archived);

--- a/server/src/internal/catalog/actions/catalogPlanPreflight.ts
+++ b/server/src/internal/catalog/actions/catalogPlanPreflight.ts
@@ -13,6 +13,7 @@ import { buildIncomingFullProduct } from "@/internal/product/actions/previewUpda
 import { buildIncomingProductV2 } from "@/internal/product/actions/previewUpdatePlan/buildIncomingProductV2.js";
 import { previewAffectedLicenses } from "@/internal/product/actions/previewUpdatePlan/previewAffectedLicenses.js";
 import { ProductService } from "@/internal/products/ProductService.js";
+import { getActiveProducts } from "@/internal/products/productUtils.js";
 import {
 	sortCatalogPlansByDependencies,
 	validateCatalogPlanVersionTargets,
@@ -59,12 +60,15 @@ const preflightCatalogLicenses = async ({
 		returnAll: true,
 	});
 	validateCatalogPlanVersionTargets({ plans, products: persistedProducts });
-	const currentById = new Map<string, FullProduct>();
+	const currentById = new Map(
+		getActiveProducts(persistedProducts).map((product) => [product.id, product]),
+	);
+	const maxVersionById = new Map<string, number>();
 	for (const product of persistedProducts) {
-		const current = currentById.get(product.id);
-		if (!current || product.version > current.version) {
-			currentById.set(product.id, product);
-		}
+		maxVersionById.set(
+			product.id,
+			Math.max(maxVersionById.get(product.id) ?? 0, product.version),
+		);
 	}
 	const currentForPlan = (plan: CatalogPlanParams) =>
 		plan.version === undefined
@@ -75,7 +79,7 @@ const preflightCatalogLicenses = async ({
 				);
 	const virtualParents = plans.map((plan, index) => {
 		const current = currentForPlan(plan);
-		const latest = currentById.get(plan.plan_id);
+		const maxVersion = maxVersionById.get(plan.plan_id);
 		const incoming = current
 			? buildIncomingFullProduct({
 					ctx,
@@ -95,7 +99,7 @@ const preflightCatalogLicenses = async ({
 			id: plan.new_plan_id ?? plan.plan_id,
 			version: current
 				? previews[index]?.versionable
-					? (latest?.version ?? current.version) + 1
+					? (maxVersion ?? current.version) + 1
 					: current.version
 				: (plan.version ?? 1),
 			archived: plan.archived,

--- a/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
+++ b/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
@@ -22,6 +22,7 @@ import {
 	validateNoDirectVariantMigrationDrafts,
 } from "@/internal/product/actions/updateProduct/createPlanMigrationDraft.js";
 import { updateProduct } from "@/internal/product/actions/updateProduct.js";
+import { activateHighestRemainingProduct } from "@/internal/products/repos/activateHighestRemainingProduct.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
 import {
@@ -59,12 +60,20 @@ const archiveProductVersions = async ({
 	});
 
 	for (const product of products) {
-		await ProductService.updateByInternalId({
+		await ProductService.archiveByInternalId({
 			db: ctx.db,
 			internalId: product.internal_id,
-			update: { archived: true },
+			orgId: ctx.org.id,
+			env: ctx.env,
 		});
 	}
+
+	await activateHighestRemainingProduct({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		productId,
+	});
 };
 
 const upsertFeatures = async ({
@@ -343,10 +352,17 @@ const applyMissingPlanRemovals = async ({
 			});
 
 			if (hasCustomers) {
-				await ProductService.updateByInternalId({
+				await ProductService.archiveByInternalId({
 					db: ctx.db,
 					internalId: product.internal_id,
-					update: { archived: true },
+					orgId: ctx.org.id,
+					env: ctx.env,
+				});
+				await activateHighestRemainingProduct({
+					db: ctx.db,
+					orgId: ctx.org.id,
+					env: ctx.env,
+					productId: planId,
 				});
 			} else {
 				await deleteProduct({

--- a/server/src/internal/catalog/actions/validateCatalogVariantUpdates.ts
+++ b/server/src/internal/catalog/actions/validateCatalogVariantUpdates.ts
@@ -59,18 +59,30 @@ export const validateCatalogVariantVersionTargets = ({
 	params: CatalogUpdateParams;
 	products: FullProduct[];
 }) => {
-	const latestByPlanId = new Map(
+	const activeBaseByPlanId = new Map(
 		products
-			.filter((product) => product.base_internal_product_id === null)
+			.filter(
+				(product) =>
+					product.base_internal_product_id === null && product.active,
+			)
 			.map((product) => [product.id, product]),
 	);
+	const maxVersionByPlanId = new Map<string, number>();
+	for (const product of products) {
+		if (product.base_internal_product_id !== null) continue;
+		maxVersionByPlanId.set(
+			product.id,
+			Math.max(maxVersionByPlanId.get(product.id) ?? 0, product.version),
+		);
+	}
 
 	for (const plan of params.plans) {
 		if ((plan.variants ?? []).length === 0) continue;
 		if (plan.version === undefined) continue;
 
-		const latest = latestByPlanId.get(plan.plan_id);
-		if (!latest || plan.version >= latest.version) continue;
+		const active = activeBaseByPlanId.get(plan.plan_id);
+		const maxVersion = maxVersionByPlanId.get(plan.plan_id) ?? 0;
+		if (plan.version === active?.version || plan.version > maxVersion) continue;
 
 		throw new RecaseError({
 			message: `Variants can only be updated under the latest version of base plan ${plan.plan_id}.`,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/propagateLicenseDraftUpserts.ts
@@ -10,6 +10,7 @@ import {
 	sortLicenseDraftUpserts,
 } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseUpsertFromPlanLicense";
 import { shouldPropagate } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 
 /** Link deltas for children that follow this parent. */
@@ -17,10 +18,12 @@ export const propagateLicenseDraftUpserts = ({
 	parent,
 	upsertProductPlans,
 	params,
+	productStatesContext,
 }: {
 	parent: UpsertProductPlan;
 	upsertProductPlans: UpsertProductPlan[];
 	params: UpdateCatalogParams;
+	productStatesContext: ProductStatesContext;
 }): LicenseDraftUpserts => {
 	let includeCustom = includeCustomForMigrationDraft({
 		upsertProductPlan: parent,
@@ -32,7 +35,13 @@ export const propagateLicenseDraftUpserts = ({
 		if (!upsertClaimsMigrationDraft({ upsertProductPlan: child, params })) {
 			continue;
 		}
-		if (!shouldPropagate({ parent, child, upsertProducts: upsertProductPlans })) {
+		if (
+			!shouldPropagate({
+				parent,
+				child,
+				productStatesContext,
+			})
+		) {
 			continue;
 		}
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/resolveLicenseMigrationTarget.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/resolveLicenseMigrationTarget.ts
@@ -38,6 +38,7 @@ export const resolveLicenseMigrationTarget = ({
 					parent: upsertProductPlan,
 					upsertProductPlans,
 					params,
+					productStatesContext,
 				});
 
 	if (upserts.length === 0) return null;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/computePlanLicensesPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/computePlanLicensesPlan.ts
@@ -98,11 +98,13 @@ export const computePlanLicensesPlan = ({
 				ctx,
 				parent: upsert,
 				upsertProducts,
+				productStatesContext,
 			}),
 			...computePropagatedPlanLicenses({
 				ctx,
 				parent: upsert,
 				upsertProducts,
+				productStatesContext,
 			}),
 		];
 		if (planLicenses.length === 0) return upsert;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/declared/resolveDeclaredPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/declared/resolveDeclaredPlanLicenses.ts
@@ -6,6 +6,7 @@ import type {
 } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { PlanLicensePlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 
 const declaredLinkChanged = ({
 	currentPlanLicense,
@@ -57,9 +58,10 @@ export const resolveDeclaredPlanLicenses = ({
 	const declaredIds = new Set(declared.map((entry) => entry.license_plan_id));
 
 	const planned: PlanLicensePlan[] = declared.map((params) => {
-		const licenseProduct =
-			productStatesContext.versionsByPlanId[params.license_plan_id]?.[0] ??
-			null;
+		const licenseProduct = activeFullProductForPlan({
+			planId: params.license_plan_id,
+			productStatesContext,
+		});
 		const currentPlanLicense =
 			currentPlanLicenseByPlanId.get(params.license_plan_id) ?? null;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
@@ -3,7 +3,9 @@ import type {
 	FullPlanLicense,
 	LicenseCustomize,
 } from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 
 /** Current plan_license links on this row. Minted versions fall back to the clone source. */
 export const upsertProductPlanToLicenses = ({
@@ -62,65 +64,55 @@ export const needsNewParentLink = ({
 	currentPlanLicense.parent_internal_product_id !==
 	parent.row.nextFullProduct.internal_id;
 
-const latestVersionOfPlan = ({
-	planId,
-	upsertProducts,
-}: {
-	planId: string;
-	upsertProducts: UpsertProductPlan[];
-}): number =>
-	Math.max(
-		...upsertProducts
-			.filter((upsert) => upsert.row.planId === planId)
-			.map((upsert) => upsert.row.version),
-	);
-
-/** Omit version = latest. `all_versions` is only the child's propagate target. */
+/** Omit / `existing` = the active pointer. `all_versions` is only the child's propagate target. */
 const propagateTargetMatchesParent = ({
 	target,
 	parent,
-	latestVersion,
+	activeVersion,
 }: {
 	target: CatalogPropagateTargetParams;
 	parent: UpsertProductPlan;
-	latestVersion: number;
+	activeVersion: number | undefined;
 }): boolean => {
 	if (target.plan_id !== parent.row.planId) return false;
 	if (target.version !== undefined) return target.version === parent.row.version;
 	if (target.versioning === "all_versions") return true;
-	return parent.row.version === latestVersion;
+	return (
+		activeVersion !== undefined && parent.row.version === activeVersion
+	);
 };
 
 export const childPropagatesToParent = ({
 	child,
 	parent,
-	upsertProducts,
+	productStatesContext,
 }: {
 	child: UpsertProductPlan;
 	parent: UpsertProductPlan;
-	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
 }): boolean => {
-	const latestVersion = latestVersionOfPlan({
+	const activeVersion = activeVersionForPlan({
 		planId: parent.row.planId,
-		upsertProducts,
+		productStatesContext,
 	});
 	return (child.propagate?.license_parents ?? []).some((target) =>
-		propagateTargetMatchesParent({ target, parent, latestVersion }),
+		propagateTargetMatchesParent({ target, parent, activeVersion }),
 	);
 };
 
 export const shouldPropagate = ({
 	parent,
 	child,
-	upsertProducts,
+	productStatesContext,
 }: {
 	parent: UpsertProductPlan;
 	child: UpsertProductPlan;
-	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
 }): boolean => {
 	if (parent.declaredLicenses !== undefined) return false;
 	if (!child.entitlementPricesPlan) return false;
-	if (!childPropagatesToParent({ child, parent, upsertProducts })) return false;
+	if (!childPropagatesToParent({ child, parent, productStatesContext }))
+		return false;
 	return true;
 };
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
@@ -1,5 +1,6 @@
 import type { FullPlanLicense } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type {
 	PlanLicensePlan,
 	UpsertProductPlan,
@@ -17,16 +18,16 @@ const shouldPin = ({
 	parent,
 	child,
 	currentPlanLicense,
-	upsertProducts,
+	productStatesContext,
 }: {
 	parent: UpsertProductPlan;
 	child: UpsertProductPlan;
 	currentPlanLicense: FullPlanLicense;
-	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
 }): boolean => {
 	if (parent.declaredLicenses !== undefined) return false;
 	if (!child.entitlementPricesPlan) return false;
-	if (shouldPropagate({ parent, child, upsertProducts })) return false;
+	if (shouldPropagate({ parent, child, productStatesContext })) return false;
 
 	if (
 		currentPlanLicense.customized &&
@@ -90,17 +91,21 @@ export const computePinnedPlanLicenses = ({
 	ctx,
 	parent,
 	upsertProducts,
+	productStatesContext,
 }: {
 	ctx: AutumnContext;
 	parent: UpsertProductPlan;
 	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
 }): PlanLicensePlan[] => {
 	const pinned: PlanLicensePlan[] = [];
 
 	for (const child of upsertProductPlansToChildPlans({ upsertProducts })) {
 		const currentPlanLicense = parentLicenseLinkForChild({ parent, child });
 		if (!currentPlanLicense) continue;
-		if (!shouldPin({ parent, child, currentPlanLicense, upsertProducts }))
+		if (
+			!shouldPin({ parent, child, currentPlanLicense, productStatesContext })
+		)
 			continue;
 
 		const planLicense = pinnedPlanLicense({

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/propagated/computePropagatedPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/propagated/computePropagatedPlanLicenses.ts
@@ -1,5 +1,6 @@
 import type { FullPlanLicense } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type {
 	PlanLicensePlan,
 	UpsertProductPlan,
@@ -100,17 +101,19 @@ export const computePropagatedPlanLicenses = ({
 	ctx,
 	parent,
 	upsertProducts,
+	productStatesContext,
 }: {
 	ctx: AutumnContext;
 	parent: UpsertProductPlan;
 	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
 }): PlanLicensePlan[] => {
 	const propagated: PlanLicensePlan[] = [];
 
 	for (const child of upsertProductPlansToChildPlans({ upsertProducts })) {
 		const currentPlanLicense = parentLicenseLinkForChild({ parent, child });
 		if (!currentPlanLicense) continue;
-		if (!shouldPropagate({ parent, child, upsertProducts })) continue;
+		if (!shouldPropagate({ parent, child, productStatesContext })) continue;
 
 		const planLicense = propagatedPlanLicense({
 			ctx,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan.ts
@@ -1,5 +1,4 @@
 import {
-	type FullProduct,
 	productToProductKey,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
@@ -17,17 +16,9 @@ import type {
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
-
-const latestFullProductForPlan = ({
-	planId,
-	productStatesContext,
-}: {
-	planId: string;
-	productStatesContext: ProductStatesContext;
-}): FullProduct | null =>
-	productStatesContext.versionsByPlanId[planId]?.[0] ?? null;
 
 const planHasVersionableCustomers = ({
 	planId,
@@ -76,11 +67,11 @@ export const computeUpsertProductPlan = ({
 		});
 	const pointer = unlink ? null : baseInternalProductId;
 
-	// Content baseline: row at this version, or latest when minting a new version.
+	// Content baseline: row at this version, or the active row when minting.
 	const baseFullProduct =
 		currentFullProduct ??
 		(versioning === "new_version"
-			? latestFullProductForPlan({
+			? activeFullProductForPlan({
 					planId: productKey.planId,
 					productStatesContext,
 				})

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/creates/deriveVariantCreates.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/creates/deriveVariantCreates.ts
@@ -4,15 +4,7 @@ import type {
 	ProductUpsertIntent,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-
-const latestVersion = ({
-	planId,
-	productStatesContext,
-}: {
-	planId: string;
-	productStatesContext: ProductStatesContext;
-}): number | undefined =>
-	productStatesContext.versionsByPlanId[planId]?.[0]?.version;
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 
 /** Missing ids with a name → `variant_link` create. Existing ids are edits. */
 export const deriveVariantCreates = ({
@@ -24,10 +16,10 @@ export const deriveVariantCreates = ({
 }): ProductUpsertIntent[] =>
 	(upsert.declaredVariants ?? []).flatMap((variant) => {
 		if (
-			latestVersion({
+			maxVersionForPlan({
 				planId: variant.variant_plan_id,
 				productStatesContext: projectedProductStatesContext,
-			}) !== undefined
+			}) !== 0
 		) {
 			return [];
 		}

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
@@ -12,6 +12,7 @@ import {
 	resolveVariantEditTargets,
 	type VariantEditTarget,
 } from "./resolveVariantEditTargets";
+import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 
 const variantProductAt = ({
 	planId,
@@ -25,15 +26,6 @@ const variantProductAt = ({
 	(productStatesContext.versionsByPlanId[planId] ?? []).find(
 		(product) => product.version === version,
 	);
-
-const latestVersionOf = ({
-	planId,
-	productStatesContext,
-}: {
-	planId: string;
-	productStatesContext: ProductStatesContext;
-}): number | undefined =>
-	productStatesContext.versionsByPlanId[planId]?.[0]?.version;
 
 /** One target row → one intent, or undefined when nothing would change. */
 const buildVariantEditIntent = ({
@@ -80,7 +72,7 @@ const buildVariantEditIntent = ({
 	const repointToNewBase =
 		newBasePointer !== undefined &&
 		target.version ===
-			latestVersionOf({ planId: target.planId, productStatesContext });
+			activeVersionForPlan({ planId: target.planId, productStatesContext });
 	const pointerIsOnlyChange =
 		!target.follow && !editDiff && !hasSettings && repointToNewBase;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/resolveVariantEditTargets.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/resolveVariantEditTargets.ts
@@ -3,6 +3,7 @@ import { productKeyToString } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { latestVariantsOfBase } from "../variantPlanUtils";
+import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 
 /** One existing variant row (plan_id@version) the base edit must touch. */
 export type VariantEditTarget = {
@@ -37,7 +38,11 @@ const targetVersionsFor = ({
 		return versions.map((product) => product.version);
 	}
 	if (version === undefined) {
-		return versions[0] !== undefined ? [versions[0].version] : [];
+		const activeVersion = activeVersionForPlan({
+			planId,
+			productStatesContext,
+		});
+		return activeVersion !== undefined ? [activeVersion] : [];
 	}
 	return versions.some((product) => product.version === version)
 		? [version]

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
@@ -9,6 +9,8 @@ import type {
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 
 const latestHasCustomers = ({
 	latest,
@@ -55,7 +57,7 @@ const mintablePlanIds = ({
 	return [...planIds];
 };
 
-/** Parent `new_version` → mint max+1 when latest has customers. */
+/** Parent `new_version` → mint max+1 when the active row has customers. */
 export const deriveVariantMints = ({
 	upsert,
 	projectedProductStatesContext,
@@ -82,12 +84,14 @@ export const deriveVariantMints = ({
 	for (const planId of mintablePlanIds({ upsert })) {
 		if (mintedPlanIds.has(planId)) continue;
 
-		const latest =
-			projectedProductStatesContext.versionsByPlanId[planId]?.[0];
-		if (!latest) continue;
+		const active = activeFullProductForPlan({
+			planId,
+			productStatesContext: projectedProductStatesContext,
+		});
+		if (!active) continue;
 		if (
 			!latestHasCustomers({
-				latest,
+				latest: active,
 				productStatesContext: projectedProductStatesContext,
 			})
 		) {
@@ -98,24 +102,29 @@ export const deriveVariantMints = ({
 			(target) => target.plan_id === planId,
 		);
 		const editDiff = buildVariantEditDiff({
-			variantProduct: latest,
+			variantProduct: active,
 			baseCurrent,
 			baseNext: upsert.row.nextFullProduct,
 			follow,
 			customize: declaredCustomizeForLatest({
 				planId,
-				latestVersion: latest.version,
+				latestVersion: active.version,
 				declaredVariants: upsert.declaredVariants ?? [],
 			}),
 			declaredLicenses: upsert.declaredLicenses,
 		});
 
+		const version =
+			maxVersionForPlan({
+				planId,
+				productStatesContext: projectedProductStatesContext,
+			}) + 1;
 		mintedPlanIds.add(planId);
 		intents.push({
-			productKey: { planId, version: latest.version + 1 },
+			productKey: { planId, version },
 			planParams: {
 				plan_id: planId,
-				version: latest.version + 1,
+				version,
 				versioning: "new_version",
 				...settingsPatch,
 			},

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/variantPlanUtils.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/variantPlanUtils.ts
@@ -1,6 +1,7 @@
 import type { FullProduct } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 
 /** True when this upsert minted a new version row (clone source is baseFullProduct). */
 export const baseRowMinted = ({
@@ -11,7 +12,7 @@ export const baseRowMinted = ({
 	upsert.row.versioning === "new_version" &&
 	upsert.row.baseFullProduct != null;
 
-/** Latest variant of this base (MAX(version) per plan id). */
+/** Active variant of this base (the representing row per child plan id). */
 export const latestVariantsOfBase = ({
 	upsert,
 	productStatesContext,
@@ -30,10 +31,11 @@ export const latestVariantsOfBase = ({
 	);
 
 	const latest: FullProduct[] = [];
-	for (const versions of Object.values(
-		productStatesContext.versionsByPlanId,
-	)) {
-		const product = versions[0];
+	for (const planId of Object.keys(productStatesContext.versionsByPlanId)) {
+		const product = activeFullProductForPlan({
+			planId,
+			productStatesContext,
+		});
 		if (!product || (!includeArchived && product.archived)) continue;
 		if (product.id === upsert.row.planId) continue;
 		if (

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
@@ -7,18 +7,12 @@ import type {
 	ProductUpsertIntent,
 	ResolvedPlanParams,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 
 const hasExplicitVersion = (
 	planParams: UpdateCatalogPlanParams,
 ): planParams is ResolvedPlanParams => planParams.version !== undefined;
-
-const latestVersionForPlan = ({
-	planId,
-	productStatesContext,
-}: {
-	planId: string;
-	productStatesContext: ProductStatesContext;
-}): number => productStatesContext.versionsByPlanId[planId]?.[0]?.version ?? 0;
 
 const groupPlanParamsByPlanId = ({
 	planParamsList,
@@ -34,7 +28,7 @@ const groupPlanParamsByPlanId = ({
 	return byPlanId;
 };
 
-/** Explicit versions ascending, then omit→latest (or v1 if plan absent).
+/** Explicit versions ascending, then omit→active (or v1 if plan absent).
  * `new_version` always mints at max+1 (requires an existing plan — guarded elsewhere). */
 const resolveVersionsForPlan = ({
 	planId,
@@ -49,8 +43,10 @@ const resolveVersionsForPlan = ({
 		.filter(hasExplicitVersion)
 		.sort((a, b) => a.version - b.version);
 
-	const maxVersion = latestVersionForPlan({ planId, productStatesContext });
-	const latestOrV1 = maxVersion || 1;
+	const maxVersion = maxVersionForPlan({ planId, productStatesContext });
+	const activeOrV1 =
+		activeVersionForPlan({ planId, productStatesContext }) ??
+		(maxVersion || 1);
 
 	const targetingLatest = planParamsList
 		.filter((planParams) => !hasExplicitVersion(planParams))
@@ -59,7 +55,7 @@ const resolveVersionsForPlan = ({
 			version:
 				planParams.versioning === "new_version"
 					? maxVersion + 1
-					: latestOrV1,
+					: activeOrV1,
 		}));
 
 	return [...withExplicitVersion, ...targetingLatest];

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
@@ -5,8 +5,10 @@ import type {
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 
-/** Mint max+1 when latest has customers; otherwise skip (follow latest in place). */
+/** Mint max+1 when the active row has customers; otherwise skip (follow in place). */
 const licenseParentMintIntent = ({
 	planId,
 	productStatesContext,
@@ -14,16 +16,16 @@ const licenseParentMintIntent = ({
 	planId: string;
 	productStatesContext: ProductStatesContext;
 }): ProductUpsertIntent | undefined => {
-	const latest = productStatesContext.versionsByPlanId[planId]?.[0];
-	if (!latest) return undefined;
+	const active = activeFullProductForPlan({ planId, productStatesContext });
+	if (!active) return undefined;
 
 	const hasCustomers = productKeyToState({
-		productKey: productToProductKey({ product: latest }),
+		productKey: productToProductKey({ product: active }),
 		productStatesContext,
 	}).customerUsage.hasVersionableCustomerProducts;
 	if (!hasCustomers) return undefined;
 
-	const version = latest.version + 1;
+	const version = maxVersionForPlan({ planId, productStatesContext }) + 1;
 	return {
 		productKey: { planId, version },
 		planParams: {

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleRemovePlanErrors/handleRemovePlanVersionErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleRemovePlanErrors/handleRemovePlanVersionErrors.ts
@@ -1,10 +1,10 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 
 /**
- * Historical versions stay put — removing one would leave a gap in the version
- * sequence. Pin the latest, or omit `version` to take the whole plan.
+ * Only the active version can be removed. Omit `version` to take the whole plan.
  */
 export const handleRemovePlanVersionErrors = ({
 	updateCatalogPlan,
@@ -16,14 +16,16 @@ export const handleRemovePlanVersionErrors = ({
 	for (const removePlan of updateCatalogPlan.removePlans) {
 		if (removePlan.allVersions) continue;
 
-		const latestVersion =
-			productStatesContext.versionsByPlanId[removePlan.planId]?.[0]?.version;
-		if (latestVersion === undefined || removePlan.version === latestVersion) {
+		const activeVersion = activeVersionForPlan({
+			planId: removePlan.planId,
+			productStatesContext,
+		});
+		if (activeVersion === undefined || removePlan.version === activeVersion) {
 			continue;
 		}
 
 		throw new RecaseError({
-			message: `Cannot remove version ${removePlan.version} of plan ${removePlan.planId}: only the latest version (${latestVersion}) can be removed. Omit "version" to remove the whole plan.`,
+			message: `Cannot remove version ${removePlan.version} of plan ${removePlan.planId}: only the latest version (${activeVersion}) can be removed. Omit "version" to remove the whole plan.`,
 			code: ErrCode.InvalidRequest,
 			statusCode: 400,
 		});

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleArchivedPropagationErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleArchivedPropagationErrors.ts
@@ -2,6 +2,7 @@ import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 
 const latestOrPinned = ({
 	planId,
@@ -16,7 +17,7 @@ const latestOrPinned = ({
 	if (version !== undefined) {
 		return versions.find((product) => product.version === version);
 	}
-	return versions[0];
+	return activeFullProductForPlan({ planId, productStatesContext }) ?? undefined;
 };
 
 const rejectArchivedPropagateTarget = ({

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
@@ -6,6 +6,7 @@ import { handlePlanLicenseErrors } from "@/internal/catalogV2/actions/updateCata
 import { handleVariantErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleVariantErrors";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 
 /** Projected-state guards for each upsertProducts row. */
 export const handleUpsertProductErrors = ({
@@ -23,8 +24,11 @@ export const handleUpsertProductErrors = ({
 
 	for (const upsert of updateCatalogPlan.upsertProducts) {
 		const { nextFullProduct } = upsert.row;
-		const latestExistingVersion =
-			productStatesContext.versionsByPlanId[upsert.row.planId]?.[0]?.version;
+		const maxVersion = maxVersionForPlan({
+			planId: upsert.row.planId,
+			productStatesContext,
+		});
+		const latestExistingVersion = maxVersion === 0 ? undefined : maxVersion;
 
 		// 1. Free trial errors (one-off products cannot trial)
 		handleFreeTrialErrors({ nextFullProduct });

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
@@ -5,6 +5,7 @@ import {
 	type UpdateCatalogParams,
 } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 
 const rejectStrategyPlusExplicitVersion = ({
 	planId,
@@ -135,7 +136,10 @@ export const handleUpsertProductVersioningErrors = ({
 			}
 			seenPinned.add(pinKey);
 
-			const maxVersion = existingVersions[0]?.version ?? 0;
+			const maxVersion = maxVersionForPlan({
+				planId: planParams.plan_id,
+				productStatesContext,
+			});
 			if (planParams.version > maxVersion + 1) {
 				throw new RecaseError({
 					message: `Version gap: plan_id=${planParams.plan_id} version=${planParams.version} exceeds max existing version ${maxVersion} + 1`,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
@@ -18,6 +18,9 @@ import type {
 } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
+import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 
 const byPlanId = (
 	left: CatalogLicenseParentPreview,
@@ -41,7 +44,7 @@ const parentVersioningOptions = ({
 	linkedVersions: NamedParentVersion[];
 	productStatesContext: ProductStatesContext;
 }): CatalogPlanVersioningStrategy[] => {
-	const latest = productStatesContext.versionsByPlanId[planId]?.[0];
+	const latest = activeFullProductForPlan({ planId, productStatesContext });
 	const latestLinked = linkedVersions.some(
 		(version) => version.version === latest?.version,
 	);
@@ -74,7 +77,7 @@ const parentVersioning = ({
 	productStatesContext: ProductStatesContext;
 }): CatalogPlanVersioning => {
 	const currentVersion =
-		productStatesContext.versionsByPlanId[planId]?.[0]?.version ??
+		maxVersionForPlan({ planId, productStatesContext }) ||
 		Math.max(...linkedVersions.map((version) => version.version));
 	const minted = linkedVersions.find(
 		(version) => version.version > currentVersion,
@@ -124,16 +127,16 @@ const findParentUpsert = ({
 const resolveLicenseAction = ({
 	parent,
 	child,
-	upsertProducts,
+	productStatesContext,
 }: {
 	parent: UpsertProductPlan | undefined;
 	child: UpsertProductPlan;
-	upsertProducts: UpsertProductPlan[];
+	productStatesContext: ProductStatesContext;
 }): CatalogLicenseAction => {
 	if (parent?.declaredLicenses !== undefined) return "explicit";
 	if (
 		parent != null &&
-		childPropagatesToParent({ child, parent, upsertProducts })
+		childPropagatesToParent({ child, parent, productStatesContext })
 	) {
 		return "propagated";
 	}
@@ -195,7 +198,7 @@ const buildParentVersionPreview = ({
 	const licenseAction = resolveLicenseAction({
 		parent: parentUpsert,
 		child,
-		upsertProducts,
+		productStatesContext,
 	});
 	const planChange = parentPlanChange({ parentUpsert });
 	const preview = {
@@ -247,18 +250,24 @@ const foldParentVersions = ({
 	}
 
 	return [...versionsByPlanId.values()].map((planVersions) => {
-		const latest = planVersions.reduce((newest, version) =>
-			version.version > newest.version ? version : newest,
-		);
+		const activeVersion = activeVersionForPlan({
+			planId: planVersions[0]!.plan_id,
+			productStatesContext,
+		});
+		const active =
+			planVersions.find((version) => version.version === activeVersion) ??
+			planVersions.reduce((newest, version) =>
+				version.version > newest.version ? version : newest,
+			);
 		const siblings = planVersions
-			.filter((version) => version.version !== latest.version)
+			.filter((version) => version.version !== active.version)
 			.map(({ name: _name, ...sibling }) => sibling)
 			.sort(byVersionAscending);
 
 		return {
-			...latest,
+			...active,
 			versioning: parentVersioning({
-				planId: latest.plan_id,
+				planId: active.plan_id,
 				linkedVersions: planVersions,
 				directUpsert,
 				upsertProducts,
@@ -311,20 +320,26 @@ export const buildLicenseParentsPreview = ({
 	);
 	const mintedVersions = upsertProducts.flatMap((parentUpsert) => {
 		if (!linkedParentPlanIds.has(parentUpsert.row.planId)) return [];
-		const latestExisting =
-			productStatesContext.versionsByPlanId[parentUpsert.row.planId]?.[0];
+		const maxVersion = maxVersionForPlan({
+			planId: parentUpsert.row.planId,
+			productStatesContext,
+		});
+		const active = activeFullProductForPlan({
+			planId: parentUpsert.row.planId,
+			productStatesContext,
+		});
 		if (
-			!latestExisting ||
+			!active ||
 			parentUpsert.row.op !== "create" ||
 			parentUpsert.row.versioning !== "new_version" ||
-			parentUpsert.row.version <= latestExisting.version
+			parentUpsert.row.version <= maxVersion
 		) {
 			return [];
 		}
 		return [
 			buildParentVersionPreview({
 				parentUpsert,
-				stateProduct: latestExisting,
+				stateProduct: active,
 				previewVersion: parentUpsert.row.version,
 				child: directUpsert,
 				upsertProducts,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage.ts
@@ -13,6 +13,7 @@ import type {
 	PreviewCatalogContext,
 	ProductStatesContext,
 } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 
 const toCappedBucket = ({
 	samples,
@@ -84,8 +85,11 @@ const variantSamples = ({
 	if (baseInternalIds.size === 0) return [];
 
 	const latest: FullProduct[] = [];
-	for (const versions of Object.values(productStatesContext.versionsByPlanId)) {
-		const product = versions[0];
+	for (const planId of Object.keys(productStatesContext.versionsByPlanId)) {
+		const product = activeFullProductForPlan({
+			planId,
+			productStatesContext,
+		});
 		if (!product?.base_internal_product_id) continue;
 		if (!baseInternalIds.has(product.base_internal_product_id)) continue;
 		latest.push(product);

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/versioningOptions/computeVersioningOptions.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/versioningOptions/computeVersioningOptions.ts
@@ -6,6 +6,8 @@ import {
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
+import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
+import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 import { computeVersioningOptionsForPlan } from "./computeVersioningOptionsForPlan";
 import { parentLicensePlanIds } from "./parentLicensePlanIds";
 
@@ -29,7 +31,7 @@ const computeVersioningOptionsForPlanId = ({
 	productStatesContext: ProductStatesContext;
 }): CatalogPlanVersioningStrategy[] => {
 	const versions = productStatesContext.versionsByPlanId[planId] ?? [];
-	const latest = versions[0];
+	const latest = activeFullProductForPlan({ planId, productStatesContext });
 	if (!latest) return [];
 
 	return computeVersioningOptionsForPlan({
@@ -54,9 +56,12 @@ export const computeVersioningOptions = ({
 }): CatalogPlanVersioningStrategy[] => {
 	const isNewVersionMint =
 		upsert.row.op === "create" && upsert.row.versioning === "new_version";
-	const latestVersion = versionsForPlan[0]?.version;
+	const activeVersion = activeVersionForPlan({
+		planId: upsert.row.planId,
+		productStatesContext,
+	});
 	const isLatestUpdate =
-		latestVersion !== undefined && latestVersion === upsert.row.version;
+		activeVersion !== undefined && activeVersion === upsert.row.version;
 
 	const options = computeVersioningOptionsForPlan({
 		hasCustomers: upsert.state.hasCustomers,

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan.ts
@@ -1,0 +1,14 @@
+import type { FullProduct } from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+
+/** The representing row for this plan_id (`active === true`), or null. */
+export const activeFullProductForPlan = ({
+	planId,
+	productStatesContext,
+}: {
+	planId: string;
+	productStatesContext: ProductStatesContext;
+}): FullProduct | null =>
+	(productStatesContext.versionsByPlanId[planId] ?? []).find(
+		(product) => product.active,
+	) ?? null;

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan.ts
@@ -1,0 +1,12 @@
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { activeFullProductForPlan } from "./activeFullProductForPlan";
+
+/** Pointer version for this plan_id, or undefined if none is active. */
+export const activeVersionForPlan = ({
+	planId,
+	productStatesContext,
+}: {
+	planId: string;
+	productStatesContext: ProductStatesContext;
+}): number | undefined =>
+	activeFullProductForPlan({ planId, productStatesContext })?.version;

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan.ts
@@ -1,0 +1,11 @@
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+
+/** Numeric tip for this plan_id (`MAX(version)`), or 0 if the plan is absent. */
+export const maxVersionForPlan = ({
+	planId,
+	productStatesContext,
+}: {
+	planId: string;
+	productStatesContext: ProductStatesContext;
+}): number =>
+	productStatesContext.versionsByPlanId[planId]?.[0]?.version ?? 0;

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/projectProductStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/projectProductStatesContext.ts
@@ -3,6 +3,7 @@ import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCa
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import type { CustomerProductVersioningFlags } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
 import { buildProductStatesContext } from "./buildProductStatesContext";
+import { activeFullProductForPlan } from "./activeFullProductForPlan";
 
 /**
  * Pure projection: product state after `upsertProducts` apply (projectCatalog
@@ -60,7 +61,10 @@ export const projectProductStatesContext = ({
 	for (const [planId, programs] of Object.entries(
 		original.rewardProgramsByPlanId,
 	)) {
-		const latest = original.versionsByPlanId[planId]?.[0];
+		const latest = activeFullProductForPlan({
+			planId,
+			productStatesContext: original,
+		});
 		const projectedId = latest
 			? (nextRowByInternalId.get(latest.internal_id)?.id ?? latest.id)
 			: planId;

--- a/server/src/internal/catalogV2/execute/executeRemovePlans.ts
+++ b/server/src/internal/catalogV2/execute/executeRemovePlans.ts
@@ -1,5 +1,9 @@
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+import {
+	activateHighestRemainingProduct,
+	deleteProductRowAndHandoffActive,
+} from "@/internal/products/repos/activateHighestRemainingProduct";
 import { ProductService } from "@/internal/products/ProductService.js";
 
 /** Archive or hard-delete each removePlans row. Pointer moves are upserts. */
@@ -10,22 +14,37 @@ export const executeRemovePlans = async ({
 	ctx: AutumnContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 }): Promise<void> => {
-	for (const row of updateCatalogPlan.removePlans) {
-		if (!row.current) continue;
-		if (row.willArchive) {
-			await ProductService.updateByInternalId({
-				db: ctx.db,
+	await ctx.db.transaction(async (tx) => {
+		const archivedPlanIds = new Set<string>();
+
+		for (const row of updateCatalogPlan.removePlans) {
+			if (!row.current) continue;
+			if (row.willArchive) {
+				await ProductService.archiveByInternalId({
+					db: tx,
+					internalId: row.current.internal_id,
+					orgId: ctx.org.id,
+					env: ctx.env,
+				});
+				archivedPlanIds.add(row.planId);
+				continue;
+			}
+
+			await deleteProductRowAndHandoffActive({
+				db: tx,
 				internalId: row.current.internal_id,
-				update: { archived: true },
+				orgId: ctx.org.id,
+				env: ctx.env,
 			});
-			continue;
 		}
 
-		await ProductService.deleteByInternalId({
-			db: ctx.db,
-			internalId: row.current.internal_id,
-			orgId: ctx.org.id,
-			env: ctx.env,
-		});
-	}
+		for (const planId of archivedPlanIds) {
+			await activateHighestRemainingProduct({
+				db: tx,
+				orgId: ctx.org.id,
+				env: ctx.env,
+				productId: planId,
+			});
+		}
+	});
 };

--- a/server/src/internal/invoices/actions/insertInvoices.ts
+++ b/server/src/internal/invoices/actions/insertInvoices.ts
@@ -54,22 +54,6 @@ export const insertInvoices = async ({
 		...new Set(params.invoices.flatMap((invoice) => invoice.plan_ids)),
 	];
 
-	const latestPlanVersions = ctx.db
-		.select({
-			id: products.id,
-			maxVersion: sql<number>`MAX(${products.version})`.as("max_version"),
-		})
-		.from(products)
-		.where(
-			and(
-				eq(products.org_id, ctx.org.id),
-				eq(products.env, ctx.env),
-				planIds.length > 0 ? inArray(products.id, planIds) : undefined,
-			),
-		)
-		.groupBy(products.id)
-		.as("latest_plan_versions");
-
 	const [customerRows, planRows, existingRows] = await Promise.all([
 		ctx.db
 			.select({ id: customers.id, internalId: customers.internal_id })
@@ -85,17 +69,11 @@ export const insertInvoices = async ({
 			? ctx.db
 					.select({ id: products.id, internalId: products.internal_id })
 					.from(products)
-					.innerJoin(
-						latestPlanVersions,
-						and(
-							eq(products.id, latestPlanVersions.id),
-							eq(products.version, latestPlanVersions.maxVersion),
-						),
-					)
 					.where(
 						and(
 							eq(products.org_id, ctx.org.id),
 							eq(products.env, ctx.env),
+							eq(products.active, true),
 							inArray(products.id, planIds),
 						),
 					)

--- a/server/src/internal/licenses/actions/links/copyPlanLicenseLinks.ts
+++ b/server/src/internal/licenses/actions/links/copyPlanLicenseLinks.ts
@@ -1,6 +1,6 @@
 import type { FullProduct } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { getLatestProducts } from "@/internal/products/productUtils.js";
+import { getActiveProducts } from "@/internal/products/productUtils.js";
 import {
 	type PlanLicenseWithPlanIds,
 	planLicenseRepo,
@@ -24,7 +24,7 @@ export const copyPlanLicenseLinks = async ({
 	if (links.length === 0) return;
 
 	const latestToProductByPlanId = new Map(
-		getLatestProducts(toProducts).map((product) => [product.id, product]),
+		getActiveProducts(toProducts).map((product) => [product.id, product]),
 	);
 
 	for (const { planLicense, licensePlanId, parentPlanId } of links) {

--- a/server/src/internal/licenses/actions/propagation/prepareLicenseParentPropagation.ts
+++ b/server/src/internal/licenses/actions/propagation/prepareLicenseParentPropagation.ts
@@ -53,13 +53,6 @@ export const prepareLicenseParentPropagation = async ({
 		orgId: ctx.org.id,
 		env: ctx.env,
 	});
-	const latestVersionByPlanId = new Map<string, number>();
-	for (const { parent } of contexts) {
-		latestVersionByPlanId.set(
-			parent.id,
-			Math.max(latestVersionByPlanId.get(parent.id) ?? 0, parent.version),
-		);
-	}
 	const selectedKeys = new Set(
 		selectedContexts.map(({ parent }) =>
 			licenseParentTargetKey({
@@ -95,9 +88,7 @@ export const prepareLicenseParentPropagation = async ({
 				licenses,
 				currentEffectivePlan,
 				hasCustomers: usage?.hasVersionableCustomerProducts ?? false,
-				isLatest:
-					context.parent.version ===
-					latestVersionByPlanId.get(context.parent.id),
+				isLatest: context.parent.active,
 				selected: selectedKeys.has(
 					licenseParentTargetKey({
 						planId: context.parent.id,

--- a/server/src/internal/product/actions/previewUpdatePlan/previewAffectedLicenseParents.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewAffectedLicenseParents.ts
@@ -72,13 +72,6 @@ export const previewAffectedLicenseParents = async ({
 	});
 	if (parentContexts.length === 0) return [];
 	const parentProducts = parentContexts.map(({ parent }) => parent);
-	const latestVersionByPlanId = new Map<string, number>();
-	for (const parent of parentProducts) {
-		latestVersionByPlanId.set(
-			parent.id,
-			Math.max(latestVersionByPlanId.get(parent.id) ?? 0, parent.version),
-		);
-	}
 	const usageByInternalId = await customerProductRepo.getVersioningUsage({
 		db: ctx.db,
 		internalProductIds: parentProducts.map((parent) => parent.internal_id),
@@ -149,7 +142,7 @@ export const previewAffectedLicenseParents = async ({
 			const usage = usageByInternalId.get(parent.internal_id);
 			const hasCustomers = usage?.hasVersionableCustomerProducts ?? false;
 			const customerCount = usage?.versionableCustomerCount ?? 0;
-			const isLatest = parent.version === latestVersionByPlanId.get(parent.id);
+			const isLatest = parent.active;
 			const hasChanges =
 				licenseChange.previous_attributes !== null ||
 				licenseChange.plan_changes !== null;

--- a/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
+++ b/server/src/internal/product/actions/previewUpdatePlan/previewAffectedVariants.ts
@@ -77,24 +77,14 @@ export const previewAffectedVariants = async ({
 		returnAll: true,
 	});
 	variants.sort((a, b) => a.id.localeCompare(b.id) || b.version - a.version);
-	const latestVersionById = new Map<string, number>();
-	for (const variant of variants) {
-		latestVersionById.set(
-			variant.id,
-			Math.max(latestVersionById.get(variant.id) ?? 0, variant.version),
-		);
-	}
 	const previewVariants =
 		data.include_versions || data.all_versions
 			? variants
-			: variants.filter(
-					(variant) => variant.version === latestVersionById.get(variant.id),
-				);
+			: variants.filter((variant) => variant.active);
 
 	return Promise.all(
 		previewVariants.map(async (variant) => {
-			const isLatestVersion =
-				variant.version === latestVersionById.get(variant.id);
+			const isLatestVersion = variant.active;
 			const currentPlan = await getPlanResponse({
 				ctx,
 				product: variant,

--- a/server/src/internal/products/ProductService.ts
+++ b/server/src/internal/products/ProductService.ts
@@ -37,6 +37,10 @@ import {
 import { getActiveProducts, isFreeProduct } from "./productUtils";
 import { sortFullProducts } from "./productUtils/sortProductUtils";
 import {
+	deleteProductRowAndHandoffActive,
+	type ProductWriteDb,
+} from "./repos/activateHighestRemainingProduct";
+import {
 	composeFullProductQuery,
 	normalizeFullProductLicenses,
 	type ProductWithLicenseRelations,
@@ -665,6 +669,29 @@ export class ProductService {
 
 	// DELETES
 
+	static async archiveByInternalId({
+		db,
+		internalId,
+		orgId,
+		env,
+	}: {
+		db: ProductWriteDb;
+		internalId: string;
+		orgId: string;
+		env: AppEnv;
+	}) {
+		await db
+			.update(products)
+			.set({ archived: true })
+			.where(
+				and(
+					eq(products.internal_id, internalId),
+					eq(products.org_id, orgId),
+					eq(products.env, env),
+				),
+			);
+	}
+
 	static async deleteByInternalId({
 		db,
 		internalId,
@@ -676,15 +703,14 @@ export class ProductService {
 		orgId: string;
 		env: AppEnv;
 	}) {
-		await db
-			.delete(products)
-			.where(
-				and(
-					eq(products.internal_id, internalId),
-					eq(products.org_id, orgId),
-					eq(products.env, env),
-				),
-			);
+		await db.transaction(async (tx) => {
+			await deleteProductRowAndHandoffActive({
+				db: tx,
+				internalId,
+				orgId,
+				env,
+			});
+		});
 	}
 
 	static async deleteByProductId({

--- a/server/src/internal/products/ProductService.ts
+++ b/server/src/internal/products/ProductService.ts
@@ -34,7 +34,7 @@ import {
 	getCachedProducts,
 	setCachedProducts,
 } from "@/external/redis/actions/productsCache/productsCache.js";
-import { getLatestProducts, isFreeProduct } from "./productUtils";
+import { getActiveProducts, isFreeProduct } from "./productUtils";
 import { sortFullProducts } from "./productUtils/sortProductUtils";
 import {
 	composeFullProductQuery,
@@ -111,9 +111,7 @@ export class ProductService {
 
 		parseFreeTrials({ products: fullProducts });
 
-		const latestProducts = getLatestProducts(fullProducts);
-
-		return latestProducts;
+		return getActiveProducts(fullProducts);
 	}
 
 	static async getByStripeProductIds({
@@ -291,26 +289,20 @@ export class ProductService {
 
 		parseFreeTrials({ products: prods });
 
-		const latestProducts = getLatestProducts(prods);
+		const activeProducts = getActiveProducts(prods);
 
 		if (onlyFree) {
-			return latestProducts.filter((p) =>
+			return activeProducts.filter((p) =>
 				isFreeProduct(p.prices),
 			) as FullProduct[];
 		}
 
-		return latestProducts as FullProduct[];
+		return activeProducts as FullProduct[];
 	}
 
 	static async insert({ db, product }: { db: DrizzleCli; product: Product }) {
-		// Dual-write for version identity (nothing reads these yet — Unit 2):
-		// every production insert funnels through here. Invariant: active tracks
-		// the max version ("latest wins", today's resolution), order-independently
-		// — a row only self-activates when no higher version exists, so multi-row
-		// catalog updates land the same end state whatever their insert order.
-		// `product.active` is the caller's explicit request (strict on
-		// ProductSchema); false opts out (future catalogV2 compute hook).
-		// unique_active_product backstops the flip against concurrent inserts.
+		// Dual-write version identity; omit-version reads resolve `active`.
+		// A row only self-activates when no higher version exists.
 		const row = {
 			...product,
 			version_slug: product.version_slug ?? `v${product.version}`,
@@ -372,7 +364,7 @@ export class ProductService {
 				eq(products.id, id),
 				eq(products.org_id, orgId),
 				eq(products.env, env),
-				version ? eq(products.version, version) : undefined,
+				version ? eq(products.version, version) : eq(products.active, true),
 			),
 			orderBy: [desc(products.version)],
 		});
@@ -492,47 +484,13 @@ export class ProductService {
 		version?: number;
 		archived?: boolean;
 	}): Promise<FullProduct[]> {
-		// Optimization: Use a subquery to only fetch the latest version of each product
-		const latestVersionsSubquery =
-			!returnAll && !version
-				? db
-						.select({
-							id: products.id,
-							maxVersion: sql<number>`MAX(${products.version})`.as(
-								"max_version",
-							),
-						})
-						.from(products)
-						.where(
-							and(
-								eq(products.org_id, orgId),
-								eq(products.env, env),
-								inIds ? inArray(products.id, inIds) : undefined,
-							),
-						)
-						.groupBy(products.id)
-						.as("latest_versions")
-				: undefined;
-
 		const rows = (await db.query.products.findMany({
 			where: and(
 				eq(products.org_id, orgId),
 				eq(products.env, env),
 				inIds ? inArray(products.id, inIds) : undefined,
 				version ? eq(products.version, version) : undefined,
-				latestVersionsSubquery
-					? exists(
-							db
-								.select()
-								.from(latestVersionsSubquery)
-								.where(
-									and(
-										eq(latestVersionsSubquery.id, products.id),
-										eq(latestVersionsSubquery.maxVersion, products.version),
-									),
-								),
-						)
-					: undefined,
+				!returnAll && !version ? eq(products.active, true) : undefined,
 			),
 			with: composeFullProductQuery(),
 		})) as ProductWithLicenseRelations[];
@@ -550,7 +508,7 @@ export class ProductService {
 			return data;
 		}
 
-		const latestProducts: FullProduct[] = getLatestProducts(data);
+		const latestProducts: FullProduct[] = getActiveProducts(data);
 
 		if (inIds) {
 			const newProducts: FullProduct[] = [];
@@ -587,42 +545,13 @@ export class ProductService {
 	}): Promise<FullProduct[]> {
 		if (baseInternalProductIds.length === 0) return [];
 
-		const latestVersionsSubquery = db
-			.select({
-				id: products.id,
-				maxVersion: sql<number>`MAX(${products.version})`.as("max_version"),
-			})
-			.from(products)
-			.where(
-				and(
-					eq(products.org_id, orgId),
-					eq(products.env, env),
-					inArray(products.base_internal_product_id, baseInternalProductIds),
-					ne(products.archived, true),
-				),
-			)
-			.groupBy(products.id)
-			.as("latest_versions");
-
 		const data = (await db.query.products.findMany({
 			where: and(
 				eq(products.org_id, orgId),
 				eq(products.env, env),
 				ne(products.archived, true),
 				inArray(products.base_internal_product_id, baseInternalProductIds),
-				returnAll
-					? undefined
-					: exists(
-							db
-								.select()
-								.from(latestVersionsSubquery)
-								.where(
-									and(
-										eq(latestVersionsSubquery.id, products.id),
-										eq(latestVersionsSubquery.maxVersion, products.version),
-									),
-								),
-						),
+				returnAll ? undefined : eq(products.active, true),
 			),
 			with: {
 				entitlements: {
@@ -638,7 +567,7 @@ export class ProductService {
 
 		parseFreeTrials({ products: data });
 
-		return returnAll ? data : getLatestProducts(data);
+		return returnAll ? data : getActiveProducts(data);
 	}
 
 	static async getFull({
@@ -665,6 +594,12 @@ export class ProductService {
 				eq(products.org_id, orgId),
 				eq(products.env, env),
 				version ? eq(products.version, version) : undefined,
+				!version
+					? or(
+							eq(products.internal_id, idOrInternalId),
+							eq(products.active, true),
+						)
+					: undefined,
 			),
 			orderBy: [desc(products.version)],
 			with: composeFullProductQuery(),

--- a/server/src/internal/products/handlers/handleCopyEnvironment/resolveVariantBaseLinks.ts
+++ b/server/src/internal/products/handlers/handleCopyEnvironment/resolveVariantBaseLinks.ts
@@ -1,7 +1,7 @@
 import { deduplicateArray, type FullProduct, notNullish } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { ProductService } from "../../ProductService.js";
-import { getLatestProducts } from "../../productUtils.js";
+import { getActiveProducts } from "../../productUtils.js";
 
 /**
  * Maps each variant in the copy set to its base plan's public id. A variant may
@@ -83,7 +83,7 @@ export const getTargetBaseInternalIds = async ({
 	});
 
 	return new Map(
-		getLatestProducts(targetBases)
+		getActiveProducts(targetBases)
 			.filter((base) => base.base_internal_product_id === null)
 			.map((base) => [base.id, base.internal_id]),
 	);

--- a/server/src/internal/products/handlers/handleVersionProduct.ts
+++ b/server/src/internal/products/handlers/handleVersionProduct.ts
@@ -69,17 +69,16 @@ export const handleVersionProductV2 = async ({
 }) => {
 	const { db, features } = ctx;
 
-	const latestForVersioning = await ProductService.getFull({
+	const maxVersion = await ProductService.getProductVersionCount({
 		db,
-		idOrInternalId: latestProduct.id,
+		productId: latestProduct.id,
 		orgId: org.id,
 		env,
 	});
-	const curVersion = latestForVersioning.version;
-	const newVersion = curVersion + 1;
+	const newVersion = maxVersion + 1;
 
 	console.log(
-		`Updating product ${latestProduct.id} version from ${curVersion} to ${newVersion}`,
+		`Updating product ${latestProduct.id} version from ${maxVersion} to ${newVersion}`,
 	);
 
 	// Deep-merge `config` so partial patches (e.g. `{ config: { ignore_past_due: true } }`)

--- a/server/src/internal/products/productUtils.ts
+++ b/server/src/internal/products/productUtils.ts
@@ -44,17 +44,15 @@ import { PriceService } from "./prices/PriceService.js";
 import { isDefaultTrialFullProduct } from "./productUtils/classifyProduct.js";
 import { applyStripeResourceReuseForProduct } from "./stripeResourceUtils/applyStripeResourceReuseForProduct.js";
 
-export const getLatestProducts = <T extends { id: string; version: number }>(
+export const getActiveProducts = <T extends { id: string; active: boolean }>(
 	products: T[],
 ): T[] => {
-	const latestById = new Map<string, T>();
+	const activeById = new Map<string, T>();
 	for (const product of products) {
-		const existing = latestById.get(product.id);
-		if (!existing || product.version > existing.version) {
-			latestById.set(product.id, product);
-		}
+		if (!product.active) continue;
+		activeById.set(product.id, product);
 	}
-	return [...latestById.values()];
+	return [...activeById.values()];
 };
 
 const getProductVersionCounts = (products: FullProduct[]) => {

--- a/server/src/internal/products/repos/activateHighestRemainingProduct.ts
+++ b/server/src/internal/products/repos/activateHighestRemainingProduct.ts
@@ -1,0 +1,108 @@
+import { type AppEnv, products } from "@autumn/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+export type ProductWriteDb = {
+	query: DrizzleCli["query"];
+	delete: DrizzleCli["delete"];
+	update: DrizzleCli["update"];
+};
+
+const samePlan = ({
+	orgId,
+	env,
+	productId,
+}: {
+	orgId: string;
+	env: AppEnv;
+	productId: string;
+}) =>
+	and(
+		eq(products.org_id, orgId),
+		eq(products.env, env),
+		eq(products.id, productId),
+	);
+
+/**
+ * Point `active` at the highest non-archived version of this plan, if any.
+ * Two statements: `unique_active_product` is not deferrable, so a one-row-flip can unique-violate.
+ */
+export const activateHighestRemainingProduct = async ({
+	db,
+	orgId,
+	env,
+	productId,
+}: {
+	db: ProductWriteDb;
+	orgId: string;
+	env: AppEnv;
+	productId: string;
+}): Promise<void> => {
+	const nextId = sql`(
+		SELECT internal_id
+		FROM ${products}
+		WHERE org_id = ${orgId}
+			AND env = ${env}
+			AND id = ${productId}
+			AND archived = false
+		ORDER BY version DESC
+		LIMIT 1
+	)`;
+
+	await db
+		.update(products)
+		.set({ active: false })
+		.where(
+			and(
+				samePlan({ orgId, env, productId }),
+				eq(products.active, true),
+				sql`${nextId} IS NOT NULL`,
+				sql`${products.internal_id} IS DISTINCT FROM ${nextId}`,
+			),
+		);
+
+	await db
+		.update(products)
+		.set({ active: true })
+		.where(sql`${products.internal_id} = ${nextId}`);
+};
+
+export const deleteProductRowAndHandoffActive = async ({
+	db,
+	internalId,
+	orgId,
+	env,
+}: {
+	db: ProductWriteDb;
+	internalId: string;
+	orgId: string;
+	env: AppEnv;
+}): Promise<void> => {
+	const row = await db.query.products.findFirst({
+		where: and(
+			eq(products.internal_id, internalId),
+			eq(products.org_id, orgId),
+			eq(products.env, env),
+		),
+		columns: { id: true, active: true },
+	});
+
+	await db
+		.delete(products)
+		.where(
+			and(
+				eq(products.internal_id, internalId),
+				eq(products.org_id, orgId),
+				eq(products.env, env),
+			),
+		);
+
+	if (row?.active) {
+		await activateHighestRemainingProduct({
+			db,
+			orgId,
+			env,
+			productId: row.id,
+		});
+	}
+};

--- a/server/src/internal/products/repos/listStripeReuseFamilyIds.ts
+++ b/server/src/internal/products/repos/listStripeReuseFamilyIds.ts
@@ -1,5 +1,5 @@
 import { type AppEnv, products } from "@autumn/shared";
-import { and, desc, eq, exists, inArray, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, ne, or, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export type StripeReuseFamilyId = {
@@ -42,22 +42,6 @@ export const listStripeReuseFamilyIds = async ({
 	const uniqueBaseInternalProductIds = [...new Set(baseInternalProductIds)];
 	if (uniqueBaseInternalProductIds.length === 0) return [];
 
-	const latestVersionsSubquery = db
-		.select({
-			id: products.id,
-			maxVersion: sql<number>`MAX(${products.version})`.as("max_version"),
-		})
-		.from(products)
-		.where(
-			familyFilter({
-				orgId,
-				env,
-				baseInternalProductIds: uniqueBaseInternalProductIds,
-			}),
-		)
-		.groupBy(products.id)
-		.as("latest_versions");
-
 	const rows = await db
 		.select({
 			baseInternalProductId:
@@ -72,19 +56,7 @@ export const listStripeReuseFamilyIds = async ({
 					env,
 					baseInternalProductIds: uniqueBaseInternalProductIds,
 				}),
-				returnAll
-					? undefined
-					: exists(
-							db
-								.select()
-								.from(latestVersionsSubquery)
-								.where(
-									and(
-										eq(latestVersionsSubquery.id, products.id),
-										eq(latestVersionsSubquery.maxVersion, products.version),
-									),
-								),
-						),
+				returnAll ? undefined : eq(products.active, true),
 			),
 		)
 		.orderBy(desc(products.version));

--- a/server/tests/integration/billing/attach/version-identity-attach.test.ts
+++ b/server/tests/integration/billing/attach/version-identity-attach.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Version identity — billing.attach omit-version uses the active catalog row.
+ *
+ * Contract under test:
+ *   v2 active (lockstep) → omit attach lands on v2
+ *   v1 forced active → omit attach lands on v1
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3, AttachParamsV1Input } from "@autumn/shared";
+import { ResetInterval } from "@autumn/shared";
+import { expectProductActive } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+type TestContext = Awaited<ReturnType<typeof initScenario>>["ctx"];
+
+const monthlyMessagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const forceActiveVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: TestContext;
+	planId: string;
+	version: number;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	for (const product of versions) {
+		if (product.active && product.version !== version) {
+			await ProductService.updateByInternalId({
+				db: ctx.db,
+				internalId: product.internal_id,
+				update: { active: false },
+			});
+		}
+	}
+	const target = versions.find((product) => product.version === version);
+	expect(target).toBeDefined();
+	await ProductService.updateByInternalId({
+		db: ctx.db,
+		internalId: target!.internal_id,
+		update: { active: true },
+	});
+	await invalidateProductsCache({ orgId: ctx.org.id, env: ctx.env });
+};
+
+const attachedVersion = ({
+	customer,
+	planId,
+}: {
+	customer: ApiCustomerV3;
+	planId: string;
+}) => customer.products.find((product) => product.id === planId)?.version;
+
+test.concurrent(
+	`${chalk.yellowBright("version identity attach: omit version with v2 active attaches v2")}`,
+	async () => {
+		const customerId = "vid-attach-lockstep";
+		const pro = products.pro({
+			id: "vid-attach-lockstep-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV1, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: pro.id,
+					versioning: "new_version",
+					items: [monthlyMessagesItem(500)],
+				},
+			],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: pro.id });
+		expect(attachedVersion({ customer, planId: pro.id })).toBe(2);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity attach: omit version with v1 forced active attaches v1")}`,
+	async () => {
+		const customerId = "vid-attach-active";
+		const pro = products.pro({
+			id: "vid-attach-active-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV1, autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: pro.id,
+					versioning: "new_version",
+					items: [monthlyMessagesItem(500)],
+				},
+			],
+		});
+		await forceActiveVersion({ ctx, planId: pro.id, version: 1 });
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		await expectProductActive({ customer, productId: pro.id });
+		expect(attachedVersion({ customer, planId: pro.id })).toBe(1);
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/create/version-identity-stripe-reuse.test.ts
+++ b/server/tests/integration/catalog-v2/plans/create/version-identity-stripe-reuse.test.ts
@@ -1,0 +1,138 @@
+/**
+ * catalogV2 stripe family reuse — omit-version reuse copies from the active base.
+ *
+ * Contract:
+ *   v2 active → new variant reuses v2 stripe product
+ *   v1 forced active → new variant reuses v1 stripe product
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval, BillingMethod, type FullProduct } from "@autumn/shared";
+import { forceActiveVersion } from "@tests/integration/utils/forceActiveVersion.js";
+import { expectProductProcessorCorrect } from "@tests/integration/utils/expectStripePriceResources.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+
+const prepaidMessagesItem = ({ amount }: { amount: number }) => ({
+	feature_id: TestFeature.Messages,
+	included: 0,
+	price: {
+		amount,
+		interval: BillingInterval.Month,
+		billing_method: BillingMethod.Prepaid,
+		billing_units: 100,
+	},
+});
+
+const getFull = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version?: number;
+}): Promise<FullProduct> =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+
+const seedPaidBaseAndV2 = async ({
+	autumn,
+	baseId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	baseId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: baseId,
+				name: "Team",
+				price: { amount: 20, interval: BillingInterval.Month },
+				items: [prepaidMessagesItem({ amount: 10 })],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: baseId,
+				versioning: "new_version",
+				price: { amount: 30, interval: BillingInterval.Month },
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity stripe reuse: variant with v2 active reuses v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_sru_ls_b");
+		const variantId = uniqueTestId("cv2_sru_ls_v");
+		await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		try {
+			await seedPaidBaseAndV2({ autumn: autumnV2_3, baseId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: baseId,
+						variants: [{ variant_plan_id: variantId, name: "Team EU" }],
+					},
+				],
+			});
+
+			const v2 = await getFull({ ctx, planId: baseId, version: 2 });
+			const variant = await getFull({ ctx, planId: variantId });
+			expectProductProcessorCorrect({
+				product: variant,
+				processorId: v2.processor?.id,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity stripe reuse: variant with v1 active reuses v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_sru_act_b");
+		const variantId = uniqueTestId("cv2_sru_act_v");
+		await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		try {
+			await seedPaidBaseAndV2({ autumn: autumnV2_3, baseId });
+			await forceActiveVersion({ ctx, planId: baseId, version: 1 });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: baseId,
+						variants: [{ variant_plan_id: variantId, name: "Team EU" }],
+					},
+				],
+			});
+
+			const v1 = await getFull({ ctx, planId: baseId, version: 1 });
+			const v2 = await getFull({ ctx, planId: baseId, version: 2 });
+			const variant = await getFull({ ctx, planId: variantId });
+			expect(v1.processor?.id).not.toBe(v2.processor?.id);
+			expectProductProcessorCorrect({
+				product: variant,
+				processorId: v1.processor?.id,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/version-identity-license-parents.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/version-identity-license-parents.test.ts
@@ -1,0 +1,134 @@
+/**
+ * catalogV2.preview_update — license_parents omit-version top card is the active parent.
+ *
+ * Contract:
+ *   v2 active (lockstep) → top v2 propagated, sibling v1 unchanged
+ *   v1 forced active → top v1 propagated, sibling v2 unchanged
+ *   versioning.current_version stays max (the number), not the pointer
+ */
+
+import { test } from "bun:test";
+import { forceActiveVersion } from "@tests/integration/utils/forceActiveVersion.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../../preview/utils/expectPlanPreview.js";
+import {
+	messagesItem,
+	seedTwoParentVersions,
+	withCatalogPlans,
+} from "../utils/seedLicensePlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("version identity preview: omit license_parents with v2 active tops v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lp_vid_ls_p");
+		const childId = uniqueTestId("cv2_lp_vid_ls_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+
+				const preview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: [
+							{
+								plan_id: childId,
+								items: [messagesItem(200)],
+								propagate: { license_parents: [{ plan_id: parentId }] },
+							},
+						],
+					}),
+				);
+
+				expectPlanPreviewRowCorrect({
+					preview,
+					expected: {
+						planId: childId,
+						licenseParents: [
+							{
+								planId: parentId,
+								version: 2,
+								licenseAction: "propagated",
+								versioning: {
+									current_version: 2,
+									new_version: null,
+									resolved: "existing",
+									options: ["existing", "all_versions"],
+								},
+								siblingVersions: [
+									{ version: 1, licenseAction: "unchanged" },
+								],
+							},
+						],
+					},
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity preview: omit license_parents with v1 active tops v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lp_vid_act_p");
+		const childId = uniqueTestId("cv2_lp_vid_act_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				await forceActiveVersion({ ctx, planId: parentId, version: 1 });
+
+				const preview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: [
+							{
+								plan_id: childId,
+								items: [messagesItem(200)],
+								propagate: { license_parents: [{ plan_id: parentId }] },
+							},
+						],
+					}),
+				);
+
+				expectPlanPreviewRowCorrect({
+					preview,
+					expected: {
+						planId: childId,
+						licenseParents: [
+							{
+								planId: parentId,
+								version: 1,
+								licenseAction: "propagated",
+								versioning: {
+									current_version: 2,
+									new_version: null,
+									resolved: "existing",
+									options: ["existing", "all_versions"],
+								},
+								siblingVersions: [
+									{ version: 2, licenseAction: "unchanged" },
+								],
+							},
+						],
+					},
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/propagated/follow-latest-or-explicit-version.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/propagated/follow-latest-or-explicit-version.test.ts
@@ -2,12 +2,15 @@
  * catalogV2.update — propagate.license_parents omit / existing / explicit version.
  * Parent absent from plans[]. Parent has v1+v2, both linked.
  *
- * omit/existing → latest follows, v1 frozen
+ * omit/existing → active pointer follows, other versions frozen
  * version: 1 → v1 follows, latest frozen
  */
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
 import { uniqueTestId } from "../../../utils/uniqueTestId.js";
 import { expectLicenseLinkCorrect } from "../utils/expectLicenseLinkCorrect.js";
 import {
@@ -15,6 +18,42 @@ import {
 	seedTwoParentVersions,
 	withCatalogPlans,
 } from "../utils/seedLicensePlans.js";
+
+const forceActiveVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	for (const product of versions) {
+		if (product.active && product.version !== version) {
+			await ProductService.updateByInternalId({
+				db: ctx.db,
+				internalId: product.internal_id,
+				update: { active: false },
+			});
+		}
+	}
+	const target = versions.find((product) => product.version === version);
+	expect(target).toBeDefined();
+	await ProductService.updateByInternalId({
+		db: ctx.db,
+		internalId: target!.internal_id,
+		update: { active: true },
+	});
+	await invalidateProductsCache({ orgId: ctx.org.id, env: ctx.env });
+};
 
 test.concurrent(
 	`${chalk.yellowBright("catalogV2 plan-licenses: omit versioning follows latest; v1 stays frozen")}`,
@@ -142,6 +181,51 @@ test.concurrent(
 					parentPlanId: parentId,
 					parentVersion: 2,
 					licensePlanId: childId,
+					customized: true,
+					messagesAllowance: 10,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: omit versioning follows active v1; v2 stays frozen")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_pact_p");
+		const childId = uniqueTestId("cv2_lic_pact_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				await forceActiveVersion({ ctx, planId: parentId, version: 1 });
+				await bumpChild({
+					autumn: autumnV2_3,
+					childId,
+					propagate: { license_parents: [{ plan_id: parentId }] },
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 1,
+					licensePlanId: childId,
+					included: 2,
+					customized: false,
+					messagesAllowance: 200,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 2,
+					licensePlanId: childId,
+					included: 2,
 					customized: true,
 					messagesAllowance: 10,
 				});

--- a/server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts
+++ b/server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Deleting (or archiving) the active version promotes the highest remaining
+ * live row so omit-version reads still resolve.
+ *
+ * Red (current):  omit-version getFull 404s after pin-delete of v2.
+ * Green (after):  omit-version getFull returns the surviving tip with active=true.
+ */
+
+import { expect, test } from "bun:test";
+import { forceActiveVersion } from "@tests/integration/utils/forceActiveVersion.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../migrations/utils/seedVersionableCustomer.js";
+import { cleanupPlanCustomerRefs } from "../utils/cleanupPlanCustomerRefs.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+
+const expectOmitVersionIs = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+}) => {
+	const omitVersion = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	expect(omitVersion.version).toBe(version);
+	expect(omitVersion.active).toBe(true);
+};
+
+const seedV1AndV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, name: "V1" }],
+	});
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, versioning: "new_version", name: "V2" }],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity remove: pin-delete of active v2 promotes v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_rmp_id_tip");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				remove_plans: [{ plan_id: planId, version: 2 }],
+			});
+			await expectOmitVersionIs({ ctx, planId, version: 1 });
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity remove: pin-delete of forced-active v1 promotes v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_rmp_id_low");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await forceActiveVersion({ ctx, planId, version: 1 });
+			await autumnV2_3.catalogV2.update({
+				remove_plans: [{ plan_id: planId, version: 1 }],
+			});
+			await expectOmitVersionIs({ ctx, planId, version: 2 });
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity remove: products.delete of the active tip promotes v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_rmp_id_del");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await autumnV2_3.products.delete(planId);
+			await expectOmitVersionIs({ ctx, planId, version: 1 });
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity remove: pin-archive of active v2 promotes v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_rmp_id_arch");
+		await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await seedVersionableCustomer({ ctx, planId, version: 2 });
+			await autumnV2_3.catalogV2.update({
+				remove_plans: [{ plan_id: planId, version: 2 }],
+			});
+			await expectOmitVersionIs({ ctx, planId, version: 1 });
+		} finally {
+			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/default-version-attach.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/default-version-attach.test.ts
@@ -1,12 +1,13 @@
 /**
  * Default plans × versioning — creating a customer must attach exactly ONE
- * version of a default plan: the latest. Covers the normal mint flow (flag
- * moves to v2) and the bad state where both versions are flagged is_default.
+ * version of a default plan: the active pointer. Covers the normal mint flow
+ * (flag moves to v2) and the bad state where both versions are flagged is_default.
  */
 
 import { expect, test } from "bun:test";
 import { customerProducts, products, ResetInterval } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
+import { forceActiveVersion } from "@tests/integration/utils/forceActiveVersion.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { and, eq } from "drizzle-orm";
@@ -157,7 +158,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 defaults: bad state — v1 AND v2 both is_default → only latest attached")}`,
+	`${chalk.yellowBright("catalogV2 defaults: bad state — v1 AND v2 both is_default → only active attached")}`,
 	async () => {
 		const { autumnV1, autumnV2_3, ctx } = await initScenario({
 			setup: [],
@@ -194,6 +195,50 @@ test.concurrent(
 				"exactly one version of the default plan may attach",
 			).toHaveLength(1);
 			expect(attachedRows[0]?.internal_product_id).toBe(v2.internal_id);
+		} finally {
+			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 defaults: both is_default, v1 forced active → attaches v1")}`,
+	async () => {
+		const { autumnV1, autumnV2_3, ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_def_active");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultFreeV1({ autumn: autumnV2_3, planId });
+			await mintV2({ autumn: autumnV2_3, planId });
+
+			const v1 = await getFull({ ctx, planId, version: 1 });
+			await ctx.db
+				.update(products)
+				.set({ is_default: true })
+				.where(eq(products.internal_id, v1.internal_id));
+			await forceActiveVersion({ ctx, planId, version: 1 });
+
+			const customer = await autumnV1.customers.create({
+				id: uniqueTestId("cv2_defcus_active"),
+				email: `${planId}-active@test.com`,
+				withAutumnId: true,
+				internalOptions: { default_group: `g_${planId}` },
+			});
+
+			const attachedRows = await fetchAttachedPlanRows({
+				ctx,
+				internalCustomerId: customer.autumn_id as string,
+				planId,
+			});
+			expect(
+				attachedRows,
+				"exactly one version of the default plan may attach",
+			).toHaveLength(1);
+			expect(attachedRows[0]?.internal_product_id).toBe(v1.internal_id);
 		} finally {
 			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
 			await deleteDbPlans({ ctx, planIds: [planId] });

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-update.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-update.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Version identity — catalogV2.update omit-version vs sequence (r3–r5).
+ *
+ * Contract under test:
+ *   r3  v1 forced active → omit catalogV2.update patches v1
+ *   r4  v1 forced active → new_version clones v1 into max+1
+ *   r5  v1 forced active → explicit version: 2 still edits v2
+ *   Lockstep (v2 active) omit-update still patches v2.
+ */
+
+import { expect, test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectDbPlansCorrect,
+	expectPlanVersionsCorrect,
+} from "../utils/expectCatalogPlans.js";
+
+type TestContext = AutumnContext;
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const forceActiveVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: TestContext;
+	planId: string;
+	version: number;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	for (const product of versions) {
+		if (product.active && product.version !== version) {
+			await ProductService.updateByInternalId({
+				db: ctx.db,
+				internalId: product.internal_id,
+				update: { active: false },
+			});
+		}
+	}
+	const target = versions.find((product) => product.version === version);
+	expect(target).toBeDefined();
+	await ProductService.updateByInternalId({
+		db: ctx.db,
+		internalId: target!.internal_id,
+		update: { active: true },
+	});
+	await invalidateProductsCache({ orgId: ctx.org.id, env: ctx.env });
+};
+
+const seedV1AndV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, name: "V1", items: [messagesItem(100)] }],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				name: "V2",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity update: omit version with v2 active edits v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_lockstep");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "V2 Edited",
+						items: [messagesItem(300)],
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1",
+						allowances: { [TestFeature.Messages]: 100 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2 Edited",
+						allowances: { [TestFeature.Messages]: 300 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity update: omit version with v1 forced active edits v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_active");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await forceActiveVersion({ ctx, planId, version: 1 });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "V1 Edited",
+						items: [messagesItem(150)],
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1 Edited",
+						allowances: { [TestFeature.Messages]: 150 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2",
+						allowances: { [TestFeature.Messages]: 200 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity update: new_version clones active v1 into max+1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_mint");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await forceActiveVersion({ ctx, planId, version: 1 });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "V3",
+						versioning: "new_version",
+					},
+				],
+			});
+
+			await expectPlanVersionsCorrect({
+				ctx,
+				planId,
+				versions: [1, 2, 3],
+			});
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1",
+						allowances: { [TestFeature.Messages]: 100 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2",
+						allowances: { [TestFeature.Messages]: 200 },
+					},
+					{
+						id: planId,
+						version: 3,
+						name: "V3",
+						allowances: { [TestFeature.Messages]: 100 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity update: explicit version 2 still edits v2 when v1 is active")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_pin");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await forceActiveVersion({ ctx, planId, version: 1 });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version: 2,
+						name: "V2 Pinned",
+						items: [messagesItem(250)],
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1",
+						allowances: { [TestFeature.Messages]: 100 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2 Pinned",
+						allowances: { [TestFeature.Messages]: 250 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/crud/plans/versioning/version-identity-fetch.test.ts
+++ b/server/tests/integration/crud/plans/versioning/version-identity-fetch.test.ts
@@ -1,8 +1,9 @@
 /**
- * Version identity read path — product fetching.
+ * Version identity read path — product fetching (r1, r2).
  *
  * Contract under test:
- *   Omit-version get/list/catalog.get resolve the active pointer, not max(version).
+ *   r1  v1+v2, v2 active (lockstep) → omit get/list/catalog.get returns v2
+ *   r2  v1 forced active → omit get/list/catalog.get returns v1
  *   Explicit version lookups are unchanged.
  */
 
@@ -84,7 +85,51 @@ const setupVersionedPlan = async (testId: string) => {
 };
 
 test.concurrent(
-	`${chalk.yellowBright("version identity fetch: getFull omit-version returns the active row, not max")}`,
+	`${chalk.yellowBright("version identity fetch r1: omit get/list/catalog.get return v2 when v2 is active")}`,
+	async () => {
+		const base = products.base({
+			id: "version_identity_fetch_lockstep",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId: "version-identity-fetch-lockstep",
+			setup: [s.customer({}), s.products({ list: [base] })],
+			actions: [],
+		});
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: base.id,
+					items: [monthlyMessagesItem(500)],
+					versioning: "new_version",
+				},
+			],
+		});
+
+		const omitVersion = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: base.id,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(omitVersion.version).toBe(2);
+		expect(omitVersion.active).toBe(true);
+
+		const catalog = await autumnV2_3.catalogV2.get({
+			include_archived: true,
+		});
+		expect(catalog.plans.find((plan) => plan.id === base.id)?.version).toBe(2);
+
+		const plan = await autumnV2_3.products.get<ApiPlanV1>(base.id);
+		expect(plan.version).toBe(2);
+
+		const listed = await autumnV2_3.products.list<ApiPlanV1[]>();
+		expect(listed.list.find((item) => item.id === base.id)?.version).toBe(2);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity fetch r2: getFull omit-version returns the active row, not max")}`,
 	async () => {
 		const { ctx, planId } = await setupVersionedPlan("getfull");
 
@@ -110,7 +155,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("version identity fetch: listFull omit-version returns the active row")}`,
+	`${chalk.yellowBright("version identity fetch r2: listFull omit-version returns the active row")}`,
 	async () => {
 		const { ctx, planId } = await setupVersionedPlan("listfull");
 
@@ -128,7 +173,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("version identity fetch: catalogV2.get and plans.get return the active row")}`,
+	`${chalk.yellowBright("version identity fetch r2: catalogV2.get and plans.get return the active row")}`,
 	async () => {
 		const { autumnV2_3, planId } = await setupVersionedPlan("catalog");
 

--- a/server/tests/integration/crud/plans/versioning/version-identity-fetch.test.ts
+++ b/server/tests/integration/crud/plans/versioning/version-identity-fetch.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Version identity read path — product fetching.
+ *
+ * Contract under test:
+ *   Omit-version get/list/catalog.get resolve the active pointer, not max(version).
+ *   Explicit version lookups are unchanged.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiPlanV1, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+type TestContext = Awaited<ReturnType<typeof initScenario>>["ctx"];
+
+const monthlyMessagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const forceActiveVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: TestContext;
+	planId: string;
+	version: number;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	for (const product of versions) {
+		if (product.active && product.version !== version) {
+			await ProductService.updateByInternalId({
+				db: ctx.db,
+				internalId: product.internal_id,
+				update: { active: false },
+			});
+		}
+	}
+	const target = versions.find((product) => product.version === version);
+	expect(target).toBeDefined();
+	await ProductService.updateByInternalId({
+		db: ctx.db,
+		internalId: target!.internal_id,
+		update: { active: true },
+	});
+	await invalidateProductsCache({ orgId: ctx.org.id, env: ctx.env });
+};
+
+const setupVersionedPlan = async (testId: string) => {
+	const base = products.base({
+		id: `version_identity_fetch_${testId}`,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId: `version-identity-fetch-${testId}`,
+		setup: [s.customer({}), s.products({ list: [base] })],
+		actions: [],
+	});
+	await autumnV2_3.catalogV2.update({
+		plans: [
+			{
+				plan_id: base.id,
+				items: [monthlyMessagesItem(500)],
+				versioning: "new_version",
+			},
+		],
+	});
+	await forceActiveVersion({ ctx, planId: base.id, version: 1 });
+	return { autumnV2_3, ctx, planId: base.id };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity fetch: getFull omit-version returns the active row, not max")}`,
+	async () => {
+		const { ctx, planId } = await setupVersionedPlan("getfull");
+
+		const omitVersion = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: planId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+		});
+		expect(omitVersion.version).toBe(1);
+		expect(omitVersion.active).toBe(true);
+
+		const pinned = await ProductService.getFull({
+			db: ctx.db,
+			idOrInternalId: planId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			version: 2,
+		});
+		expect(pinned.version).toBe(2);
+		expect(pinned.active).toBe(false);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity fetch: listFull omit-version returns the active row")}`,
+	async () => {
+		const { ctx, planId } = await setupVersionedPlan("listfull");
+
+		const listed = await ProductService.listFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			inIds: [planId],
+			skipCache: true,
+		});
+		expect(listed).toHaveLength(1);
+		expect(listed[0]?.version).toBe(1);
+		expect(listed[0]?.active).toBe(true);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity fetch: catalogV2.get and plans.get return the active row")}`,
+	async () => {
+		const { autumnV2_3, planId } = await setupVersionedPlan("catalog");
+
+		const catalog = await autumnV2_3.catalogV2.get({
+			include_archived: true,
+		});
+		const catalogPlan = catalog.plans.find((plan) => plan.id === planId);
+		expect(catalogPlan?.version).toBe(1);
+
+		const plan = await autumnV2_3.products.get<ApiPlanV1>(planId);
+		expect(plan.version).toBe(1);
+
+		const listed = await autumnV2_3.products.list<ApiPlanV1[]>();
+		const listedPlan = listed.list.find((item) => item.id === planId);
+		expect(listedPlan?.version).toBe(1);
+	},
+);

--- a/server/tests/integration/crud/plans/versioning/version-identity-legacy-update.test.ts
+++ b/server/tests/integration/crud/plans/versioning/version-identity-legacy-update.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Version identity — legacy plans.update omit-version vs force_version (r6).
+ *
+ * Contract under test:
+ *   r6a  v1+v2, v2 active → omit plans.update patches v2
+ *   r6b  v1 forced active → omit plans.update patches v1
+ *   r6c  v1 forced active, v2 exists → force_version clones v1 into max+1 (v3)
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiPlanV1,
+	ApiVersion,
+	ResetInterval,
+	type UpdatePlanParamsV2Input,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+type RpcUpdate = Omit<UpdatePlanParamsV2Input, "plan_id">;
+type TestContext = Awaited<ReturnType<typeof initScenario>>["ctx"];
+type FullProductRow = Awaited<ReturnType<typeof ProductService.listFull>>[number];
+
+const monthlyMessagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const forceActiveVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: TestContext;
+	planId: string;
+	version: number;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	for (const product of versions) {
+		if (product.active && product.version !== version) {
+			await ProductService.updateByInternalId({
+				db: ctx.db,
+				internalId: product.internal_id,
+				update: { active: false },
+			});
+		}
+	}
+	const target = versions.find((product) => product.version === version);
+	expect(target).toBeDefined();
+	await ProductService.updateByInternalId({
+		db: ctx.db,
+		internalId: target!.internal_id,
+		update: { active: true },
+	});
+	await invalidateProductsCache({ orgId: ctx.org.id, env: ctx.env });
+};
+
+const allowanceFor = ({ product }: { product: FullProductRow }) =>
+	product.entitlements.find(
+		(entitlement) => entitlement.feature_id === TestFeature.Messages,
+	)?.allowance;
+
+const setupVersionedPlan = async (testId: string) => {
+	const base = products.base({
+		id: `version_identity_legacy_${testId}`,
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const { autumnV2_3, ctx } = await initScenario({
+		customerId: `version-identity-legacy-${testId}`,
+		setup: [s.customer({}), s.products({ list: [base] })],
+		actions: [],
+	});
+	await autumnV2_3.catalogV2.update({
+		plans: [
+			{
+				plan_id: base.id,
+				name: "V2",
+				items: [monthlyMessagesItem(200)],
+				versioning: "new_version",
+			},
+		],
+	});
+	const rpc = new AutumnRpcCli({
+		secretKey: ctx.orgSecretKey,
+		version: ApiVersion.V2_1,
+	});
+	return { ctx, planId: base.id, rpc };
+};
+
+const listVersions = async ({
+	ctx,
+	planId,
+}: {
+	ctx: TestContext;
+	planId: string;
+}) =>
+	ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+
+test.concurrent(
+	`${chalk.yellowBright("version identity legacy r6a: omit plans.update with v2 active patches v2")}`,
+	async () => {
+		const { ctx, planId, rpc } = await setupVersionedPlan("lockstep");
+
+		await rpc.plans.update<ApiPlanV1, RpcUpdate>(planId, {
+			name: "V2 Edited",
+		});
+
+		const versions = await listVersions({ ctx, planId });
+		const v1 = versions.find((product) => product.version === 1);
+		const v2 = versions.find((product) => product.version === 2);
+		expect(v1?.name).not.toBe("V2 Edited");
+		expect(v2?.name).toBe("V2 Edited");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity legacy r6b: omit plans.update with v1 forced active patches v1")}`,
+	async () => {
+		const { ctx, planId, rpc } = await setupVersionedPlan("omit");
+		await forceActiveVersion({ ctx, planId, version: 1 });
+
+		await rpc.plans.update<ApiPlanV1, RpcUpdate>(planId, {
+			name: "V1 Edited",
+		});
+
+		const versions = await listVersions({ ctx, planId });
+		const v1 = versions.find((product) => product.version === 1);
+		const v2 = versions.find((product) => product.version === 2);
+		expect(v1?.name).toBe("V1 Edited");
+		expect(v2?.name).toBe("V2");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity legacy r6c: force_version clones active v1 into max+1")}`,
+	async () => {
+		const { ctx, planId, rpc } = await setupVersionedPlan("force");
+		await forceActiveVersion({ ctx, planId, version: 1 });
+
+		await rpc.plans.update<ApiPlanV1, RpcUpdate>(planId, {
+			name: "V3",
+			force_version: true,
+		});
+
+		const versions = await listVersions({ ctx, planId });
+		expect(versions.map((product) => product.version).sort()).toEqual([
+			1, 2, 3,
+		]);
+		const v1 = versions.find((product) => product.version === 1)!;
+		const v2 = versions.find((product) => product.version === 2)!;
+		const v3 = versions.find((product) => product.version === 3)!;
+		expect(v2.name).toBe("V2");
+		expect(v3.name).toBe("V3");
+		expect(allowanceFor({ product: v3 })).toBe(100);
+		expect(v3.active).toBe(true);
+		expect(v1.active).toBe(false);
+		expect(v2.active).toBe(false);
+	},
+);

--- a/server/tests/integration/invoices/invoices-insert.test.ts
+++ b/server/tests/integration/invoices/invoices-insert.test.ts
@@ -9,7 +9,7 @@
  *     - POST /v1/invoices.insert -> { invoices: ApiInsertedInvoice[] }
  *   New behaviors:
  *     - response order matches request order
- *     - customer_id, entity_id, and latest plan versions resolve in batched queries
+ *     - customer_id, entity_id, and active plan versions resolve in batched queries
  *     - currency defaults to org.default_currency
  *     - hosted_invoice_url is optional, persisted, and echoed directly
  *     - existing stripe_id rows are fully updated while retaining their Autumn IDs
@@ -93,11 +93,16 @@ test.concurrent(
 		});
 		expect(proV1).toBeDefined();
 		const proV2InternalId = `prod_invoice_v2_${runTag}`;
+		await ctx.db
+			.update(products)
+			.set({ active: false })
+			.where(eq(products.internal_id, proV1!.internal_id));
 		await ctx.db.insert(products).values({
 			...proV1!,
 			internal_id: proV2InternalId,
 			version: proV1!.version + 1,
 			created_at: proV1!.created_at + 1,
+			active: true,
 		});
 
 		const freePlan = await ctx.db.query.products.findFirst({

--- a/server/tests/integration/invoices/version-identity-insert.test.ts
+++ b/server/tests/integration/invoices/version-identity-insert.test.ts
@@ -1,0 +1,127 @@
+/**
+ * invoices.insert — omit-version plan_ids resolve to the active product row.
+ *
+ * Contract:
+ *   v2 active (lockstep) → internal_product_ids is v2
+ *   v1 forced active → internal_product_ids is v1
+ */
+
+import { expect, test } from "bun:test";
+import { invoices } from "@autumn/shared";
+import { forceActiveVersion } from "@tests/integration/utils/forceActiveVersion.js";
+import { items } from "@tests/utils/fixtures/items";
+import { products as productFixtures } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+const internalIdForVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	planId: string;
+	version: number;
+}) => {
+	const product = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+	return product.internal_id;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity invoices.insert: v2 active stamps v2 internal_id")}`,
+	async () => {
+		const customerId = "vid-inv-lockstep";
+		const stripeId = `in_vid_lockstep_${Date.now()}`;
+		const pro = productFixtures.pro({
+			id: "vid-inv-lockstep-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [{ plan_id: pro.id, versioning: "new_version" }],
+		});
+
+		await autumnV2_3.post("/invoices.insert", {
+			invoices: [
+				{
+					customer_id: customerId,
+					plan_ids: [pro.id],
+					stripe_id: stripeId,
+					processor_type: "stripe",
+					status: "paid",
+					total: 20,
+					created_at: Date.UTC(2016, 0, 1),
+				},
+			],
+		});
+
+		const stored = await ctx.db.query.invoices.findFirst({
+			where: eq(invoices.stripe_id, stripeId),
+		});
+		expect(stored?.internal_product_ids).toEqual([
+			await internalIdForVersion({ ctx, planId: pro.id, version: 2 }),
+		]);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity invoices.insert: v1 forced active stamps v1 internal_id")}`,
+	async () => {
+		const customerId = "vid-inv-active";
+		const stripeId = `in_vid_active_${Date.now()}`;
+		const pro = productFixtures.pro({
+			id: "vid-inv-active-pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [{ plan_id: pro.id, versioning: "new_version" }],
+		});
+		await forceActiveVersion({ ctx, planId: pro.id, version: 1 });
+
+		await autumnV2_3.post("/invoices.insert", {
+			invoices: [
+				{
+					customer_id: customerId,
+					plan_ids: [pro.id],
+					stripe_id: stripeId,
+					processor_type: "stripe",
+					status: "paid",
+					total: 20,
+					created_at: Date.UTC(2016, 0, 1),
+				},
+			],
+		});
+
+		const stored = await ctx.db.query.invoices.findFirst({
+			where: eq(invoices.stripe_id, stripeId),
+		});
+		expect(stored?.internal_product_ids).toEqual([
+			await internalIdForVersion({ ctx, planId: pro.id, version: 1 }),
+		]);
+	},
+);

--- a/server/tests/integration/utils/forceActiveVersion.ts
+++ b/server/tests/integration/utils/forceActiveVersion.ts
@@ -1,0 +1,41 @@
+import { expect } from "bun:test";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+/** Unique index `unique_active_product` requires deactivating the current pointer first. */
+export const forceActiveVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	for (const product of versions) {
+		if (product.active && product.version !== version) {
+			await ProductService.updateByInternalId({
+				db: ctx.db,
+				internalId: product.internal_id,
+				update: { active: false },
+			});
+		}
+	}
+	const target = versions.find((product) => product.version === version);
+	expect(target).toBeDefined();
+	await ProductService.updateByInternalId({
+		db: ctx.db,
+		internalId: target!.internal_id,
+		update: { active: true },
+	});
+	await invalidateProductsCache({ orgId: ctx.org.id, env: ctx.env });
+};


### PR DESCRIPTION
## Summary
- Omit-version `ProductService` fetches (`get` / `getFull` / `listFull` / `listDefault` / `listVariantsByParent`) now select the `active` row instead of `MAX(version)`. Explicit `version` still means that row.
- Catalog update, license propagate, invoices `plan_ids`, Stripe reuse, and legacy `handleVersionProduct` clone from the active row and mint at `max+1`. `version` stays a sequence number (gap checks and mint).
- Deleting or archiving the active version promotes the highest remaining non-archived row so omit-version reads keep resolving. Catalog-v2 removes run in one transaction.
- Cover tests pin a non-tip version as active (`forceActiveVersion`) and assert omit-version follows that pointer, including after pin-delete / pin-archive.

Out of this stack: promote / `willActivate`, dashboard `numVersions` / CLI `isHistoricalPlan`, nested variant `active` filtering on GET catalog.

## Test plan
- [x] `server/tests/integration/crud/plans/versioning/version-identity-fetch.test.ts`
- [x] `server/tests/integration/catalog-v2/plans/versions/version-identity-update.test.ts`
- [x] `server/tests/integration/crud/plans/versioning/version-identity-legacy-update.test.ts`
- [x] `server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts`
- [x] `server/tests/integration/catalog-v2/plans/remove` (unarchive / archive-all)
- [x] `server/tests/integration/billing/attach/version-identity-attach.test.ts`
- [x] `server/tests/integration/catalog-v2/plans/licenses/propagated/follow-latest-or-explicit-version.test.ts`
- [x] `server/tests/integration/catalog-v2/plans/licenses/preview/version-identity-license-parents.test.ts`
- [x] `server/tests/integration/invoices/version-identity-insert.test.ts`
- [ ] `server/tests/integration/catalog-v2/plans/create/version-identity-stripe-reuse.test.ts` (v2-active case green; v1-active precondition fails because `new_version` clones `processor`)
- [x] `server/tests/integration/catalog-v2/plans/versions/default-version-attach.test.ts`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes omitted-version product operations to use each plan's active pointer while preserving maximum-version numbering for newly minted rows.

- **[API changes]** Product reads and related catalog operations now resolve an omitted version through the active product row.
- **[Improvements]** New versions clone active content but continue using the maximum existing version plus one.
- **[Bug fixes]** Product removal now reassigns the active pointer, although mixed remove-all operations can still leave an archived version active.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a mixed remove-all operation can leave an archived product active and visible through normal omitted-version reads.

Immediate handoff after deleting one version can activate another version that the same operation subsequently archives, and the final reconciliation does not clear that pointer when no live survivor remains.

**Files Needing Attention:** server/src/internal/catalogV2/execute/executeRemovePlans.ts, server/src/internal/products/repos/activateHighestRemainingProduct.ts, server/src/internal/products/ProductService.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/products/ProductService.ts | Omit-version reads now select active products while exact internal-ID lookups continue to preserve row identity. |
| server/src/internal/products/repos/activateHighestRemainingProduct.ts | Adds active-pointer handoff after deletion, but does not clear the pointer when no non-archived replacement exists. |
| server/src/internal/catalogV2/execute/executeRemovePlans.ts | Coordinates archive and deletion handoffs, but per-row handoff can activate a version that a later iteration archives. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleRemovePlanErrors/handleRemovePlanVersionErrors.ts | Restricts explicit single-version removal to the active version, consistent with active-pointer semantics. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Remove every version] --> B[Delete active highest version]
  B --> C[Immediately activate lower survivor]
  C --> D[Archive lower survivor]
  D --> E[No non-archived replacement exists]
  E --> F[Archived row remains active]
  F --> G[Omit-version reads return archived plan]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/catalogV2/execute/executeRemovePlans.ts:33-38
**Archived version remains active**

When removing all versions where the active highest version is deleted but a lower customer-used version is archived, this immediate handoff activates the lower version before the loop archives it. Since archiving does not clear `active` and the final reconciliation finds no non-archived replacement, omit-version reads continue returning the archived plan.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(products): hand off active when the ..."](https://github.com/useautumn/autumn/commit/33cf133a2cc305e636daa9863042ccfb489e0c3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55150715)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->