### PR TITLE
fix(agent-rules): let non-organisation:read roles read agent rules

### DIFF
--- a/server/src/internal/agent/rules/handlers/handleGetAgentRules.ts
+++ b/server/src/internal/agent/rules/handlers/handleGetAgentRules.ts
@@ -3,8 +3,18 @@ import { z } from "zod/v4";
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { agentRulesRepo } from "../repos/index.js";
 
+/**
+ * Agent rules are the bot's operating instructions, so every role that can talk
+ * to the bot has to be able to read them. `organisation:read` alone locked out
+ * `sales` — the one role without that scope. Granting it to `sales` is not the
+ * fix: it also gates Stripe, SSO, webhook and sandbox config.
+ */
+const AGENT_RULES_READ_SCOPES = {
+	ANY: [Scopes.Organisation.Read, Scopes.Billing.Read, Scopes.Customers.Read],
+} as const;
+
 export const handleGetAgentRules = createRoute({
-	scopes: [Scopes.Organisation.Read],
+	scopes: AGENT_RULES_READ_SCOPES,
 	body: z.object({}).strict(),
 	handler: async (c) => {
 		const ctx = c.get("ctx");


### PR DESCRIPTION
## Problem

Every Slack bot request from a `sales`-role user 403s on the org-context preload, so the agent runs without the org's agent rules — and then tells users the org has none configured.

`handleGetAgentRules` was gated on `[organisation:read]`. `sales` is the only role in `ROLE_SCOPES` without that scope:

| role | has `organisation:read`? |
|---|---|
| owner / admin | yes (via `admin` meta-scope) |
| developer | yes |
| member | yes |
| **sales** | **no** |

The chain:

1. `getScopesForUserInOrg` returns `ROLE_SCOPES.sales` (7 scopes, no `organisation:read`).
2. `resolveSlackUserAuth.ts:106` filters against `OAUTH_CEILING`, dropping `rewards:write` → 6 scopes.
3. Token minted with those 6.
4. `agent.get_rules` → `403 insufficient_scopes`, permanently.

Observed in production for `resend` on 2026-08-20 at 13:27, 18:57 and 20:05 UTC:

```
403 {"message":"Insufficient scopes. Missing: organisation:read","code":"insufficient_scopes"}
scopes: ["customers:write","billing:write","balances:write","plans:read","features:read","analytics:read"]
```

## Why not just give `sales` the scope

`organisation:read` also gates 20 other routes — Stripe account, SSO config, Vercel and RevenueCat config, webhook subscriptions, sandboxes, dev data. Adding it to `sales` would hand sales users the org's billing-provider and SSO configuration. There's also an existing test asserting sales deliberately lacks it (`resolve-sandbox.test.ts:182`).

## Fix

Gate on `ANY` of `organisation:read` / `billing:read` / `customers:read` — satisfied by all five roles, and honest in intent: if you can see customers or billing, you can see the rules governing how the agent handles them.

Note `expandScopes` maps `:write` → `:read`, so `sales`'s `customers:write` and `billing:write` both satisfy this.

## Scope of change

7 lines in one file. No behaviour change for any role that already worked.

## Testing

- No existing test covers this route's scopes — `scope-403.test.ts` only inventories v1 secret-key routes, and `agent.get_rules` is on `rpcRouter`. Nothing in the suite changes as a result of this diff.
- The `{ ANY: [...] }` shape is already used by `handleGetOrCreateCustomerV2` and handled by `checkScopes`; `createRoute` types `scopes` as `RouteScopeRequirement`.
- I was not able to run Biome or `bun ts` in this environment (no `node_modules`), so please let CI confirm formatting and types.

## Follow-ups (not in this PR)

1. **The failure was silent.** `orgContextService.ts` uses `Promise.allSettled`, but `executeTool` *resolves* with an `isError` envelope rather than rejecting — so `leaf.autumn_mcp_org_context_preload_failed` never fired, and the raw 403 text got pasted into the prompt as a `getAgentRules` result. That's how the agent came to state "no custom rules on file" as fact.
2. **`rewards:read` ceiling gap.** `DEFAULT_OAUTH_RESOURCE_SCOPES` has no `rewards:*`, but a tool in the bot's allowlist calls a rewards route. Orgs `genie` and `nathan_james_18009163` are hitting `Missing: rewards:read` with otherwise-full 12-scope tokens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDso9wvpXdmvSkpnycj8kH)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let non-`organisation:read` roles read agent rules so Slack bot requests from `sales` no longer 403. Previously `agent.get_rules` required `organisation:read`; now it accepts any of `organisation:read`, `billing:read`, or `customers:read`, enabling `sales` access without exposing broader org config.

**Review notes**
- Adds `AGENT_RULES_READ_SCOPES = { ANY: [organisation:read, billing:read, customers:read] }` and passes it to `createRoute`.
- `expandScopes` maps `:write` to `:read`, so `sales` tokens with `customers:write` or `billing:write` satisfy the check.
- No behavior change for roles that already had access; change is limited to this route.

<sup>Written for commit 0e9538978801e7871eb4b07c6be7960079e975ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

