### PR TITLE
Fix the variant-targets fixture for active-pointer semantics

### DIFF
--- a/server/tests/unit/catalog/validateCatalogVariantUpdates.test.ts
+++ b/server/tests/unit/catalog/validateCatalogVariantUpdates.test.ts
@@ -4,25 +4,24 @@ import { UpdateVariantParamsSchema } from "@autumn/shared/api/products/crud/vari
 import { validateCatalogVariantVersionTargets } from "@/internal/catalog/actions/validateCatalogVariantUpdates.js";
 
 const product = ({
+	active = false,
 	baseInternalProductId = null,
 	id,
 	version,
 }: {
+	active?: boolean;
 	baseInternalProductId?: string | null;
 	id: string;
 	version: number;
 }) =>
 	({
+		active,
 		id,
 		version,
 		base_internal_product_id: baseInternalProductId,
 	}) as FullProduct;
 
-const params = ({
-	version,
-}: {
-	version?: number;
-}): CatalogUpdateParams =>
+const params = ({ version }: { version?: number }): CatalogUpdateParams =>
 	({
 		features: [],
 		plans: [
@@ -44,7 +43,7 @@ const params = ({
 	}) as CatalogUpdateParams;
 
 test("catalog variant updates must target the latest base version", () => {
-	const products = [product({ id: "pro", version: 2 })];
+	const products = [product({ active: true, id: "pro", version: 2 })];
 
 	expect(() =>
 		validateCatalogVariantVersionTargets({


### PR DESCRIPTION
## What

`server/tests/unit/catalog/validateCatalogVariantUpdates.test.ts` fails on main: the active-pointer work changed `validateCatalogVariantVersionTargets` to resolve the latest base version via `product.active`, but the fixture predates the `active` column — no product is active, so the valid same-version case throws.

Real products carry `active` from migration 0066's backfill; the fixture now does too.

## Why nobody saw it

Server unit tests only run on PRs — main pushes run schema validation + ECR only — so the breaking merge landed red silently and surfaced on unrelated PRs' checks (e.g. #2940, whose `server/` was byte-identical to main).

Test passes, `tsc` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark the test fixture’s latest base product as active so `validateCatalogVariantVersionTargets` resolves the correct base version. Previously the fixture had no active product, so the same-version case threw; now the latest base is active, matching the migration 0066 backfill and making the test pass.

- Adds an optional `active` flag to the `product(...)` test helper and sets `active: true` for the base product in the failing test.
- Test-only change; no runtime behavior or migrations.

<sup>Written for commit 1052abebce14b795be1ff543f94b2629710948b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

