### PR TITLE
fix(dashboard): normalize legacy zero rollover caps

### DIFF
--- a/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
+++ b/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
@@ -35,7 +35,7 @@ const planItemsToCatalogParams = (
 						rollover: {
 							expiry_duration_type: rollover.expiry_duration_type,
 							expiry_duration_length: rollover.expiry_duration_length,
-							...(rollover.max != null ? { max: rollover.max } : {}),
+							...(rollover.max ? { max: rollover.max } : {}),
 							...(rollover.max_percentage != null
 								? { max_percentage: rollover.max_percentage }
 								: {}),

--- a/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
+++ b/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
@@ -6,6 +6,7 @@ import {
 	FeatureUsageType,
 	type FrontendProduct,
 	ProductItemInterval,
+	RolloverExpiryDurationType,
 	UpdateCatalogPlanParamsSchema,
 } from "@autumn/shared";
 import {
@@ -243,6 +244,38 @@ describe("buildUpdateCatalogPlanParams", () => {
 			expect(item.stripe_price_id).toBeUndefined();
 			expect(item.price?.stripe_price_id).toBeUndefined();
 		}
+	});
+
+	/** Red: legacy max 0 is rejected on save. Green: serialize it as uncapped rollover. */
+	test("normalizes a legacy zero rollover cap", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: {
+				...editedProduct,
+				items: [
+					{
+						feature_id: "messages",
+						included_usage: 500,
+						interval: ProductItemInterval.Month,
+						interval_count: 1,
+						config: {
+							rollover: {
+								max: 0,
+								max_percentage: null,
+								duration: RolloverExpiryDurationType.Month,
+								length: 1,
+							},
+						},
+					},
+				],
+			},
+			features,
+		});
+
+		expect(params.items?.[0]?.rollover).toEqual({
+			expiry_duration_type: RolloverExpiryDurationType.Month,
+			expiry_duration_length: 1,
+		});
 	});
 
 	test("create omits version and versioning", () => {


### PR DESCRIPTION
## Summary
- omit legacy rollover `max: 0` from catalog update payloads so it is treated as uncapped
- keep strict server validation unchanged
- add regression coverage for saving an affected plan

## Tests
- `bun test tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts`
- `bun run ts` (vite)
- `bunx tsgo --build --noEmit` (server)
- `bunx biome check` on changed files
- React Doctor: 100/100

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes legacy rollover caps by treating `rollover.max: 0` as uncapped. Previously we serialized `max: 0` and the server rejected the payload; now we omit `max` when it is `0`, and the server accepts it as uncapped. Server validation remains unchanged.

- **Review notes**
  - Serializer now includes `rollover.max` only when truthy in `buildUpdateCatalogPlanParams.ts`.
  - Adds a regression test to confirm `max: 0` serializes to an uncapped rollover.
  - No backend changes or migrations required.

<sup>Written for commit 7b7960e9a2c8b8c25507a0a3559892f95fd223fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

