### PR TITLE
Add atomic graduated credit rating

### DIFF
--- a/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/applyFieldUpdates.lua
+++ b/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/applyFieldUpdates.lua
@@ -86,6 +86,15 @@ local function apply_entities_update(params)
   end
 end
 
+local function apply_usage_attribution_update(params)
+  local subject_balance = params.subject_balance
+  local update = params.update
+
+  if not is_absent(update.usage_attribution) then
+    subject_balance.usage_attribution = update.usage_attribution
+  end
+end
+
 local function apply_next_reset_at_update(params)
 	local subject_balance = params.subject_balance
 	local update = params.update

--- a/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/updateSubjectBalances.lua
+++ b/server/src/_luaScriptsV2/fullSubject/updateSubjectBalances/updateSubjectBalances.lua
@@ -30,6 +30,7 @@
         additional_balance: number | null,
         adjustment: number | null,
         entities: object | null,
+        usage_attribution: object | null,
         reset_cycle_anchor: number | null,
         next_reset_at: number | null,
         expected_next_reset_at: number | null,
@@ -108,6 +109,7 @@ for _, update in ipairs(updates) do
 
       apply_balance_and_adjustment_update(helper_params)
       apply_entities_update(helper_params)
+      apply_usage_attribution_update(helper_params)
       apply_reset_cycle_anchor_update(helper_params)
       apply_next_reset_at_update(helper_params)
       apply_pooled_granted_update(helper_params)

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/contextUtilsV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/contextUtilsV2.lua
@@ -17,6 +17,56 @@ local function mark_customer_entitlement_for_update(context, customer_entitlemen
   table.insert(context.pending_writes, customer_entitlement_id)
 end
 
+local function get_credit_rate_current_units(context, customer_entitlement_id, rate_card)
+  if is_nil(rate_card) or is_nil(rate_card.source_internal_feature_id) then
+    return 0
+  end
+
+  local ent_data = context.customer_entitlements[customer_entitlement_id]
+  if not ent_data then
+    return 0
+  end
+
+  local attribution = safe_table(ent_data.subject_balance.usage_attribution)
+  local item = attribution[rate_card.source_internal_feature_id]
+  return type(item) == 'table' and safe_number(item.units) or 0
+end
+
+local function apply_credit_rate_attribution_change(params)
+  local rate_card = params.rate_card
+  if is_nil(rate_card) or is_nil(rate_card.source_internal_feature_id) then
+    return
+  end
+
+  local ent_data = params.context.customer_entitlements[params.customer_entitlement_id]
+  if not ent_data then
+    return
+  end
+
+  local attribution = safe_table(ent_data.subject_balance.usage_attribution)
+  local source_feature_id = rate_card.source_internal_feature_id
+  local current = safe_table(attribution[source_feature_id])
+  local next_units = safe_number(current.units) + safe_number(params.units)
+  local next_credits = safe_number(current.credits) + safe_number(params.credits)
+
+  if math.abs(next_units) <= CREDIT_RATE_EPSILON
+      and math.abs(next_credits) <= CREDIT_RATE_EPSILON
+  then
+    attribution[source_feature_id] = nil
+  else
+    attribution[source_feature_id] = {
+      units = next_units,
+      credits = next_credits,
+    }
+  end
+
+  ent_data.subject_balance.usage_attribution = attribution
+  mark_customer_entitlement_for_update(
+    params.context,
+    params.customer_entitlement_id
+  )
+end
+
 local function init_context(params)
   local logs = {}
   local read_result = read_subject_balances({
@@ -83,6 +133,10 @@ local function init_context(params)
         balance = has_entity_scope and 0 or safe_number(subject_balance.balance),
         entities = has_entity_scope and entities or nil,
       }
+
+      subject_balance.usage_attribution = safe_table(
+        subject_balance.usage_attribution
+      )
 
       context.customer_entitlements[ent_id] = ent_data
 

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/creditRateUtils.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/creditRateUtils.lua
@@ -1,0 +1,156 @@
+-- Graduated credit-rate math. Usage boundaries are raw feature units; costs
+-- are credits per feature_amount units.
+
+local CREDIT_RATE_EPSILON = 1e-10
+
+local function credit_rate_cost_at_usage(rate_card, usage)
+  local bounded_usage = math.max(0, safe_number(usage))
+  local feature_amount = safe_number(rate_card.feature_amount)
+  if feature_amount <= 0 then
+    error('INVALID_CREDIT_RATE_CARD_FEATURE_AMOUNT')
+  end
+
+  if rate_card.tier_behavior ~= 'graduated' then
+    return bounded_usage
+      * safe_number(rate_card.credit_amount)
+      / feature_amount
+  end
+
+  local total_cost = 0
+  local previous_boundary = 0
+  local tiers = safe_table(rate_card.tiers)
+
+  for index, tier in ipairs(tiers) do
+    local is_infinite = tier.to == 'inf'
+    local boundary = is_infinite and bounded_usage or safe_number(tier.to)
+    local tier_units = math.max(
+      0,
+      math.min(bounded_usage, boundary) - previous_boundary
+    )
+    total_cost = total_cost
+      + tier_units * safe_number(tier.credit_amount) / feature_amount
+
+    if bounded_usage <= boundary or is_infinite then
+      return total_cost
+    end
+    previous_boundary = boundary
+  end
+
+  error('INVALID_CREDIT_RATE_CARD_FINAL_TIER')
+end
+
+local function credit_rate_cost_for_units(rate_card, current_units, units)
+  local before_cost = credit_rate_cost_at_usage(rate_card, current_units)
+  local after_units = math.max(0, safe_number(current_units) + safe_number(units))
+  return credit_rate_cost_at_usage(rate_card, after_units) - before_cost
+end
+
+local function credit_rate_units_for_credit_change(params)
+  local rate_card = params.rate_card
+  local current_units = math.max(0, safe_number(params.current_units))
+  local requested_units = safe_number(params.requested_units)
+  local allowed_credits = math.abs(safe_number(params.allowed_credit_change))
+  local remaining_units = math.abs(requested_units)
+  local direction = requested_units < 0 and -1 or 1
+
+  if remaining_units <= CREDIT_RATE_EPSILON then
+    return 0
+  end
+
+  if direction < 0 then
+    remaining_units = math.min(remaining_units, current_units)
+  end
+
+  local feature_amount = safe_number(rate_card.feature_amount)
+  if feature_amount <= 0 then
+    error('INVALID_CREDIT_RATE_CARD_FEATURE_AMOUNT')
+  end
+
+  local tiers = rate_card.tier_behavior == 'graduated'
+      and safe_table(rate_card.tiers)
+    or {{ to = 'inf', credit_amount = rate_card.credit_amount }}
+  local position = current_units
+  local applied_units = 0
+
+  if direction > 0 then
+    local previous_boundary = 0
+    for _, tier in ipairs(tiers) do
+      if remaining_units <= CREDIT_RATE_EPSILON then
+        break
+      end
+
+      local is_infinite = tier.to == 'inf'
+      local boundary = is_infinite and (position + remaining_units) or safe_number(tier.to)
+      if position < boundary then
+        local segment_start = math.max(position, previous_boundary)
+        local segment_units = math.min(
+          remaining_units,
+          math.max(0, boundary - segment_start)
+        )
+        local unit_cost = safe_number(tier.credit_amount) / feature_amount
+        local units_to_apply = segment_units
+
+        if unit_cost > CREDIT_RATE_EPSILON then
+          units_to_apply = math.min(segment_units, allowed_credits / unit_cost)
+          allowed_credits = math.max(
+            0,
+            allowed_credits - units_to_apply * unit_cost
+          )
+        end
+
+        position = position + units_to_apply
+        applied_units = applied_units + units_to_apply
+        remaining_units = remaining_units - units_to_apply
+
+        if units_to_apply + CREDIT_RATE_EPSILON < segment_units then
+          break
+        end
+      end
+
+      if not is_infinite then
+        previous_boundary = boundary
+      end
+    end
+  else
+    for index = #tiers, 1, -1 do
+      if remaining_units <= CREDIT_RATE_EPSILON then
+        break
+      end
+
+      local tier = tiers[index]
+      local lower_boundary = index == 1
+          and 0
+        or safe_number(tiers[index - 1].to)
+      local upper_boundary = tier.to == 'inf'
+          and position
+        or safe_number(tier.to)
+
+      if position > lower_boundary and position <= upper_boundary then
+        local segment_units = math.min(
+          remaining_units,
+          position - lower_boundary
+        )
+        local unit_cost = safe_number(tier.credit_amount) / feature_amount
+        local units_to_apply = segment_units
+
+        if unit_cost > CREDIT_RATE_EPSILON then
+          units_to_apply = math.min(segment_units, allowed_credits / unit_cost)
+          allowed_credits = math.max(
+            0,
+            allowed_credits - units_to_apply * unit_cost
+          )
+        end
+
+        position = position - units_to_apply
+        applied_units = applied_units + units_to_apply
+        remaining_units = remaining_units - units_to_apply
+
+        if units_to_apply + CREDIT_RATE_EPSILON < segment_units then
+          break
+        end
+      end
+    end
+  end
+
+  return direction * applied_units
+end

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/deductFromSubjectBalances.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/deductFromSubjectBalances.lua
@@ -300,6 +300,7 @@ for _, cus_ent_id in ipairs(unwind_modified_cus_ent_ids) do
         additional_balance = 0,
         adjustment = ent_data.adjustment or 0,
         entities = ent_data.entities or {},
+        usage_attribution = ent_data.subject_balance.usage_attribution or {},
         deducted = 0,
       }
     end

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/runDeductionOnContextV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/runDeductionOnContextV2.lua
@@ -51,6 +51,7 @@ local function process_deduction_pass(params)
 
     local ent_id = ent_obj.customer_entitlement_id
     local credit_cost = ent_obj.credit_cost
+    local rate_card = ent_obj.rate_card
     local ent_feature_id = ent_obj.feature_id
     if credit_cost == cjson.null or credit_cost == nil or credit_cost == 0 then
       credit_cost = 1
@@ -105,6 +106,9 @@ local function process_deduction_pass(params)
         context = context,
         ent_feature_id = ent_feature_id,
         credit_cost = credit_cost,
+        rate_card = rate_card,
+        current_units = get_credit_rate_current_units(context, ent_id, rate_card),
+        requested_units = remaining_amount,
       })
       if not is_nil(available_from_usage_windows)
           and available_from_usage_windows < ent_amount then
@@ -119,22 +123,90 @@ local function process_deduction_pass(params)
     if not should_process then
       logger.log("%s skipping %s - %s", pass_name, ent_id, skip_reason)
     else
-      local deducted = deduct_from_main_balance({
-        context = context,
-        ent_id = ent_id,
-        target_entity_id = target_entity_id,
-        amount = ent_amount,
-        credit_cost = credit_cost,
-        pass_number = pass_number,
-        available_overage = available_overage,
-        min_balance = ent_obj.min_balance,
-        max_balance = ent_obj.max_balance,
-        alter_granted_balance = alter_granted_balance,
-        overage_behavior_is_allow = overage_behavior_is_allow,
-        log_prefix = pass_name,
-      })
+      local current_rate_units = get_credit_rate_current_units(
+        context,
+        ent_id,
+        rate_card
+      )
+      local effective_credit_cost = credit_cost
+      local requested_credit_change = nil
+      if not is_nil(rate_card) then
+        requested_credit_change = credit_rate_cost_for_units(
+          rate_card,
+          current_rate_units,
+          ent_amount
+        )
+        if math.abs(ent_amount) > CREDIT_RATE_EPSILON then
+          effective_credit_cost = requested_credit_change / ent_amount
+        end
+      end
+
+      local mutation_log_start = #(context.mutation_logs or {})
+      local deducted = 0
+      if is_nil(rate_card)
+          or math.abs(requested_credit_change or 0) > CREDIT_RATE_EPSILON
+      then
+        deducted = deduct_from_main_balance({
+          context = context,
+          ent_id = ent_id,
+          target_entity_id = target_entity_id,
+          amount = ent_amount,
+          credit_cost = effective_credit_cost,
+          pass_number = pass_number,
+          available_overage = available_overage,
+          min_balance = ent_obj.min_balance,
+          max_balance = ent_obj.max_balance,
+          alter_granted_balance = alter_granted_balance,
+          overage_behavior_is_allow = overage_behavior_is_allow,
+          log_prefix = pass_name,
+        })
+      end
 
       local deducted_units = deducted / credit_cost
+      if not is_nil(rate_card) then
+        deducted_units = credit_rate_units_for_credit_change({
+          rate_card = rate_card,
+          current_units = current_rate_units,
+          requested_units = ent_amount,
+          allowed_credit_change = deducted,
+        })
+
+        if math.abs(deducted_units) > CREDIT_RATE_EPSILON then
+          apply_credit_rate_attribution_change({
+            context = context,
+            customer_entitlement_id = ent_id,
+            rate_card = rate_card,
+            units = deducted_units,
+            credits = deducted,
+          })
+
+          if math.abs(deducted) <= CREDIT_RATE_EPSILON then
+            append_mutation_log({
+              context = context,
+              target_type = 'customer_entitlement',
+              customer_entitlement_id = ent_id,
+              credit_cost = 0,
+              balance_delta = 0,
+              adjustment_delta = 0,
+              usage_delta = 0,
+              value_delta = deducted_units,
+            })
+          else
+            for log_index = mutation_log_start + 1, #context.mutation_logs do
+              local mutation_log = context.mutation_logs[log_index]
+              if mutation_log.customer_entitlement_id == ent_id then
+                local log_credit_change = -safe_number(mutation_log.balance_delta)
+                local log_units = deducted_units * log_credit_change / deducted
+                mutation_log.value_delta = log_units
+                mutation_log.credit_cost = math.abs(log_units) > CREDIT_RATE_EPSILON
+                    and log_credit_change / log_units
+                  or 0
+              end
+            end
+          end
+        end
+      end
+
       remaining_amount = remaining_amount - deducted_units
 
       -- Settle the gate: record what this ent actually drained against every
@@ -144,9 +216,10 @@ local function process_deduction_pass(params)
         ent_feature_id = ent_feature_id,
         credit_cost = credit_cost,
         units = deducted_units,
+        credits = deducted,
       })
 
-      if deducted ~= 0 then
+      if deducted ~= 0 or deducted_units ~= 0 then
         if not updates[ent_id] then
           updates[ent_id] = { deducted = 0, additional_deducted = 0 }
         end
@@ -489,6 +562,7 @@ local function run_deduction_on_context(params)
 
       update.adjustment = ent_data.adjustment or 0
       update.additional_balance = 0
+      update.usage_attribution = ent_data.subject_balance.usage_attribution or {}
     end
   end
 

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/usageWindows/usageWindowContextUtilsV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/usageWindows/usageWindowContextUtilsV2.lua
@@ -42,6 +42,7 @@ local function get_available_from_usage_windows(params)
   local context = params.context
   local ent_feature_id = params.ent_feature_id
   local credit_cost = params.credit_cost or 1
+  local rate_card = params.rate_card
   local allowed = nil
 
   for feature_id, feature_windows in pairs(context.usage_windows or {}) do
@@ -55,7 +56,16 @@ local function get_available_from_usage_windows(params)
       if entry.dimension_type ~= 'balance' then
         units = headroom
       elseif not is_nil(ent_feature_id) and feature_id == ent_feature_id then
-        units = headroom / credit_cost
+        if not is_nil(rate_card) then
+          units = credit_rate_units_for_credit_change({
+            rate_card = rate_card,
+            current_units = params.current_units,
+            requested_units = params.requested_units,
+            allowed_credit_change = headroom,
+          })
+        else
+          units = headroom / credit_cost
+        end
       end
 
       if units ~= nil and (allowed == nil or units < allowed) then
@@ -76,6 +86,7 @@ local function consume_usage_window_headroom(params)
   local ent_feature_id = params.ent_feature_id
   local credit_cost = params.credit_cost or 1
   local units = params.units or 0
+  local credits = params.credits
 
   if units <= 0 then
     return
@@ -87,7 +98,7 @@ local function consume_usage_window_headroom(params)
       if entry.dimension_type ~= 'balance' then
         consumed = units
       elseif not is_nil(ent_feature_id) and feature_id == ent_feature_id then
-        consumed = units * credit_cost
+        consumed = is_nil(credits) and units * credit_cost or credits
       end
 
       if consumed ~= nil and consumed > 0 then

--- a/server/src/_luaScriptsV2/luaScriptsV2.ts
+++ b/server/src/_luaScriptsV2/luaScriptsV2.ts
@@ -27,6 +27,7 @@ import updateEntityDataV2Script from "./fullSubject/updateEntityDataV2.lua";
 // ============================================================================
 
 import CONTEXT_UTILS_V2 from "./fullSubjectDeduction/contextUtilsV2.lua";
+import CREDIT_RATE_UTILS from "./fullSubjectDeduction/creditRateUtils.lua";
 import DEDUCT_FROM_MAIN_BALANCE_V2 from "./fullSubjectDeduction/deductFromMainBalanceV2.lua";
 import DEDUCT_FROM_ROLLOVERS_V2 from "./fullSubjectDeduction/deductFromRolloversV2.lua";
 import DEDUCT_FROM_SUBJECT_BALANCES_MAIN from "./fullSubjectDeduction/deductFromSubjectBalances.lua";
@@ -78,6 +79,7 @@ ${updateCustomerProductV2MainScript}`;
  * Composed from shared helper modules + V2-specific storage adapters.
  */
 export const DEDUCT_FROM_SUBJECT_BALANCES_SCRIPT = `${LUA_UTILS}
+${CREDIT_RATE_UTILS}
 ${READ_SUBJECT_BALANCES}
 ${READ_USAGE_WINDOWS}
 ${CONTEXT_UTILS_V2}

--- a/server/src/db/initializeDatabaseFunctions.ts
+++ b/server/src/db/initializeDatabaseFunctions.ts
@@ -23,6 +23,7 @@ export const initializeDatabaseFunctions = async () => {
 			// Helper functions
 			"deductFromRollovers.sql",
 			"deductFromMainBalance.sql",
+			"creditRateUtils.sql",
 			"unwindFromLockReceipt.sql",
 			"getTotalBalance.sql",
 			"deductFromAdditionalBalance.sql",

--- a/server/src/internal/balances/check/getCheckResponseV2.ts
+++ b/server/src/internal/balances/check/getCheckResponseV2.ts
@@ -3,7 +3,10 @@ import {
 	CheckResponseV3Schema,
 	FeatureType,
 } from "@autumn/shared";
-import { featureToCreditSystem } from "@/internal/features/creditSystemUtils.js";
+import {
+	featureToCreditSystem,
+	getCreditRateCurrentUsage,
+} from "@/internal/features/creditSystemUtils.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
 
 export const getCheckResponseV2 = async ({
@@ -35,6 +38,11 @@ export const getCheckResponseV2 = async ({
 			featureId: originalFeature.id,
 			creditSystem: featureToUse,
 			amount: requiredBalance,
+			currentUsage: getCreditRateCurrentUsage({
+				fullSubject: checkData.fullSubject,
+				creditSystemId: featureToUse.id,
+				sourceInternalFeatureId: originalFeature.internal_id,
+			}),
 		});
 	}
 

--- a/server/src/internal/balances/check/runCheckWithTrackV2.ts
+++ b/server/src/internal/balances/check/runCheckWithTrackV2.ts
@@ -16,7 +16,10 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getTrackFeatureDeductions } from "@/internal/balances/track/utils/getFeatureDeductions.js";
 import { runTrackV3 } from "@/internal/balances/track/v3/runTrackV3.js";
 import { buildLockScheduleName } from "@/internal/balances/utils/lock/buildLockScheduleName.js";
-import { featureToCreditSystem } from "@/internal/features/creditSystemUtils.js";
+import {
+	featureToCreditSystem,
+	getCreditRateCurrentUsage,
+} from "@/internal/features/creditSystemUtils.js";
 import { workflows } from "@/queue/workflows.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
 
@@ -24,9 +27,7 @@ import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
  * Checks if the customer has any entitlement for the requested feature.
  * Returns false when apiBalance is undefined, indicating no customer_entitlement exists.
  */
-const customerHasEntitlementForFeature = (
-	checkData: CheckDataV2,
-): boolean => {
+const customerHasEntitlementForFeature = (checkData: CheckDataV2): boolean => {
 	return checkData.apiBalance !== undefined;
 };
 
@@ -153,6 +154,11 @@ export const runCheckWithTrackV2 = async ({
 			featureId: originalFeature.id,
 			creditSystem: featureToUse,
 			amount: requiredBalance,
+			currentUsage: getCreditRateCurrentUsage({
+				fullSubject: checkData.fullSubject,
+				creditSystemId: featureToUse.id,
+				sourceInternalFeatureId: originalFeature.internal_id,
+			}),
 		});
 	}
 

--- a/server/src/internal/balances/utils/deduction/applyDeductionUpdateToFullCustomer.ts
+++ b/server/src/internal/balances/utils/deduction/applyDeductionUpdateToFullCustomer.ts
@@ -43,6 +43,7 @@ export const applyDeductionUpdateToFullCustomer = ({
 					balance: update.balance,
 					entities: update.entities,
 					adjustment: update.adjustment,
+					usage_attribution: update.usage_attribution ?? ce.usage_attribution,
 					replaceables,
 				};
 				return; // Found and updated, exit early
@@ -79,6 +80,7 @@ export const applyDeductionUpdateToFullCustomer = ({
 				balance: update.balance,
 				entities: update.entities,
 				adjustment: update.adjustment,
+				usage_attribution: update.usage_attribution ?? ce.usage_attribution,
 				replaceables,
 			};
 			return; // Found and updated, exit early

--- a/server/src/internal/balances/utils/deduction/computeCreditCosts.ts
+++ b/server/src/internal/balances/utils/deduction/computeCreditCosts.ts
@@ -1,24 +1,41 @@
 import {
+	AllowanceType,
+	type CreditSchemaItem,
 	creditSystemContainsFeature,
+	ErrCode,
+	type Feature,
+	FeatureType,
 	type FullCusEntWithFullCusProduct,
+	RecaseError,
 } from "@autumn/shared";
 import { logger } from "@/external/logtail/logtailUtils.js";
-import { getCreditCost } from "@/internal/features/creditSystemUtils.js";
+import {
+	type CreditRateCard,
+	getCreditCost,
+	getCreditRateCard,
+} from "@/internal/features/creditSystemUtils.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
 
 const DEFAULT_CREDIT_COST = 1;
 
-export type CreditCostLookup = (entitlementId: string) => number;
+export type ComputedCreditCost = {
+	creditCost: number;
+	rateCard?: CreditRateCard;
+};
+
+export type CreditCostLookup = (entitlementId: string) => ComputedCreditCost;
 
 /** Per-entitlement credit cost lookup. Pure schema math — no I/O. */
 export const computeCreditCosts = ({
 	cusEnts,
 	deduction,
+	catalogFeatures,
 }: {
 	cusEnts: FullCusEntWithFullCusProduct[];
 	deduction: FeatureDeduction;
+	catalogFeatures?: Feature[];
 }): CreditCostLookup => {
-	const costMap = new Map<string, number>();
+	const costMap = new Map<string, ComputedCreditCost>();
 
 	for (const ce of cusEnts) {
 		// Token cost is USD: 1:1 on its own ent; parents apply their ratio to it.
@@ -26,19 +43,63 @@ export const computeCreditCosts = ({
 			deduction.tokens &&
 			ce.entitlement.feature.id === deduction.feature.id
 		) {
-			costMap.set(ce.id, deduction.tokens.cost);
+			costMap.set(ce.id, { creditCost: deduction.tokens.cost });
 			continue;
 		}
 
 		try {
-			costMap.set(
-				ce.id,
-				getCreditCost({
+			const rateCard = !deduction.tokens
+				? getCreditRateCard({
+						sourceFeature: deduction.feature,
+						creditSystem: ce.entitlement.feature,
+					})
+				: undefined;
+			if (
+				rateCard?.tier_behavior === "graduated" &&
+				(ce.unlimited ||
+					ce.entitlement.allowance_type === AllowanceType.Unlimited)
+			) {
+				throw new RecaseError({
+					message:
+						"Graduated credit rate cards with unlimited credit balances are not supported yet",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+			if (
+				rateCard?.tier_behavior === "graduated" &&
+				(ce.rollovers?.length ?? 0) > 0
+			) {
+				throw new RecaseError({
+					message:
+						"Graduated credit rate cards with rollover balances are not supported yet",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+			const hasAdditionalBalance =
+				Math.abs(ce.additional_balance ?? 0) > 0 ||
+				Object.values(ce.entities ?? {}).some(
+					(entityBalance) =>
+						Math.abs(entityBalance.additional_balance ?? 0) > 0,
+				);
+			if (rateCard?.tier_behavior === "graduated" && hasAdditionalBalance) {
+				throw new RecaseError({
+					message:
+						"Graduated credit rate cards with additional balances are not supported yet",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+
+			costMap.set(ce.id, {
+				creditCost: getCreditCost({
 					featureId: deduction.feature.id,
 					creditSystem: ce.entitlement.feature,
 					amount: deduction.tokens?.cost,
 				}),
-			);
+				...(rateCard ? { rateCard } : {}),
+			});
 		} catch (error) {
 			// A configured rate that cannot be evaluated must fail closed.
 			if (
@@ -50,6 +111,37 @@ export const computeCreditCosts = ({
 				throw error;
 			}
 
+			const currentCreditSystem = catalogFeatures?.find(
+				(feature) =>
+					feature.internal_id === ce.entitlement.feature.internal_id ||
+					feature.id === ce.entitlement.feature.id,
+			);
+			const currentSchemaItem: CreditSchemaItem | undefined =
+				currentCreditSystem?.type === FeatureType.CreditSystem
+					? currentCreditSystem.config.schema.find(
+							(schemaItem: CreditSchemaItem) =>
+								schemaItem.metered_feature_id === deduction.feature.id,
+						)
+					: undefined;
+			if (
+				currentCreditSystem &&
+				currentSchemaItem &&
+				(currentCreditSystem.config.invoice_credit ||
+					currentSchemaItem.tier_behavior === "graduated")
+			) {
+				throw new RecaseError({
+					message:
+						"Stale credit rate card: refresh the customer balance before tracking usage",
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+					data: {
+						featureId: deduction.feature.id,
+						creditSystemId: currentCreditSystem.id,
+						customerEntitlementId: ce.id,
+					},
+				});
+			}
+
 			// Cached cusEnt schemas can briefly trail a feature update; deduct at
 			// 1:1 rather than failing the track.
 			logger.warn("[computeCreditCosts] falling back to credit cost 1", {
@@ -58,9 +150,10 @@ export const computeCreditCosts = ({
 				customer_entitlement_id: ce.id,
 				error: String(error),
 			});
-			costMap.set(ce.id, DEFAULT_CREDIT_COST);
+			costMap.set(ce.id, { creditCost: DEFAULT_CREDIT_COST });
 		}
 	}
 
-	return (entitlementId) => costMap.get(entitlementId) ?? DEFAULT_CREDIT_COST;
+	return (entitlementId) =>
+		costMap.get(entitlementId) ?? { creditCost: DEFAULT_CREDIT_COST };
 };

--- a/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
@@ -1,6 +1,7 @@
 import {
 	AllowanceType,
 	cusEntToStartingBalance,
+	ErrCode,
 	type FullCusEntWithFullCusProduct,
 	type FullCustomer,
 	fullCustomerToCustomerEntitlements,
@@ -13,6 +14,7 @@ import {
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
+	RecaseError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
@@ -92,12 +94,16 @@ export const prepareFeatureDeduction = ({
 			.map((ce) => ce.entitlement.feature.id),
 	);
 
-	const getCreditCostForEnt = computeCreditCosts({ cusEnts, deduction });
+	const getCreditCostForEnt = computeCreditCosts({
+		cusEnts,
+		deduction,
+		catalogFeatures: ctx.features,
+	});
 
 	// Build input for each customer entitlement
 	const customerEntitlementDeductions: CustomerEntitlementDeduction[] =
 		cusEnts.map((ce) => {
-			const creditCost = getCreditCostForEnt(ce.id);
+			const { creditCost, rateCard } = getCreditCostForEnt(ce.id);
 			const maxOverage = getMaxOverage({ cusEnt: ce });
 
 			const isFreeAllocated =
@@ -131,6 +137,7 @@ export const prepareFeatureDeduction = ({
 			return {
 				customer_entitlement_id: ce.id,
 				credit_cost: creditCost,
+				...(rateCard ? { rate_card: rateCard } : {}),
 				feature_id: ce.entitlement.feature.id,
 				entity_feature_id: ce.entitlement.entity_feature_id ?? null,
 				usage_allowed: isUnlimited || effectiveUsageAllowed,
@@ -140,6 +147,19 @@ export const prepareFeatureDeduction = ({
 				...(isUnlimited ? { unlimited: true } : {}),
 			};
 		});
+
+	if (
+		lock?.enabled &&
+		customerEntitlementDeductions.some(
+			(entry) => entry.rate_card?.tier_behavior === "graduated",
+		)
+	) {
+		throw new RecaseError({
+			message: "Graduated credit rate cards do not support balance locks yet",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
 
 	// The deduction sort only prefers unlimited within a tier (entity level and
 	// credit systems sort first/last regardless), but the sink contract is that
@@ -160,7 +180,7 @@ export const prepareFeatureDeduction = ({
 	// Collect and sort rollovers by expires_at (oldest first), including credit_cost from parent entitlement
 	const sortedRollovers = cusEnts
 		.flatMap((ce) => {
-			const creditCost = getCreditCostForEnt(ce.id);
+			const { creditCost } = getCreditCostForEnt(ce.id);
 			return (ce.rollovers || []).map((r) => ({
 				...r,
 				credit_cost: creditCost,

--- a/server/src/internal/balances/utils/deductionV2/applyDeductionUpdateToFullSubject.ts
+++ b/server/src/internal/balances/utils/deductionV2/applyDeductionUpdateToFullSubject.ts
@@ -45,6 +45,8 @@ const applyUpdate = ({
 	additional_balance: update.additional_balance,
 	adjustment: update.adjustment,
 	entities: update.entities,
+	usage_attribution:
+		update.usage_attribution ?? customerEntitlement.usage_attribution,
 	replaceables: getUpdatedReplaceables({
 		replaceables: customerEntitlement.replaceables,
 		update,

--- a/server/src/internal/balances/utils/deductionV2/normalizeDeductionSyncStateV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/normalizeDeductionSyncStateV2.ts
@@ -11,6 +11,7 @@ const buildZeroDeductionUpdate = ({
 	additional_balance: customerEntitlement.additional_balance ?? 0,
 	adjustment: customerEntitlement.adjustment ?? 0,
 	entities: customerEntitlement.entities ?? {},
+	usage_attribution: customerEntitlement.usage_attribution ?? {},
 	deducted: 0,
 });
 

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -1,6 +1,7 @@
 import {
 	AllowanceType,
 	cusEntToStartingBalance,
+	ErrCode,
 	type FullCusEntWithFullCusProduct,
 	type FullSubject,
 	fullSubjectToCustomerEntitlements,
@@ -14,6 +15,7 @@ import {
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
+	RecaseError,
 	usageLimitFilterMatchesProperties,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -140,11 +142,14 @@ export const prepareFeatureDeductionV2 = ({
 	const getCreditCostForEnt = computeCreditCosts({
 		cusEnts: customerEntitlements,
 		deduction,
+		catalogFeatures: ctx.features,
 	});
 
 	const customerEntitlementDeductions: CustomerEntitlementDeduction[] =
 		customerEntitlements.map((customerEntitlement) => {
-			const creditCost = getCreditCostForEnt(customerEntitlement.id);
+			const { creditCost, rateCard } = getCreditCostForEnt(
+				customerEntitlement.id,
+			);
 
 			const maxOverage = getMaxOverage({
 				cusEnt: customerEntitlement,
@@ -182,6 +187,7 @@ export const prepareFeatureDeductionV2 = ({
 			return {
 				customer_entitlement_id: customerEntitlement.id,
 				credit_cost: creditCost,
+				...(rateCard ? { rate_card: rateCard } : {}),
 				feature_id: customerEntitlement.entitlement.feature.id,
 				entity_feature_id:
 					customerEntitlement.entitlement.entity_feature_id ?? null,
@@ -192,6 +198,19 @@ export const prepareFeatureDeductionV2 = ({
 				...(isUnlimited ? { unlimited: true } : {}),
 			};
 		});
+
+	if (
+		lock?.enabled &&
+		customerEntitlementDeductions.some(
+			(entry) => entry.rate_card?.tier_behavior === "graduated",
+		)
+	) {
+		throw new RecaseError({
+			message: "Graduated credit rate cards do not support balance locks yet",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
 
 	// The deduction sort only prefers unlimited within a tier (entity level and
 	// credit systems sort first/last regardless), but the sink contract is that
@@ -210,7 +229,7 @@ export const prepareFeatureDeductionV2 = ({
 	}
 
 	const rolloverArrays = customerEntitlements.map((customerEntitlement) => {
-		const creditCost = getCreditCostForEnt(customerEntitlement.id);
+		const { creditCost } = getCreditCostForEnt(customerEntitlement.id);
 		return (customerEntitlement.rollovers || []).map((rollover) => ({
 			...rollover,
 			credit_cost: creditCost,

--- a/server/src/internal/balances/utils/deductionV2/syncDeductionUpdatesToFullSubjectCache.ts
+++ b/server/src/internal/balances/utils/deductionV2/syncDeductionUpdatesToFullSubjectCache.ts
@@ -1,4 +1,8 @@
-import type { EntityRolloverBalance, FullSubject } from "@autumn/shared";
+import type {
+	EntityRolloverBalance,
+	FullSubject,
+	UsageAttribution,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
 import { FULL_SUBJECT_CACHE_TTL_SECONDS } from "@/internal/customers/cache/fullSubject/config/fullSubjectCacheConfig.js";
@@ -19,6 +23,7 @@ interface SubjectBalanceUpdate {
 	additional_balance: number | null;
 	adjustment: number | null;
 	entities: Record<string, unknown> | null;
+	usage_attribution: UsageAttribution | null;
 	next_reset_at: number | null;
 	expected_next_reset_at: number | null;
 	rollover_insert: unknown | null;
@@ -94,6 +99,7 @@ export const syncDeductionUpdatesToFullSubjectCache = async ({
 					additional_balance: update.additional_balance ?? null,
 					adjustment: update.adjustment ?? null,
 					entities: update.entities ?? null,
+					usage_attribution: update.usage_attribution ?? null,
 					next_reset_at: null,
 					expected_next_reset_at: cusEntNextResetAts[cusEntId] ?? null,
 					rollover_insert: null,

--- a/server/src/internal/balances/utils/sql/creditRateUtils.sql
+++ b/server/src/internal/balances/utils/sql/creditRateUtils.sql
@@ -1,0 +1,396 @@
+DROP FUNCTION IF EXISTS credit_rate_cost_at_usage(jsonb, numeric);
+
+CREATE FUNCTION credit_rate_cost_at_usage(rate_card jsonb, usage numeric)
+RETURNS numeric
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  bounded_usage numeric := GREATEST(0, COALESCE(usage, 0));
+  feature_amount numeric := COALESCE((rate_card->>'feature_amount')::numeric, 0);
+  previous_boundary numeric := 0;
+  boundary numeric;
+  tier_units numeric;
+  total_cost numeric := 0;
+  tier jsonb;
+BEGIN
+  IF feature_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_CREDIT_RATE_CARD_FEATURE_AMOUNT';
+  END IF;
+
+  IF COALESCE(rate_card->>'tier_behavior', '') != 'graduated' THEN
+    RETURN bounded_usage
+      * COALESCE((rate_card->>'credit_amount')::numeric, 0)
+      / feature_amount;
+  END IF;
+
+  FOR tier IN SELECT * FROM jsonb_array_elements(rate_card->'tiers')
+  LOOP
+    boundary := CASE
+      WHEN tier->>'to' = 'inf' THEN bounded_usage
+      ELSE (tier->>'to')::numeric
+    END;
+    tier_units := GREATEST(
+      0,
+      LEAST(bounded_usage, boundary) - previous_boundary
+    );
+    total_cost := total_cost
+      + tier_units * COALESCE((tier->>'credit_amount')::numeric, 0)
+        / feature_amount;
+
+    IF bounded_usage <= boundary OR tier->>'to' = 'inf' THEN
+      RETURN total_cost;
+    END IF;
+    previous_boundary := boundary;
+  END LOOP;
+
+  RAISE EXCEPTION 'INVALID_CREDIT_RATE_CARD_FINAL_TIER';
+END;
+$$;
+
+DROP FUNCTION IF EXISTS credit_rate_units_for_credit_change(jsonb, numeric, numeric, numeric);
+
+CREATE FUNCTION credit_rate_units_for_credit_change(
+  rate_card jsonb,
+  current_units numeric,
+  requested_units numeric,
+  allowed_credit_change numeric
+)
+RETURNS numeric
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  epsilon numeric := 0.0000000001;
+  position numeric := GREATEST(0, COALESCE(current_units, 0));
+  remaining_units numeric := ABS(COALESCE(requested_units, 0));
+  remaining_credits numeric := ABS(COALESCE(allowed_credit_change, 0));
+  direction integer := CASE WHEN requested_units < 0 THEN -1 ELSE 1 END;
+  feature_amount numeric := COALESCE((rate_card->>'feature_amount')::numeric, 0);
+  tiers jsonb;
+  tier jsonb;
+  tier_index integer;
+  previous_boundary numeric := 0;
+  lower_boundary numeric;
+  upper_boundary numeric;
+  segment_start numeric;
+  segment_units numeric;
+  unit_cost numeric;
+  units_to_apply numeric;
+  applied_units numeric := 0;
+BEGIN
+  IF remaining_units <= epsilon THEN
+    RETURN 0;
+  END IF;
+  IF direction < 0 THEN
+    remaining_units := LEAST(remaining_units, position);
+  END IF;
+  IF feature_amount <= 0 THEN
+    RAISE EXCEPTION 'INVALID_CREDIT_RATE_CARD_FEATURE_AMOUNT';
+  END IF;
+
+  tiers := CASE
+    WHEN rate_card->>'tier_behavior' = 'graduated' THEN rate_card->'tiers'
+    ELSE jsonb_build_array(jsonb_build_object(
+      'to', 'inf',
+      'credit_amount', COALESCE((rate_card->>'credit_amount')::numeric, 0)
+    ))
+  END;
+
+  IF direction > 0 THEN
+    FOR tier IN SELECT * FROM jsonb_array_elements(tiers)
+    LOOP
+      EXIT WHEN remaining_units <= epsilon;
+      upper_boundary := CASE
+        WHEN tier->>'to' = 'inf' THEN position + remaining_units
+        ELSE (tier->>'to')::numeric
+      END;
+
+      IF position < upper_boundary THEN
+        segment_start := GREATEST(position, previous_boundary);
+        segment_units := LEAST(
+          remaining_units,
+          GREATEST(0, upper_boundary - segment_start)
+        );
+        unit_cost := COALESCE((tier->>'credit_amount')::numeric, 0)
+          / feature_amount;
+        units_to_apply := segment_units;
+
+        IF unit_cost > epsilon THEN
+          units_to_apply := LEAST(segment_units, remaining_credits / unit_cost);
+          remaining_credits := GREATEST(
+            0,
+            remaining_credits - units_to_apply * unit_cost
+          );
+        END IF;
+
+        position := position + units_to_apply;
+        applied_units := applied_units + units_to_apply;
+        remaining_units := remaining_units - units_to_apply;
+        EXIT WHEN units_to_apply + epsilon < segment_units;
+      END IF;
+
+      IF tier->>'to' != 'inf' THEN
+        previous_boundary := upper_boundary;
+      END IF;
+    END LOOP;
+  ELSE
+    FOR tier_index IN REVERSE (jsonb_array_length(tiers) - 1)..0
+    LOOP
+      EXIT WHEN remaining_units <= epsilon;
+      tier := tiers->tier_index;
+      lower_boundary := CASE
+        WHEN tier_index = 0 THEN 0
+        ELSE (tiers->(tier_index - 1)->>'to')::numeric
+      END;
+      upper_boundary := CASE
+        WHEN tier->>'to' = 'inf' THEN position
+        ELSE (tier->>'to')::numeric
+      END;
+
+      IF position > lower_boundary AND position <= upper_boundary THEN
+        segment_units := LEAST(remaining_units, position - lower_boundary);
+        unit_cost := COALESCE((tier->>'credit_amount')::numeric, 0)
+          / feature_amount;
+        units_to_apply := segment_units;
+
+        IF unit_cost > epsilon THEN
+          units_to_apply := LEAST(segment_units, remaining_credits / unit_cost);
+          remaining_credits := GREATEST(
+            0,
+            remaining_credits - units_to_apply * unit_cost
+          );
+        END IF;
+
+        position := position - units_to_apply;
+        applied_units := applied_units + units_to_apply;
+        remaining_units := remaining_units - units_to_apply;
+        EXIT WHEN units_to_apply + epsilon < segment_units;
+      END IF;
+    END LOOP;
+  END IF;
+
+  RETURN direction * applied_units;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS credit_rate_current_units(jsonb, jsonb);
+
+CREATE FUNCTION credit_rate_current_units(
+  usage_attribution jsonb,
+  rate_card jsonb
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(
+    (
+      COALESCE(usage_attribution, '{}'::jsonb)
+        ->(rate_card->>'source_internal_feature_id')
+        ->>'units'
+    )::numeric,
+    0
+  );
+$$;
+
+DROP FUNCTION IF EXISTS apply_credit_rate_attribution(jsonb, jsonb, numeric, numeric);
+
+CREATE FUNCTION apply_credit_rate_attribution(
+  usage_attribution jsonb,
+  rate_card jsonb,
+  units_delta numeric,
+  credits_delta numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  result jsonb := COALESCE(usage_attribution, '{}'::jsonb);
+  source_feature_id text := rate_card->>'source_internal_feature_id';
+  current_item jsonb := COALESCE(result->source_feature_id, '{}'::jsonb);
+  next_units numeric := COALESCE((current_item->>'units')::numeric, 0)
+    + COALESCE(units_delta, 0);
+  next_credits numeric := COALESCE((current_item->>'credits')::numeric, 0)
+    + COALESCE(credits_delta, 0);
+BEGIN
+  IF ABS(next_units) <= 0.0000000001
+     AND ABS(next_credits) <= 0.0000000001 THEN
+    RETURN result - source_feature_id;
+  END IF;
+
+  RETURN jsonb_set(
+    result,
+    ARRAY[source_feature_id],
+    jsonb_build_object('units', next_units, 'credits', next_credits),
+    true
+  );
+END;
+$$;
+
+DROP FUNCTION IF EXISTS reprice_credit_rate_mutation_logs(jsonb, text, numeric, numeric);
+
+CREATE FUNCTION reprice_credit_rate_mutation_logs(
+  mutation_logs jsonb,
+  customer_entitlement_id text,
+  deducted_credits numeric,
+  deducted_units numeric
+)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(
+    jsonb_agg(
+      CASE
+        WHEN log_item->>'customer_entitlement_id' = customer_entitlement_id
+          AND deducted_credits != 0
+        THEN jsonb_set(
+          jsonb_set(
+            log_item,
+            '{value_delta}',
+            to_jsonb(
+              deducted_units
+                * (-(log_item->>'balance_delta')::numeric)
+                / deducted_credits
+            )
+          ),
+          '{credit_cost}',
+          to_jsonb(
+            CASE
+              WHEN deducted_units = 0 THEN 0
+              ELSE deducted_credits / deducted_units
+            END
+          )
+        )
+        ELSE log_item
+      END
+    ),
+    '[]'::jsonb
+  )
+  FROM jsonb_array_elements(COALESCE(mutation_logs, '[]'::jsonb)) log_item;
+$$;
+
+DROP FUNCTION IF EXISTS deduct_from_credit_rate_main_balance(jsonb);
+
+CREATE FUNCTION deduct_from_credit_rate_main_balance(params jsonb)
+RETURNS TABLE (
+  deducted numeric,
+  deducted_units numeric,
+  new_balance numeric,
+  new_entities jsonb,
+  new_adjustment numeric,
+  new_usage_attribution jsonb,
+  mutation_logs jsonb
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  epsilon numeric := 0.0000000001;
+  customer_entitlement_id text := NULLIF(
+    params->>'customer_entitlement_id',
+    ''
+  );
+  rate_card jsonb := params->'rate_card';
+  current_usage_attribution jsonb := COALESCE(
+    params->'current_usage_attribution',
+    '{}'::jsonb
+  );
+  requested_units numeric := COALESCE(
+    (params->>'amount_to_deduct')::numeric,
+    0
+  );
+  current_units numeric;
+  requested_credit_change numeric;
+  effective_credit_cost numeric;
+BEGIN
+  IF rate_card IS NULL OR jsonb_typeof(rate_card) != 'object' THEN
+    RAISE EXCEPTION 'MISSING_CREDIT_RATE_CARD';
+  END IF;
+
+  current_units := credit_rate_current_units(
+    current_usage_attribution,
+    rate_card
+  );
+  requested_credit_change := credit_rate_cost_at_usage(
+    rate_card,
+    GREATEST(0, current_units + requested_units)
+  ) - credit_rate_cost_at_usage(rate_card, current_units);
+
+  deducted := 0;
+  deducted_units := 0;
+  new_balance := (params->>'current_balance')::numeric;
+  new_entities := COALESCE(params->'current_entities', '{}'::jsonb);
+  new_adjustment := COALESCE(
+    (params->>'current_adjustment')::numeric,
+    0
+  );
+  new_usage_attribution := current_usage_attribution;
+  mutation_logs := '[]'::jsonb;
+
+  IF ABS(requested_units) <= epsilon THEN
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  IF ABS(requested_credit_change) > epsilon THEN
+    effective_credit_cost := requested_credit_change / requested_units;
+
+    SELECT
+      deduction_result.deducted,
+      deduction_result.new_balance,
+      deduction_result.new_entities,
+      deduction_result.new_adjustment,
+      deduction_result.mutation_logs
+    INTO
+      deducted,
+      new_balance,
+      new_entities,
+      new_adjustment,
+      mutation_logs
+    FROM deduct_from_main_balance(
+      params || jsonb_build_object('credit_cost', effective_credit_cost)
+    ) deduction_result;
+  END IF;
+
+  deducted_units := credit_rate_units_for_credit_change(
+    rate_card,
+    current_units,
+    requested_units,
+    deducted
+  );
+
+  IF ABS(deducted_units) > epsilon THEN
+    new_usage_attribution := apply_credit_rate_attribution(
+      current_usage_attribution,
+      rate_card,
+      deducted_units,
+      deducted
+    );
+
+    IF ABS(deducted) <= epsilon THEN
+      mutation_logs := jsonb_build_array(jsonb_build_object(
+        'target_type', 'customer_entitlement',
+        'customer_entitlement_id', customer_entitlement_id,
+        'rollover_id', NULL,
+        'entity_id', NULLIF(params->>'target_entity_id', ''),
+        'credit_cost', 0,
+        'balance_delta', 0,
+        'adjustment_delta', 0,
+        'usage_delta', 0,
+        'value_delta', deducted_units
+      ));
+    ELSE
+      mutation_logs := reprice_credit_rate_mutation_logs(
+        mutation_logs,
+        customer_entitlement_id,
+        deducted,
+        deducted_units
+      );
+    END IF;
+  END IF;
+
+  RETURN NEXT;
+END;
+$$;

--- a/server/src/internal/balances/utils/sql/performDeduction.sql
+++ b/server/src/internal/balances/utils/sql/performDeduction.sql
@@ -70,6 +70,7 @@ DECLARE
   -- Entitlement properties
   ent_id text;
   credit_cost numeric;
+  rate_card jsonb;
   usage_allowed boolean;
   ent_feature_id text;
   spend_limit jsonb;
@@ -88,6 +89,7 @@ DECLARE
   current_additional_balance numeric;
   current_adjustment numeric;
   current_entities jsonb;
+  current_usage_attribution jsonb;
 
   -- Balance update (alter_granted) variables
   diff numeric;
@@ -102,6 +104,8 @@ DECLARE
   new_balance numeric;
   new_entities jsonb;
   new_adjustment numeric;
+  new_usage_attribution jsonb;
+  deducted_units numeric;
   step_mutation_logs jsonb := '[]'::jsonb;
   unwind_updates_json jsonb := '{}'::jsonb;
   unwind_modified_rollover_ids text[] := ARRAY[]::text[];
@@ -196,18 +200,25 @@ BEGIN
     ent_obj := sorted_entitlements->0;
     ent_id := ent_obj->>'customer_entitlement_id';
     credit_cost := (ent_obj->>'credit_cost')::numeric;
+    rate_card := ent_obj->'rate_card';
     has_entity_scope := (ent_obj->>'entity_feature_id') IS NOT NULL;
+
+    IF rate_card IS NOT NULL THEN
+      RAISE EXCEPTION 'UNSUPPORTED_GRADUATED_CREDIT_RATE_CARD_UNLIMITED';
+    END IF;
 
     SELECT
       ce.balance,
       COALESCE(ce.additional_balance, 0),
       COALESCE(ce.adjustment, 0),
-      COALESCE(ce.entities, '{}'::jsonb)
+      COALESCE(ce.entities, '{}'::jsonb),
+      COALESCE(ce.usage_attribution, '{}'::jsonb)
     INTO
       current_balance,
       current_additional_balance,
       current_adjustment,
-      current_entities
+      current_entities,
+      current_usage_attribution
     FROM customer_entitlements ce
     WHERE ce.id = ent_id;
 
@@ -289,6 +300,7 @@ BEGIN
           'additional_balance', current_additional_balance,
           'adjustment', current_adjustment,
           'entities', new_entities,
+          'usage_attribution', current_usage_attribution,
           'deducted', COALESCE((updates_json->ent_id->>'deducted')::numeric, 0) + deducted,
           'additional_deducted', COALESCE((updates_json->ent_id->>'additional_deducted')::numeric, 0)
         )
@@ -325,6 +337,7 @@ BEGIN
     -- Extract entitlement properties
     ent_id := ent_obj->>'customer_entitlement_id';
     credit_cost := (ent_obj->>'credit_cost')::numeric;
+    rate_card := ent_obj->'rate_card';
     usage_allowed := COALESCE((ent_obj->>'usage_allowed')::boolean, false);
     ent_feature_id := NULLIF(ent_obj->>'feature_id', '');
     min_balance := (ent_obj->>'min_balance')::numeric;
@@ -336,17 +349,23 @@ BEGIN
     -- into this entitlement. Rollovers and additional_balance are intentionally
     -- untouched (reset windows are TS-suppressed).
     IF is_unlimited THEN
+      IF rate_card IS NOT NULL THEN
+        RAISE EXCEPTION 'UNSUPPORTED_GRADUATED_CREDIT_RATE_CARD_UNLIMITED';
+      END IF;
+
       -- Fetch current state (rows already locked in STEP 0)
       SELECT
         ce.balance,
         COALESCE(ce.additional_balance, 0),
         COALESCE(ce.adjustment, 0),
-        COALESCE(ce.entities, '{}'::jsonb)
+        COALESCE(ce.entities, '{}'::jsonb),
+        COALESCE(ce.usage_attribution, '{}'::jsonb)
       INTO
         current_balance,
         current_additional_balance,
         current_adjustment,
-        current_entities
+        current_entities,
+        current_usage_attribution
       FROM customer_entitlements ce
       WHERE ce.id = ent_id;
 
@@ -398,6 +417,7 @@ BEGIN
             'additional_balance', new_additional_balance,
             'adjustment', new_adjustment,
             'entities', new_entities,
+            'usage_attribution', current_usage_attribution,
             'deducted', COALESCE((updates_json->ent_id->>'deducted')::numeric, 0) + deducted,
             'additional_deducted', COALESCE((updates_json->ent_id->>'additional_deducted')::numeric, 0)
           )
@@ -431,14 +451,29 @@ BEGIN
       ce.balance,
       COALESCE(ce.additional_balance, 0),
       COALESCE(ce.adjustment, 0),
-      COALESCE(ce.entities, '{}'::jsonb)
+      COALESCE(ce.entities, '{}'::jsonb),
+      COALESCE(ce.usage_attribution, '{}'::jsonb)
     INTO
       current_balance,
       current_additional_balance,
       current_adjustment,
-      current_entities
+      current_entities,
+      current_usage_attribution
     FROM customer_entitlements ce
     WHERE ce.id = ent_id;
+
+    IF rate_card IS NOT NULL AND (
+      ABS(current_additional_balance) > 0.0000000001
+      OR EXISTS (
+        SELECT 1
+        FROM jsonb_each(current_entities) entity_entry
+        WHERE ABS(
+          COALESCE((entity_entry.value->>'additional_balance')::numeric, 0)
+        ) > 0.0000000001
+      )
+    ) THEN
+      RAISE EXCEPTION 'UNSUPPORTED_GRADUATED_CREDIT_RATE_CARD_ADDITIONAL_BALANCE';
+    END IF;
 
     -- STEP 2: Deduct from additional_balance (customer-level and entity-level) [TODO: add max balance here?]
     SELECT * INTO additional_deducted, new_additional_balance, new_adjustment, current_entities
@@ -458,12 +493,39 @@ BEGIN
     remaining_amount := remaining_amount - additional_deducted;
 
     -- STEP 3: Perform deduction from main balance (Pass 1: allow_negative = false)
-    SELECT * INTO deducted, new_balance, new_entities, new_adjustment, step_mutation_logs
-    FROM deduct_from_main_balance(jsonb_build_object(
-      'customer_entitlement_id', ent_id,
-      'current_balance', current_balance,
-      'current_entities', current_entities,
-      'current_adjustment', new_adjustment,
+    IF rate_card IS NOT NULL THEN
+      SELECT * INTO
+        deducted,
+        deducted_units,
+        new_balance,
+        new_entities,
+        new_adjustment,
+        new_usage_attribution,
+        step_mutation_logs
+      FROM deduct_from_credit_rate_main_balance(jsonb_build_object(
+        'customer_entitlement_id', ent_id,
+        'current_balance', current_balance,
+        'current_entities', current_entities,
+        'current_adjustment', new_adjustment,
+        'current_usage_attribution', current_usage_attribution,
+        'amount_to_deduct', remaining_amount,
+        'rate_card', rate_card,
+        'allow_negative', false,
+        'has_entity_scope', has_entity_scope,
+        'target_entity_id', target_entity_id,
+        'available_overage', NULL,
+        'min_balance', min_balance,
+        'max_balance', max_balance,
+        'alter_granted_balance', alter_granted_balance,
+        'overage_behavior_is_allow', overage_behavior_is_allow
+      ));
+    ELSE
+      SELECT * INTO deducted, new_balance, new_entities, new_adjustment, step_mutation_logs
+      FROM deduct_from_main_balance(jsonb_build_object(
+        'customer_entitlement_id', ent_id,
+        'current_balance', current_balance,
+        'current_entities', current_entities,
+        'current_adjustment', new_adjustment,
         'amount_to_deduct', remaining_amount,
         'credit_cost', credit_cost,
         'allow_negative', false,
@@ -473,11 +535,14 @@ BEGIN
         'min_balance', min_balance,
         'max_balance', max_balance,
         'alter_granted_balance', alter_granted_balance,
-      'overage_behavior_is_allow', overage_behavior_is_allow
-    ));
+        'overage_behavior_is_allow', overage_behavior_is_allow
+      ));
+      deducted_units := deducted / credit_cost;
+      new_usage_attribution := current_usage_attribution;
+    END IF;
 
     -- STEP 4: Update database if any deduction occurred
-    IF deducted != 0 OR additional_deducted != 0 THEN
+    IF deducted != 0 OR deducted_units != 0 OR additional_deducted != 0 THEN
       mutation_logs_json := mutation_logs_json || COALESCE(step_mutation_logs, '[]'::jsonb);
       IF has_entity_scope THEN
         UPDATE customer_entitlements ce
@@ -485,7 +550,8 @@ BEGIN
           balance = new_balance,
           additional_balance = new_additional_balance,
           entities = new_entities,
-          adjustment = new_adjustment
+          adjustment = new_adjustment,
+          usage_attribution = new_usage_attribution
         WHERE ce.id = ent_id;
       ELSE
         -- Don't update entities for non-entity-scoped entitlements (keep NULL)
@@ -493,7 +559,8 @@ BEGIN
         SET
           balance = new_balance,
           additional_balance = new_additional_balance,
-          adjustment = new_adjustment
+          adjustment = new_adjustment,
+          usage_attribution = new_usage_attribution
         WHERE ce.id = ent_id;
       END IF;
 
@@ -506,12 +573,13 @@ BEGIN
           'additional_balance', new_additional_balance,
           'adjustment', new_adjustment,
           'entities', new_entities,
+          'usage_attribution', new_usage_attribution,
           'deducted', COALESCE((updates_json->ent_id->>'deducted')::numeric, 0) + deducted + additional_deducted,
           'additional_deducted', COALESCE((updates_json->ent_id->>'additional_deducted')::numeric, 0) + additional_deducted
         )
       );
 
-      remaining_amount := remaining_amount - (deducted / credit_cost);
+      remaining_amount := remaining_amount - deducted_units;
     END IF;
   END LOOP;
 
@@ -526,6 +594,7 @@ BEGIN
       -- Extract entitlement properties
       ent_id := ent_obj->>'customer_entitlement_id';
       credit_cost := (ent_obj->>'credit_cost')::numeric;
+      rate_card := ent_obj->'rate_card';
       usage_allowed := COALESCE((ent_obj->>'usage_allowed')::boolean, false) OR overage_behavior_is_allow;
       ent_feature_id := NULLIF(ent_obj->>'feature_id', '');
       -- 'overflow' removes the per-entitlement overage floor; spend limits
@@ -572,12 +641,14 @@ BEGIN
         ce.balance,
         COALESCE(ce.additional_balance, 0),
         COALESCE(ce.adjustment, 0),
-        COALESCE(ce.entities, '{}'::jsonb)
+        COALESCE(ce.entities, '{}'::jsonb),
+        COALESCE(ce.usage_attribution, '{}'::jsonb)
       INTO
         current_balance,
         current_additional_balance,
         current_adjustment,
-        current_entities
+        current_entities,
+        current_usage_attribution
       FROM customer_entitlements ce
       WHERE ce.id = ent_id;
 
@@ -585,26 +656,56 @@ BEGIN
       new_additional_balance := current_additional_balance;
 
       -- Perform deduction (Pass 2: allow_negative = true)
-      SELECT * INTO deducted, new_balance, new_entities, new_adjustment, step_mutation_logs
-      FROM deduct_from_main_balance(jsonb_build_object(
-        'customer_entitlement_id', ent_id,
-        'current_balance', current_balance,
-        'current_entities', current_entities,
-        'current_adjustment', current_adjustment,
-        'amount_to_deduct', remaining_amount,
-        'credit_cost', credit_cost,
-        'allow_negative', true,
-        'has_entity_scope', has_entity_scope,
-        'target_entity_id', target_entity_id,
-        'available_overage', available_overage,
-        'min_balance', min_balance,
-        'max_balance', max_balance,
-        'alter_granted_balance', alter_granted_balance,
-        'overage_behavior_is_allow', overage_behavior_is_allow
-      ));
+      IF rate_card IS NOT NULL THEN
+        SELECT * INTO
+          deducted,
+          deducted_units,
+          new_balance,
+          new_entities,
+          new_adjustment,
+          new_usage_attribution,
+          step_mutation_logs
+        FROM deduct_from_credit_rate_main_balance(jsonb_build_object(
+          'customer_entitlement_id', ent_id,
+          'current_balance', current_balance,
+          'current_entities', current_entities,
+          'current_adjustment', current_adjustment,
+          'current_usage_attribution', current_usage_attribution,
+          'amount_to_deduct', remaining_amount,
+          'rate_card', rate_card,
+          'allow_negative', true,
+          'has_entity_scope', has_entity_scope,
+          'target_entity_id', target_entity_id,
+          'available_overage', available_overage,
+          'min_balance', min_balance,
+          'max_balance', max_balance,
+          'alter_granted_balance', alter_granted_balance,
+          'overage_behavior_is_allow', overage_behavior_is_allow
+        ));
+      ELSE
+        SELECT * INTO deducted, new_balance, new_entities, new_adjustment, step_mutation_logs
+        FROM deduct_from_main_balance(jsonb_build_object(
+          'customer_entitlement_id', ent_id,
+          'current_balance', current_balance,
+          'current_entities', current_entities,
+          'current_adjustment', current_adjustment,
+          'amount_to_deduct', remaining_amount,
+          'credit_cost', credit_cost,
+          'allow_negative', true,
+          'has_entity_scope', has_entity_scope,
+          'target_entity_id', target_entity_id,
+          'available_overage', available_overage,
+          'min_balance', min_balance,
+          'max_balance', max_balance,
+          'alter_granted_balance', alter_granted_balance,
+          'overage_behavior_is_allow', overage_behavior_is_allow
+        ));
+        deducted_units := deducted / credit_cost;
+        new_usage_attribution := current_usage_attribution;
+      END IF;
 
       -- Update database if deduction occurred (or addition with negative amount)
-      IF deducted != 0 THEN
+      IF deducted != 0 OR deducted_units != 0 THEN
         mutation_logs_json := mutation_logs_json || COALESCE(step_mutation_logs, '[]'::jsonb);
         IF has_entity_scope THEN
           UPDATE customer_entitlements ce
@@ -612,7 +713,8 @@ BEGIN
             balance = new_balance,
             additional_balance = new_additional_balance,
             entities = new_entities,
-            adjustment = new_adjustment
+            adjustment = new_adjustment,
+            usage_attribution = new_usage_attribution
           WHERE ce.id = ent_id;
         ELSE
           -- Don't update entities for non-entity-scoped entitlements (keep NULL)
@@ -620,7 +722,8 @@ BEGIN
           SET
             balance = new_balance,
             additional_balance = new_additional_balance,
-            adjustment = new_adjustment
+            adjustment = new_adjustment,
+            usage_attribution = new_usage_attribution
           WHERE ce.id = ent_id;
         END IF;
 
@@ -636,6 +739,7 @@ BEGIN
               'additional_balance', new_additional_balance,
               'adjustment', new_adjustment,
               'entities', new_entities,
+              'usage_attribution', new_usage_attribution,
               'deducted', (updates_json->ent_id->>'deducted')::numeric + deducted,
               'additional_deducted', COALESCE((updates_json->ent_id->>'additional_deducted')::numeric, 0)
             )
@@ -650,13 +754,14 @@ BEGIN
               'additional_balance', new_additional_balance,
               'adjustment', new_adjustment,
               'entities', new_entities,
+              'usage_attribution', new_usage_attribution,
               'deducted', deducted,
               'additional_deducted', 0
             )
           );
         END IF;
 
-        remaining_amount := remaining_amount - (deducted / credit_cost);
+        remaining_amount := remaining_amount - deducted_units;
       END IF;
     END LOOP;
   END IF;

--- a/server/src/internal/balances/utils/sql/syncBalancesV2.sql
+++ b/server/src/internal/balances/utils/sql/syncBalancesV2.sql
@@ -6,6 +6,8 @@
 --     - balance: number
 --     - adjustment: number
 --     - entities: jsonb (the full entities object)
+--     - usage_attribution: jsonb (optional for old queued payloads; the full
+--       per-source rate-card counters when present)
 --     - next_reset_at: bigint/number (unix timestamp, for conflict detection)
 --     - entity_count: number (for conflict detection)
 --     - cache_version: number (if defined, skip write if DB cache_version differs)
@@ -44,6 +46,7 @@ DECLARE
   ent_balance numeric;
   ent_adjustment numeric;
   ent_entities jsonb;
+  ent_usage_attribution jsonb;
   ent_next_reset_at bigint;
   ent_entity_count int;
   ent_cache_version int;
@@ -110,6 +113,7 @@ BEGIN
       ent_balance := (ent_obj->>'balance')::numeric;
       ent_adjustment := (ent_obj->>'adjustment')::numeric;
       ent_entities := ent_obj->'entities';
+      ent_usage_attribution := ent_obj->'usage_attribution';
       ent_next_reset_at := (ent_obj->>'next_reset_at')::bigint;
       ent_entity_count := COALESCE((ent_obj->>'entity_count')::int, 0);
       ent_cache_version := COALESCE((ent_obj->>'cache_version')::int, 0);
@@ -149,12 +153,14 @@ BEGIN
       SET
         balance = COALESCE(ent_balance, ce.balance),
         adjustment = COALESCE(ent_adjustment, ce.adjustment),
-        entities = COALESCE(ent_entities, ce.entities)
+        entities = COALESCE(ent_entities, ce.entities),
+        usage_attribution = COALESCE(ent_usage_attribution, ce.usage_attribution)
       WHERE ce.id = ent_id
         AND (
           ce.balance IS DISTINCT FROM COALESCE(ent_balance, ce.balance)
           OR ce.adjustment IS DISTINCT FROM COALESCE(ent_adjustment, ce.adjustment)
           OR ce.entities IS DISTINCT FROM COALESCE(ent_entities, ce.entities)
+          OR ce.usage_attribution IS DISTINCT FROM COALESCE(ent_usage_attribution, ce.usage_attribution)
         );
 
       IF FOUND THEN
@@ -164,7 +170,8 @@ BEGIN
           jsonb_build_object(
             'balance', ent_balance,
             'adjustment', ent_adjustment,
-            'entities', ent_entities
+            'entities', ent_entities,
+            'usage_attribution', ent_usage_attribution
           )
         );
       END IF;

--- a/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
+++ b/server/src/internal/balances/utils/sync/flushSubjectBalancesToDb.ts
@@ -2,6 +2,7 @@ import type {
 	EntityBalance,
 	EntityRolloverBalance,
 	SubjectBalance,
+	UsageAttribution,
 } from "@autumn/shared";
 import { tryCatch } from "@autumn/shared";
 import { sql } from "drizzle-orm";
@@ -28,6 +29,7 @@ export interface SyncEntry {
 	balance: number;
 	adjustment: number;
 	entities: Record<string, EntityBalance> | null;
+	usage_attribution: UsageAttribution;
 	next_reset_at: number | null;
 	entity_count: number;
 	cache_version: number | null;
@@ -50,6 +52,7 @@ export const subjectBalanceToSyncEntry = ({
 	balance: subjectBalance.balance ?? 0,
 	adjustment: subjectBalance.adjustment ?? 0,
 	entities: subjectBalance.entities ?? null,
+	usage_attribution: subjectBalance.usage_attribution ?? {},
 	next_reset_at: subjectBalance.next_reset_at ?? null,
 	entity_count: subjectBalance.entities
 		? Object.keys(subjectBalance.entities).length

--- a/server/src/internal/balances/utils/types/deductionTypes.ts
+++ b/server/src/internal/balances/utils/types/deductionTypes.ts
@@ -4,6 +4,7 @@ import type {
 	FullCusEntWithFullCusProduct,
 	UsageWindowLimit,
 } from "@autumn/shared";
+import type { CreditRateCard } from "@/internal/features/creditSystemUtils.js";
 
 /** Behavior options for deduction */
 export type DeductionOptions = {
@@ -28,6 +29,7 @@ export type DeductionOptions = {
 export type CustomerEntitlementDeduction = {
 	customer_entitlement_id: string;
 	credit_cost: number;
+	rate_card?: CreditRateCard;
 	feature_id: string;
 	entity_feature_id: string | null;
 	usage_allowed: boolean;

--- a/server/src/internal/balances/utils/types/deductionUpdate.ts
+++ b/server/src/internal/balances/utils/types/deductionUpdate.ts
@@ -2,6 +2,7 @@ import type {
 	EntityBalance,
 	InsertReplaceable,
 	Replaceable,
+	UsageAttribution,
 } from "@autumn/shared";
 
 export interface DeductionUpdate {
@@ -9,6 +10,7 @@ export interface DeductionUpdate {
 	additional_balance: number;
 	additional_granted_balance?: number;
 	entities: Record<string, EntityBalance>;
+	usage_attribution?: UsageAttribution;
 	adjustment: number;
 	deducted: number;
 	additional_deducted?: number;

--- a/server/src/internal/features/creditSystemUtils.ts
+++ b/server/src/internal/features/creditSystemUtils.ts
@@ -1,13 +1,220 @@
 import {
 	type CreditSchemaItem,
+	type CreditTier,
 	ErrCode,
 	type Feature,
 	FeatureType,
+	type FullSubject,
+	fullSubjectToCustomerEntitlements,
 	isAiCreditSystem,
 	isAnyCreditSystem,
 	RecaseError,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
+
+export type CreditRateCard = {
+	source_internal_feature_id: string;
+	feature_amount: number;
+} & (
+	| {
+			credit_amount: number;
+			tier_behavior?: never;
+			tiers?: never;
+	  }
+	| {
+			credit_amount?: never;
+			tier_behavior: "graduated";
+			tiers: CreditTier[];
+	  }
+);
+
+const invalidCreditRateCard = ({
+	featureId,
+	creditSystemId,
+	message,
+}: {
+	featureId: string;
+	creditSystemId: string;
+	message: string;
+}) =>
+	new RecaseError({
+		message,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+		data: { featureId, creditSystemId },
+	});
+
+const getGraduatedCreditCostAtUsage = ({
+	featureId,
+	creditSystemId,
+	schemaItem,
+	usage,
+}: {
+	featureId: string;
+	creditSystemId: string;
+	schemaItem: Extract<CreditSchemaItem, { tier_behavior: "graduated" }>;
+	usage: number;
+}) => {
+	const featureAmount = schemaItem.feature_amount ?? 1;
+	if (!Number.isFinite(featureAmount) || featureAmount <= 0) {
+		throw invalidCreditRateCard({
+			featureId,
+			creditSystemId,
+			message: "Credit rate-card billing units must be greater than zero",
+		});
+	}
+
+	if (schemaItem.tiers.length === 0) {
+		throw invalidCreditRateCard({
+			featureId,
+			creditSystemId,
+			message: "Graduated credit rate cards require at least one tier",
+		});
+	}
+
+	const boundedUsage = Decimal.max(new Decimal(usage), 0);
+	let previousBoundary = new Decimal(0);
+	let totalCost = new Decimal(0);
+
+	for (const [index, tier] of schemaItem.tiers.entries()) {
+		if (!Number.isFinite(tier.credit_amount) || tier.credit_amount < 0) {
+			throw invalidCreditRateCard({
+				featureId,
+				creditSystemId,
+				message: "Credit tier costs must be finite and non-negative",
+			});
+		}
+
+		const isLastTier = index === schemaItem.tiers.length - 1;
+		if (tier.to === "inf") {
+			if (!isLastTier) {
+				throw invalidCreditRateCard({
+					featureId,
+					creditSystemId,
+					message: "Only the final credit tier may have an infinite boundary",
+				});
+			}
+
+			const tierUnits = Decimal.max(boundedUsage.minus(previousBoundary), 0);
+			return totalCost.plus(
+				tierUnits.div(featureAmount).mul(tier.credit_amount),
+			);
+		}
+
+		if (!Number.isFinite(tier.to) || tier.to <= previousBoundary.toNumber()) {
+			throw invalidCreditRateCard({
+				featureId,
+				creditSystemId,
+				message: "Credit tier boundaries must be strictly increasing",
+			});
+		}
+
+		if (isLastTier) {
+			throw invalidCreditRateCard({
+				featureId,
+				creditSystemId,
+				message: "The final credit tier must have an infinite boundary",
+			});
+		}
+
+		const boundary = new Decimal(tier.to);
+		const tierUnits = Decimal.max(
+			Decimal.min(boundedUsage, boundary).minus(previousBoundary),
+			0,
+		);
+		totalCost = totalCost.plus(
+			tierUnits.div(featureAmount).mul(tier.credit_amount),
+		);
+		previousBoundary = boundary;
+
+		if (boundedUsage.lte(boundary)) return totalCost;
+	}
+
+	throw invalidCreditRateCard({
+		featureId,
+		creditSystemId,
+		message: "The final credit tier must have an infinite boundary",
+	});
+};
+
+const getSchemaItemCreditCost = ({
+	featureId,
+	creditSystemId,
+	schemaItem,
+	amount,
+	currentUsage,
+}: {
+	featureId: string;
+	creditSystemId: string;
+	schemaItem: CreditSchemaItem;
+	amount: number;
+	currentUsage: number;
+}) => {
+	if (schemaItem.tier_behavior === "graduated") {
+		const beforeCost = getGraduatedCreditCostAtUsage({
+			featureId,
+			creditSystemId,
+			schemaItem,
+			usage: currentUsage,
+		});
+		const afterCost = getGraduatedCreditCostAtUsage({
+			featureId,
+			creditSystemId,
+			schemaItem,
+			usage: Math.max(0, new Decimal(currentUsage).plus(amount).toNumber()),
+		});
+		return afterCost.minus(beforeCost).toNumber();
+	}
+
+	return new Decimal(schemaItem.credit_amount)
+		.div(schemaItem.feature_amount ?? 1)
+		.mul(amount)
+		.toNumber();
+};
+
+const getCreditSchemaItem = ({
+	featureId,
+	creditSystem,
+}: {
+	featureId: string;
+	creditSystem: Feature;
+}) => {
+	const schema: CreditSchemaItem[] = creditSystem.config.schema;
+	return schema.find(
+		(schemaItem) => schemaItem.metered_feature_id === featureId,
+	);
+};
+
+export const getCreditRateCard = ({
+	sourceFeature,
+	creditSystem,
+}: {
+	sourceFeature: Feature;
+	creditSystem: Feature;
+}): CreditRateCard | undefined => {
+	if (
+		creditSystem.type !== FeatureType.CreditSystem ||
+		sourceFeature.id === creditSystem.id
+	) {
+		return undefined;
+	}
+
+	const schemaItem = getCreditSchemaItem({
+		featureId: sourceFeature.id,
+		creditSystem,
+	});
+	if (!schemaItem || schemaItem.tier_behavior !== "graduated") return undefined;
+
+	const base = {
+		source_internal_feature_id: sourceFeature.internal_id,
+		feature_amount: schemaItem.feature_amount ?? 1,
+	};
+	return {
+		...base,
+		tier_behavior: "graduated",
+		tiers: schemaItem.tiers,
+	};
+};
 
 const creditSystemContainsFeature = ({
 	creditSystem,
@@ -67,36 +274,46 @@ export const getCreditSystemsFromFeature = ({
 	);
 };
 
+export const getCreditRateCurrentUsage = ({
+	fullSubject,
+	creditSystemId,
+	sourceInternalFeatureId,
+}: {
+	fullSubject: FullSubject;
+	creditSystemId: string;
+	sourceInternalFeatureId: string;
+}) => {
+	const customerEntitlement = fullSubjectToCustomerEntitlements({
+		fullSubject,
+		featureIds: [creditSystemId],
+	})[0];
+
+	return (
+		customerEntitlement?.usage_attribution?.[sourceInternalFeatureId]?.units ??
+		0
+	);
+};
+
 export const featureToCreditSystem = ({
 	featureId,
 	creditSystem,
 	amount,
+	currentUsage = 0,
 }: {
 	featureId: string;
 	creditSystem: Feature;
 	amount: number;
+	currentUsage?: number;
 }) => {
-	const schema: CreditSchemaItem[] = creditSystem.config.schema;
-
-	for (const schemaItem of schema) {
-		if (schemaItem.metered_feature_id === featureId) {
-			if (schemaItem.tier_behavior === "graduated") {
-				throw new RecaseError({
-					message: "Graduated credit rating is not supported yet",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-					data: { featureId, creditSystemId: creditSystem.id },
-				});
-			}
-			const creditAmount = schemaItem.credit_amount;
-			const featureAmount = schemaItem.feature_amount ?? 1;
-
-			return new Decimal(creditAmount)
-				.div(featureAmount)
-				.mul(amount)
-				.toNumber();
-		}
-	}
+	const schemaItem = getCreditSchemaItem({ featureId, creditSystem });
+	if (schemaItem)
+		return getSchemaItemCreditCost({
+			featureId,
+			creditSystemId: creditSystem.id,
+			schemaItem,
+			amount,
+			currentUsage,
+		});
 
 	return amount;
 };
@@ -106,10 +323,12 @@ export const getCreditCost = ({
 	featureId,
 	creditSystem,
 	amount = 1,
+	currentUsage = 0,
 }: {
 	featureId: string;
 	creditSystem: Feature;
 	amount?: number;
+	currentUsage?: number;
 }) => {
 	if (!isAnyCreditSystem(creditSystem.type)) {
 		return amount;
@@ -126,23 +345,15 @@ export const getCreditCost = ({
 			data: { featureId, creditSystemId: creditSystem.id },
 		});
 	}
-	const schema: CreditSchemaItem[] = creditSystem.config.schema;
-	for (const schemaItem of schema) {
-		if (schemaItem.metered_feature_id === featureId) {
-			if (schemaItem.tier_behavior === "graduated") {
-				throw new RecaseError({
-					message: "Graduated credit rating is not supported yet",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-					data: { featureId, creditSystemId: creditSystem.id },
-				});
-			}
-			return new Decimal(schemaItem.credit_amount)
-				.div(schemaItem.feature_amount ?? 1)
-				.mul(amount)
-				.toNumber();
-		}
-	}
+	const schemaItem = getCreditSchemaItem({ featureId, creditSystem });
+	if (schemaItem)
+		return getSchemaItemCreditCost({
+			featureId,
+			creditSystemId: creditSystem.id,
+			schemaItem,
+			amount,
+			currentUsage,
+		});
 
 	throw new RecaseError({
 		message: "Feature is not included in credit system schema",

--- a/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Contract: graduated credit cards charge marginal cumulative usage, advance
+ * tier position with the balance atomically, and keep Redis/Postgres parity.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV3,
+	customerEntitlements,
+	fullSubjectToCustomerEntitlements,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { executePostgresDeductionV2 } from "@/internal/balances/utils/deductionV2/executePostgresDeductionV2.js";
+import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
+import { getCachedFeatureBalance } from "@/internal/customers/cache/fullSubject/balances/getCachedFeatureBalances.js";
+
+const makeCreditProduct = ({
+	id,
+	withOwnAllowance = false,
+}: {
+	id: string;
+	withOwnAllowance?: boolean;
+}) =>
+	products.base({
+		id,
+		items: [
+			...(withOwnAllowance
+				? [
+						items.free({
+							featureId: TestFeature.TieredAction,
+							includedUsage: 50,
+						}),
+					]
+				: []),
+			items.free({
+				featureId: TestFeature.TieredCredits,
+				includedUsage: 1_000,
+			}),
+		],
+	});
+
+const getPersistedCreditEntitlement = async ({
+	ctx,
+	internalCustomerId,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	internalCustomerId: string;
+}) => {
+	const rows = await ctx.db
+		.select({
+			balance: customerEntitlements.balance,
+			usageAttribution: customerEntitlements.usage_attribution,
+		})
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.internal_customer_id, internalCustomerId),
+				eq(customerEntitlements.feature_id, TestFeature.TieredCredits),
+			),
+		)
+		.limit(1);
+
+	return rows[0];
+};
+
+test(
+	`${chalk.yellowBright("graduated-credit-rating: Redis handles checks, concurrent boundary crossing, and refunds")}`,
+	async () => {
+		const customerId = "graduated-credit-rating-redis";
+		const product = makeCreditProduct({ id: "graduated-credit-redis" });
+		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.attach({ productId: product.id })],
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 9_950,
+		});
+
+		const check = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			required_balance: 100,
+		});
+		expect(check.allowed).toBe(true);
+		expect(check.required_balance).toBeCloseTo(0.9, 10);
+
+		await Promise.all([
+			autumnV2_3.track({
+				customer_id: customerId,
+				feature_id: TestFeature.TieredAction,
+				value: 100,
+			}),
+			autumnV2_3.track({
+				customer_id: customerId,
+				feature_id: TestFeature.TieredAction,
+				value: 100,
+			}),
+		]);
+
+		const afterConcurrent =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(
+			afterConcurrent.features[TestFeature.TieredCredits].balance,
+		).toBeCloseTo(898.8, 10);
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: -200,
+		});
+
+		const afterRefund = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(afterRefund.features[TestFeature.TieredCredits].balance).toBeCloseTo(
+			900.5,
+			10,
+		);
+
+		await timeout(3_000);
+		const persisted = await getPersistedCreditEntitlement({
+			ctx,
+			internalCustomerId: customer.internal_id,
+		});
+		const sourceInternalFeatureId = ctx.features.find(
+			(feature) => feature.id === TestFeature.TieredAction,
+		)?.internal_id;
+		expect(sourceInternalFeatureId).toBeDefined();
+		expect(persisted?.balance).toBeCloseTo(900.5, 10);
+		expect(persisted?.usageAttribution[sourceInternalFeatureId!]).toEqual({
+			units: 9_950,
+			credits: 99.5,
+		});
+
+		expect(
+			autumnV2_3.check({
+				customer_id: customerId,
+				feature_id: TestFeature.TieredAction,
+				required_balance: 100,
+				lock: {
+					enabled: true,
+					lock_id: "graduated-credit-rating-lock",
+				},
+			}),
+		).rejects.toThrow(/graduated credit.*lock/i);
+	},
+	{ timeout: 120_000 },
+);
+
+test(
+	`${chalk.yellowBright("graduated-credit-rating: only usage spilling past the source allowance enters the card")}`,
+	async () => {
+		const customerId = "graduated-credit-rating-spill";
+		const product = makeCreditProduct({
+			id: "graduated-credit-spill",
+			withOwnAllowance: true,
+		});
+		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.attach({ productId: product.id })],
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 100,
+		});
+
+		const response = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(response.features[TestFeature.TieredAction].balance).toBe(0);
+		expect(response.features[TestFeature.TieredCredits].balance).toBeCloseTo(
+			999.5,
+			10,
+		);
+
+		await timeout(3_000);
+		const persisted = await getPersistedCreditEntitlement({
+			ctx,
+			internalCustomerId: customer.internal_id,
+		});
+		const sourceInternalFeatureId = ctx.features.find(
+			(feature) => feature.id === TestFeature.TieredAction,
+		)?.internal_id;
+		expect(persisted?.usageAttribution[sourceInternalFeatureId!]).toEqual({
+			units: 50,
+			credits: 0.5,
+		});
+	},
+	{ timeout: 120_000 },
+);
+
+test(
+	`${chalk.yellowBright("graduated-credit-rating: Postgres fallback matches marginal rating")}`,
+	async () => {
+		const customerId = "graduated-credit-rating-postgres";
+		const product = makeCreditProduct({ id: "graduated-credit-postgres" });
+		const { customer, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.attach({ productId: product.id })],
+		});
+		const fullSubject = await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: "track-graduated-credit-system-test",
+		});
+		const feature = ctx.features.find(
+			(candidate) => candidate.id === TestFeature.TieredAction,
+		);
+		expect(feature).toBeDefined();
+		const creditEntitlement = fullSubjectToCustomerEntitlements({
+			fullSubject,
+			featureIds: [TestFeature.TieredCredits],
+		})[0];
+		expect(creditEntitlement).toBeDefined();
+
+		await executePostgresDeductionV2({
+			ctx,
+			fullSubject,
+			customerId,
+			deductions: [{ feature: feature!, deduction: 10_050 }],
+		});
+
+		const persisted = await getPersistedCreditEntitlement({
+			ctx,
+			internalCustomerId: customer.internal_id,
+		});
+		const sourceInternalFeatureId = feature!.internal_id;
+		expect(persisted?.balance).toBeCloseTo(899.6, 10);
+		expect(persisted?.usageAttribution[sourceInternalFeatureId]).toEqual({
+			units: 10_050,
+			credits: 100.4,
+		});
+
+		const cached = await getCachedFeatureBalance({
+			ctx,
+			customerId,
+			featureId: TestFeature.TieredCredits,
+			customerEntitlementIds: [creditEntitlement.id],
+			readMaster: true,
+		});
+		expect(cached.kind).toBe("ok");
+		if (cached.kind === "ok") {
+			expect(
+				cached.value.balances[0]?.usage_attribution?.[sourceInternalFeatureId],
+			).toEqual({ units: 10_050, credits: 100.4 });
+		}
+	},
+	{ timeout: 120_000 },
+);

--- a/server/tests/setup/v2Features.ts
+++ b/server/tests/setup/v2Features.ts
@@ -26,6 +26,8 @@ export enum TestFeature {
 
 	Action3 = "action3", // single use (pay per use)
 	Credits2 = "credits2", // credit system
+	TieredAction = "tiered_action",
+	TieredCredits = "tiered_credits",
 
 	Credits3 = "credits3", // credit system (overlaps with credits on action1)
 
@@ -130,6 +132,41 @@ export const getFeatures = ({ orgId }: { orgId: string }) => ({
 			},
 		],
 	}),
+	[TestFeature.TieredAction]: constructMeteredFeature({
+		featureId: TestFeature.TieredAction,
+		orgId,
+		env: AppEnv.Sandbox,
+		usageType: FeatureUsageType.Single,
+	}),
+	[TestFeature.TieredCredits]: {
+		...constructCreditSystem({
+			featureId: TestFeature.TieredCredits,
+			orgId,
+			env: AppEnv.Sandbox,
+			schema: [
+				{
+					metered_feature_id: TestFeature.TieredAction,
+					credit_cost: 1,
+				},
+			],
+		}),
+		config: {
+			usage_type: FeatureUsageType.Single,
+			invoice_credit: true,
+			schema: [
+				{
+					metered_feature_id: TestFeature.TieredAction,
+					feature_amount: 100,
+					tier_behavior: "graduated" as const,
+					tiers: [
+						{ to: 10_000, credit_amount: 1 },
+						{ to: 50_000, credit_amount: 0.8 },
+						{ to: "inf" as const, credit_amount: 0.5 },
+					],
+				},
+			],
+		},
+	},
 	// Overlaps with Credits on action1, and is seeded after it in the catalog
 	[TestFeature.Credits3]: constructCreditSystem({
 		featureId: TestFeature.Credits3,

--- a/server/tests/unit/balances/compute-credit-costs.test.ts
+++ b/server/tests/unit/balances/compute-credit-costs.test.ts
@@ -38,6 +38,10 @@ const credits = makeFeature("credits", FeatureType.CreditSystem, [
 const staleCredits = makeFeature("credits", FeatureType.CreditSystem, [
 	{ metered_feature_id: "other_feature", credit_amount: 5 },
 ]);
+const currentInvoiceCredits = {
+	...credits,
+	config: { ...credits.config, invoice_credit: true },
+} as Feature;
 const graduatedCredits = makeFeature("credits", FeatureType.CreditSystem, [
 	{
 		metered_feature_id: "messages",
@@ -54,8 +58,8 @@ describe("computeCreditCosts", () => {
 			deduction,
 		});
 
-		expect(lookup("ce_msg")).toBe(1);
-		expect(lookup("ce_cred")).toBe(0.2);
+		expect(lookup("ce_msg")).toEqual({ creditCost: 1 });
+		expect(lookup("ce_cred")).toEqual({ creditCost: 0.2 });
 	});
 
 	test("token deductions use their USD cost 1:1 and ratio-map to parents", () => {
@@ -76,8 +80,8 @@ describe("computeCreditCosts", () => {
 			deduction,
 		});
 
-		expect(lookup("ce_ai")).toBe(0.125);
-		expect(lookup("ce_orbs")).toBe(125);
+		expect(lookup("ce_ai")).toEqual({ creditCost: 0.125 });
+		expect(lookup("ce_orbs")).toEqual({ creditCost: 125 });
 	});
 
 	test("stale schema snapshot falls back to 1 instead of failing the track", () => {
@@ -87,19 +91,82 @@ describe("computeCreditCosts", () => {
 			deduction,
 		});
 
-		expect(lookup("ce_stale")).toBe(1);
+		expect(lookup("ce_stale")).toEqual({ creditCost: 1 });
 	});
 
-	// Red: graduated cards silently used the stale-schema 1:1 fallback.
-	// Green: configured graduated cards fail closed while absent mappings still fall back.
-	test("graduated schemas fail instead of falling back to 1", () => {
+	test("rejects a stale cached schema for an invoice credit rate card", () => {
 		const deduction: FeatureDeduction = { feature: messages, deduction: 10 };
 
 		expect(() =>
 			computeCreditCosts({
-				cusEnts: [makeCusEnt("ce_graduated", graduatedCredits)],
+				cusEnts: [makeCusEnt("ce_stale", staleCredits)],
+				deduction,
+				catalogFeatures: [messages, currentInvoiceCredits],
+			}),
+		).toThrow(/stale credit rate card/i);
+	});
+
+	test("passes graduated cards to the atomic deduction engine", () => {
+		const deduction: FeatureDeduction = { feature: messages, deduction: 10 };
+		const lookup = computeCreditCosts({
+			cusEnts: [makeCusEnt("ce_graduated", graduatedCredits)],
+			deduction,
+		});
+
+		expect(lookup("ce_graduated")).toEqual({
+			creditCost: 0.5,
+			rateCard: {
+				source_internal_feature_id: messages.internal_id,
+				feature_amount: 1,
+				tier_behavior: "graduated",
+				tiers: [{ to: "inf", credit_amount: 0.5 }],
+			},
+		});
+	});
+
+	test("rejects graduated cards backed by an unlimited credit entitlement", () => {
+		const deduction: FeatureDeduction = { feature: messages, deduction: 10 };
+		const unlimitedEntitlement = {
+			...makeCusEnt("ce_graduated", graduatedCredits),
+			unlimited: true,
+		} as FullCusEntWithFullCusProduct;
+
+		expect(() =>
+			computeCreditCosts({
+				cusEnts: [unlimitedEntitlement],
 				deduction,
 			}),
-		).toThrow("Graduated credit rating is not supported yet");
+		).toThrow(/graduated credit rate cards.*unlimited/i);
+	});
+
+	test("rejects graduated cards backed by additional balances", () => {
+		const deduction: FeatureDeduction = { feature: messages, deduction: 10 };
+		const customerAdditionalBalance = {
+			...makeCusEnt("ce_customer_additional", graduatedCredits),
+			additional_balance: 1,
+		} as FullCusEntWithFullCusProduct;
+		const entityAdditionalBalance = {
+			...makeCusEnt("ce_entity_additional", graduatedCredits),
+			entities: {
+				entity_1: {
+					id: "entity_1",
+					balance: 100,
+					adjustment: 0,
+					additional_balance: 1,
+				},
+			},
+		} as FullCusEntWithFullCusProduct;
+
+		for (const customerEntitlement of [
+			customerAdditionalBalance,
+			entityAdditionalBalance,
+		]) {
+			expect(() =>
+				computeCreditCosts({
+					cusEnts: [customerEntitlement],
+					deduction,
+				}),
+			).toThrow(/graduated credit rate cards.*additional balances/i);
+		}
 	});
 });

--- a/server/tests/unit/features/get-credit-cost.test.ts
+++ b/server/tests/unit/features/get-credit-cost.test.ts
@@ -41,6 +41,98 @@ const aiCreditFeature: Feature = {
 	},
 };
 
+const graduatedCreditFeature: Feature = {
+	...aiCreditFeature,
+	internal_id: "fe_credits",
+	id: "credits",
+	name: "Credits",
+	type: FeatureType.CreditSystem,
+	config: {
+		usage_type: FeatureUsageType.Single,
+		schema: [
+			{
+				metered_feature_id: "messages",
+				feature_amount: 100,
+				tier_behavior: "graduated",
+				tiers: [
+					{ to: 10_000, credit_amount: 1 },
+					{ to: 50_000, credit_amount: 0.8 },
+					{ to: "inf", credit_amount: 0.5 },
+				],
+			},
+		],
+	},
+	model_markups: null,
+};
+
+describe("getCreditCost — graduated rate cards", () => {
+	test("charges the marginal cost when usage crosses one tier", () => {
+		const cost = getCreditCost({
+			featureId: "messages",
+			creditSystem: graduatedCreditFeature,
+			amount: 100,
+			currentUsage: 9_950,
+		});
+
+		expect(cost).toBeCloseTo(0.9, 10);
+	});
+
+	test("charges the marginal cost when one track crosses multiple tiers", () => {
+		const cost = getCreditCost({
+			featureId: "messages",
+			creditSystem: graduatedCreditFeature,
+			amount: 40_200,
+			currentUsage: 9_900,
+		});
+
+		expect(cost).toBeCloseTo(321.5, 10);
+	});
+
+	test("one hundred single-unit tracks equal one hundred-unit track", () => {
+		let currentUsage = 9_950;
+		let incrementalCost = 0;
+
+		for (let index = 0; index < 100; index++) {
+			incrementalCost += getCreditCost({
+				featureId: "messages",
+				creditSystem: graduatedCreditFeature,
+				amount: 1,
+				currentUsage,
+			});
+			currentUsage += 1;
+		}
+
+		const batchedCost = getCreditCost({
+			featureId: "messages",
+			creditSystem: graduatedCreditFeature,
+			amount: 100,
+			currentUsage: 9_950,
+		});
+
+		expect(incrementalCost).toBeCloseTo(batchedCost, 10);
+	});
+
+	test("negative usage reverses the same marginal tiers without going below zero", () => {
+		expect(
+			getCreditCost({
+				featureId: "messages",
+				creditSystem: graduatedCreditFeature,
+				amount: -100,
+				currentUsage: 10_050,
+			}),
+		).toBeCloseTo(-0.9, 10);
+
+		expect(
+			getCreditCost({
+				featureId: "messages",
+				creditSystem: graduatedCreditFeature,
+				amount: -100,
+				currentUsage: 50,
+			}),
+		).toBeCloseTo(-0.5, 10);
+	});
+});
+
 describe("getCreditCost — AI credit system schema math", () => {
 	test("self feature maps 1:1 (plain /track values, queued replays)", () => {
 		const cost = getCreditCost({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds atomic graduated credit rating with per-source usage attribution across Redis and PostgreSQL. Replaces flat per-unit pricing with marginal cost from the customer’s cumulative usage, so concurrent tracks, tier crossings, refunds, and allowance spill price correctly.

- Rates credits as cost(after) − cost(before) in new Lua `creditRateUtils` and SQL helpers; re-prices mutation logs with unit deltas and aligns usage-window headroom to tiers.
- Persists per-source `usage_attribution` `{ units, credits }` on each credit entitlement; included in cache/DB sync, and older sync payloads that omit it leave the DB value unchanged.
- Deduction accepts a per-entitlement `rate_card`, computes effective credit change and applied units, updates attribution, and amends mutation logs with unit deltas; PostgreSQL uses `deduct_from_credit_rate_main_balance` for parity.
- Checks compute `required_balance` from the customer’s current graduated position and return `currentUsage` for the metered feature (non-tiered mappings remain 1:1).
- Fails closed for graduated cards with locks, rollovers, unlimited credit entitlements, or any non-zero additional balances; rejects stale invoice/graduated schemas with an instruction to refresh the customer balance (non-invoice absent mappings still fall back to 1:1).

<sup>Written for commit 9ed8caab00ac041c2ef8353475ca44f4b2c4cacf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary

Adds the atomic rating engine for graduated enterprise credit rate cards on top of #2897.

- computes each track from the customer's cumulative usage position rather than pricing each request independently
- records one attribution entry per source feature on the credit customer entitlement
- updates the credit balance and attribution in the same Redis Lua or PostgreSQL operation
- keeps Redis-to-PostgreSQL and PostgreSQL-to-Redis synchronization lossless
- reverses the same marginal curve for negative tracks

## Rating model

```text
credits for a track =
  cost(total attributed units after)
  - cost(total attributed units before)
```

For example, 100 one-unit tracks cost exactly the same as one 100-unit track. If a source feature has its own allowance, only the units that spill into the credit system are rated and attributed.

Attribution is stored on the existing customer entitlement:

```json
{
  "internal_feature_a_id": {
    "units": 30000,
    "credits": 260
  }
}
```

The internal feature ID remains stable if the public feature ID or name changes.

## Execution paths

- Redis: the Lua deduction reads the current attribution, evaluates the marginal tier cost, mutates balance plus attribution, and writes both atomically.
- PostgreSQL fallback: the SQL deduction locks the entitlement row and performs equivalent rating and attribution updates.
- Synchronization: balance sync payloads include attribution, while older payloads that omit it preserve the current database value.

## Scope

This PR implements graduated rating and ordinary track-time attribution. It intentionally keeps graduated cards fail-closed for locks, rollovers, unlimited credit entitlements, and non-zero additional balances.

Lock unwind, reset/carry-over lifecycle handling, pooled/direct mutation guards, and Stripe invoice rendering remain separate stacked PRs.

## Validation

- focused graduated-rating unit suite: 19 tests previously passed
- Redis concurrency, allowance-spill, negative-reversal, PostgreSQL-parity, and cache-sync integration scenarios previously passed
- existing flat credit-system check/track regressions previously passed
- GitHub server type, unit, and unused-code checks pass on restacked head `4759fbd84`
- the local integration suite was not rerun during this rebase





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds atomic graduated credit rating based on each customer’s cumulative usage, with consistent state updates across Redis and PostgreSQL.
- **[Improvements]** Calculates marginal credit cost as the difference between cumulative cost before and after each usage event.
- **[Improvements]** Stores per-source usage and credit attribution with each credit entitlement and synchronizes it between Redis and PostgreSQL.
- **[Improvements]** Handles tier crossings, allowance spill, concurrent deductions, and negative usage reversals through atomic balance operations.
- **[API changes]** Uses current graduated usage when computing check responses and required credit balances.
- **[Bug fixes]** Preserves attribution when older synchronization payloads omit the new field and rejects unsupported graduated-card configurations.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/_luaScriptsV2/fullSubjectDeduction/creditRateUtils.lua | Implements cumulative graduated-cost calculation and conversion between available credits and applicable feature units for Redis deductions. |
| server/src/_luaScriptsV2/fullSubjectDeduction/runDeductionOnContextV2.lua | Integrates marginal rating, attribution updates, usage-window accounting, and mutation-log repricing into the atomic Lua deduction flow. |
| server/src/internal/balances/utils/sql/creditRateUtils.sql | Adds PostgreSQL helpers for graduated rating, attribution mutation, unit conversion, and deduction-log repricing. |
| server/src/internal/balances/utils/sql/performDeduction.sql | Applies the graduated rating helpers while holding entitlement locks and persists balance and attribution together. |
| server/src/internal/balances/utils/deduction/computeCreditCosts.ts | Builds per-entitlement rate cards and rejects unsupported or stale graduated-credit configurations before deduction. |
| server/src/internal/features/creditSystemUtils.ts | Adds validated graduated-tier cost calculation, rate-card construction, and current attribution lookup for checks. |
| server/src/internal/balances/utils/sql/syncBalancesV2.sql | Synchronizes usage attribution while preserving the database value when older payloads omit the field. |
| server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts | Adds integration coverage for graduated rating behavior and Redis/PostgreSQL consistency. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Track or check usage] --> B[Resolve credit rate card]
  B --> C[Read source usage attribution]
  C --> D[Calculate marginal tier cost]
  D --> E{Execution path}
  E -->|Redis| F[Atomic Lua balance and attribution update]
  E -->|PostgreSQL| G[Locked SQL balance and attribution update]
  F --> H[Mutation log and updated balance]
  G --> H
  H --> I[Synchronize cache and database state]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Add atomic graduated credit rating"](https://github.com/useautumn/autumn/commit/bde566524e98789fe33e025bffc38b622ee2a78f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56598054)</sub>

**Context used:**

- Knowledge Base — [Event metering, balances, and insights](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/event-metering-and-insights.md)
- Knowledge Base — [Database schema, relations, and migrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/database-schema-and-migrations.md)

<!-- /greptile_comment -->