### PR TITLE
Render fixed-price refund lines in Autumn's description format

### DIFF
--- a/server/src/internal/billing/v2/utils/lineItems/chargeRowToRefundLineItem.ts
+++ b/server/src/internal/billing/v2/utils/lineItems/chargeRowToRefundLineItem.ts
@@ -7,13 +7,47 @@ import {
 	type DbInvoiceLineItem,
 	type FullCusProduct,
 	type FullProductWithoutLicenses,
+	fixedPriceToDescription,
 	type InvoiceLineItemDiscount,
+	isFixedPrice,
 	type LineItem,
 	type LineItemContext,
 	LineItemSchema,
 	type Price,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+/**
+ * A stored charge row may carry Stripe's own wording, which renders a flat fee as
+ * its subscription quantity and the product's `unit_label` ("1 emails × Plan").
+ * Fixed prices are re-rendered in Autumn's format; usage prices keep the stored
+ * text, which carries tier detail Autumn's description would drop.
+ */
+const refundLineDescription = ({
+	chargeRow,
+	price,
+	product,
+	context,
+	preferStoredText,
+}: {
+	chargeRow: DbInvoiceLineItem;
+	price: Price;
+	product: { name: string };
+	context: LineItemContext;
+	/** License credits keep stored wording so the assigned quantity stays visible. */
+	preferStoredText: boolean;
+}): string => {
+	if (!preferStoredText && isFixedPrice(price)) {
+		return fixedPriceToDescription({
+			price,
+			currency: context.currency,
+			context,
+		});
+	}
+
+	if (chargeRow.description) return `Unused ${chargeRow.description}`;
+	return `Unused ${product.name}`;
+};
 
 export const chargeRowToRefundLineItem = ({
 	chargeRow,
@@ -93,9 +127,13 @@ export const chargeRowToRefundLineItem = ({
 		customerEntitlement: matchingCusEnt,
 	};
 
-	const description = chargeRow.description
-		? `Unused ${chargeRow.description}`
-		: `Unused ${product.name}`;
+	const description = refundLineDescription({
+		chargeRow,
+		price,
+		product,
+		context,
+		preferStoredText: contextOverride !== undefined,
+	});
 
 	const lineItemData = {
 		id: generateKsuid({ prefix: "invoice_li_" }),

--- a/shared/utils/billingUtils/index.ts
+++ b/shared/utils/billingUtils/index.ts
@@ -9,6 +9,7 @@ export * from "./intervalUtils/intervalArithmetic";
 
 export * from "./invoicingUtils/backdateUtils/applyBackdatedLineItemAmount.js";
 export * from "./invoicingUtils/billingConstants.js";
+export * from "./invoicingUtils/descriptionUtils/fixedPriceToLineDescription.js";
 export * from "./invoicingUtils/filterUnchangedPricesFromLineItems.js";
 export * from "./invoicingUtils/lineItemBuilders/buildLineItem.js";
 export * from "./invoicingUtils/lineItemBuilders/fixedPriceToLineItem.js";


### PR DESCRIPTION
## Problem

Refund lines built from a stored charge row reuse that row's `description` verbatim. When the stored text came from Stripe (`description_source: "stripe"`), Stripe renders a flat fee as the subscription **quantity** plus the product's **`unit_label`** — so the two lines in one preview disagree:

```
Unused 1 emails × Transactional Scale (at $825.00 / month)     <- Stripe's wording
Enterprise - Base Price (from 20 Aug 2026 to 14 Sep 2026)      <- Autumn's wording
```

The `1` is the subscription item quantity (one unit of a flat $825 licensed price) and `emails` is `unit_label` on the Stripe product — verified on live invoice `in_1U4GaJJEBzQpmA4QsFwVpiTm`:

```json
"description": "1 emails × Transactional Scale (at $825.00 / month)",
"quantity": 1,
"pricing": { "price_details": { "product": "prod_R0WQwMpeGGIyeo" } }
```

and `prod_R0WQwMpeGGIyeo` carries `"unit_label": "emails"`. It reads as nonsense because the $825 line isn't "1 email" — the org set `unit_label` for their own invoice display. An org whose `unit_label` is unset or placeholder gets worse output still (`Unused 1 unit_label × Transactional Pro`).

## Fix

Fixed prices are re-rendered through `fixedPriceToDescription`, which already applies the `Unused ` prefix for refund-direction contexts.

**Deliberately left on the stored text:**
- **Usage prices** — for multi-item/tiered groups the stored Stripe text carries tier detail (`"0 × Automations (Tier 1 at $0.00 / month)"`) that Autumn's description would drop. See the `useStripeDescription` branch in `stripeLineItemGroupToDbLineItems.ts:236`.
- **License credits** — they pass `contextOverride`, and their wording shows the assigned quantity via `includeQuantityInDescription`.

Also exports `fixedPriceToLineDescription` from the `billingUtils` barrel — it was already implemented, just not reachable from `@autumn/shared`.

## Scope

This changes text on **every fixed-price refund line**, not only `remove_plan_ids` ones. Amounts are untouched.

## Testing

No new test. `expectLicenseBillingPreviewCorrect.ts:71` asserts refund descriptions still start with `Unused `, which holds on both branches; nothing else asserts this text.

> [!NOTE]
> Verified by `bun ts` and Biome only. The integration suite could not be run — the dev DB is behind on migrations and every test fails at setup on `products_licenses_product.version_slug does not exist` (pre-existing, reproduced on untouched suites).

Related: #2925 (which surfaced these credit lines in the first place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render fixed‑price refund line descriptions with Autumn’s formatter instead of Stripe’s stored text. This removes the “quantity × unit_label” wording and makes refund lines match charge lines.

- Applies only to fixed‑price refund lines; usage‑based and license‑credit refunds still use the stored Stripe description to preserve tier/quantity details.
- Changes text only; amounts and grouping are unchanged, and the “Unused ” prefix remains.
- Exposes `fixedPriceToLineDescription` from `@autumn/shared` for reuse.

<sup>Written for commit 01954360e7cfc23b25497b88a8a8575dd655af2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

