### PR TITLE
fix: let all org roles read agent rules

### DIFF
--- a/server/src/internal/agent/rules/handlers/handleGetAgentRules.ts
+++ b/server/src/internal/agent/rules/handlers/handleGetAgentRules.ts
@@ -4,7 +4,9 @@ import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { agentRulesRepo } from "../repos/index.js";
 
 export const handleGetAgentRules = createRoute({
-	scopes: [Scopes.Organisation.Read],
+	// plans:read, not organisation:read — every org role holds it (sales lacks
+	// organisation:read), and agent rules are billing guidance those roles need.
+	scopes: [Scopes.Plans.Read],
 	body: z.object({}).strict(),
 	handler: async (c) => {
 		const ctx = c.get("ctx");


### PR DESCRIPTION
Sales-role users' tokens lack `organisation:read`, so every `agent.get_rules` call 403s for them and org custom agent rules silently never load (seen with Resend). `agent.get_rules` now requires `plans:read`, which every role — including sales — holds (write implies read); the update/generate routes keep `organisation:write`.

Verified against `ROLE_SCOPES`: all five roles pass `plans:read`; sales was the only role failing `organisation:read`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow all org roles to read agent rules by changing `agent.get_rules` scope from `organisation:read` to `plans:read`. Sales tokens no longer 403 on `agent.get_rules`, so org custom agent rules load; write capabilities are unchanged.

- Old: `organisation:read` required. New: `plans:read` required (all roles have it; write implies read).
- Verified against `ROLE_SCOPES`: all roles pass `plans:read`; Sales lacked `organisation:read`.
- Other routes unchanged; update/generate keep `organisation:write`. No migrations or config changes.

<sup>Written for commit 7a349e3cbec30afda476b1ab3882381415ab76ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

