### PR TITLE
fix(migrations): truncate long migration name in delete dialog title

### DIFF
--- a/vite/src/views/migrations/migration-list/DeleteMigrationDialog.tsx
+++ b/vite/src/views/migrations/migration-list/DeleteMigrationDialog.tsx
@@ -40,8 +40,10 @@ export function DeleteMigrationDialog({
 			onOpenChange={(nextOpen) => !isDeleting && onOpenChange(nextOpen)}
 		>
 			<DialogContent className="max-w-md">
-				<DialogHeader>
-					<DialogTitle className="truncate">Delete {migration.id}</DialogTitle>
+				<DialogHeader className="min-w-0">
+					<DialogTitle className="truncate pr-6">
+						Delete {migration.id}
+					</DialogTitle>
 					<DialogDescription>
 						This migration will be permanently deleted. This action cannot be
 						undone.


### PR DESCRIPTION
## Problem

Long migration names (e.g. `transactional-pro-plans-must-have-10-domains-not-1000`) overflow the delete-confirmation dialog: the title runs under the close button and past the dialog edge, even though it already has `truncate`.

## Root cause

`DialogContent` is a CSS grid and grid items default to `min-width: auto`, so `DialogHeader` gets sized to the unbreakable title's min-content width — wider than the dialog. `truncate` never gets a constrained width to work against.

## Fix

Scoped to this dialog only:

- `DialogHeader`: `min-w-0` — lets the header shrink to the dialog width so `truncate` actually applies.
- `DialogTitle`: `pr-6` — the ellipsis stops before the absolutely-positioned close button instead of running under it.

Note: the same latent issue exists in `DeleteInvoiceTemplateDialog` (and `DeleteFeatureDialog` / `DeletePlanDialog` work around it with `max-w-[400px]`). A shared fix in `packages/ui` `dialog.tsx` was considered but deliberately kept out to avoid touching the base component.
