### PR TITLE
feat: leaf observability — turn timing, telemetry, and log hygiene

### DIFF
--- a/apps/leaf/src/index.ts
+++ b/apps/leaf/src/index.ts
@@ -14,8 +14,12 @@ if (embedEve === "1") {
 	const { startEmbeddedEveServer } = await import(
 		"./internal/agentRuntime/eve/embeddedServer.js"
 	);
-	startEmbeddedEveServer().catch((error) => {
-		console.error("Embedded eve server failed to start", error);
+	const { logger } = await import("./lib/logger.js");
+	startEmbeddedEveServer().catch(async (error) => {
+		logger.error("Embedded eve server failed to start", error, {
+			event: "leaf.eve_process_start_failed",
+		});
+		await logger.flush?.();
 		process.exit(1);
 	});
 }

--- a/apps/leaf/src/internal/agentRuntime/actions/resolveCatalogDecision/resolveCatalogDecision.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/resolveCatalogDecision/resolveCatalogDecision.ts
@@ -114,7 +114,7 @@ export const resolveCatalogDecision = async ({
 	} catch (error) {
 		logger.warn("Could not deny updateCatalog pending decision", {
 			event: "leaf.eve_catalog_decision_deny_failed",
-			data: { error: error instanceof Error ? error.message : String(error) },
+			data: { error },
 		});
 		return undefined;
 	}

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/applyEveEvent.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/applyEveEvent.ts
@@ -1,8 +1,8 @@
 import { parsePreviewPayload } from "@autumn/render";
 import type { AppEnv } from "@autumn/shared";
+import { db } from "../../../../../lib/db.js";
 import { toolRequestFromArgs } from "../../../../approvals/utils/toolRequest.js";
 import { executeAutumnMcpTool } from "../../../../autumnMcp/client.js";
-import { db } from "../../../../../lib/db.js";
 import type { AgentActionProgress } from "../../../domain/agentTurnContext.js";
 import type { EveEvent } from "../../../eve/eveEventSchemas.js";
 import { isPreviewToolName } from "../../../eve/events.js";
@@ -84,6 +84,7 @@ const applyEveEffect = async ({
 				db,
 				env: session.env,
 				orgId,
+				reason: "session_failed",
 				sessionId: session.sessionId,
 				threadKey: session.threadKey,
 			});

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -48,6 +48,7 @@ const closeReasoningOutput = ({
 
 const streamPassEvents = async ({
 	abandonForStop,
+	onFirstStreamEvent,
 	run,
 	signal,
 	turn,
@@ -56,6 +57,7 @@ const streamPassEvents = async ({
 		progress: EveTurnProgress;
 		stop: NonNullable<ActiveRun["stop"]>;
 	}) => Promise<EveTurnOutcome>;
+	onFirstStreamEvent?: () => void;
 	run?: ActiveRun;
 	signal: AbortSignal;
 	turn: EveTurnContext;
@@ -65,6 +67,7 @@ const streamPassEvents = async ({
 	let sawEvent = false;
 	try {
 		for await (const event of streamEveEvents({ auth, session, signal })) {
+			if (!sawEvent) onFirstStreamEvent?.();
 			sawEvent = true;
 			session.state.streamIndex += 1;
 			session.state.lastEventAt = Date.now();
@@ -157,6 +160,7 @@ export const consumeAgentTurn = async ({
 	env,
 	logger,
 	onAction,
+	onFirstStreamEvent,
 	onReasoning,
 	onThinking,
 	orgId,
@@ -168,6 +172,7 @@ export const consumeAgentTurn = async ({
 	env: AppEnv;
 	logger: AutumnLogger;
 	onAction?: EveEventContext["onAction"];
+	onFirstStreamEvent?: () => void;
 	onReasoning?: EveEventContext["onReasoning"];
 	onThinking?: EveEventContext["onThinking"];
 	orgId: string;
@@ -224,6 +229,7 @@ export const consumeAgentTurn = async ({
 
 			const pass = await streamPassEvents({
 				abandonForStop,
+				onFirstStreamEvent: streamedAnyEvent ? undefined : onFirstStreamEvent,
 				run,
 				signal: abortController.signal,
 				turn,

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
@@ -44,6 +44,7 @@ export type EveTurnProgress = Readonly<{
 	/** Child sessions spawned by delegated subagents — the pointer for
 	 * attributing proxied approvals and following child streams. */
 	subagentChildSessionIds: ReadonlySet<string>;
+	subagentStartedAtByCallId: ReadonlyMap<string, number>;
 	toolInputs: ReadonlyMap<string, Record<string, unknown>>;
 	toolLabels: ReadonlyMap<string, string>;
 	turnStarted: boolean;
@@ -70,6 +71,7 @@ export const createEveTurnProgress = (): EveTurnProgress => ({
 	finalText: "",
 	pendingText: "",
 	subagentChildSessionIds: new Set(),
+	subagentStartedAtByCallId: new Map(),
 	toolInputs: new Map(),
 	toolLabels: new Map(),
 	turnStarted: false,
@@ -356,6 +358,10 @@ export const reduceEveTurnEvent = ({
 			const subagentChildSessionIds = event.childSessionId
 				? new Set([...progress.subagentChildSessionIds, event.childSessionId])
 				: progress.subagentChildSessionIds;
+			logger.info("Eve subagent called", {
+				event: "leaf.eve_subagent_called",
+				data: { child_session_id: event.childSessionId, subagent: name },
+			});
 			return {
 				effects: [
 					{
@@ -367,8 +373,31 @@ export const reduceEveTurnEvent = ({
 						},
 					},
 				],
-				progress: { ...progress, subagentChildSessionIds },
+				progress: {
+					...progress,
+					subagentChildSessionIds,
+					subagentStartedAtByCallId: event.callId
+						? new Map([
+								...progress.subagentStartedAtByCallId,
+								[event.callId, Date.now()],
+							])
+						: progress.subagentStartedAtByCallId,
+				},
 			};
+		}
+		case "subagent.completed": {
+			const startedAt = event.callId
+				? progress.subagentStartedAtByCallId.get(event.callId)
+				: undefined;
+			logger.info("Eve subagent completed", {
+				event: "leaf.eve_subagent_completed",
+				data: {
+					duration_ms:
+						startedAt === undefined ? undefined : Date.now() - startedAt,
+					subagent: event.subagentName ?? "subagent",
+				},
+			});
+			return { effects: [], progress };
 		}
 		case "step.started":
 			return { effects: [{ kind: "thinking" }], progress };

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/finalize/resolveAgentTurnOutcome.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/finalize/resolveAgentTurnOutcome.ts
@@ -68,6 +68,7 @@ export const resolveAgentTurnOutcome = async ({
 			db,
 			env,
 			orgId,
+			reason: "turn_unusable",
 			sessionId,
 			threadKey: session.threadKey,
 		});

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -50,12 +50,15 @@ export const runAgentTurn = async ({
 	const titlePromise = titleSourceText?.trim()
 		? generateThreadTitle({ logger, text: titleSourceText })
 		: undefined;
+	const startedAt = Date.now();
+	let firstEventAt: number | undefined;
 
 	try {
 		const { existingSession, orgContext } = await prepareAgentTurn({
 			auth,
 			context: ctx,
 		});
+		const preparedAt = Date.now();
 		const session = await startAgentTurn({
 			auth: { ...auth, orgInstructions: orgContext?.instructions },
 			env,
@@ -80,6 +83,9 @@ export const runAgentTurn = async ({
 			env,
 			logger,
 			onAction,
+			onFirstStreamEvent: () => {
+				firstEventAt ??= Date.now();
+			},
 			onReasoning,
 			onThinking,
 			orgId: org.id,
@@ -88,13 +94,27 @@ export const runAgentTurn = async ({
 			token,
 		});
 
-		return await resolveAgentTurnOutcome({
+		const result = await resolveAgentTurnOutcome({
 			env,
 			logger,
 			orgId: org.id,
 			outcome,
 			session,
 		});
+		logger.info("Agent turn completed", {
+			event: "leaf.agent_turn_completed",
+			data: {
+				duration_ms: Date.now() - startedAt,
+				new_session: !existingSession,
+				outcome_kind: result.kind,
+				prepare_ms: preparedAt - startedAt,
+				session_id: session.sessionId,
+				time_to_first_event_ms: firstEventAt
+					? firstEventAt - startedAt
+					: undefined,
+			},
+		});
+		return result;
 	} finally {
 		if (titlePromise) {
 			void persistThreadTitle({

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/prepareAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/prepareAgentTurn.ts
@@ -52,6 +52,7 @@ export const prepareAgentTurn = async ({
 			db,
 			env,
 			orgId: org.id,
+			reason: "session_gone",
 			sessionId: existingSession.sessionId,
 			threadKey: existingSession.threadKey,
 		});

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/startAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/setup/startAgentTurn.ts
@@ -46,6 +46,7 @@ export const startAgentTurn = async ({
 				db,
 				env,
 				orgId,
+				reason: "post_failed",
 				sessionId: session.sessionId,
 				threadKey: session.threadKey,
 			});

--- a/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/consumeResumedAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/consumeResumedAgentTurn.ts
@@ -28,6 +28,10 @@ const parsedResultText = (output: unknown): unknown => {
 	try {
 		return JSON.parse(text);
 	} catch {
+		logger.warn("Autumn MCP result text was not JSON", {
+			event: "leaf.autumn_mcp_result_parse_failed",
+			data: { text: text.slice(0, 300) },
+		});
 		return undefined;
 	}
 };
@@ -313,7 +317,7 @@ export const consumeResumedAgentTurn = async ({
 				event: "leaf.eve_child_verification_failed",
 				data: {
 					child_session_id: childSessionId,
-					error: error instanceof Error ? error.message : String(error),
+					error,
 				},
 			});
 		}

--- a/apps/leaf/src/internal/agentRuntime/eve/client.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/client.ts
@@ -1,5 +1,6 @@
 import { ms } from "@autumn/shared";
 import { env } from "../../../lib/env.js";
+import { logger } from "../../../lib/logger.js";
 import { withRetry } from "../../../lib/withRetry.js";
 import { type EveEvent, parseEveEvent } from "./eveEventSchemas.js";
 import {
@@ -140,6 +141,19 @@ export const postEveMessage = async ({
 	const response = await withRetry({
 		attempts: POST_RETRY_ATTEMPTS,
 		baseDelayMs: POST_RETRY_BASE_DELAY_MS,
+		onRecovered: ({ attempt }) => {
+			logger.info("Eve session post recovered after retry", {
+				event: "leaf.eve_post_recovered",
+				data: { attempts_used: attempt, session_id: session?.sessionId },
+			});
+		},
+		onRetry: ({ attempt, error }) => {
+			logger.warn("Eve session post failed; retrying", {
+				data: { attempt, session_id: session?.sessionId },
+				error,
+				event: "leaf.eve_post_retry",
+			});
+		},
 		operation: post,
 		shouldRetry: (error) =>
 			isConnectionRefusedError(error) ||
@@ -313,8 +327,14 @@ const countEveReplayableEvents = async ({
 				if (line) count += 1;
 			}
 		}
-	} catch {
+	} catch (error) {
 		// Aborting on the quiet gap is the normal exit.
+		if (!(error instanceof Error && error.name === "AbortError")) {
+			logger.warn("Eve replay recount failed", {
+				data: { error, session_id: sessionId },
+				event: "leaf.eve_replay_count_failed",
+			});
+		}
 	} finally {
 		clearTimeout(quietTimer);
 	}

--- a/apps/leaf/src/internal/agentRuntime/eve/embeddedServer.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/embeddedServer.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import { logger } from "../../../lib/logger.js";
 
 const EVE_PORT = process.env.EVE_PORT ?? "3999";
 // Leaf's own listen port — eve's MCP connection dials leaf back on loopback.
@@ -37,8 +38,12 @@ export const startEmbeddedEveServer = async () => {
 		stdout: "inherit",
 	});
 	// Fail fast so the supervisor restarts the task with both servers in sync.
-	eve.exited.then((code) => {
-		console.error(`Embedded eve server exited (code ${code})`);
+	eve.exited.then(async (code) => {
+		logger.error("Embedded eve server exited", {
+			data: { code },
+			event: "leaf.eve_process_exited",
+		});
+		await logger.flush?.();
 		process.exit(code === 0 ? 0 : 1);
 	});
 };

--- a/apps/leaf/src/internal/agentRuntime/eve/eveEventSchemas.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/eveEventSchemas.ts
@@ -85,6 +85,7 @@ const subagentCalledSchema = z.object({
 /** Only the event's arrival matters today — it marks resumed-turn activity;
  * the child's output is read from its own stream, not from this event. */
 const subagentCompletedSchema = z.object({
+	callId: z.string().optional(),
 	subagentName: z.string().optional(),
 });
 

--- a/apps/leaf/src/internal/agentRuntime/eve/repo.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/repo.ts
@@ -2,6 +2,7 @@ import { AppEnv, harnessSessions } from "@autumn/shared";
 import { all } from "better-all";
 import { and, desc, eq, isNull, like } from "drizzle-orm";
 import type { ChatDb } from "../../../lib/db.js";
+import { logger } from "../../../lib/logger.js";
 import type { AgentThreadRef } from "../domain/agentTurnContext.js";
 import { buildAgentThreadKey } from "../sessions/agentThreadKey.js";
 import {
@@ -139,19 +140,32 @@ export const upsertEveSession = async ({
 
 /** Forgets a session id eve no longer streams anything for. The row is the only
  * pointer to it, so keeping it replays the same dead resume on every message. */
+export type EveSessionDeleteReason =
+	| "approval_session_gone"
+	| "post_failed"
+	| "session_failed"
+	| "session_gone"
+	| "turn_unusable";
+
 export const deleteEveSession = async ({
 	db,
 	env,
 	orgId,
+	reason,
 	sessionId,
 	threadKey,
 }: {
 	db: ChatDb;
 	env: AppEnv;
 	orgId: string;
+	reason: EveSessionDeleteReason;
 	sessionId: string;
 	threadKey: string;
 }) => {
+	logger.warn("Deleting Eve session", {
+		event: "leaf.eve_session_deleted",
+		data: { reason, session_id: sessionId },
+	});
 	await db
 		.delete(harnessSessions)
 		.where(

--- a/apps/leaf/src/internal/agentRuntime/sessions/agentThreadTitle.ts
+++ b/apps/leaf/src/internal/agentRuntime/sessions/agentThreadTitle.ts
@@ -37,7 +37,7 @@ export const generateThreadTitle = async ({
 	} catch (error) {
 		logger.warn("Thread title generation failed", {
 			event: "leaf.thread_title_failed",
-			data: { error: String(error) },
+			data: { error },
 		});
 		return undefined;
 	}
@@ -71,7 +71,7 @@ export const persistThreadTitle = async ({
 	} catch (error) {
 		logger.warn("Thread title persist failed", {
 			event: "leaf.thread_title_persist_failed",
-			data: { error: String(error) },
+			data: { error },
 		});
 	}
 };

--- a/apps/leaf/src/internal/approvals/actions/createChainedApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/createChainedApproval.ts
@@ -77,7 +77,7 @@ export const createChainedApproval = async ({
 			event: "leaf.eve_chained_preview_backfill_failed",
 			tool: chained.toolName,
 			data: {
-				error: error instanceof Error ? error.message : String(error),
+				error,
 			},
 		});
 	}

--- a/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
@@ -24,6 +24,7 @@ const dropEveSession = async ({ approval }: { approval: ChatApproval }) => {
 		db,
 		env: session.env,
 		orgId: approval.org_id,
+		reason: "approval_session_gone",
 		sessionId: session.sessionId,
 		threadKey: session.threadKey,
 	});

--- a/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
+++ b/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
@@ -53,6 +53,11 @@ export const submitApprovalInput = async ({
 	providerUserId: string;
 }): Promise<ApprovalRunResult> => {
 	if (!(approval.run_id && approval.tool_call_id)) {
+		logger.warn("Approval is missing Eve session state", {
+			event: "leaf.approval_session_missing",
+			approval_id: approval.id,
+			data: { org_id: approval.org_id, tool: approval.tool_name },
+		});
 		return {
 			error: true,
 			message: "Eve approval is missing session state.",
@@ -65,13 +70,30 @@ export const submitApprovalInput = async ({
 		sessionId: approval.run_id,
 	});
 	if (!session) {
+		// Retryable, so the row returns to pending — the "button does nothing"
+		// symptom starts here.
+		logger.warn("Eve session not found for approval", {
+			event: "leaf.approval_eve_session_not_found",
+			approval_id: approval.id,
+			data: {
+				org_id: approval.org_id,
+				run_id: approval.run_id,
+				tool: approval.tool_name,
+			},
+		});
 		return {
 			error: true,
 			message: "Eve session not found.",
 			retryable: true,
 		};
 	}
+	const startedAt = Date.now();
 	const auth = approvalAuth({ approval, providerUserId });
+	const siblingRequestIds = siblingRequestIdsFromToolArgs(approval.tool_args);
+	const approvalLogData = {
+		session_id: session.sessionId,
+		tool: approval.tool_name,
+	};
 	const {
 		approvedWriteFailed,
 		approvedWriteUnverified,
@@ -101,7 +123,7 @@ export const submitApprovalInput = async ({
 		orgId: approval.org_id,
 		requestId: approval.tool_call_id,
 		session,
-		siblingRequestIds: siblingRequestIdsFromToolArgs(approval.tool_args),
+		siblingRequestIds,
 	});
 	const chainedApprovalId = chained
 		? await createChainedApproval({
@@ -123,7 +145,7 @@ export const submitApprovalInput = async ({
 		logger.error("Approved Eve action failed", undefined, {
 			event: "leaf.eve_approval_failed",
 			approval_id: approval.id,
-			data: { session_id: session.sessionId, tool: approval.tool_name },
+			data: approvalLogData,
 		});
 		return {
 			chainedApprovalId,
@@ -137,13 +159,26 @@ export const submitApprovalInput = async ({
 		logger.error("Approved Eve action was not executed", undefined, {
 			event: "leaf.eve_approval_not_executed",
 			approval_id: approval.id,
-			data: { session_id: session.sessionId, tool: approval.tool_name },
+			data: approvalLogData,
 		});
 		return {
 			error: true,
 			message: APPROVAL_NOT_EXECUTED_MESSAGE,
 			retryable: true,
 		};
+	}
+	if (expectExecution) {
+		logger.info("Approved action applied", {
+			event: "leaf.approval_applied",
+			approval_id: approval.id,
+			data: {
+				...approvalLogData,
+				chained_approval_id: chainedApprovalId,
+				duration_ms: Date.now() - startedAt,
+				sibling_count: siblingRequestIds.length,
+				verified: !approvedWriteUnverified,
+			},
+		});
 	}
 	return {
 		chainedApprovalId,

--- a/apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts
+++ b/apps/leaf/src/internal/approvals/actions/withdrawSupersededApprovals.ts
@@ -68,7 +68,7 @@ const withdrewInEve = async ({
 		logger.warn("Could not deny superseded Eve approval", {
 			event: "leaf.eve_superseded_approval_deny_failed",
 			approval_id: approval.id,
-			data: { error: error instanceof Error ? error.message : String(error) },
+			data: { error },
 		});
 		return "undecided";
 	}

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -133,6 +133,20 @@ const defaultApprovalActionDeps: ApprovalActionDeps = {
 	},
 };
 
+/** Every decide-path log line carries the click's identifiers, so approval
+ * incidents reconstruct from logs without a DB lookup first. */
+const contextualApprovalLogger = ({
+	base,
+	fields,
+}: {
+	base: ApprovalActionDeps["logger"];
+	fields: Record<string, unknown>;
+}): ApprovalActionDeps["logger"] => ({
+	error: (...args) => base.error(...args, fields),
+	info: (...args) => base.info(...args, fields),
+	warn: (...args) => base.warn(...args, fields),
+});
+
 // Maps a DB row to the card state shown when a click can no longer act on it.
 const cardStatusForApproval = ({
 	approval,
@@ -148,7 +162,7 @@ const cardStatusForApproval = ({
 };
 
 export const handleApprovalActionWithDeps = async ({
-	deps = defaultApprovalActionDeps,
+	deps: providedDeps = defaultApprovalActionDeps,
 	event,
 }: {
 	deps?: ApprovalActionDeps;
@@ -157,6 +171,18 @@ export const handleApprovalActionWithDeps = async ({
 	const approvalId = event.value;
 	if (!approvalId) return;
 	const providerUserId = event.user.userId;
+	const deps: ApprovalActionDeps = {
+		...providedDeps,
+		logger: contextualApprovalLogger({
+			base: providedDeps.logger,
+			fields: {
+				approval_id: approvalId,
+				provider_user_id: providerUserId,
+				slack_message_id: event.messageId,
+				slack_thread_id: event.threadId,
+			},
+		}),
+	};
 
 	const editToCurrentStatus = async () => {
 		const current = await deps.getApproval({ approvalId });

--- a/apps/leaf/src/internal/approvals/utils/fetchApprovalPreview.ts
+++ b/apps/leaf/src/internal/approvals/utils/fetchApprovalPreview.ts
@@ -8,6 +8,10 @@ import {
 import { normalizeToolName } from "../../agentRuntime/tools/toolPolicy.js";
 import { executeAutumnMcpTool } from "../../autumnMcp/client.js";
 import {
+	autumnMcpErrorText,
+	rawErrorShapeText,
+} from "../../autumnMcp/errorResult.js";
+import {
 	resolveApprovalDisplay,
 	withApprovalDisplay,
 } from "./approvalDisplay.js";
@@ -110,7 +114,7 @@ export const fetchApprovalPreview = async ({
 }: {
 	env: AppEnv;
 	executeTool?: typeof executeAutumnMcpTool;
-	logger: Pick<AutumnLogger, "warn">;
+	logger: Pick<AutumnLogger, "debug" | "warn">;
 	request: Record<string, unknown>;
 	token: string;
 	toolName: string;
@@ -126,23 +130,21 @@ export const fetchApprovalPreview = async ({
 		});
 		// Failed previews use two response shapes; neither should replace the
 		// card's params-only fallback.
-		if (result && typeof result === "object") {
-			const record = result as Record<string, unknown>;
-			const isErrorShape =
-				Boolean(record.error) ||
-				"cause" in record ||
-				(typeof record.message === "string" &&
-					("code" in record || "domain" in record));
-			if (isErrorShape) return FAILED_APPROVAL_PREVIEW;
+		// executeAutumnMcpTool already warned with the error detail.
+		if (autumnMcpErrorText(result) ?? rawErrorShapeText(result)) {
+			logger.debug("Approval preview returned an error result", {
+				data: { env },
+				event: "leaf.approval_preview_failed",
+				tool: toolName,
+			});
+			return FAILED_APPROVAL_PREVIEW;
 		}
 		return result;
 	} catch (error) {
 		logger.warn("Could not backfill approval preview", {
+			data: { env, error },
 			event: "leaf.approval_preview_backfill_failed",
 			tool: toolName,
-			data: {
-				error: error instanceof Error ? error.message : String(error),
-			},
 		});
 		return FAILED_APPROVAL_PREVIEW;
 	}
@@ -160,7 +162,7 @@ export const resolveApprovalPreview = async ({
 	env: AppEnv;
 	executeTool?: typeof executeAutumnMcpTool;
 	getToken: () => Promise<string>;
-	logger: Pick<AutumnLogger, "warn">;
+	logger: Pick<AutumnLogger, "debug" | "warn">;
 	preview: unknown;
 	request?: Record<string, unknown>;
 	toolName: string;
@@ -184,7 +186,7 @@ export const resolveApprovalPreview = async ({
 	} catch (error) {
 		logger.warn("Could not backfill approval preview", {
 			event: "leaf.approval_preview_backfill_failed",
-			error,
+			data: { env, error },
 			tool: toolName,
 		});
 		return preview;
@@ -203,7 +205,7 @@ export const withGroupedWritePreviews = async ({
 	env: AppEnv;
 	executeTool?: typeof executeAutumnMcpTool;
 	getToken: () => Promise<string>;
-	logger: Pick<AutumnLogger, "warn">;
+	logger: Pick<AutumnLogger, "debug" | "warn">;
 	toolArgs: Record<string, unknown>;
 }) => {
 	const withheld = withheldWritesFromToolArgs(toolArgs);

--- a/apps/leaf/src/internal/autumnMcp/client.ts
+++ b/apps/leaf/src/internal/autumnMcp/client.ts
@@ -2,7 +2,9 @@ import { isSecretKeyPrefix } from "@autumn/auth";
 import { type AppEnv, ms } from "@autumn/shared";
 import { MCPClient } from "@mastra/mcp";
 import { env } from "../../lib/env.js";
+import { logger } from "../../lib/logger.js";
 import { createTtlCache } from "../../lib/ttlCache.js";
+import { autumnMcpErrorText } from "./errorResult.js";
 
 type AutumnTool = {
 	execute?: (
@@ -118,7 +120,7 @@ const pooledAutumnClient = ({
 
 export const executeAutumnMcpTool = async ({
 	args,
-	env,
+	env: appEnv,
 	token,
 	toolName,
 }: {
@@ -127,12 +129,37 @@ export const executeAutumnMcpTool = async ({
 	token: string;
 	toolName: string;
 }) => {
-	const pooled = await pooledAutumnClient({ appEnv: env, token });
+	const pooled = await pooledAutumnClient({ appEnv, token });
 	const tool = pooled.tools[toolName.replace(/^autumn_/, "")];
 	if (!tool?.execute) throw new Error(`Unknown Autumn MCP tool: ${toolName}`);
 	pooled.inUse += 1;
+	const startedAt = Date.now();
 	try {
-		return await tool.execute(args);
+		const result = await tool.execute(args);
+		const errorText = autumnMcpErrorText(result);
+		if (errorText) {
+			logger.warn("Autumn MCP tool returned an error result", {
+				data: {
+					duration_ms: Date.now() - startedAt,
+					env: appEnv,
+					error: errorText,
+					tool: toolName,
+				},
+				event: "leaf.autumn_mcp_tool_error",
+			});
+		}
+		return result;
+	} catch (error) {
+		logger.warn("Autumn MCP tool call failed", {
+			data: {
+				duration_ms: Date.now() - startedAt,
+				env: appEnv,
+				tool: toolName,
+			},
+			error,
+			event: "leaf.autumn_mcp_tool_failed",
+		});
+		throw error;
 	} finally {
 		pooled.inUse -= 1;
 		if (pooled.disconnectRequested) disconnectPooledClient(pooled);

--- a/apps/leaf/src/internal/autumnMcp/errorResult.ts
+++ b/apps/leaf/src/internal/autumnMcp/errorResult.ts
@@ -1,0 +1,61 @@
+const MAX_ERROR_TEXT_LENGTH = 500;
+
+const compact = (value: unknown) =>
+	(typeof value === "string" ? value : JSON.stringify(value)).slice(
+		0,
+		MAX_ERROR_TEXT_LENGTH,
+	);
+
+const contentText = (content: unknown) => {
+	if (!Array.isArray(content)) return;
+	const text = (content[0] as { text?: unknown } | undefined)?.text;
+	return typeof text === "string" ? text : undefined;
+};
+
+const parsedContentRecord = (
+	content: unknown,
+): Record<string, unknown> | undefined => {
+	const text = contentText(content);
+	if (!text) return;
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+	} catch {
+		return;
+	}
+	return;
+};
+
+/** MCP tool failures come back as FULFILLED results, not rejections: thrown
+ * server errors as `isError` envelopes, guardResponseSize refusals as
+ * `{error: true, message}` payloads. Skipping this check treats both as success. */
+export const autumnMcpErrorText = (value: unknown): string | undefined => {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return;
+	const record = value as Record<string, unknown>;
+	if (record.isError === true) {
+		return compact(contentText(record.content) ?? record.content ?? record);
+	}
+	const payload = parsedContentRecord(record.content);
+	if (payload?.error === true && typeof payload.message === "string") {
+		return compact(payload.message);
+	}
+	return;
+};
+
+/** Raw payload variant: some callers see unwrapped payloads where a failure
+ * is a bare `{error}` / `{message, code|domain}` / `{cause}` record. */
+export const rawErrorShapeText = (value: unknown): string | undefined => {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return;
+	const record = value as Record<string, unknown>;
+	if (record.error) return compact(record.error);
+	if (
+		typeof record.message === "string" &&
+		("code" in record || "domain" in record || "cause" in record)
+	) {
+		return compact(record.message);
+	}
+	if ("cause" in record) return compact(record.cause ?? record);
+	return;
+};

--- a/apps/leaf/src/internal/autumnMcp/orgContextService.ts
+++ b/apps/leaf/src/internal/autumnMcp/orgContextService.ts
@@ -3,6 +3,7 @@ import { parsePreviewPayload } from "@autumn/render";
 import { type AppEnv, ms } from "@autumn/shared";
 import { createTtlCache } from "../../lib/ttlCache.js";
 import { executeAutumnMcpTool } from "./client.js";
+import { autumnMcpErrorText } from "./errorResult.js";
 import {
 	compactFeatures,
 	compactPlans,
@@ -99,67 +100,86 @@ export const loadAutumnOrgContext = async ({
 }): Promise<AutumnOrgContext | undefined> => {
 	const intent =
 		"Preload the org's identity, agent rules, plans, and features at session start so they are ready for the user's first request.";
-	const args = { intent, request: {} };
-	const organizationArgs = { intent };
-	const [organizationResult, agentRulesResult, plansResult, featuresResult] =
-		await Promise.allSettled([
-			executeTool({
-				env,
-				token,
-				toolName: "getCurrentOrganization",
-				args: organizationArgs,
-			}),
-			executeTool({ env, token, toolName: "getAgentRules", args }),
-			executeTool({ env, token, toolName: "listPlans", args }),
-			executeTool({ env, token, toolName: "listFeatures", args }),
-		]);
-
-	const outcomes: Record<string, string> = {};
-	for (const [toolName, result] of [
-		["getCurrentOrganization", organizationResult],
-		["getAgentRules", agentRulesResult],
-		["listPlans", plansResult],
-		["listFeatures", featuresResult],
-	] as const) {
+	const requestArgs = { intent, request: {} };
+	const preloadTool = async (
+		toolName: string,
+		callArgs: Record<string, unknown>,
+	) => {
+		const startedAt = Date.now();
+		const value = await executeTool({ args: callArgs, env, token, toolName });
+		return {
+			bytes: JSON.stringify(value).length,
+			durationMs: Date.now() - startedAt,
+			errorText: autumnMcpErrorText(value),
+			toolName,
+			value,
+		};
+	};
+	const settled = await Promise.allSettled([
+		preloadTool("getCurrentOrganization", { intent }),
+		preloadTool("getAgentRules", requestArgs),
+		preloadTool("listPlans", requestArgs),
+		preloadTool("listFeatures", requestArgs),
+	]);
+	const toolNames = [
+		"getCurrentOrganization",
+		"getAgentRules",
+		"listPlans",
+		"listFeatures",
+	];
+	const preloads = settled.map((result, index) => {
 		if (result.status === "rejected") {
-			outcomes[toolName] = "rejected";
+			return { status: "rejected", tool: toolNames[index] };
+		}
+		const { bytes, durationMs, errorText, toolName } = result.value;
+		return {
+			bytes,
+			duration_ms: durationMs,
+			status: errorText ? "error" : "ok",
+			tool: toolName,
+		};
+	});
+	const preloadedValue = (index: number) => {
+		const result = settled[index];
+		if (!result) return;
+		if (result.status === "rejected") {
+			// A throw can predate the MCP call (pool/connect), so it is not
+			// guaranteed to have been logged at the tool boundary.
 			logger.warn("Could not preload Autumn org context", {
 				event: "leaf.autumn_mcp_org_context_preload_failed",
-				data: {
-					error:
-						result.reason instanceof Error
-							? result.reason.message
-							: String(result.reason),
-					tool: toolName,
-				},
+				data: { error: result.reason, tool: toolNames[index] },
 			});
-		} else {
-			outcomes[toolName] = JSON.stringify(result.value).length.toString();
+			return;
 		}
-	}
-	logger.debug("Preloaded Autumn org context", {
+		if (result.value.errorText) {
+			// executeAutumnMcpTool already warned with the error detail.
+			logger.debug("Skipping failed Autumn org context preload", {
+				event: "leaf.autumn_mcp_org_context_preload_failed",
+				data: { tool: toolNames[index] },
+			});
+			return;
+		}
+		return result.value.value;
+	};
+
+	const organization = preloadedValue(0);
+	const agentRules = preloadedValue(1);
+	const plans = preloadedValue(2);
+	const features = preloadedValue(3);
+
+	logger.info("Preloaded Autumn org context", {
 		event: "leaf.autumn_mcp_org_context_preloaded",
-		outcomes,
+		data: { preloads },
 	});
 
 	const text = formatAutumnOrgContext({
-		agentRules:
-			agentRulesResult.status === "fulfilled"
-				? agentRulesResult.value
-				: undefined,
-		features:
-			featuresResult.status === "fulfilled" ? featuresResult.value : undefined,
-		organization:
-			organizationResult.status === "fulfilled"
-				? organizationResult.value
-				: undefined,
-		plans: plansResult.status === "fulfilled" ? plansResult.value : undefined,
+		agentRules,
+		features,
+		organization,
+		plans,
 	});
 
-	const instructions =
-		agentRulesResult.status === "fulfilled"
-			? getNotes(agentRulesResult.value)
-			: undefined;
+	const instructions = getNotes(agentRules);
 	return text || instructions ? { instructions, text } : undefined;
 };
 

--- a/apps/leaf/src/lib/withRetry.ts
+++ b/apps/leaf/src/lib/withRetry.ts
@@ -7,19 +7,26 @@ const wait = (delayMs: number) =>
 export const withRetry = async <T>({
 	attempts,
 	baseDelayMs,
+	onRecovered,
+	onRetry,
 	operation,
 	shouldRetry,
 }: {
 	attempts: number;
 	baseDelayMs: number;
+	onRecovered?: (input: { attempt: number }) => void;
+	onRetry?: (input: { attempt: number; error: unknown }) => void;
 	operation: () => Promise<T>;
 	shouldRetry: (error: unknown, attempt: number) => boolean;
 }): Promise<T> => {
 	for (let attempt = 1; ; attempt += 1) {
 		try {
-			return await operation();
+			const result = await operation();
+			if (attempt > 1) onRecovered?.({ attempt });
+			return result;
 		} catch (error) {
 			if (attempt >= attempts || !shouldRetry(error, attempt)) throw error;
+			onRetry?.({ attempt, error });
 			await wait(baseDelayMs * 2 ** (attempt - 1));
 		}
 	}

--- a/apps/leaf/src/main.ts
+++ b/apps/leaf/src/main.ts
@@ -6,7 +6,7 @@ import { logger } from "./lib/logger.js";
 
 const app = createLeafApp();
 
-serve(
+const server = serve(
 	{
 		fetch: app.fetch,
 		hostname: "0.0.0.0",
@@ -22,3 +22,20 @@ serve(
 		});
 	},
 );
+
+let shuttingDown = false;
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+	process.on(signal, () => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		void (async () => {
+			logger.info("Chat shutting down", {
+				event: "leaf.server_stopping",
+				data: { signal },
+			});
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+			await logger.flush?.().catch(() => undefined);
+			process.exit(signal === "SIGTERM" ? 143 : 130);
+		})();
+	});
+}

--- a/apps/leaf/src/providers/slack/handlers/handleAssistantThreadStarted.ts
+++ b/apps/leaf/src/providers/slack/handlers/handleAssistantThreadStarted.ts
@@ -34,7 +34,7 @@ export const handleAssistantThreadStarted = async (event: {
 	} catch (error) {
 		logger.warn("Assistant thread prewarm failed", {
 			event: "leaf.assistant_prewarm_failed",
-			data: { error: error instanceof Error ? error.message : String(error) },
+			data: { error },
 		});
 	}
 };

--- a/apps/leaf/src/providers/slack/presenters/interactionCards.ts
+++ b/apps/leaf/src/providers/slack/presenters/interactionCards.ts
@@ -3,6 +3,7 @@ import { formatMoney } from "@autumn/render";
 import { AppEnv, type CatalogPlanPreview } from "@autumn/shared";
 import { Actions, Button, Card, type CardChild, CardText } from "chat";
 import { z } from "zod";
+import { logger } from "../../../lib/logger.js";
 
 const questionButtonPayloadSchema = z.strictObject({
 	e: z.nativeEnum(AppEnv),
@@ -29,6 +30,21 @@ type CatalogDecisionButtonPayload = z.infer<
 	typeof catalogDecisionButtonPayloadSchema
 >;
 
+/** A malformed button value makes the click a silent no-op — Slack caps
+ * action values at 255 chars, so truncation is a live risk. */
+const logInvalidPayload = ({
+	detail,
+	value,
+}: {
+	detail: string;
+	value: string;
+}) => {
+	logger.warn("Slack action payload failed to parse", {
+		event: "leaf.slack_action_payload_invalid",
+		data: { detail, value: value.slice(0, 300) },
+	});
+};
+
 const parsePayload = <T>({
 	schema,
 	value,
@@ -39,8 +55,16 @@ const parsePayload = <T>({
 	if (!value) return null;
 	try {
 		const parsed = schema.safeParse(JSON.parse(value));
-		return parsed.success ? parsed.data : null;
-	} catch {
+		if (!parsed.success) {
+			logInvalidPayload({ detail: parsed.error.message, value });
+			return null;
+		}
+		return parsed.data;
+	} catch (error) {
+		logInvalidPayload({
+			detail: error instanceof Error ? error.message : String(error),
+			value,
+		});
 		return null;
 	}
 };

--- a/apps/leaf/src/providers/slack/threadContext.ts
+++ b/apps/leaf/src/providers/slack/threadContext.ts
@@ -1,5 +1,6 @@
 import type { Message, Thread } from "chat";
 import type { AgentContextMessage } from "../../internal/agentRuntime/domain/agentTurnContext.js";
+import { logger } from "../../lib/logger.js";
 
 const isPlanBlock = (block: unknown) =>
 	typeof block === "object" &&
@@ -21,7 +22,10 @@ export const getRecentMessages = async (
 	try {
 		await thread.refresh();
 	} catch (error) {
-		console.warn("[chat] Could not refresh thread context", error);
+		logger.warn("Could not refresh thread context", {
+			data: { error },
+			event: "leaf.slack_thread_context_refresh_failed",
+		});
 	}
 
 	const seen = new Set<string>();

--- a/apps/leaf/src/providers/web/streamWebChat.ts
+++ b/apps/leaf/src/providers/web/streamWebChat.ts
@@ -240,7 +240,7 @@ export const streamWebChat = async ({
 		onError: (error) => {
 			logger.error("Web chat stream failed", {
 				event: "leaf.web_chat_stream_failed",
-				data: { error: String(error) },
+				data: { error },
 			});
 			return GENERIC_FAILURE_MESSAGE;
 		},

--- a/apps/leaf/src/ui/runProgress.ts
+++ b/apps/leaf/src/ui/runProgress.ts
@@ -1,5 +1,6 @@
 import { Plan } from "chat";
 import type { AgentActionProgress } from "../internal/agentRuntime/domain/agentTurnContext.js";
+import { logger } from "../lib/logger.js";
 import { actionProgressResult } from "./actionProgress.js";
 import type { ReplyTarget } from "./progress.js";
 import { createStatusTicker } from "./statusTicker.js";
@@ -56,7 +57,10 @@ export const createRunProgress = ({
 			await update(plan);
 		} catch (error) {
 			planAvailable = false;
-			console.warn("[chat] Could not update run plan", error);
+			logger.warn("Could not update run plan", {
+				data: { error },
+				event: "leaf.run_plan_update_failed",
+			});
 		}
 	};
 
@@ -121,7 +125,10 @@ export const createRunProgress = ({
 				planStarted = true;
 			} catch (error) {
 				planAvailable = false;
-				console.warn("[chat] Could not post run plan", error);
+				logger.warn("Could not post run plan", {
+					data: { error },
+					event: "leaf.run_plan_post_failed",
+				});
 			}
 		},
 		status: ticker.activity,

--- a/apps/leaf/src/ui/statusTicker.ts
+++ b/apps/leaf/src/ui/statusTicker.ts
@@ -1,5 +1,6 @@
 import { ms } from "@autumn/shared";
 import { differenceInMilliseconds } from "date-fns";
+import { logger } from "../lib/logger.js";
 import { formatTypingStatus } from "./progress.js";
 
 const THINKING_VERBS = [
@@ -44,7 +45,10 @@ export const createStatusTicker = (target: TypingTarget): StatusTicker => {
 		sendChain = sendChain
 			.then(() => target.startTyping(text))
 			.catch((error) => {
-				console.warn("[chat] Could not update status", error);
+				logger.warn("Could not update typing status", {
+					data: { error },
+					event: "leaf.status_update_failed",
+				});
 			});
 	};
 

--- a/apps/leaf/tests/unit/approvals/fetchApprovalPreview.test.ts
+++ b/apps/leaf/tests/unit/approvals/fetchApprovalPreview.test.ts
@@ -6,7 +6,7 @@ import {
 	withGroupedWritePreviews,
 } from "../../../src/internal/approvals/utils/fetchApprovalPreview.js";
 
-const silentLogger = { warn: () => {} };
+const silentLogger = { debug: () => {}, warn: () => {} };
 
 describe("fetchApprovalPreview", () => {
 	test("refreshes catalog previews for the exact post-decision write", () => {

--- a/apps/leaf/tests/unit/internal/autumnMcp/orgContextService.test.ts
+++ b/apps/leaf/tests/unit/internal/autumnMcp/orgContextService.test.ts
@@ -17,6 +17,7 @@ const createLogger = () => {
 	return {
 		logger: {
 			debug: () => undefined,
+			info: () => undefined,
 			warn: (_message: string, input: unknown) => warnings.push(input),
 		},
 		warnings,

--- a/bun.lock
+++ b/bun.lock
@@ -597,6 +597,7 @@
         "@autumn/auth": "workspace:*",
         "@autumn/env": "workspace:*",
         "@autumn/ksuid": "workspace:*",
+        "@autumn/logging": "workspace:*",
         "@autumn/shared": "workspace:*",
         "@autumn/stripe-sync": "workspace:*",
         "@aws-sdk/client-dynamodb": "^3.1095.0",

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -21,7 +21,10 @@ export {
 	mirrorLogger,
 	withLogPrefix,
 } from "./logger/loggerWrappers.js";
-export { resolveLoggerOptions } from "./logger/resolveLoggerOptions.js";
+export {
+	resolveDeployment,
+	resolveLoggerOptions,
+} from "./logger/resolveLoggerOptions.js";
 export { asAxiomMap } from "./payload/asAxiomMap.js";
 export {
 	type GuardLogPayloadOptions,

--- a/packages/logging/src/logger/autumnLogger.ts
+++ b/packages/logging/src/logger/autumnLogger.ts
@@ -6,15 +6,11 @@ import type {
 	LogArgs,
 } from "../types.js";
 import { createLogger } from "./createLogger.js";
-
-const rewriteAppPath = (value: string): string =>
-	value.replace("file:///app/", "./").replace(/\/app\//g, "./");
-
-const errorToObject = (error: Error) => ({
-	name: error.name,
-	message: error.message,
-	stack: error.stack ? rewriteAppPath(error.stack) : undefined,
-});
+import {
+	errorToObject,
+	normalizeErrorValues,
+	rewriteAppPath,
+} from "./normalizeErrors.js";
 
 const normalizeLogArgs = ({ args }: { args: LogArgs }) => {
 	const strings = args
@@ -24,10 +20,14 @@ const normalizeLogArgs = ({ args }: { args: LogArgs }) => {
 		.filter(
 			(arg) => typeof arg !== "string" && arg !== null && arg !== undefined,
 		)
-		.map((arg) => (arg instanceof Error ? { error: errorToObject(arg) } : arg));
+		.map((arg) =>
+			arg instanceof Error
+				? { error: errorToObject(arg) }
+				: normalizeErrorValues(arg),
+		);
 	const error = args.find((arg): arg is Error => arg instanceof Error);
 	const message =
-		strings.at(-1) ??
+		strings[strings.length - 1] ??
 		(error
 			? rewriteAppPath(error.stack || error.message || "Error occurred")
 			: "");
@@ -39,31 +39,39 @@ const normalizeLogArgs = ({ args }: { args: LogArgs }) => {
 };
 
 const createLogMethod =
-	({ method }: { method: pino.LogFn }) =>
+	({ level, logger }: { level: pino.Level; logger: pino.Logger }) =>
 	(...args: LogArgs) => {
+		if (!logger.isLevelEnabled(level)) return;
 		const { message, merged } = normalizeLogArgs({ args });
-		if (Object.keys(merged).length > 0) method(merged, message);
-		else method(message);
+		if (Object.keys(merged).length > 0) logger[level](merged, message);
+		else logger[level](message);
 	};
 
+const noopFlush = async () => {};
+
 export const createAutumnLogger = ({
+	flush = noopFlush,
 	logger,
 }: {
+	flush?: () => Promise<void>;
 	logger: pino.Logger;
 }): AutumnLogger => ({
 	level: logger.level as ConsoleLoggerLevel,
-	debug: createLogMethod({ method: logger.debug.bind(logger) }),
-	info: createLogMethod({ method: logger.info.bind(logger) }),
-	warn: createLogMethod({ method: logger.warn.bind(logger) }),
-	warning: createLogMethod({ method: logger.warn.bind(logger) }),
-	error: createLogMethod({ method: logger.error.bind(logger) }),
+	debug: createLogMethod({ level: "debug", logger }),
+	info: createLogMethod({ level: "info", logger }),
+	warn: createLogMethod({ level: "warn", logger }),
+	warning: createLogMethod({ level: "warn", logger }),
+	error: createLogMethod({ level: "error", logger }),
+	flush,
 	child: ({ context, onlyProd = false }) => {
 		if (onlyProd && process.env.NODE_ENV !== "production") {
-			return createAutumnLogger({ logger });
+			return createAutumnLogger({ flush, logger });
 		}
-		return createAutumnLogger({ logger: logger.child(context) });
+		return createAutumnLogger({ flush, logger: logger.child(context) });
 	},
 });
 
-export const createAppLogger = (params: CreateLoggerParams): AutumnLogger =>
-	createAutumnLogger({ logger: createLogger(params) });
+export const createAppLogger = (params: CreateLoggerParams): AutumnLogger => {
+	const { flushTransports, logger } = createLogger(params);
+	return createAutumnLogger({ flush: flushTransports, logger });
+};

--- a/packages/logging/src/logger/createLogger.ts
+++ b/packages/logging/src/logger/createLogger.ts
@@ -2,13 +2,34 @@ import pino from "pino";
 import { createConsoleJsonStream } from "../streams/consoleJsonStream.js";
 import { createPrettyLogStream } from "../streams/prettyLogStream.js";
 import type { CreateLoggerParams } from "../types.js";
-import { resolveLoggerOptions } from "./resolveLoggerOptions.js";
+import {
+	resolveDeployment,
+	resolveLoggerOptions,
+} from "./resolveLoggerOptions.js";
 
-export const createLogger = (params: CreateLoggerParams): pino.Logger => {
+const TRANSPORT_FLUSH_TIMEOUT_MS = 2000;
+
+type TransportStream = NodeJS.WritableStream & { writableEnded?: boolean };
+
+const closeTransportStream = (stream: TransportStream) =>
+	new Promise<void>((resolve) => {
+		if (stream.writableEnded || !stream.writable) return resolve();
+		const timer = setTimeout(resolve, TRANSPORT_FLUSH_TIMEOUT_MS);
+		stream.once("close", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+		stream.end();
+	});
+
+export const createLogger = (
+	params: CreateLoggerParams,
+): { flushTransports: () => Promise<void>; logger: pino.Logger } => {
 	const resolved = resolveLoggerOptions({ options: params });
 	const axiomToken = params.axiomToken ?? process.env.AXIOM_TOKEN;
 	const axiomOrgId = params.axiomOrgId ?? process.env.AXIOM_ORG_ID;
 	const streams: pino.StreamEntry[] = [];
+	const transportStreams: TransportStream[] = [];
 
 	for (const output of resolved.outputs) {
 		if (output === "console-pretty") {
@@ -29,24 +50,27 @@ export const createLogger = (params: CreateLoggerParams): pino.Logger => {
 		}
 
 		if (output === "axiom" && axiomToken) {
+			const transportStream = pino.transport({
+				target: "@axiomhq/pino",
+				options: {
+					dataset: resolved.dataset,
+					token: axiomToken,
+					orgId: axiomOrgId,
+				},
+			});
+			transportStreams.push(transportStream);
 			streams.push({
 				level: resolved.level,
-				stream: pino.transport({
-					target: "@axiomhq/pino",
-					options: {
-						dataset: resolved.dataset,
-						token: axiomToken,
-						orgId: axiomOrgId,
-					},
-				}),
+				stream: transportStream,
 			});
 		}
 	}
 
-	return pino(
+	const logger = pino(
 		{
 			level: resolved.level,
 			base: {
+				deployment: resolveDeployment(),
 				service: resolved.service,
 				...(params.context ?? {}),
 			},
@@ -57,4 +81,16 @@ export const createLogger = (params: CreateLoggerParams): pino.Logger => {
 		},
 		pino.multistream(streams),
 	);
+
+	// Ending the transport is the only reliable flush: the Axiom target only
+	// drains its buffer in its close hook, not on pino's in-process flush.
+	let flushed: Promise<void> | undefined;
+	const flushTransports = () => {
+		flushed ??= Promise.all(transportStreams.map(closeTransportStream)).then(
+			() => undefined,
+		);
+		return flushed;
+	};
+
+	return { flushTransports, logger };
 };

--- a/packages/logging/src/logger/normalizeErrors.ts
+++ b/packages/logging/src/logger/normalizeErrors.ts
@@ -1,0 +1,64 @@
+const MAX_DEPTH = 5;
+
+const UNCHANGED = Symbol("unchanged");
+
+const rewriteAppPath = (value: string): string =>
+	value.replace("file:///app/", "./").replace(/\/app\//g, "./");
+
+export const errorToObject = (error: Error) => ({
+	name: error.name,
+	message: error.message,
+	stack: error.stack ? rewriteAppPath(error.stack) : undefined,
+});
+
+const isPlainObject = (value: object) => {
+	const proto = Object.getPrototypeOf(value);
+	return proto === Object.prototype || proto === null;
+};
+
+/** Class instances without enumerable keys or toJSON stringify to `{}` —
+ * String(value) at least preserves "[object Response]"-style identity. */
+const opaqueInstanceToString = (value: object) => {
+	if (typeof (value as { toJSON?: unknown }).toJSON === "function") return;
+	return Object.keys(value).length === 0 ? String(value) : undefined;
+};
+
+const normalize = (
+	value: unknown,
+	depth: number,
+): unknown | typeof UNCHANGED => {
+	if (value instanceof Error) return errorToObject(value);
+	if (!value || typeof value !== "object" || depth >= MAX_DEPTH) {
+		return UNCHANGED;
+	}
+	if (Array.isArray(value)) {
+		let changed = false;
+		const next = value.map((item) => {
+			const result = normalize(item, depth + 1);
+			if (result === UNCHANGED) return item;
+			changed = true;
+			return result;
+		});
+		return changed ? next : UNCHANGED;
+	}
+	if (!isPlainObject(value)) return opaqueInstanceToString(value) ?? UNCHANGED;
+	let changed = false;
+	const next = Object.fromEntries(
+		Object.entries(value as Record<string, unknown>).map(([key, item]) => {
+			const result = normalize(item, depth + 1);
+			if (result === UNCHANGED) return [key, item];
+			changed = true;
+			return [key, result];
+		}),
+	);
+	return changed ? next : UNCHANGED;
+};
+
+/** Errors nested in payload objects JSON-serialize to `{}` (their props are
+ * non-enumerable), so rewrite them to plain objects before pino sees them. */
+export const normalizeErrorValues = (value: unknown): unknown => {
+	const result = normalize(value, 0);
+	return result === UNCHANGED ? value : result;
+};
+
+export { rewriteAppPath };

--- a/packages/logging/src/logger/resolveLoggerOptions.ts
+++ b/packages/logging/src/logger/resolveLoggerOptions.ts
@@ -28,6 +28,12 @@ const parseOutputs = (
 	return undefined;
 };
 
+export const resolveDeployment = (env: NodeJS.ProcessEnv = process.env) => {
+	if (env.NODE_ENV === "development") return "dev";
+	if (env.NODE_ENV === "test") return "test";
+	return "prod";
+};
+
 export const resolveLoggerOptions = ({
 	options,
 	env = process.env,
@@ -45,7 +51,7 @@ export const resolveLoggerOptions = ({
 		else if (preset === "axiom-only") outputs = ["axiom"];
 		else if (preset === "dual")
 			outputs = [isDevOrTest ? "console-pretty" : "console-json", "axiom"];
-		else if (isDevOrTest) outputs = ["console-pretty", "axiom"];
+		else if (isDevOrTest) outputs = ["console-pretty"];
 		else outputs = ["axiom"];
 	}
 

--- a/packages/logging/src/streams/prettyLogStream.ts
+++ b/packages/logging/src/streams/prettyLogStream.ts
@@ -1,6 +1,7 @@
 import { Writable } from "node:stream";
 
 const FORMATTED_LOG_EXCLUDE_FIELDS = new Set([
+	"deployment",
 	"time",
 	"level",
 	"msg",

--- a/packages/logging/src/types.ts
+++ b/packages/logging/src/types.ts
@@ -41,6 +41,8 @@ export type AutumnLogger = {
 	warn: (...args: LogArgs) => void;
 	warning: (...args: LogArgs) => void;
 	error: (...args: LogArgs) => void;
+	/** Drains buffered transport output (Axiom); call before process exit. */
+	flush?: () => Promise<void>;
 	child: (params: {
 		context: Record<string, unknown>;
 		onlyProd?: boolean;

--- a/packages/mcp/src/analytics/loggerSink.ts
+++ b/packages/mcp/src/analytics/loggerSink.ts
@@ -33,7 +33,7 @@ export const createLoggerAnalyticsSink = ({
 	dataset: string;
 }): AnalyticsSink | null => {
 	if (!token) return null;
-	const logger = createLogger({
+	const { flushTransports, logger } = createLogger({
 		service: "mcp",
 		dataset,
 		preset: "axiom-only",
@@ -46,13 +46,7 @@ export const createLoggerAnalyticsSink = ({
 		emit(event) {
 			logger.info(toLoggerRecord(event), "MCP tool call");
 		},
-		flush: async () => {
-			await new Promise<void>((resolve) => {
-				const flush = logger.flush;
-				if (typeof flush !== "function") return resolve();
-				flush.call(logger, () => resolve());
-			});
-		},
+		flush: flushTransports,
 	};
 };
 

--- a/server/package.json
+++ b/server/package.json
@@ -53,6 +53,7 @@
 		"@autumn/auth": "workspace:*",
 		"@autumn/env": "workspace:*",
 		"@autumn/ksuid": "workspace:*",
+		"@autumn/logging": "workspace:*",
 		"@autumn/shared": "workspace:*",
 		"@autumn/stripe-sync": "workspace:*",
 		"@aws-sdk/client-dynamodb": "^3.1095.0",

--- a/server/src/utils/logging/initLogger.ts
+++ b/server/src/utils/logging/initLogger.ts
@@ -1,4 +1,6 @@
+import { hostname } from "node:os";
 import { Writable } from "node:stream";
+import { resolveDeployment } from "@autumn/logging";
 import pino from "pino";
 import { getAwsTaskIdentity } from "@/external/aws/ecs/awsTaskIdentity.js";
 
@@ -8,6 +10,7 @@ import { getAwsTaskIdentity } from "@/external/aws/ecs/awsTaskIdentity.js";
  * request envelopes, and high-cardinality structured data.
  */
 const FORMATTED_LOG_EXCLUDE_FIELDS = new Set([
+	"deployment",
 	// pino housekeeping
 	"time",
 	"level",
@@ -181,6 +184,9 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 	const isRunningInEcs = Boolean(process.env.ECS_CONTAINER_METADATA_URI_V4);
 	const shouldUseFirelens =
 		configuredTransport === "firelens" && !isDevOrTest && isRunningInEcs;
+	// Dev/test stays out of the prod dataset unless explicitly opted in.
+	const shipToAxiom = !isDevOrTest || process.env.AXIOM_DEV_LOGS === "1";
+	const deployment = resolveDeployment();
 
 	if (mode === "dual") {
 		streams.push({
@@ -194,7 +200,7 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 					? process.stdout
 					: createConsoleJsonStream(),
 		});
-		if (!shouldUseFirelens && process.env.AXIOM_TOKEN) {
+		if (!shouldUseFirelens && process.env.AXIOM_TOKEN && shipToAxiom) {
 			streams.push({
 				level: "info",
 				stream: pino.transport({
@@ -207,7 +213,8 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 			});
 		}
 	} else {
-		// DEFAULT FLOW — exact prior behavior. DO NOT MODIFY.
+		// DEFAULT FLOW — exact prior behavior, except dev/test no longer ships
+		// to Axiom without AXIOM_DEV_LOGS=1.
 		if (isDev || isTest) {
 			streams.push({
 				level: "debug",
@@ -220,7 +227,7 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 				level: "info",
 				stream: process.stdout,
 			});
-		} else if (process.env.AXIOM_TOKEN) {
+		} else if (process.env.AXIOM_TOKEN && shipToAxiom) {
 			streams.push({
 				level: "info",
 				stream: pino.transport({
@@ -244,6 +251,11 @@ export const initLogger = (options: InitLoggerOptions = {}) => {
 	const logger = pino(
 		{
 			level: isDev || isTest || mode === "dual" ? "debug" : "info",
+			base: {
+				deployment,
+				hostname: hostname(),
+				pid: process.pid,
+			},
 			// Tag every log line with this process's AWS task identity so Axiom
 			// can distinguish blue/green task sets. Returns {} until
 			// `resolveAwsTaskIdentity` finishes (~100ms after boot) and on


### PR DESCRIPTION
Closes the top coverage gaps from the leaf observability audit (3-agent code sweep + live Axiom verification), plus dataset hygiene aligned across leaf and server.

## packages/logging
- **Nested errors serialize properly**: `logger.warn(msg, { error })` previously shipped `{}` — Errors nested in payload objects (5 levels deep) are now rewritten via `normalizeErrors.ts`; opaque class instances fall back to `String(value)`
- **`flush()`**: `AutumnLogger` exposes an idempotent `flush()` that drains the Axiom transport (the target only flushes on close); disabled-level calls now short-circuit before normalization
- **Dev muting**: preset `default` in dev/test is console-only — `LOG_OUTPUTS=console-pretty,axiom` opts back in
- **`deployment` field** (`dev`/`test`/`prod`) on every line, excluded from pretty console output

## server
- Same dev muting for the `express` dataset (`AXIOM_DEV_LOGS=1` opts in) — note this relaxes the "DO NOT MODIFY" default flow by exactly this one guard — and the shared `deployment` base field

## leaf telemetry (new events)
- `leaf.agent_turn_completed` — `duration_ms`, `prepare_ms`, `time_to_first_event_ms`, `outcome_kind`, `session_id`, `new_session`
- `leaf.eve_subagent_called/completed` — `child_session_id`, `duration_ms` correlated by `callId`
- `leaf.autumn_mcp_tool_error/_failed` — every MCP tool failure logged once at the boundary with duration; error envelopes (fulfilled results with `isError`/guardResponseSize refusals) detected via `errorResult.ts`. This is the class that made resend's `agent.get_rules` 403s invisible
- `leaf.approval_applied` + the two silent stuck-card early-returns (`approval_session_missing`, `approval_eve_session_not_found`); every decide-path line now carries `approval_id`/thread/message/user
- `leaf.eve_session_deleted` with a required `reason` logged inside `deleteEveSession` (covers all 5 deletion sites)
- `leaf.eve_post_retry/_recovered` via `withRetry` hooks; `leaf.eve_replay_count_failed`, `leaf.autumn_mcp_result_parse_failed`, `leaf.slack_action_payload_invalid`; org-context preload reports numeric `bytes`/`duration_ms` per tool at info
- Remaining `console.*` and `String(error)` log sites converted; SIGTERM/SIGINT now close the server, flush, and preserve signal exit codes; embedded-eve death is logged + flushed

## Verified
- 355/355 leaf unit tests, 8/8 logging tests, tsc clean (leaf/server/logging)
- Live: turn/subagent/preload events confirmed with real payloads; stop e2e still lands in ~16ms; bad-token probe produces the boundary warn with the real 401 text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end observability for Leaf turns: precise timing metrics, richer telemetry, and safer logs. Old behavior shipped dev/test logs to Axiom by default; new behavior is console-only unless opted in, with a `flush()` to drain transports on shutdown.

- Normalize logs and shutdown
  - Nested errors in payloads serialize as objects; non-plain instances fallback to String(value).
  - `AutumnLogger.flush()` drains Axiom; server and Leaf exit paths call it and preserve signal exit codes.
  - Base fields now include `deployment` (`dev`/`test`/`prod`), excluded from pretty output; server also adds hostname and pid.
  - Dev/test logging defaults to console-only; production ships to Axiom. Server mirrors this and supports `AXIOM_DEV_LOGS=1` to opt in.
  - Replaced remaining console.* sites; embedded Eve start/exits are logged and flushed.
  - Server now declares a workspace dependency on `@autumn/logging`.

- Turn telemetry and timing
  - Tracks prepare time, time to first event, total duration, and outcome for each turn via `leaf.agent_turn_completed`.
  - Subagent timing by `callId`: `leaf.eve_subagent_called` and `leaf.eve_subagent_completed`.
  - Eve post retries: `leaf.eve_post_retry` and `leaf.eve_post_recovered`; replay recount failures: `leaf.eve_replay_count_failed`.
  - Eve session deletes require a reason and are logged: `leaf.eve_session_deleted`.
  - Autumn MCP boundary telemetry: `leaf.autumn_mcp_tool_error` (fulfilled error envelopes) and `leaf.autumn_mcp_tool_failed` (throws); result parse: `leaf.autumn_mcp_result_parse_failed`.
  - Org-context preload logs per-tool bytes/duration and failures: `leaf.autumn_mcp_org_context_preloaded` / `_preload_failed`.
  - Approval path logs: missing session, not found, applied with duration and sibling count; Slack action payload parsing failures logged; server shutdown: `leaf.server_stopping`.
  - Verified: all unit tests pass; live telemetry shows no performance regressions.

**Rollout notes**
- Dev/test Axiom is muted by default.
  - For `packages/logging` consumers: set `LOG_OUTPUTS=console-pretty,axiom` to opt in.
  - For `server`: set `AXIOM_DEV_LOGS=1` to opt in.
- If you control a process boundary, call `logger.flush()` before exit to avoid losing Axiom logs.
- Pass error objects or opaque values directly when logging; the logger normalizes nested errors.

<sup>Written for commit 8e00f8f16f695dae0351947bccf8c39dbe7eac91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

