### PR TITLE
fix(dashboard): persist plan base variant changes

### DIFF
--- a/server/src/internal/catalog/actions/validateCatalogVariantUpdates.ts
+++ b/server/src/internal/catalog/actions/validateCatalogVariantUpdates.ts
@@ -1,8 +1,8 @@
 import {
-	ErrCode,
-	RecaseError,
 	type CatalogUpdateParams,
+	ErrCode,
 	type FullProduct,
+	RecaseError,
 } from "@autumn/shared";
 
 export const validateCatalogVariantUpdates = ({
@@ -82,7 +82,8 @@ export const validateCatalogVariantVersionTargets = ({
 
 		const active = activeBaseByPlanId.get(plan.plan_id);
 		const maxVersion = maxVersionByPlanId.get(plan.plan_id) ?? 0;
-		if (plan.version === active?.version || plan.version > maxVersion) continue;
+		const targetVersion = active?.version ?? maxVersion;
+		if (plan.version === targetVersion || plan.version > maxVersion) continue;
 
 		throw new RecaseError({
 			message: `Variants can only be updated under the latest version of base plan ${plan.plan_id}.`,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan.ts
@@ -1,14 +1,12 @@
-import {
-	type FullProduct,
-	productToProductKey,
-} from "@autumn/shared";
+import { type FullProduct, productToProductKey } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { assembleNextFullProduct } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/assembleNextFullProduct";
-import { declaredVariantsForSource } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/declaredVariantsForSource";
 import { computeCatalogEntitlementPricesPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeCatalogEntitlementPricesPlan/computeCatalogEntitlementPricesPlan";
 import { computeFreeTrialPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeFreeTrialPlan/computeFreeTrialPlan";
 import { computeProductDetailsPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan";
+import { declaredVariantsForSource } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/declaredVariantsForSource";
 import { shouldUnlinkDirectVariant } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/shouldUnlinkDirectVariant";
+import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
 import { resolveUpsertOp } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/resolveUpsertOp";
 import { resolveUpsertVersioning } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/resolveUpsertVersioning";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -16,7 +14,6 @@ import type {
 	ProductUpsertIntent,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
-import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
 
@@ -67,13 +64,14 @@ export const computeUpsertProductPlan = ({
 	});
 	const unlink =
 		intent.unlink === true ||
-		shouldUnlinkDirectVariant({
-			source,
-			planId: productKey.planId,
-			currentFullProduct,
-			productStatesContext,
-			declaredVariantPlanIdsByBasePlanId,
-		});
+		(baseInternalProductId === undefined &&
+			shouldUnlinkDirectVariant({
+				source,
+				planId: productKey.planId,
+				currentFullProduct,
+				productStatesContext,
+				declaredVariantPlanIdsByBasePlanId,
+			}));
 	const pointer = unlink ? null : baseInternalProductId;
 
 	// Content baseline: row at this version, or latest when minting a new version.
@@ -166,8 +164,7 @@ export const computeUpsertProductPlan = ({
 			versioning,
 			currentFullProduct,
 			// Mint-only clone source for preview; null on in-place writes.
-			baseFullProduct:
-				versioning === "new_version" ? baseFullProduct : null,
+			baseFullProduct: versioning === "new_version" ? baseFullProduct : null,
 			nextFullProduct,
 		},
 		...(details.changed ? { details } : {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
@@ -20,6 +20,20 @@ const latestVersionForPlan = ({
 	productStatesContext: ProductStatesContext;
 }): number => productStatesContext.versionsByPlanId[planId]?.[0]?.version ?? 0;
 
+const resolveBaseInternalProductId = ({
+	basePlanId,
+	productStatesContext,
+}: {
+	basePlanId: string | null | undefined;
+	productStatesContext: ProductStatesContext;
+}): string | null | undefined => {
+	if (basePlanId === undefined) return undefined;
+	if (basePlanId === null) return null;
+	return (
+		productStatesContext.versionsByPlanId[basePlanId]?.[0]?.internal_id ?? null
+	);
+};
+
 const groupPlanParamsByPlanId = ({
 	planParamsList,
 }: {
@@ -57,9 +71,7 @@ const resolveVersionsForPlan = ({
 		.map((planParams) => ({
 			...planParams,
 			version:
-				planParams.versioning === "new_version"
-					? maxVersion + 1
-					: latestOrV1,
+				planParams.versioning === "new_version" ? maxVersion + 1 : latestOrV1,
 		}));
 
 	return [...withExplicitVersion, ...targetingLatest];
@@ -91,4 +103,12 @@ export const deriveDirectIntents = ({
 			},
 			planParams,
 			source: "direct" as const,
+			...(planParams.base_plan_id !== undefined
+				? {
+						baseInternalProductId: resolveBaseInternalProductId({
+							basePlanId: planParams.base_plan_id,
+							productStatesContext,
+						}),
+					}
+				: {}),
 		}));

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVersionSiblingIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVersionSiblingIntents.ts
@@ -147,6 +147,9 @@ export const deriveVersionSiblingIntents = ({
 				source: inheritAllVersions ? ("all_versions" as const) : "repoint",
 				...(editDiff ? { editDiff } : {}),
 				...(upsert.unlink ? { unlink: true } : {}),
+				...(inheritAllVersions && intent.baseInternalProductId !== undefined
+					? { baseInternalProductId: intent.baseInternalProductId }
+					: {}),
 			};
 		});
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleBasePlanLinkErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleBasePlanLinkErrors.ts
@@ -1,0 +1,60 @@
+import { ErrCode, RecaseError, type UpdateCatalogParams } from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+
+const rejectBasePlanLink = (message: string): never => {
+	throw new RecaseError({
+		message,
+		code: ErrCode.InvalidPropagationTarget,
+		statusCode: StatusCodes.BAD_REQUEST,
+	});
+};
+
+export const handleBasePlanLinkErrors = ({
+	params,
+	productStatesContext,
+}: {
+	params: UpdateCatalogParams;
+	productStatesContext: ProductStatesContext;
+}): void => {
+	for (const plan of params.plans) {
+		if (plan.base_plan_id === undefined) continue;
+
+		const targetVersions =
+			productStatesContext.versionsByPlanId[plan.plan_id] ?? [];
+		if (targetVersions.length === 0) {
+			rejectBasePlanLink("base_plan_id can only be set on an existing plan.");
+		}
+		if (plan.base_plan_id === null) continue;
+		if (plan.base_plan_id === plan.plan_id) {
+			rejectBasePlanLink("A plan cannot be linked to itself as a base plan.");
+		}
+
+		const base = productStatesContext.versionsByPlanId[plan.base_plan_id]?.[0];
+		if (!base || base.archived) {
+			rejectBasePlanLink(`Invalid base plan: ${plan.base_plan_id}`);
+		}
+		if (base.base_internal_product_id !== null) {
+			rejectBasePlanLink("A variant plan cannot be used as a base plan.");
+		}
+
+		const targetInternalIds = new Set(
+			targetVersions.map((version) => version.internal_id),
+		);
+		const hasVariants = Object.values(
+			productStatesContext.versionsByPlanId,
+		).some((versions) =>
+			versions.some(
+				(version) =>
+					version.id !== plan.plan_id &&
+					version.base_internal_product_id != null &&
+					targetInternalIds.has(version.base_internal_product_id),
+			),
+		);
+		if (hasVariants) {
+			rejectBasePlanLink(
+				"A plan with variants cannot be linked to another base plan.",
+			);
+		}
+	}
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -1,5 +1,6 @@
 import type { UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { handleBasePlanLinkErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleBasePlanLinkErrors";
 import { handleRemoveFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemoveFeatureErrors/handleRemoveFeatureErrors";
 import { handleRemovePlanErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemovePlanErrors/handleRemovePlanErrors";
 import { handleUpdateFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/handleUpdateFeatureErrors";
@@ -35,6 +36,10 @@ export const handleUpdateCatalogErrors = ({
 		params,
 		productStatesContext: catalogContext.productStatesContext,
 		updateCatalogPlan,
+	});
+	handleBasePlanLinkErrors({
+		params,
+		productStatesContext: catalogContext.productStatesContext,
 	});
 	handleUpsertProductErrors({
 		updateCatalogPlan,

--- a/server/tests/integration/catalog-v2/plans/variants/pointer/unlink.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/pointer/unlink.test.ts
@@ -18,8 +18,8 @@ import { TestFeature } from "@tests/setup/v2Features.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { uniqueTestId } from "../../../utils/uniqueTestId.js";
-import { deleteDbPlans } from "../../utils/expectCatalogPlans.js";
 import { messagesItem } from "../../licenses/utils/seedLicensePlans.js";
+import { deleteDbPlans } from "../../utils/expectCatalogPlans.js";
 import {
 	expectVariantPlanCorrect,
 	expectVariantPointerCorrect,
@@ -29,6 +29,48 @@ import {
 	seedBaseWithVariant,
 	seedVariantNewVersion,
 } from "../utils/seedVariantPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: base_plan_id links and detaches an existing plan")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_link_base");
+		const variantId = uniqueTestId("cv2_var_link_child");
+		await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: baseId, name: "Team", items: [messagesItem(100)] },
+					{
+						plan_id: variantId,
+						name: "Team EU",
+						items: [messagesItem(200)],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: variantId, base_plan_id: baseId }],
+			});
+			await expectVariantPointerCorrect({
+				ctx,
+				variantPlanId: variantId,
+				basePlanId: baseId,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: variantId, base_plan_id: null }],
+			});
+			await expectVariantUnlinkedCorrect({
+				ctx,
+				variantPlanId: variantId,
+				versions: [1],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		}
+	},
+);
 
 test.concurrent(
 	`${chalk.yellowBright("catalogV2 variants: omit + top-level unlinks every variant version")}`,
@@ -42,10 +84,7 @@ test.concurrent(
 			await seedVariantNewVersion({ autumn: autumnV2_3, variantId });
 
 			await autumnV2_3.catalogV2.update({
-				plans: [
-					{ plan_id: baseId, variants: [] },
-					{ plan_id: variantId },
-				],
+				plans: [{ plan_id: baseId, variants: [] }, { plan_id: variantId }],
 			});
 
 			await expectVariantUnlinkedCorrect({
@@ -111,10 +150,7 @@ test.concurrent(
 			await seedBaseWithVariant({ autumn: autumnV2_3, baseId, variantId });
 
 			await autumnV2_3.catalogV2.update({
-				plans: [
-					{ plan_id: baseId, variants: [] },
-					{ plan_id: variantId },
-				],
+				plans: [{ plan_id: baseId, variants: [] }, { plan_id: variantId }],
 			});
 			await expectVariantUnlinkedCorrect({
 				ctx,
@@ -127,10 +163,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: baseId,
-						items: [
-							messagesItem(100),
-							{ feature_id: TestFeature.Dashboard },
-						],
+						items: [messagesItem(100), { feature_id: TestFeature.Dashboard }],
 					},
 				],
 			});

--- a/server/tests/unit/catalogV2/variants/direct-base-link.test.ts
+++ b/server/tests/unit/catalogV2/variants/direct-base-link.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { UpdateCatalogParams } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/db/products";
+import { deriveDirectIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents";
+import { handleBasePlanLinkErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleBasePlanLinkErrors";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+
+const base = {
+	...products.createFull({ id: "team" }),
+	internal_id: "prod_team",
+	base_internal_product_id: null,
+};
+const child = {
+	...products.createFull({ id: "team-eu" }),
+	internal_id: "prod_team_eu",
+	base_internal_product_id: null,
+};
+const productStatesContext: ProductStatesContext = {
+	statesByPlanVersion: {},
+	versionsByPlanId: { team: [base], "team-eu": [child] },
+	rewardProgramsByPlanId: {},
+};
+const params = (basePlanId: string | null): UpdateCatalogParams => ({
+	features: [],
+	remove_features: [],
+	plans: [{ plan_id: "team-eu", base_plan_id: basePlanId }],
+	remove_plans: [],
+});
+
+describe("catalog direct base plan links", () => {
+	test("resolves the selected base plan to its internal product pointer", () => {
+		const [intent] = deriveDirectIntents({
+			params: params("team"),
+			productStatesContext,
+		});
+
+		expect(intent?.baseInternalProductId).toBe(base.internal_id);
+	});
+
+	test("preserves explicit null for detach", () => {
+		const [intent] = deriveDirectIntents({
+			params: params(null),
+			productStatesContext,
+		});
+
+		expect(intent?.baseInternalProductId).toBeNull();
+	});
+
+	test("rejects a missing or nested base plan", () => {
+		expect(() =>
+			handleBasePlanLinkErrors({
+				params: params("missing"),
+				productStatesContext,
+			}),
+		).toThrow("Invalid base plan: missing");
+
+		expect(() =>
+			handleBasePlanLinkErrors({
+				params: params("team"),
+				productStatesContext: {
+					...productStatesContext,
+					versionsByPlanId: {
+						...productStatesContext.versionsByPlanId,
+						team: [{ ...base, base_internal_product_id: "prod_parent" }],
+					},
+				},
+			}),
+		).toThrow("A variant plan cannot be used as a base plan.");
+	});
+});

--- a/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
@@ -62,6 +62,17 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 	metadata: ProductMetadataSchema.optional().meta({
 		description: "Arbitrary key-value metadata shared across all versions.",
 	}),
+	base_plan_id: z
+		.string()
+		.nonempty()
+		.regex(idRegex)
+		.nullable()
+		.optional()
+		.meta({
+			internal: true,
+			description:
+				"Link this existing plan version to a base plan, or null to detach it.",
+		}),
 
 	// ── Catalog update ────────────────────────────────────────────────────
 	version: z.number().int().min(1).optional().meta({

--- a/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
+++ b/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
@@ -101,6 +101,9 @@ export const buildUpdateCatalogPlanParams = ({
 			: {}),
 		config: plan.config,
 		billing_controls: plan.billing_controls,
+		...(editedProduct.base_id !== undefined
+			? { base_plan_id: editedProduct.base_id }
+			: {}),
 		...(licenses !== undefined ? { licenses } : {}),
 		...(propagate !== undefined ? { propagate } : {}),
 		...(migration !== undefined ? { migration } : {}),

--- a/vite/src/views/products/plan/components/SaveChangesBar.tsx
+++ b/vite/src/views/products/plan/components/SaveChangesBar.tsx
@@ -7,6 +7,7 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import {
 	useHasChanges,
+	useHasContentChanges,
 	useIsCusPlanEditor,
 	useProductStore,
 } from "@/hooks/stores/useProductStore";
@@ -43,8 +44,10 @@ export const SaveChangesBar = ({
 	const setProduct = useProductStore((s) => s.setProduct);
 	const { type: sheetType } = useSheetStore();
 	const planHasChanges = useHasChanges();
+	const planHasContentChanges = useHasContentChanges();
 	const licenseHasChanges = useHasLicenseChanges();
 	const hasChanges = planHasChanges || licenseHasChanges;
+	const needsCatalogPreview = planHasContentChanges || licenseHasChanges;
 	const planLicenses = catalogLicenses.map(({ planLicense }) => planLicense);
 	const { features = [] } = useFeaturesQuery();
 	const fetchPreviewUpdateCatalog = useFetchPreviewUpdateCatalog();
@@ -62,7 +65,7 @@ export const SaveChangesBar = ({
 	}
 
 	const handleSaveClicked = async () => {
-		if (planHasChanges) {
+		if (planHasContentChanges) {
 			for (const item of product.items) {
 				if (!checkItemCurrenciesValid(item)) return;
 			}
@@ -90,7 +93,7 @@ export const SaveChangesBar = ({
 				editedProduct: product,
 				features,
 				licenses,
-				includeContent: planHasChanges,
+				includeContent: planHasContentChanges,
 			});
 		} catch (error) {
 			toast.error(
@@ -99,7 +102,7 @@ export const SaveChangesBar = ({
 			return;
 		}
 
-		if (!isOnboarding && hasChanges) {
+		if (!isOnboarding && needsCatalogPreview) {
 			setSaving(true);
 			try {
 				const preview = await fetchPreviewUpdateCatalog({

--- a/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
+++ b/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
@@ -208,6 +208,29 @@ describe("buildUpdateCatalogPlanParams", () => {
 		);
 	});
 
+	test("carries explicit base plan links and detaches", () => {
+		const linked = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: { ...editedProduct, base_id: "starter" },
+			features,
+		});
+		expect(linked.base_plan_id).toBe("starter");
+
+		const detached = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: { ...editedProduct, base_id: null },
+			features,
+		});
+		expect(detached.base_plan_id).toBeNull();
+
+		const untouched = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct,
+			features,
+		});
+		expect(untouched.base_plan_id).toBeUndefined();
+	});
+
 	test("strips stripe_price_id off price and items", () => {
 		const params = buildUpdateCatalogPlanParams({
 			baseProduct,


### PR DESCRIPTION
The plan editor started saving through `catalog.update`, but that API could not express changing an existing plan's base link. The selected base therefore remained only in frontend state.

Add first-class `base_plan_id` support to catalog plan updates, including attach, detach, validation, version-aware pointer updates, and `all_versions` propagation. The frontend now carries the pending link in its existing catalog payload and skips the versioning preview when the link is the only change.

Tests cover catalog intent resolution, invalid bases, persisted attach/detach behavior, pointer diffs, and frontend payload construction.