### PR TITLE
Credit unused time for plans removed via remove_plan_ids

### DIFF
--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts
@@ -105,6 +105,11 @@ export const computeAttachPlan = ({
 					ctx,
 					newCustomerProducts: [newCustomerProduct],
 					deletedCustomerProduct: currentCustomerProduct,
+					// Plans dropped via `remove_plan_ids` are expired mid-cycle, so they
+					// owe the same unused-time credit as a same-group replacement.
+					deletedCustomerProducts: removeCustomerProducts.map(
+						(update) => update.customerProduct,
+					),
 					billingContext: attachBillingContext,
 					includeArrearLineItems,
 				})

--- a/server/src/internal/billing/v2/actions/attach/compute/computeAttachRemovals.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeAttachRemovals.ts
@@ -28,10 +28,15 @@ export const computeAttachRemovals = ({
 		currentEpochMs,
 	} = attachBillingContext;
 
-	// The current product is already expired via the transition update.
-	const removePlanIds = (params.remove_plan_ids ?? []).filter(
-		(productId) => productId !== currentCustomerProduct?.product.id,
-	);
+	// The current product is already expired via the transition update. Repeats
+	// are collapsed so one plan cannot be credited or settled twice.
+	const removePlanIds = [
+		...new Set(
+			(params.remove_plan_ids ?? []).filter(
+				(productId) => productId !== currentCustomerProduct?.product.id,
+			),
+		),
+	];
 	if (removePlanIds.length === 0) return [];
 
 	// Carry-over reads a single source. With no same-group product to carry from,

--- a/server/tests/integration/billing/attach/params/remove-plan-ids/remove-plan-ids-proration.test.ts
+++ b/server/tests/integration/billing/attach/params/remove-plan-ids/remove-plan-ids-proration.test.ts
@@ -179,3 +179,53 @@ test.concurrent(
 		});
 	},
 );
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 3: A repeated plan id is credited exactly once
+//
+// remove_plan_ids has no uniqueness constraint, so ["legacy", "legacy"] resolves
+// the same customer product twice. Each occurrence would otherwise reach the
+// line-item builder and credit the unused time again.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("remove-plan-ids proration 3: a repeated plan id is credited once")}`,
+	async () => {
+		const customerId = "remove-plan-ids-proration-3";
+		const legacy = legacyPlan();
+		const current = currentPlan();
+
+		const { autumnV1, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [legacy, current] }),
+			],
+			actions: [
+				s.billing.attach({ productId: legacy.id }),
+				s.advanceTestClock({ days: 15 }),
+			],
+		});
+
+		const expectedTotal = await calculateProratedDiff({
+			customerId,
+			advancedTo,
+			oldAmount: 30,
+			newAmount: 50,
+		});
+
+		const preview = await autumnV1.billing.previewAttach({
+			customer_id: customerId,
+			product_id: current.id,
+			remove_plan_ids: [legacy.id, legacy.id],
+		});
+
+		// Same total as the single-removal case, and exactly one credit line.
+		expect(preview.total).toBeCloseTo(expectedTotal, 0);
+
+		const legacyCredits = (preview.line_items ?? []).filter(
+			(lineItem: { plan_id: string }) => lineItem.plan_id === legacy.id,
+		);
+		expect(legacyCredits).toHaveLength(1);
+	},
+);

--- a/server/tests/integration/billing/attach/params/remove-plan-ids/remove-plan-ids-proration.test.ts
+++ b/server/tests/integration/billing/attach/params/remove-plan-ids/remove-plan-ids-proration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * remove_plan_ids - Proration Tests
+ *
+ * A plan dropped via remove_plan_ids is expired mid-cycle, so the customer is
+ * owed a credit for its unused time — the same credit a same-group replacement
+ * produces. The removed plan lives in `updateCustomerProducts`, which was not
+ * being passed to the line-item builder, so no credit was ever generated and
+ * Stripe issued none either (Autumn always sends proration_behavior: "none").
+ *
+ * Key behaviors:
+ * - Removing a paid cross-group plan credits its unused time on the invoice.
+ * - billing_behavior: "none" still suppresses all proration.
+ */
+
+import { expect, test } from "bun:test";
+import type { ApiCustomerV3 } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { calculateProratedDiff } from "@tests/integration/billing/utils/proration";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+const legacyPlan = () =>
+	products.base({
+		id: "legacy-plan",
+		group: "legacy",
+		items: [
+			items.monthlyPrice({ price: 30 }),
+			items.monthlyMessages({ includedUsage: 100 }),
+		],
+	});
+
+const currentPlan = () =>
+	products.base({
+		id: "current-plan",
+		group: "current",
+		items: [
+			items.monthlyPrice({ price: 50 }),
+			items.monthlyMessages({ includedUsage: 500 }),
+		],
+	});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 1: Removed cross-group plan is credited for its unused time
+//
+// Legacy plan ($30/mo, group "legacy") active, advance 15 days.
+// Attach current plan ($50/mo, group "current") with remove_plan_ids: [legacy].
+// Expected: ($50 - $30) x remaining ratio — the legacy credit nets off the charge.
+// Before the fix: the full prorated $50 with no credit at all.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("remove-plan-ids proration 1: removed cross-group plan is credited")}`,
+	async () => {
+		const customerId = "remove-plan-ids-proration-1";
+		const legacy = legacyPlan();
+		const current = currentPlan();
+
+		const { autumnV1, advancedTo } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [legacy, current] }),
+			],
+			actions: [
+				s.billing.attach({ productId: legacy.id }),
+				s.advanceTestClock({ days: 15 }),
+			],
+		});
+
+		const expectedTotal = await calculateProratedDiff({
+			customerId,
+			advancedTo,
+			oldAmount: 30,
+			newAmount: 50,
+		});
+
+		const preview = await autumnV1.billing.previewAttach({
+			customer_id: customerId,
+			product_id: current.id,
+			remove_plan_ids: [legacy.id],
+		});
+
+		expect(preview.total).toBeCloseTo(expectedTotal, 0);
+
+		// The credit must be its own line item attributed to the removed plan,
+		// not just folded into the total.
+		const legacyCredit = preview.line_items?.find(
+			(lineItem: { plan_id: string; total: number }) =>
+				lineItem.plan_id === legacy.id,
+		);
+		expect(legacyCredit).toBeDefined();
+		expect(legacyCredit!.total).toBeLessThan(0);
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: current.id,
+			remove_plan_ids: [legacy.id],
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		await expectCustomerProducts({
+			customer,
+			active: [current.id],
+			notPresent: [legacy.id],
+		});
+
+		// Invoices: legacy ($30) + the netted switch charge.
+		await expectCustomerInvoiceCorrect({
+			customerId,
+			count: 2,
+			latestTotal: preview.total,
+			latestInvoiceProductIds: [current.id, legacy.id],
+		});
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TEST 2: billing_behavior "none" still suppresses the credit
+//
+// Same setup, but the caller opts out of proration entirely. Neither the charge
+// nor the removal credit should reach the invoice.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("remove-plan-ids proration 2: billing_behavior none produces no credit")}`,
+	async () => {
+		const customerId = "remove-plan-ids-proration-2";
+		const legacy = legacyPlan();
+		const current = currentPlan();
+
+		const { autumnV1 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [legacy, current] }),
+			],
+			actions: [
+				s.billing.attach({ productId: legacy.id }),
+				s.advanceTestClock({ days: 15 }),
+			],
+		});
+
+		const preview = await autumnV1.billing.previewAttach({
+			customer_id: customerId,
+			product_id: current.id,
+			remove_plan_ids: [legacy.id],
+			billing_behavior: "none",
+		});
+
+		expect(preview.line_items ?? []).toHaveLength(0);
+		expect(preview.total).toBe(0);
+
+		await autumnV1.billing.attach({
+			customer_id: customerId,
+			product_id: current.id,
+			remove_plan_ids: [legacy.id],
+			billing_behavior: "none",
+			redirect_mode: "if_required",
+		});
+
+		const customer = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+
+		await expectCustomerProducts({
+			customer,
+			active: [current.id],
+			notPresent: [legacy.id],
+		});
+
+		// Only the original legacy invoice — the switch charged nothing.
+		await expectCustomerInvoiceCorrect({
+			customerId,
+			count: 1,
+			latestTotal: 30,
+		});
+	},
+);


### PR DESCRIPTION
## Problem

An attach that drops a plan through `remove_plan_ids` expires that plan mid-cycle, but the customer is never credited for its unused time.

```
computeAttachPlan
  ├─ computeAttachTransitionUpdates  -> updateCustomerProduct
  ├─ computeAttachRemovals           -> updateCustomerProducts   <- removals land HERE
  │
  └─ buildAutumnLineItems({
        newCustomerProducts: [incoming],
        deletedCustomerProduct: currentCustomerProduct   <- removals never passed in
     })                                                     ^^^ getRefundLineItems never runs
```

Stripe doesn't cover the gap either: Autumn always sends `proration_behavior: "none"` and computes proration as its own invoice lines, so deleting the subscription item yields no credit.

Cross-group removals are hit hardest — with no same-group product, `currentCustomerProduct` is `undefined`, so the invoice carries the full prorated charge for the incoming plan and no credit at all.

### Real occurrence

A live customer previewing `enterprise` (group `null`) with `remove_plan_ids: ["transactional_scale_1500k"]` (group `"Transactional"`):

```
autumnBillingPlan.updateCustomerProduct : "none"
autumnBillingPlan.deleteCustomerProduct : "none"
autumnBillingPlan.lineItems             : [ "Enterprise - Base Price ... : 599.798" ]   <- 1 item only
stripeBillingPlan.subscription.params   : proration_behavior: "none",
                                          items: [ ..., { id: "si_QI5m...", deleted: true } ]
```

Billed $599.80 for Enterprise while losing ~$660 of unused Transactional Scale ($825/mo, paid 14 Aug, removed 20 Aug, cycle ends 14 Sep).

## Fix

`buildAutumnLineItems` already accepted `deletedCustomerProducts`, and `computeImmediateMultiProductPlan` already used it. Attach just never passed it.

## Behaviour change to note

Removals now also feed the **arrear** loop, so a removed plan's accrued metered usage settles at the switch instead of being dropped. This matches what a same-group swap already does. Not covered by the tests here — both fixture plans are flat-priced.

## Tests

`server/tests/integration/billing/attach/params/remove-plan-ids/remove-plan-ids-proration.test.ts`

1. Legacy $30/mo (group `legacy`) active, advance 15 days, attach $50/mo (group `current`) with `remove_plan_ids`. Asserts the prorated total, that a **negative line item carries `plan_id === legacy.id`** (a correct total alone would pass without the credit being attributed), and that the real invoice matches the preview.
2. Same setup with `billing_behavior: "none"` — no line items, total 0. Guards the opt-out path in `finalizeLineItems`.

> [!IMPORTANT]
> **The tests have not been executed.** The dev DB is behind on migrations, so the whole integration suite fails at setup on `products_licenses_product.version_slug does not exist` — confirmed pre-existing by running the untouched `carry-over-usages` suite (15/15 fail identically). Neither the red nor the green has been observed. Please run before merging.

Verified: `bun ts` and Biome clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Credits unused time when a plan is removed via `remove_plan_ids` during attach. Previously, the removed plan expired mid‑cycle with no credit; now removals are passed into `buildAutumnLineItems` so refund and arrear line items are generated and attributed to the removed plan.

- Cross‑group removals now emit a negative line item for the removed plan; previews and invoices show the incoming charge and the credit. `billing_behavior: "none"` still suppresses all proration.
- Removed plans participate in the arrear loop, settling accrued metered usage at the switch (matches same‑group swaps).
- Repeated ids in `remove_plan_ids` are deduped to avoid double credit/settlement; previews show a single credit line for the plan.
- Tests cover credited removal, dedupe, and the opt‑out path. Action: run the integration suite with up‑to‑date DB migrations before merging.

<sup>Written for commit 3b8748defa4f3155e7b97db081dd9e8f3c269118. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR credits unused time when an attach operation removes additional plans, and adds integration coverage for normal and no-billing behavior.
- **Bug fixes:** Pass plans removed through `remove_plan_ids` into the existing refund and arrear line-item builder.
- **Improvements:** Verify that cross-group removals receive a plan-attributed credit and that preview totals match real invoices.
- **Improvements:** Verify that `billing_behavior: "none"` continues to suppress all proration line items.
</details>

<h3>Confidence Score: 4/5</h3>

The duplicate-ID invoice calculation should be fixed before merging because one removed plan can receive the same credit twice.

The new forwarding path processes every remove_plan_ids entry, while the request schema and removal computation permit duplicates and the line-item builder does not deduplicate them.

**Files Needing Attention:** server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts | Adds removed plans to refund and arrear calculation, but repeated remove_plan_ids entries can now generate duplicate invoice adjustments. |
| server/tests/integration/billing/attach/params/remove-plan-ids/remove-plan-ids-proration.test.ts | Covers ordinary cross-group credits and the no-billing opt-out, but does not cover duplicate plan IDs. |

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Attach request] --> B[Compute plan removals]
  B --> C[Removed customer products]
  C --> D[Build Autumn line items]
  D --> E[Unused-time credits]
  D --> F[Accrued usage settlement]
  E --> G[Preview or invoice]
  F --> G
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/billing/v2/actions/attach/compute/computeAttachPlan.ts:110-112
**Duplicate removal credits invoices twice**

When `remove_plan_ids` repeats an active plan ID, this map forwards the same customer product more than once and the line-item builder processes each occurrence, causing duplicate unused-time credits and potentially duplicate metered-usage settlement on the invoice.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Credit unused time for plans removed via..."](https://github.com/useautumn/autumn/commit/8972c65621afaa03d8a2f4939d1050f038fb552c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55169098)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->