### PR TITLE
fix(products): keep the active pointer unchanged on archive

### DIFF
--- a/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
+++ b/server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts
@@ -22,7 +22,6 @@ import {
 	validateNoDirectVariantMigrationDrafts,
 } from "@/internal/product/actions/updateProduct/createPlanMigrationDraft.js";
 import { updateProduct } from "@/internal/product/actions/updateProduct.js";
-import { activateHighestRemainingProduct } from "@/internal/products/repos/activateHighestRemainingProduct.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
 import {
@@ -67,13 +66,6 @@ const archiveProductVersions = async ({
 			env: ctx.env,
 		});
 	}
-
-	await activateHighestRemainingProduct({
-		db: ctx.db,
-		orgId: ctx.org.id,
-		env: ctx.env,
-		productId,
-	});
 };
 
 const upsertFeatures = async ({
@@ -357,12 +349,6 @@ const applyMissingPlanRemovals = async ({
 					internalId: product.internal_id,
 					orgId: ctx.org.id,
 					env: ctx.env,
-				});
-				await activateHighestRemainingProduct({
-					db: ctx.db,
-					orgId: ctx.org.id,
-					env: ctx.env,
-					productId: planId,
 				});
 			} else {
 				await deleteProduct({

--- a/server/src/internal/catalogV2/execute/executeRemovePlans.ts
+++ b/server/src/internal/catalogV2/execute/executeRemovePlans.ts
@@ -1,12 +1,9 @@
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
-import {
-	activateHighestRemainingProduct,
-	deleteProductRowAndHandoffActive,
-} from "@/internal/products/repos/activateHighestRemainingProduct";
+import { deleteProductRowAndHandoffActive } from "@/internal/products/repos/activateHighestRemainingProduct";
 import { ProductService } from "@/internal/products/ProductService.js";
 
-/** Archive or hard-delete each removePlans row. Pointer moves are upserts. */
+/** Archive leaves `active` in place. Hard-delete of the active row promotes a survivor. */
 export const executeRemovePlans = async ({
 	ctx,
 	updateCatalogPlan,
@@ -15,8 +12,6 @@ export const executeRemovePlans = async ({
 	updateCatalogPlan: UpdateCatalogPlan;
 }): Promise<void> => {
 	await ctx.db.transaction(async (tx) => {
-		const archivedPlanIds = new Set<string>();
-
 		for (const row of updateCatalogPlan.removePlans) {
 			if (!row.current) continue;
 			if (row.willArchive) {
@@ -26,7 +21,6 @@ export const executeRemovePlans = async ({
 					orgId: ctx.org.id,
 					env: ctx.env,
 				});
-				archivedPlanIds.add(row.planId);
 				continue;
 			}
 
@@ -35,15 +29,6 @@ export const executeRemovePlans = async ({
 				internalId: row.current.internal_id,
 				orgId: ctx.org.id,
 				env: ctx.env,
-			});
-		}
-
-		for (const planId of archivedPlanIds) {
-			await activateHighestRemainingProduct({
-				db: tx,
-				orgId: ctx.org.id,
-				env: ctx.env,
-				productId: planId,
 			});
 		}
 	});

--- a/server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts
+++ b/server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts
@@ -1,6 +1,6 @@
 /**
- * Deleting (or archiving) the active version promotes the highest remaining
- * live row so omit-version reads still resolve.
+ * Hard-delete of the active version promotes the highest remaining live row.
+ * Archive does not move `active` — it is all-or-nothing on the plan.
  *
  * Red (current):  omit-version getFull 404s after pin-delete of v2.
  * Green (after):  omit-version getFull returns the surviving tip with active=true.
@@ -105,7 +105,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("version identity remove: pin-archive of active v2 promotes v1")}`,
+	`${chalk.yellowBright("version identity remove: pin-archive of active v2 leaves the pointer on v2")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const planId = uniqueTestId("cv2_rmp_id_arch");
@@ -117,7 +117,21 @@ test.concurrent(
 			await autumnV2_3.catalogV2.update({
 				remove_plans: [{ plan_id: planId, version: 2 }],
 			});
-			await expectOmitVersionIs({ ctx, planId, version: 1 });
+
+			const versions = await ProductService.listFull({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				env: ctx.env,
+				inIds: [planId],
+				returnAll: true,
+				skipCache: true,
+			});
+			const v1 = versions.find((product) => product.version === 1);
+			const v2 = versions.find((product) => product.version === 2);
+			expect(v2?.archived).toBe(true);
+			expect(v2?.active).toBe(true);
+			expect(v1?.archived).toBe(false);
+			expect(v1?.active).toBe(false);
 		} finally {
 			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
 			await deleteDbPlans({ ctx, planIds: [planId] });


### PR DESCRIPTION
## Summary
- Archiving a plan no longer reassigns `active`. Archive is all-or-nothing, so the pointer stays on whichever version was already active (including the archived tip).
- Hard-delete of the active row still promotes the highest remaining live version.
- Catalog v1 archive paths match catalog v2 `executeRemovePlans`.

## Test plan
- [ ] `server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts` (pin-archive leaves v2 active)
- [ ] `server/tests/integration/catalog-v2/plans/remove/unarchive-plans.test.ts` (omit-version unarchive still finds the archived tip)
- [ ] Pin-delete / `products.delete` still promote a survivor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archiving a plan no longer moves the `active` pointer; hard-deleting the active row still promotes the highest remaining live version. This prevents unintended pointer swaps and aligns catalog v1 and v2 behavior.

- Remove `activateHighestRemainingProduct` calls on archive paths in `server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts` and `server/src/internal/catalogV2/execute/executeRemovePlans.ts`; retain `deleteProductRowAndHandoffActive` for hard-deletes.
- Update `server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts` to assert pin-archive of an active version leaves `active` on the archived tip; delete still hands off correctly.
- No migrations. API and payloads unchanged. If callers need to move `active`, they must upsert a pointer change; archive will not reassign it.

<sup>Written for commit 176c9ce1a72376c18c167f00c0291e8baa46cbe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes plan archival so it preserves the existing active-version pointer while hard deletion continues promoting a live survivor.
- **Bug fixes:** Catalog v1 and v2 archive paths no longer reassign the active version.
- **Improvements:** Hard-delete behavior remains distinct, promoting the highest remaining live version when necessary.
- **Improvements:** Integration coverage now verifies that archiving an active version leaves the pointer unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because its archive and hard-delete paths consistently implement the explicitly documented pointer semantics.

Archive operations now preserve the active pointer as intended, while the unchanged hard-delete path still promotes a surviving live version; no concrete uncovered failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| server/src/internal/catalog/actions/updateCatalog/updateCatalog.ts | Catalog v1 archive branches stop promoting another version, consistently preserving the existing active pointer. |
| server/src/internal/catalogV2/execute/executeRemovePlans.ts | Catalog v2 removes archive-time pointer handoff while retaining survivor promotion for hard deletion. |
| server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts | The archive assertion now verifies that the archived v2 tip remains active and the live v1 version remains inactive. |

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Catalog
    participant DB
    Client->>Catalog: Remove plan version
    alt Archive
        Catalog->>DB: "Set archived = true"
        Note over DB: Preserve existing active pointer
    else Hard-delete
        Catalog->>DB: Delete selected row
        alt Deleted row was active
            Catalog->>DB: Promote highest remaining live version
        end
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(products): keep the active pointer u..."](https://github.com/useautumn/autumn/commit/176c9ce1a72376c18c167f00c0291e8baa46cbe7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55176916)</sub>

<!-- /greptile_comment -->