### PR TITLE
fix: land run stops immediately and silence typing status

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -209,6 +209,9 @@ export const consumeAgentTurn = async ({
 	let idleRetries = 0;
 	let disconnectRetries = 0;
 
+	const abortForRunStop = () => abortController.abort();
+	if (run) run.abortTurnStream = abortForRunStop;
+
 	try {
 		while (idleRetries < MAX_IDLE_RETRIES) {
 			// Eve cannot be interrupted server-side.
@@ -228,6 +231,13 @@ export const consumeAgentTurn = async ({
 			turn = { ...turn, progress: pass.progress };
 			streamedAnyEvent ||= pass.sawEvent;
 			if (pass.outcome) return pass.outcome;
+
+			if (run?.stop) {
+				return await abandonForStop({
+					progress: turn.progress,
+					stop: run.stop,
+				});
+			}
 
 			if (pass.error instanceof EveStreamDisconnectedError) {
 				disconnectRetries += 1;
@@ -264,6 +274,8 @@ export const consumeAgentTurn = async ({
 			);
 		}
 	} finally {
+		if (run?.abortTurnStream === abortForRunStop)
+			run.abortTurnStream = undefined;
 		abortController.abort();
 	}
 

--- a/apps/leaf/src/internal/runs/runCoordinator.ts
+++ b/apps/leaf/src/internal/runs/runCoordinator.ts
@@ -53,7 +53,6 @@ export const dispatchThreadMessage = async <Result>({
 				event: "leaf.run_stop_keyword",
 				data: { run_key: runKey },
 			});
-			await active.logAction?.(`Stopping — requested by <@${providerUserId}>…`);
 			await active.requestStop({ byUserId: providerUserId, reason: "user" });
 			return;
 		}

--- a/apps/leaf/src/internal/runs/runRegistry.ts
+++ b/apps/leaf/src/internal/runs/runRegistry.ts
@@ -6,6 +6,10 @@ const SESSION_RESOLVE_TIMEOUT_MS = ms.seconds(15);
 export type RunStopReason = "timeout" | "user";
 
 export type ActiveRun = {
+	/** Aborts the locally-consumed turn stream so a stop lands immediately. */
+	abortTurnStream?: () => void;
+	/** Silences run progress (ticker/typing) the moment a stop is requested. */
+	onStop?: () => void;
 	/** Set by the pump once it stops consuming turns — no more injections. */
 	closed?: boolean;
 	/** Interrupts the current turn and delivers the text as the next turn. */
@@ -111,6 +115,8 @@ export const registerRun = ({
 		requestStop: async ({ byUserId, reason }) => {
 			if (run.stop) return;
 			run.stop = { byUserId, reason };
+			run.onStop?.();
+			run.abortTurnStream?.();
 			if (interruptSent) return;
 			interruptSent = true;
 			// The session id may never resolve if the run failed during setup.

--- a/apps/leaf/src/providers/slack/actions/dispatchSlackAgentMessage.ts
+++ b/apps/leaf/src/providers/slack/actions/dispatchSlackAgentMessage.ts
@@ -142,6 +142,7 @@ const runAndReply = async ({
 		await progress.start();
 		const logAction = progress.activity;
 		run.logAction = logAction;
+		run.onStop = progress.stop;
 		const rawFiles = getSlackFilesFromRaw({ raw });
 		const botToken = decrypt(installation.bot_access_token);
 

--- a/apps/leaf/src/ui/statusTicker.ts
+++ b/apps/leaf/src/ui/statusTicker.ts
@@ -37,6 +37,16 @@ export const createStatusTicker = (target: TypingTarget): StatusTicker => {
 	let lastRendered = "";
 	let lastVerbAt = 0;
 	let verbIndex = 0;
+	// Serialized so the stop() clear can never be overtaken by an in-flight update.
+	let sendChain: Promise<void> = Promise.resolve();
+
+	const enqueue = (text: string) => {
+		sendChain = sendChain
+			.then(() => target.startTyping(text))
+			.catch((error) => {
+				console.warn("[chat] Could not update status", error);
+			});
+	};
 
 	const send = (text: string) => {
 		if (stopped || text === lastRendered) return;
@@ -44,9 +54,7 @@ export const createStatusTicker = (target: TypingTarget): StatusTicker => {
 		lastRenderAt = Date.now();
 		// formatTypingStatus enforces Slack's length cap; the empty-string clear
 		// in stop() stays raw because the formatter swaps "" for a default label.
-		target.startTyping(formatTypingStatus(text)).catch((error) => {
-			console.warn("[chat] Could not update status", error);
-		});
+		enqueue(formatTypingStatus(text));
 	};
 
 	const tick = () => {
@@ -112,9 +120,7 @@ export const createStatusTicker = (target: TypingTarget): StatusTicker => {
 			}
 			// Explicitly clear the status: without this, a snippet rendered just
 			// before stop() outlives the run as a stuck "thinking" line.
-			if (lastRendered) {
-				target.startTyping("").catch(() => {});
-			}
+			if (lastRendered) enqueue("");
 		},
 	};
 };

--- a/apps/leaf/tests/e2e/stopRun.e2e.ts
+++ b/apps/leaf/tests/e2e/stopRun.e2e.ts
@@ -1,0 +1,105 @@
+/**
+ * Stop must land immediately: mid-delegation the parent stream is silent, so
+ * "stop" has to abort the local stream, return kind "stopped" fast, and leave
+ * the typing status cleared — not cycling "Reasoning…".
+ *
+ *   bun tests/e2e/stopRun.e2e.ts
+ */
+import {
+	registerRun,
+	runKeyForThread,
+} from "../../src/internal/runs/runRegistry.js";
+import { logger } from "../../src/lib/logger.js";
+import { runSlackAgentTurn } from "../../src/providers/slack/actions/runSlackAgentTurn.js";
+import type { SlackChatInstallation } from "../../src/providers/slack/domain/slackAgentTurn.js";
+import { findInstallationWithOrg } from "../../src/providers/slack/installations.js";
+import { createStatusTicker } from "../../src/ui/statusTicker.js";
+
+const WORKSPACE_ID = process.env.E2E_SLACK_WORKSPACE ?? "T07NPTDCU69";
+const STOP_AFTER_MS = Number(process.env.E2E_STOP_AFTER_MS ?? 10_000);
+
+const results: Array<{ name: string; ok: boolean }> = [];
+const check = (name: string, ok: boolean, detail?: string) => {
+	results.push({ name, ok });
+	console.log(`${ok ? "✅" : "❌"} ${name}${detail ? ` — ${detail}` : ""}`);
+};
+
+const typingCalls: string[] = [];
+const target = {
+	post: async () => ({ id: "msg-1" }),
+	startTyping: async (text: string) => {
+		typingCalls.push(text);
+		if (stopRequestedAt > 0) typingAfterStop.push(text);
+	},
+};
+
+const installation = (await findInstallationWithOrg(
+	"slack",
+	WORKSPACE_ID,
+)) as SlackChatInstallation | null;
+if (!installation) throw new Error(`No slack installation for ${WORKSPACE_ID}`);
+const providerUserId = installation.installed_by_provider_user_id ?? "";
+const threadId = `stop-run-${Date.now().toString(36)}`;
+
+const run = registerRun({
+	key: runKeyForThread({
+		channelId: threadId,
+		provider: "slack",
+		threadId,
+		workspaceId: WORKSPACE_ID,
+	}),
+	kind: "message",
+	ownerProviderUserId: providerUserId,
+});
+
+const ticker = createStatusTicker(target as never);
+ticker.thinking();
+let stopRequestedAt = 0;
+
+const turnPromise = runSlackAgentTurn({
+	channelId: threadId,
+	installation,
+	logger,
+	onAction: (message) => {
+		const label = typeof message === "string" ? message : message.label;
+		console.log(`   action: ${label}`);
+		ticker.activity(label);
+	},
+	onApprovalsSuperseded: () => {},
+	onReasoning: () => {},
+	onThinking: ticker.thinking,
+	providerUserId,
+	run,
+	text: "Put customer leaf-0001 on a custom enterprise plan for $0/month.",
+	threadId,
+});
+
+run.onStop = ticker.stop;
+const typingAfterStop: string[] = [];
+setTimeout(() => {
+	stopRequestedAt = Date.now();
+	console.log("   requesting stop…");
+	void run.requestStop({ byUserId: providerUserId, reason: "user" });
+}, STOP_AFTER_MS);
+
+const turn = await turnPromise;
+const stopLatencyMs = Date.now() - stopRequestedAt;
+await new Promise((resolve) => setTimeout(resolve, 3_000));
+
+check("turn ended as stopped", turn.kind === "stopped", `kind: ${turn.kind}`);
+check(
+	"stop landed fast",
+	stopRequestedAt > 0 && stopLatencyMs < 5_000,
+	`${stopLatencyMs}ms after requestStop`,
+);
+check(
+	"typing status cleared last",
+	typingCalls.length > 0 && typingCalls[typingCalls.length - 1] === "",
+	`calls: ${typingCalls.length}`,
+);
+check(
+	"no status shown after stop",
+	typingAfterStop.every((text) => text === ""),
+	`after-stop calls: ${JSON.stringify(typingAfterStop)}`,
+);
+process.exit(results.every((result) => result.ok) ? 0 : 1);


### PR DESCRIPTION
"Stop" mid-turn only set a flag the stream consumer checks per event — and during a subagent delegation the parent stream is silent, so a stop could take up to the 2-minute idle timeout while the typing status kept cycling "Reasoning…".

- `requestStop` now silences run progress instantly (`run.onStop`) and aborts the local stream read (`run.abortTurnStream`), so the turn returns `stopped` in milliseconds
- removed the coordinator's "Stopping — requested by…" status line — after a stop nothing shows except the real "Stopped by user" message
- status ticker sends are serialized so the final clear can't be overtaken by an in-flight update

Verified with `tests/e2e/stopRun.e2e.ts`: stop requested mid-delegation lands in ~20ms, turn ends `stopped`, no status after stop, status cleared last (2/2 runs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops land immediately and silence typing status. Previously, Stop only set a flag checked by the event stream; during delegation the parent stream was idle, so Stop could take up to the 2-minute timeout while the status cycled.

- Abort on stop: wire `run.abortTurnStream` in `consumeAgentTurn`; invoke it from `registerRun.requestStop`; check `run.stop` during consumption and return a `stopped` outcome immediately.
- Silence progress instantly: add `run.onStop` and call it on stop; set `run.onStop = progress.stop` for Slack; remove the coordinator’s “Stopping — requested by …” line so only “Stopped by user” remains.
- Make status clearing reliable: serialize status ticker sends so the final clear cannot be overtaken by an in-flight update.
- E2E coverage: `tests/e2e/stopRun.e2e.ts` asserts fast stop (~20ms), turn ends `stopped`, no post-stop status, and the clear happens last.

<sup>Written for commit 0f043f9883ae2cfe4b1f61d19ab0d6abf2c94875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

