### PR TITLE
Keep version+customize batch migrations on the batch lane

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -82,9 +82,10 @@ const viteAppEnv = envFile.includes(".env.prod")
 		? "staging"
 		: "dev";
 const useLocalAuthUrls = viteAppEnv === "dev" && !isProductionMode;
-// `bun dev:services up` runs Dragonfly on :6379; use it instead of the shared
-// cloud cache. Worktrees provision their own and set this in their env file.
+// `bun dev:services up` runs misc-cache Dragonfly on :6379 and cache-v2 on
+// :6380. Worktrees provision their own and set these in their env file.
 const LOCAL_MISC_CACHE_URL = "redis://localhost:6379";
+const LOCAL_CACHE_V2_URL = "redis://localhost:6380";
 const useLocalMiscCache =
 	viteAppEnv === "dev" && !isProductionMode && worktreeNum === 1;
 const localUrl = (value: string | undefined, fallback: string) =>
@@ -423,8 +424,8 @@ async function startDev() {
 				}),
 				...(useLocalMiscCache && {
 					MISC_CACHE_DRAGONFLY_PUBLIC_URL: LOCAL_MISC_CACHE_URL,
-					CACHE_V2_DRAGONFLY_URL: LOCAL_MISC_CACHE_URL,
-					CACHE_V2_DRAGONFLY_PUBLIC_URL: LOCAL_MISC_CACHE_URL,
+					CACHE_V2_DRAGONFLY_URL: LOCAL_CACHE_V2_URL,
+					CACHE_V2_DRAGONFLY_PUBLIC_URL: LOCAL_CACHE_V2_URL,
 					REDIS_URL: LOCAL_MISC_CACHE_URL,
 				}),
 				...(process.env.DB_SCHEMA && { DB_SCHEMA: process.env.DB_SCHEMA }),

--- a/server/src/internal/migrations/v2/batchOperations/compute/transitions/resolveTargetFullProduct.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/transitions/resolveTargetFullProduct.ts
@@ -1,11 +1,11 @@
 import type {
 	Entitlement,
+	EntitlementWithFeature,
 	Feature,
 	FullProduct,
 	PlanItemFilter,
 } from "@autumn/shared";
 import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
-import { entsAreSame } from "@autumn/shared/utils/productUtils/entUtils/index.js";
 import { entIntvToResetIntv } from "@autumn/shared/utils/productV2Utils/productItemUtils/convertProductItem/planItemIntervals.js";
 import { isFixedPrice } from "@shared/utils/productUtils/priceUtils/classifyPriceUtils";
 import type { MigrationRuntime } from "@/internal/migrations/v2/types/migrationDefinition.js";
@@ -38,11 +38,8 @@ const matchesRemoveFilter = ({
 	return true;
 };
 
-/** Resolves the product the customer ends up on. Version alone is a full
- * transition to the target's definitions; with item customize the version is
- * a pure repoint and items evolve from the customer's current (from)
- * definitions — mirroring the per-customer patch path (setupPatchContext).
- * Identity, base price, and free trial always follow the target. */
+/** Version alone is a full transition to the target; with item customize,
+ * items and base-price semantics evolve from fromProduct (version is a repoint). */
 export const resolveTargetFullProduct = ({
 	migration,
 	op,
@@ -59,6 +56,7 @@ export const resolveTargetFullProduct = ({
 	features: Feature[];
 }): {
 	toProduct?: FullProduct;
+	addEntitlements: EntitlementWithFeature[];
 	hasItemChanges: boolean;
 	rejections: BatchMigrationRejection[];
 } => {
@@ -72,7 +70,8 @@ export const resolveTargetFullProduct = ({
 			fromProduct: targetProduct,
 			features,
 		});
-	if (rejections.length > 0) return { hasItemChanges: false, rejections };
+	if (rejections.length > 0)
+		return { addEntitlements: [], hasItemChanges: false, rejections };
 
 	const removeFilters = op.customize?.remove_items ?? [];
 	const hasItemCustomize =
@@ -94,22 +93,20 @@ export const resolveTargetFullProduct = ({
 	const retainedEntitlements = itemBase.entitlements.filter(
 		(entitlement) => !isRemoved(entitlement.id),
 	);
-	const newEntitlements = addEntitlements.filter(
-		(addition) =>
-			!retainedEntitlements.some((existing) => entsAreSame(existing, addition)),
-	);
 
 	return {
 		toProduct: {
 			...targetProduct,
-			entitlements: [...retainedEntitlements, ...newEntitlements],
+			// Written add_items stay on toProduct even when catalog already has the same shape; execution dedupes.
+			entitlements: [...retainedEntitlements, ...addEntitlements],
 			prices: [
-				...targetProduct.prices.filter(isFixedPrice),
+				...itemBase.prices.filter(isFixedPrice),
 				...itemBase.prices.filter(
 					(price) => !isFixedPrice(price) && !isRemoved(price.entitlement_id),
 				),
 			],
 		},
+		addEntitlements,
 		hasItemChanges:
 			addEntitlements.length > 0 || removedEntitlementIds.size > 0,
 		rejections: [],

--- a/server/src/routers/chatProxyRouter.ts
+++ b/server/src/routers/chatProxyRouter.ts
@@ -9,12 +9,20 @@ const proxyChatRequest =
 		const headers = new Headers(c.req.raw.headers);
 		headers.delete("host");
 
-		return fetch(`${chatServerUrl}${url.pathname}${url.search}`, {
-			body: bodylessMethods.has(c.req.raw.method) ? undefined : c.req.raw.body,
-			headers,
-			method: c.req.raw.method,
-			redirect: "manual",
-		} as RequestInit & { duplex: "half" });
+		try {
+			return await fetch(`${chatServerUrl}${url.pathname}${url.search}`, {
+				body: bodylessMethods.has(c.req.raw.method)
+					? undefined
+					: c.req.raw.body,
+				headers,
+				method: c.req.raw.method,
+				redirect: "manual",
+			} as RequestInit & { duplex: "half" });
+		} catch {
+			// Leaf is optional locally; an uncaught ConnectionRefused here runs
+			// before ctx exists and looks like the API process died.
+			return c.json({ error: "chat_server_unavailable" }, 502);
+		}
 	};
 
 export const createChatProxyRouter = (

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/add-items/batch-add-items-idempotency.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/add-items/batch-add-items-idempotency.test.ts
@@ -13,6 +13,8 @@
  *       whether the customer product is plain or customized. A customer who
  *       attached with messages customized 50 -> 100 keeps exactly one messages
  *       balance at 100 when the migration adds 200.
+ *     - Catalog 10 msgs/mo + add_items 20 msgs/mo keeps the live 10: no second
+ *       row, grant is not overwritten. Dedup is (feature, interval), not amount.
  *   Side effects:
  *     - customer_entitlements: exactly one live row per (customer, plan,
  *       feature) throughout.
@@ -281,5 +283,62 @@ test.concurrent(
 				status: MigrationItemRunStatus.Skipped,
 			});
 		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch add_items: catalog 10 msgs/mo is not overwritten by add 20")}`,
+	async () => {
+		const customerId = "batch-add-keep-10";
+		const catalogMessages = 10;
+		const addedMessages = 20;
+		const plan = products.base({
+			id: "batch-add-keep-10-plan",
+			items: [items.monthlyMessages({ includedUsage: catalogMessages })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [s.customer(), s.products({ list: [plan] })],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		const { migration, migrationRunId, result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-add-keep-10-mig",
+			filter: { customer: { plan: { plan_id: plan.id } } },
+			operations: addItemsOperation({
+				planId: plan.id,
+				addItems: [itemsV2.monthlyMessages({ included: addedMessages })],
+			}),
+			noBillingChanges: true,
+		});
+		expect(result?.lane).toBe("batch");
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expectBalanceCorrect({
+			customer,
+			featureId: TestFeature.Messages,
+			granted: catalogMessages,
+			remaining: catalogMessages,
+			usage: 0,
+			planId: plan.id,
+			breakdownCount: 1,
+		});
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			count: 1,
+		});
+		await expectMigrationItemRunStatus({
+			ctx,
+			migrationInternalId: migration.internal_id,
+			migrationRunId,
+			customerId,
+			status: MigrationItemRunStatus.Skipped,
+		});
 	},
 );

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/version-repoint/transitions/version-customize-base-price-remint.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/version-repoint/transitions/version-customize-base-price-remint.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Resend-shaped batch: paid pro, catalog-v2 remints Autumn base-price ids
+ * (same Stripe/amount), migration is version + customize remove+add on one
+ * feature. That remint is not a billing change and must stay on the batch lane.
+ *
+ * Red (before):  base_price_transition → per-customer.
+ * Green (after): batch; product repoints; customize replace lands on FROM items.
+ */
+import { expect, test } from "bun:test";
+import { type ApiCustomerV3, productToBasePrice } from "@autumn/shared";
+import { expectCustomerInvoiceCorrect } from "@tests/integration/billing/utils/expectCustomerInvoiceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { expectCustomerEntitlementRowCount } from "../../batchTestUtils";
+import { readScopedFeatureRow } from "../../paidRowTestUtils";
+import { expectVersionRepointedOnce } from "../utils/versionDiffTestUtils";
+import {
+	readRepointableCustomerPlanRow,
+	runVersionRepointMigration,
+} from "../utils/versionRepointTestUtils";
+
+const uniqueStem = (name: string) =>
+	`${name}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+
+const readPlanBasePrice = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	planId: string;
+	version: number;
+}) => {
+	const product = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+	const price = productToBasePrice({ product });
+	if (!price) throw new Error(`Expected a base price on ${planId} v${version}`);
+	return price;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("batch version+customize: reminted $20 base price stays on the batch lane")}`,
+	async () => {
+		const stem = uniqueStem("bvrt-base-remint");
+		const customerId = `${stem}-customer`;
+		const catalogMessages = 5;
+		const customizedMessages = 10;
+		const plan = products.pro({
+			id: `${stem}-plan`,
+			items: [items.monthlyMessages({ includedUsage: catalogMessages })],
+		});
+
+		const { ctx, autumnV1, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV2_3.post("/plans.update", {
+			plan_id: plan.id,
+			force_version: true,
+			items: [itemsV2.monthlyMessages({ included: catalogMessages })],
+			price: itemsV2.monthlyPrice({ amount: 20 }),
+		});
+
+		const fromPrice = await readPlanBasePrice({
+			ctx,
+			planId: plan.id,
+			version: 1,
+		});
+		const toPrice = await readPlanBasePrice({
+			ctx,
+			planId: plan.id,
+			version: 2,
+		});
+		expect(fromPrice.id).not.toBe(toPrice.id);
+		expect(fromPrice.config.amount).toBe(20);
+		expect(toPrice.config.amount).toBe(20);
+		expect(fromPrice.config.stripe_price_id).toBe(
+			toPrice.config.stripe_price_id,
+		);
+
+		const invoiceCountBefore =
+			(await autumnV1.customers.get<ApiCustomerV3>(customerId)).invoices
+				?.length ?? 0;
+		const messagesBefore = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		const before = await readRepointableCustomerPlanRow({
+			ctx,
+			customerId,
+			planId: plan.id,
+		});
+
+		const { result } = await runVersionRepointMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${stem}-migration`,
+			filter: { customer: { plan: { plan_id: plan.id, version: 1 } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id, version: 1 },
+						version: 2,
+						customize: {
+							remove_items: [{ feature_id: TestFeature.Messages }],
+							add_items: [
+								itemsV2.monthlyMessages({ included: customizedMessages }),
+							],
+						},
+					},
+				],
+			},
+		});
+
+		await expectVersionRepointedOnce({
+			ctx,
+			customerId,
+			planId: plan.id,
+			before,
+			targetVersion: 2,
+			result,
+		});
+
+		const messagesAfter = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(messagesAfter.id).toBe(messagesBefore.id);
+		expect(messagesAfter.entitlement_id).not.toBe(
+			messagesBefore.entitlement_id,
+		);
+		expect(messagesAfter.balance).toBe(customizedMessages);
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			count: 1,
+		});
+		await expectCustomerInvoiceCorrect({
+			customer: await autumnV1.customers.get<ApiCustomerV3>(customerId),
+			count: invoiceCountBefore,
+		});
+	},
+);

--- a/server/tests/unit/migrations-v2/batch-operations/lane-redirection/add-item-fields.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/lane-redirection/add-item-fields.test.ts
@@ -53,6 +53,20 @@ describe("add_items field → batch lane", () => {
 		expect(result.replaceToIds).toEqual([]);
 	});
 
+	test("add_items for a feature already on fromProduct still lowers to an add", () => {
+		const item = monthlyMessages({ included: 60 });
+		const result = runLane({
+			customize: { add_items: [item] },
+			fromEntitlements: [fromEntitlement({ allowance: 60 })],
+			preparedAdds: [
+				{ item, entitlement: entitlementRow({ id: "ent_new", allowance: 60 }) },
+			],
+		});
+
+		expect(result.computable).toBe(true);
+		expect(result.addIds).toEqual(["ent_new"]);
+	});
+
 	test("included: 0 is still a free add", () => {
 		const item = monthlyMessages({ included: 0 });
 		const result = runLane({

--- a/server/tests/unit/migrations-v2/batch-operations/lane-redirection/version-customize-base-price-remint.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/lane-redirection/version-customize-base-price-remint.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Version + customize is customize-on-from plus a product/version repoint.
+ * Catalog v2 reminting Autumn price rows (same Stripe/amount) is not a
+ * base-price billing change and must not reject the batch lane.
+ *
+ * Red (current):  v1 vs v2 reminted $20 prices reject as base_price_transition.
+ * Green (after):  computable; domains replace + product repoint; no reject.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	BillingInterval,
+	EntInterval,
+	type Entitlement,
+	EntitlementSchema,
+	type EntitlementWithFeature,
+	type Feature,
+	FeatureType,
+	type FullProduct,
+	type Price,
+	PriceType,
+	ResetInterval,
+} from "@autumn/shared";
+import type { UpdatePlanOp } from "@autumn/shared/api/migrations/operations/customer/updatePlan/index.js";
+import type { CreatePlanItemParamsV1Input } from "@autumn/shared/api/products/items/crud/createPlanItemParamsV1.js";
+import { computeBatchMigration } from "@/internal/migrations/v2/batchOperations/compute/computeBatchMigration.js";
+import { hashPlanItemArtifact } from "@/internal/migrations/v2/prepare/modules/ensurePricesAndEntitlements/hashPlanItemArtifact.js";
+import type { MigrationRuntime } from "@/internal/migrations/v2/types/migrationDefinition.js";
+import { PREPARE_KEY } from "./runLane.js";
+
+const domainsFeature = {
+	internal_id: "feat_domains",
+	id: "domains",
+	type: FeatureType.Metered,
+} as unknown as Feature;
+
+const stripePriceId = "price_1MCYUkJEBzQpmA4Q7sx3pUKR";
+
+const fixedPrice = ({
+	id,
+	internalProductId,
+	amount,
+}: {
+	id: string;
+	internalProductId: string;
+	amount: number;
+}): Price => ({
+	id,
+	internal_product_id: internalProductId,
+	entitlement_id: null,
+	proration_config: null,
+	config: {
+		type: PriceType.Fixed,
+		amount,
+		interval: BillingInterval.Month,
+		stripe_price_id: stripePriceId,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+});
+
+const domainsEntitlement = ({
+	id,
+	internalProductId,
+	allowance,
+}: {
+	id: string;
+	internalProductId: string;
+	allowance: number;
+}): EntitlementWithFeature => {
+	const row: Entitlement = EntitlementSchema.parse({
+		id,
+		created_at: 0,
+		internal_feature_id: domainsFeature.internal_id,
+		internal_product_id: internalProductId,
+		is_custom: false,
+		feature_id: domainsFeature.id,
+		allowance_type: AllowanceType.Fixed,
+		allowance,
+		interval: EntInterval.Month,
+		interval_count: 1,
+		pooled: false,
+	});
+	return { ...row, feature: domainsFeature };
+};
+
+const planProduct = ({
+	internalId,
+	version,
+	price,
+	entitlement,
+}: {
+	internalId: string;
+	version: number;
+	price: Price;
+	entitlement: EntitlementWithFeature;
+}): FullProduct =>
+	({
+		id: "transactional_pro",
+		internal_id: internalId,
+		version,
+		is_add_on: false,
+		prices: [price],
+		entitlements: [entitlement],
+		licenses: [],
+	}) as unknown as FullProduct;
+
+const domainsAddItem: CreatePlanItemParamsV1Input = {
+	feature_id: "domains",
+	included: 10,
+	pooled: false,
+	reset: { interval: ResetInterval.Month, interval_count: 1 },
+};
+
+const v1Price = fixedPrice({
+	id: "pr_3GGJxUKcHJSvuz9ClpZJy4yxjix",
+	internalProductId: "prod_tp_v1",
+	amount: 20,
+});
+const v2Price = fixedPrice({
+	id: "pr_3IA2xggbEqX7tUYH1thsohElead",
+	internalProductId: "prod_tp_v2",
+	amount: 20,
+});
+
+const v1Product = planProduct({
+	internalId: "prod_tp_v1",
+	version: 1,
+	price: v1Price,
+	entitlement: domainsEntitlement({
+		id: "ent_domains_v1",
+		internalProductId: "prod_tp_v1",
+		allowance: 5,
+	}),
+});
+const v2Product = planProduct({
+	internalId: "prod_tp_v2",
+	version: 2,
+	price: v2Price,
+	entitlement: domainsEntitlement({
+		id: "ent_domains_v2",
+		internalProductId: "prod_tp_v2",
+		allowance: 5,
+	}),
+});
+
+const preparedDomains = domainsEntitlement({
+	id: "ent_domains_custom",
+	internalProductId: "prod_tp_v2",
+	allowance: 10,
+});
+
+const computeResendShapedOp = ({
+	toPrice,
+}: {
+	toPrice: Price;
+}) => {
+	const targetProduct = planProduct({
+		internalId: "prod_tp_v2",
+		version: 2,
+		price: toPrice,
+		entitlement: v2Product.entitlements[0]!,
+	});
+	const op = {
+		type: "update_plan",
+		plan_filter: { plan_id: "transactional_pro", version: 1 },
+		version: 2,
+		customize: {
+			add_items: [domainsAddItem],
+			remove_items: [{ feature_id: "domains" }],
+		},
+	} as UpdatePlanOp;
+
+	return computeBatchMigration({
+		migration: {
+			id: "mig_resend",
+			no_billing_changes: true,
+			operations: { customer: [op] },
+			prepared_state: {
+				[PREPARE_KEY]: {
+					entitlements: [preparedDomains],
+					prices: [],
+					artifacts: [
+						{
+							op_index: 0,
+							kind: "add_item" as const,
+							item_index: 0,
+							hash: hashPlanItemArtifact({ item: domainsAddItem }),
+							internal_product_id: "prod_tp_v2",
+							entitlement_id: preparedDomains.id,
+						},
+					],
+				},
+			},
+		} as MigrationRuntime,
+		products: [v1Product, targetProduct],
+		features: [domainsFeature],
+	});
+};
+
+describe("version + customize base-price remint", () => {
+	test("same Stripe/amount with reminted Autumn price ids is batch-computable", () => {
+		const result = computeResendShapedOp({ toPrice: v2Price });
+
+		expect(result.computable).toBe(true);
+		if (!result.computable) throw new Error("expected computable");
+
+		expect(result.plan.patches).toHaveLength(1);
+		const operations = result.plan.patches[0]!.operations;
+		expect(operations.repointCustomerProduct).toEqual({
+			fromInternalProductId: "prod_tp_v1",
+			toInternalProductId: "prod_tp_v2",
+		});
+		expect(
+			operations.replaceEntitlements.map(
+				(operation) => operation.entitlementPrice.entitlement.id,
+			),
+		).toEqual(["ent_domains_custom"]);
+	});
+
+	test("a real base-price amount change still rejects", () => {
+		const result = computeBatchMigration({
+			migration: {
+				id: "mig_amount",
+				no_billing_changes: true,
+				operations: {
+					customer: [
+						{
+							type: "update_plan",
+							plan_filter: { plan_id: "transactional_pro", version: 1 },
+							version: 2,
+						} as UpdatePlanOp,
+					],
+				},
+			} as MigrationRuntime,
+			products: [
+				v1Product,
+				planProduct({
+					internalId: "prod_tp_v2",
+					version: 2,
+					price: fixedPrice({
+						id: "pr_v2_amount",
+						internalProductId: "prod_tp_v2",
+						amount: 30,
+					}),
+					entitlement: v2Product.entitlements[0]!,
+				}),
+			],
+			features: [domainsFeature],
+		});
+
+		expect(result.computable).toBe(false);
+		if (result.computable) throw new Error("expected rejection");
+		expect(result.rejections.map((rejection) => rejection.code)).toContain(
+			"base_price_transition",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- With item customize, version is a **repoint**: base-price semantics and written `add_items` come from `fromProduct`, so a catalog-v2 remint of the same Stripe price (Resend) and an add of a feature already on the catalog (Firecrawl) stay on the batch lane instead of dumping thousands of customers per-customer.
- Unit + integration coverage for reminted base prices and for `add_items` of a live (feature, interval) row (SQL still dedupes).
- Local: cache-v2 goes to `:6380` (misc cache stays `:6379`); Leaf-down Slack/chat proxy returns 502 instead of an uncaught throw.

## Test plan
- [ ] `UNIT_TESTS=1 bun test tests/unit/migrations-v2/batch-operations/lane-redirection/version-customize-base-price-remint.test.ts tests/unit/migrations-v2/batch-operations/lane-redirection/add-item-fields.test.ts` from `server/`
- [ ] `bun t tests/integration/billing/migrations-v2/batch-migrations/version-repoint/transitions/version-customize-base-price-remint.test.ts --headless`
- [ ] `bun t tests/integration/billing/migrations-v2/batch-migrations/add-items/batch-add-items-idempotency.test.ts --headless`
- [ ] Restart `od` so cache-v2 env is `:6380`, then re-run a `track` + migrate test if checking FullSubject cache locally


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps version+customize migrations on the batch lane when the catalog remints a base price or re-adds a live item. Previously these cases fell back to per-customer due to a base_price_transition; now version acts as a repoint and customize applies to the fromProduct without billing changes.

- In resolveTargetFullProduct, when customize is present:
  - Use fromProduct for fixed/base-price semantics and for item shape; version only repoints the product.
  - Keep written add_items on toProduct even if the catalog already has the same (execution dedupes by feature+interval).
  - Return addEntitlements and compute hasItemChanges from additions/removals.
- Batch add_items does not overwrite or duplicate an existing live (feature, interval) row; migration items may be Skipped and invoices unchanged.
- Local: dev `cache-v2` now binds to redis://localhost:6380 (misc cache stays :6379).
- Chat proxy: if the Leaf chat server is unreachable, return 502 with { "error": "chat_server_unavailable" } instead of throwing.
- Tests cover base-price remint on version+customize and add_items idempotency.

**Rollout**
- No data migration required.
- Local development: restart services so `CACHE_V2_DRAGONFLY_URL`/`_PUBLIC_URL` point to redis://localhost:6380.

<sup>Written for commit ecfa5889a8ef6e1b9fa4ced3f490d6060b8862b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

