### PR TITLE
fix: repair tw warm cache recovery

### DIFF
--- a/scripts/tw/helpers/modal.ts
+++ b/scripts/tw/helpers/modal.ts
@@ -210,12 +210,10 @@ const warmImageByName = new Map<string, Image>();
  * account-wide named snapshots (cross-process AND cross-teammate).
  */
 const WARM_IMAGE_REPO = "tw-warm";
-/** Warm image retention — long enough for a week of stale fast-forwards. */
-const WARM_IMAGE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+/** Published warm names must never outlive their underlying image. */
+const WARM_IMAGE_TTL_MS = null;
 /** Warm names served from the STALE `:latest` image — their workers fast-forward. */
 const staleWarmNames = new Set<string>();
-/** Opt-out: force exact-sha warm builds (no stale `:latest` serving). */
-const STALE_WARM_DISABLED = process.env.TW_MODAL_NO_STALE === "1";
 
 /** `tw-warm-<sha12>` → `<sha12>`, or undefined for non-warm sandbox names. */
 const warmShaFromName = (name: string): string | undefined =>
@@ -811,7 +809,7 @@ const makeModalProvider = (v2: boolean): ProviderImpl => {
 					);
 					return { name, handle: undefined, warmHit: "exact" };
 				}
-				if (!STALE_WARM_DISABLED) {
+				if (process.env.TW_MODAL_NO_STALE !== "1") {
 					const latest = await lookupPublishedWarmImage("latest");
 					if (latest) {
 						warmImageByName.set(name, latest);

--- a/scripts/tw/helpers/modalImage.ts
+++ b/scripts/tw/helpers/modalImage.ts
@@ -230,7 +230,7 @@ export const buildBaseImage = (
 					"apt-get update && " +
 					`bun x playwright@${playwrightVersion} install --with-deps chromium && ` +
 					"rm -rf /var/lib/apt/lists/* && " +
-					'test -x "$(ls -d /root/.cache/ms-playwright/chromium-*/chrome-linux/chrome | head -1)"',
+					'test -n "$(find /root/.cache/ms-playwright/chromium-* -type f -name chrome -perm -111 -print -quit)"',
 			])
 			.build(app)
 	);


### PR DESCRIPTION
## Summary

- retain published Modal warm snapshots so durable tags cannot point at expired images
- read `TW_MODAL_NO_STALE` at lookup time so `refresh-warm` can reject dead cache entries
- make the Chromium build probe compatible with current Playwright extraction layouts

## Validation

- `bun tw advanced/usage/usage1.test.ts --max=1 --per-worker=1 --allow-dirty --no-dashboard`: 10 passed, clean teardown
- `bun tw core --max=200 --allow-dirty --ref=dev --fanout-bench --no-dashboard`: 200/200 workers ready in 25s, clean teardown
- `bunx biome check scripts/tw/helpers/modal.ts scripts/tw/helpers/modalImage.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs `tw` warm cache recovery to avoid serving expired images and to make the stale fallback controllable at lookup time. Previously warm snapshots expired after 14 days and the stale `:latest` decision was fixed at module load; now warm names track their underlying image lifetime and `TW_MODAL_NO_STALE` is evaluated per lookup.

- Published warm snapshots no longer expire on a fixed TTL; durable tags cannot point to expired images.
- `TW_MODAL_NO_STALE=1` is read at lookup time, allowing callers (e.g., `refresh-warm`) to force exact-sha builds and reject stale `:latest` entries.
- Chromium build probe updated to match current Playwright cache layout; no change to runtime image contents.

<sup>Written for commit 7f7fa76acb49b9825af5ca61be05c6e3b78b3ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

