### PR TITLE
feat(verify-stripe): link shared-customer mismatch to Autumn customers

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -132,11 +132,23 @@
 		},
 		"apps/leaf": {
 			"entry": [
-				"tests/**/*.ts"
+				"tests/**/*.ts",
+				"agent/**/*.ts"
 			],
 			"project": [
 				"src/**/*.ts",
-				"tests/**/*.ts"
+				"tests/**/*.ts",
+				"agent/**/*.ts"
+			]
+		},
+		"packages/agent-docs": {
+			"entry": [
+				"**/*.test.ts",
+				"scripts/**/*.ts"
+			],
+			"project": [
+				"src/**/*.ts",
+				"scripts/**/*.ts"
 			]
 		},
 		"packages/gateway": {
@@ -165,9 +177,6 @@
 		"packages/render": {
 			"project": [
 				"src/**/*.ts"
-			],
-			"ignore": [
-				"src/billing/planDisplay.ts"
 			]
 		},
 		"packages/env": {

--- a/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSharedStripeCustomer.ts
+++ b/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSharedStripeCustomer.ts
@@ -24,6 +24,7 @@ export const evaluateSharedStripeCustomer = async ({
 		.map((customer) => ({
 			id: customer.id ?? customer.internal_id,
 			name: customer.name ?? null,
+			email: customer.email ?? null,
 		}));
 
 	if (otherCustomers.length === 0) return [];

--- a/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSharedStripeCustomer.ts
+++ b/server/src/internal/billing/v2/actions/verify/evaluate/evaluateSharedStripeCustomer.ts
@@ -1,8 +1,4 @@
-import {
-	type FullCustomer,
-	notNullish,
-	type SubscriptionMismatch,
-} from "@autumn/shared";
+import type { FullCustomer, SubscriptionMismatch } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusService } from "@/internal/customers/CusService";
 
@@ -23,18 +19,21 @@ export const evaluateSharedStripeCustomer = async ({
 		stripeId: stripeCustomerId,
 	});
 
-	const otherCustomerIds = linkedCustomers
+	const otherCustomers = linkedCustomers
 		.filter((customer) => customer.internal_id !== fullCustomer.internal_id)
-		.map((customer) => customer.id ?? customer.internal_id)
-		.filter(notNullish);
+		.map((customer) => ({
+			id: customer.id ?? customer.internal_id,
+			name: customer.name ?? null,
+		}));
 
-	if (otherCustomerIds.length === 0) return [];
+	if (otherCustomers.length === 0) return [];
 
 	return [
 		{
 			type: "shared_stripe_customer",
 			stripe_customer_id: stripeCustomerId,
-			other_customer_ids: otherCustomerIds,
+			other_customer_ids: otherCustomers.map((customer) => customer.id),
+			other_customers: otherCustomers,
 		},
 	];
 };

--- a/shared/api/billing/verify/verifyParamsV1.ts
+++ b/shared/api/billing/verify/verifyParamsV1.ts
@@ -183,7 +183,13 @@ export const SharedStripeCustomerMismatchSchema = z.object({
 	stripe_customer_id: z.string(),
 	other_customer_ids: z.array(z.string()),
 	other_customers: z
-		.array(z.object({ id: z.string(), name: z.string().nullable() }))
+		.array(
+			z.object({
+				id: z.string(),
+				name: z.string().nullable(),
+				email: z.string().nullable(),
+			}),
+		)
 		.optional(),
 });
 export type SharedStripeCustomerMismatch = z.infer<

--- a/shared/api/billing/verify/verifyParamsV1.ts
+++ b/shared/api/billing/verify/verifyParamsV1.ts
@@ -182,6 +182,9 @@ export const SharedStripeCustomerMismatchSchema = z.object({
 	severity,
 	stripe_customer_id: z.string(),
 	other_customer_ids: z.array(z.string()),
+	other_customers: z
+		.array(z.object({ id: z.string(), name: z.string().nullable() }))
+		.optional(),
 });
 export type SharedStripeCustomerMismatch = z.infer<
 	typeof SharedStripeCustomerMismatchSchema

--- a/vite/src/views/customers2/components/verify-stripe/SharedStripeCustomerDetails.tsx
+++ b/vite/src/views/customers2/components/verify-stripe/SharedStripeCustomerDetails.tsx
@@ -9,7 +9,11 @@ export function SharedStripeCustomerDetails({
 }) {
 	const otherCustomers =
 		mismatch.other_customers ??
-		mismatch.other_customer_ids.map((id) => ({ id, name: null }));
+		mismatch.other_customer_ids.map((id) => ({
+			id,
+			name: null,
+			email: null,
+		}));
 
 	return (
 		<span className="block whitespace-normal break-words text-tertiary-foreground py-2">
@@ -27,7 +31,7 @@ export function SharedStripeCustomerDetails({
 						rel="noopener"
 						className="text-foreground underline underline-offset-2 hover:text-primary"
 					>
-						{customer.name ?? customer.id}
+						{customer.name ?? customer.email ?? customer.id}
 					</a>
 				</Fragment>
 			))}

--- a/vite/src/views/customers2/components/verify-stripe/SharedStripeCustomerDetails.tsx
+++ b/vite/src/views/customers2/components/verify-stripe/SharedStripeCustomerDetails.tsx
@@ -1,0 +1,36 @@
+import type { SharedStripeCustomerMismatch } from "@autumn/shared";
+import { Fragment } from "react";
+import { pushPage } from "@/utils/genUtils";
+
+export function SharedStripeCustomerDetails({
+	mismatch,
+}: {
+	mismatch: SharedStripeCustomerMismatch;
+}) {
+	const otherCustomers =
+		mismatch.other_customers ??
+		mismatch.other_customer_ids.map((id) => ({ id, name: null }));
+
+	return (
+		<span className="block whitespace-normal break-words text-tertiary-foreground py-2">
+			Stripe customer {mismatch.stripe_customer_id} is also linked to Autumn
+			customer{otherCustomers.length === 1 ? "" : "(s)"}:{" "}
+			{otherCustomers.map((customer, index) => (
+				<Fragment key={customer.id}>
+					{index > 0 && ", "}
+					<a
+						href={pushPage({
+							path: `/customers/${customer.id}`,
+							preserveParams: false,
+						})}
+						target="_blank"
+						rel="noopener"
+						className="text-foreground underline underline-offset-2 hover:text-primary"
+					>
+						{customer.name ?? customer.id}
+					</a>
+				</Fragment>
+			))}
+		</span>
+	);
+}

--- a/vite/src/views/customers2/components/verify-stripe/VerifyStripeColumns.tsx
+++ b/vite/src/views/customers2/components/verify-stripe/VerifyStripeColumns.tsx
@@ -2,6 +2,7 @@ import type { SubscriptionMismatch } from "@autumn/shared";
 import { WarningCircleIcon } from "@phosphor-icons/react";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 import { cn } from "@/lib/utils";
+import { SharedStripeCustomerDetails } from "./SharedStripeCustomerDetails";
 
 const ISSUE_LABELS: Record<SubscriptionMismatch["type"], string> = {
 	base_price_mismatch: "Base price",
@@ -46,10 +47,16 @@ export const createVerifyMismatchColumns = (): ColumnDef<
 	{
 		header: "Details",
 		id: "details",
-		cell: ({ row }: { row: Row<SubscriptionMismatch> }) => (
-			<span className="block whitespace-normal break-words text-tertiary-foreground py-2">
-				{row.original.message}
-			</span>
-		),
+		cell: ({ row }: { row: Row<SubscriptionMismatch> }) => {
+			const mismatch = row.original;
+			if (mismatch.type === "shared_stripe_customer") {
+				return <SharedStripeCustomerDetails mismatch={mismatch} />;
+			}
+			return (
+				<span className="block whitespace-normal break-words text-tertiary-foreground py-2">
+					{mismatch.message}
+				</span>
+			);
+		},
 	},
 ];


### PR DESCRIPTION
## Summary

From Ryan's feedback: the Verify Stripe sheet's "Shared customer" row listed the colliding Autumn customer IDs as plain text, forcing you to open new tabs and search for them.

- `SharedStripeCustomerMismatchSchema` gains an optional `other_customers` (`{id, name}[]`); `other_customer_ids` is kept for compatibility
- `evaluateSharedStripeCustomer` populates names from the customer rows it already fetches
- The Details cell renders each colliding customer as a link (name when set, ID otherwise) that opens the customer page in a new tab, sandbox-prefix aware via `pushPage`
- Other mismatch types keep rendering `mismatch.message` unchanged

Also includes a knip config fix for pre-existing drift on dev that blocked commits repo-wide:
- `apps/leaf` globs now cover `agent/**`, whose imports make `rpcClient.ts` used
- `packages/agent-docs` gets a workspace block so its test file registers as an entry
- drops the `packages/render` ignore for the deleted `planDisplay.ts`

## Test plan

- `bun run knip` clean at root
- `bun ts` clean in `server/` and `vite/`
- Verify sheet on a customer with a shared Stripe customer: names render as links to `/customers/<id>`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links shared Stripe-customer collisions in Verify Stripe to Autumn customer pages. Previously the row showed raw IDs; now it shows links that use the customer name or email (then ID) and open in a new tab.

- Extends `SharedStripeCustomerMismatchSchema` in `@autumn/shared` with optional `other_customers` ({ id, name, email }); retains `other_customer_ids` for compatibility.
- Server populates `other_customers`; UI renders only this mismatch type differently and falls back to name → email → ID for link text.
- Updates knip config to include `apps/leaf/agent/**`, add `packages/agent-docs` entries, and drop a stale `packages/render` ignore to unblock `knip` runs.

<sup>Written for commit 47a3da3a60b262deac1f04b81c0456af67f7e177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

