### PR TITLE
Org agent-rule notes reach every agent, with a live eval

### DIFF
--- a/apps/leaf/agent/instructions/org.ts
+++ b/apps/leaf/agent/instructions/org.ts
@@ -1,14 +1,3 @@
-import { defineDynamic, defineInstructions } from "eve/instructions";
+import { orgInstructions } from "../lib/orgInstructions.js";
 
-export default defineDynamic({
-	events: {
-		"session.started": (_event, ctx) => {
-			const instructions = ctx.session.auth.current?.attributes.orgInstructions;
-			if (typeof instructions !== "string" || !instructions.trim()) return null;
-
-			return defineInstructions({
-				markdown: `## Custom organization instructions\n\nThe following instructions were configured for this organization:\n\n${instructions}`,
-			});
-		},
-	},
-});
+export default orgInstructions();

--- a/apps/leaf/agent/lib/orgInstructions.ts
+++ b/apps/leaf/agent/lib/orgInstructions.ts
@@ -1,0 +1,21 @@
+import { defineDynamic, defineInstructions } from "eve/instructions";
+
+/** Org-level policy (agent rules `notes`) rides the session auth attributes,
+ * which eve copies verbatim to child runs — every agent must render it, or
+ * specialists execute without the org's standing instructions. Session-scoped
+ * keeps the prompt cache stable. */
+export const orgInstructions = () =>
+	defineDynamic({
+		events: {
+			"session.started": (_event, ctx) => {
+				const instructions =
+					ctx.session.auth.current?.attributes.orgInstructions;
+				if (typeof instructions !== "string" || !instructions.trim()) {
+					return null;
+				}
+				return defineInstructions({
+					markdown: `## Custom organization instructions\n\nThe following instructions were configured for this organization and MUST be followed:\n\n${instructions}`,
+				});
+			},
+		},
+	});

--- a/apps/leaf/agent/subagents/billing/instructions/org.ts
+++ b/apps/leaf/agent/subagents/billing/instructions/org.ts
@@ -1,0 +1,3 @@
+import { orgInstructions } from "../../../lib/orgInstructions.js";
+
+export default orgInstructions();

--- a/apps/leaf/agent/subagents/investigator/instructions/org.ts
+++ b/apps/leaf/agent/subagents/investigator/instructions/org.ts
@@ -1,0 +1,3 @@
+import { orgInstructions } from "../../../lib/orgInstructions.js";
+
+export default orgInstructions();

--- a/apps/leaf/src/internal/autumnMcp/orgContextService.ts
+++ b/apps/leaf/src/internal/autumnMcp/orgContextService.ts
@@ -1,4 +1,5 @@
 import type { AutumnLogger } from "@autumn/logging";
+import { parsePreviewPayload } from "@autumn/render";
 import { type AppEnv, ms } from "@autumn/shared";
 import { createTtlCache } from "../../lib/ttlCache.js";
 import { executeAutumnMcpTool } from "./client.js";
@@ -15,15 +16,27 @@ export type AutumnOrgContext = {
 
 type ExecuteAutumnTool = typeof executeAutumnMcpTool;
 
+// Preload results arrive as raw MCP envelopes; notes must be read off the
+// parsed body or the org instructions silently never reach any agent.
+const parsedAgentRules = (
+	value: unknown,
+): Record<string, unknown> | undefined => {
+	const unwrapped = parsePreviewPayload(value) ?? value;
+	if (!unwrapped || typeof unwrapped !== "object" || Array.isArray(unwrapped)) {
+		return undefined;
+	}
+	return unwrapped as Record<string, unknown>;
+};
+
 const withoutNotes = (value: unknown) => {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-	const { notes: _notes, ...rest } = value as Record<string, unknown>;
+	const rules = parsedAgentRules(value);
+	if (!rules) return value;
+	const { notes: _notes, ...rest } = rules;
 	return rest;
 };
 
 const getNotes = (value: unknown) => {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return;
-	const notes = (value as Record<string, unknown>).notes;
+	const notes = parsedAgentRules(value)?.notes;
 	return typeof notes === "string" && notes.trim() ? notes.trim() : undefined;
 };
 

--- a/apps/leaf/tests/e2e/orgInstructions.e2e.ts
+++ b/apps/leaf/tests/e2e/orgInstructions.e2e.ts
@@ -1,0 +1,118 @@
+import { AppEnv } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+import { executeAutumnMcpTool } from "../../src/internal/autumnMcp/client.js";
+import { getInstallationOAuthAccessToken } from "../../src/internal/installations/actions/getInstallationOAuthAccessToken.js";
+import { db } from "../../src/lib/db.js";
+import { logger } from "../../src/lib/logger.js";
+import { runSlackAgentTurn } from "../../src/providers/slack/actions/runSlackAgentTurn.js";
+import { createEveSlackPresenter } from "../../src/providers/slack/evePresenter.js";
+import { findInstallationWithOrg } from "../../src/providers/slack/installations.js";
+import { createStatusTicker } from "../../src/ui/statusTicker.js";
+
+const WORKSPACE_ID = process.env.E2E_SLACK_WORKSPACE ?? "T07NPTDCU69";
+const CUSTOMER = process.env.E2E_CUSTOMER ?? "leaf-0004";
+const MARKER_POLICY =
+	"POLICY (must follow): every plan attach MUST use a FINALIZED invoice — set invoice_mode.enabled true AND invoice_mode.finalize true on every attach request. Never use draft invoices.";
+
+const installation = await findInstallationWithOrg("slack", WORKSPACE_ID);
+if (!installation) throw new Error("no installation");
+const providerUserId = installation.installed_by_provider_user_id ?? "";
+const token = await getInstallationOAuthAccessToken({
+	env: AppEnv.Sandbox,
+	installation,
+	orgId: installation.org_id,
+});
+const callTool = async (toolName: string, request: Record<string, unknown>) => {
+	const result = (await executeAutumnMcpTool({
+		args: { request },
+		env: AppEnv.Sandbox,
+		token,
+		toolName,
+	})) as { content?: Array<{ text?: string }> };
+	return JSON.parse(result.content?.[0]?.text ?? "{}");
+};
+
+// The installation token lacks organisation:write, so the test writes notes
+// where the API would: the agent_rules row.
+const setNotes = async (notes: string) => {
+	await db.execute(
+		sql`insert into agent_rules (org_id, org_slug, entity_rules, credit_rules, notes)
+			values (${installation.org_id}, ${"unit-test-org"}, ${"{}"}::jsonb, ${"{}"}::jsonb, ${notes})
+			on conflict (org_id) do update set notes = excluded.notes`,
+	);
+};
+const originalRules = await callTool("getAgentRules", {});
+const originalNotes: string = originalRules.notes ?? "";
+console.log(`original notes: ${JSON.stringify(originalNotes).slice(0, 80)}`);
+
+let exitCode = 1;
+try {
+	await setNotes(MARKER_POLICY);
+	const verify = await callTool("getAgentRules", {});
+	if (!String(verify.notes ?? "").includes("POLICY")) {
+		throw new Error("marker notes did not persist");
+	}
+	console.log("marker policy set");
+
+	const threadId = `orginstr-${Date.now().toString(36)}`;
+	const target = {
+		post: async (content: unknown) => {
+			const postable = content as {
+				getPostData?: () => { stream: AsyncIterable<unknown> };
+				kind?: string;
+			};
+			if (postable?.kind === "stream" && postable.getPostData) {
+				for await (const _ of postable.getPostData().stream) {
+				}
+			}
+			return { id: "msg-1" };
+		},
+		startTyping: async () => {},
+	};
+	const ticker = createStatusTicker(target);
+	const presenter = createEveSlackPresenter({ setStatus: ticker.activity });
+	const output = await runSlackAgentTurn({
+		channelId: threadId,
+		installation,
+		logger,
+		onAction: (message) => presenter.onAction(message),
+		onApprovalsSuperseded: () => {},
+		onReasoning: presenter.onReasoning,
+		onThinking: ticker.thinking,
+		providerUserId,
+		text: `attach the launch plan to ${CUSTOMER}`,
+		threadId,
+	});
+	ticker.stop();
+
+	const approval = (
+		output as {
+			approval?: { toolArgs: Record<string, unknown>; toolName: string };
+			kind: string;
+		}
+	).approval;
+	if (!approval) {
+		console.log(`❌ no approval produced — kind=${output.kind}`);
+	} else {
+		const request = (approval.toolArgs as { request?: Record<string, unknown> })
+			.request;
+		const invoiceMode = (request?.invoice_mode ?? {}) as {
+			enabled?: boolean;
+			finalize?: boolean;
+		};
+		console.log(`parked invoice_mode: ${JSON.stringify(invoiceMode)}`);
+		// The skill default is a DRAFT invoice (finalize false); only the org
+		// policy demands finalized — so finalize=true proves the billing child
+		// received and followed the org instructions.
+		if (invoiceMode.enabled === true && invoiceMode.finalize === true) {
+			console.log("✅ billing child followed the org policy");
+			exitCode = 0;
+		} else {
+			console.log("❌ org policy ignored — expected finalize=true");
+		}
+	}
+} finally {
+	await setNotes(originalNotes);
+	console.log("original notes restored");
+}
+process.exit(exitCode);

--- a/apps/leaf/tests/unit/agent/orgInstructionsCoverage.test.ts
+++ b/apps/leaf/tests/unit/agent/orgInstructionsCoverage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const agentRoot = join(import.meta.dir, "../../../agent");
+
+// Org policy rides the session auth to every child; a subagent without the
+// org instruction module silently executes without the org's standing rules.
+describe("org instructions coverage", () => {
+	test("the root agent renders org instructions", () => {
+		expect(existsSync(join(agentRoot, "instructions/org.ts"))).toBe(true);
+	});
+
+	test("every subagent renders org instructions", () => {
+		const subagents = readdirSync(join(agentRoot, "subagents"), {
+			withFileTypes: true,
+		}).filter((entry) => entry.isDirectory());
+		expect(subagents.length).toBeGreaterThan(0);
+		for (const subagent of subagents) {
+			expect(
+				existsSync(
+					join(agentRoot, "subagents", subagent.name, "instructions/org.ts"),
+				),
+			).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## What

Investigating "the agent is ignoring org-specific instructions" found **two real bugs** — org notes were effectively never applied on the Eve surface:

1. **The notes never left leaf.** `getNotes`/`withoutNotes` read `.notes` off the raw MCP envelope (`{content:[{text}]}`) instead of the parsed rules body, so `orgInstructions` was always empty — the auth header never carried the policy.
2. **Only the root rendered them.** Eve copies session auth attributes to child runs verbatim, but only the orchestrator had `instructions/org.ts` — the billing/investigator specialists (the agents actually building requests) executed without the org's standing policy.

## Fix

- Notes parse through `parsePreviewPayload` before extraction
- The org-instruction module is a shared factory (`agent/lib/orgInstructions.ts`) registered by the root **and every subagent**
- A unit test fails any future subagent dir that ships without it

## Eval (100% end-to-end proof)

`tests/e2e/orgInstructions.e2e.ts`: writes a marker policy to `agent_rules.notes` ("every attach MUST use finalized invoices"), runs a live delegated attach, and asserts the **billing child's parked request** carries `invoice_mode.finalize: true` — unambiguous, because the skill default is draft invoices. Restores the org's notes afterward. Verified passing (and it caught bug #1 on its first run by failing).

## Performance

Zero new fetches — the notes already ride the session auth attributes. The instruction is session-scoped (prompt-cache stable) and tiny.

## Side finding (not fixed here)

`updateAgentRules` via the installation token 403s with `Insufficient scopes. Missing: organisation:write` — the agent's own rules-update tool can't work for this org's credential. The eval writes the row directly for this reason; the scope gap is worth a follow-up.

355/355 unit, `tsc` + biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Org agent-rule notes now reach and render in every agent, so org-specific instructions take effect. Previously, notes were read from raw MCP envelopes and only the root agent rendered them; now we parse the rules body and register a shared instruction module across all agents. Behavior change: subagents follow org policy (e.g., billing attaches can default to finalized invoices when required).

- `apps/leaf/src/internal/autumnMcp/orgContextService.ts`: parse preload payloads with `@autumn/render`’s `parsePreviewPayload`; fix `getNotes`/`withoutNotes` so `orgInstructions` populates session auth attributes.
- New shared `agent/lib/orgInstructions.ts` (uses `eve/instructions`), registered by root and subagents; adds a unit test that fails any future subagent missing it.
- Adds an end-to-end eval that writes a marker policy and verifies the billing child’s parked request sets `invoice_mode.finalize: true`.
- No new network calls; instruction is session-scoped and prompt-cache stable.
- Known limitation: the installation token lacks `organisation:write`, so the rules-update tool remains blocked; the eval writes the row directly (follow-up needed).

<sup>Written for commit b6cbc5f10b0b9a96301e52dde86ead1d6b525cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

