### PR TITLE
fix(auto-topup): 5m billing lock and 3h SQS visibility

### DIFF
--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -199,7 +199,7 @@ export const autoTopup = async ({
 				env,
 				customerId,
 			}),
-			ttlMs: 60_000,
+			ttlMs: ms.minutes(5),
 			errorMessage: `Another billing operation is already in progress for customer ${customerId}`,
 			fn: executeAutoTopup,
 		});

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -1,7 +1,8 @@
 import "../sentry.js";
 
-import { ms, withTimeout } from "@autumn/shared";
+import { ms, seconds, withTimeout } from "@autumn/shared";
 import {
+	ChangeMessageVisibilityCommand,
 	DeleteMessageBatchCommand,
 	DeleteMessageCommand,
 	type Message,
@@ -61,11 +62,13 @@ const QUEUE_CAPACITY_RETRY_MS = 1_000;
 const DELETE_RETRY_DELAYS_MS = [100, 250, 500] as const;
 
 type JobOverride = {
-	ack: "upfront" | "always-after-processing";
-	dispatch: "inline" | "background";
+	ack?: "upfront" | "always-after-processing";
+	dispatch?: "inline" | "background";
 	/** Per-message bound. Omit for MESSAGE_TIMEOUT_MS; `null` runs unbounded,
 	 * which is only safe when the message is ACKed upfront. */
 	timeoutMs?: number | null;
+	/** Extend this message's SQS visibility after receive. Queue default is 30s. */
+	visibilityTimeoutSeconds?: number;
 };
 
 // Jobs with nonstandard acknowledgement or dispatch behavior. Inline dispatch
@@ -93,6 +96,11 @@ const JOB_OVERRIDES: Partial<Record<JobName, JobOverride>> = {
 		ack: "always-after-processing",
 		dispatch: "inline",
 		timeoutMs: BATCH_RESET_MESSAGE_TIMEOUT_MS,
+	},
+	// Hold this message past the 5-minute billing lock so the 30s queue
+	// visibility cannot redeliver while Stripe is still in flight.
+	[JobName.AutoTopUp]: {
+		visibilityTimeoutSeconds: seconds.hours(3),
 	},
 };
 
@@ -323,6 +331,16 @@ export const startPollingLoop = async ({
 
 		const job: SqsJob = JSON.parse(message.Body);
 		const override = getJobOverride(job.name);
+
+		if (override?.visibilityTimeoutSeconds != null && message.ReceiptHandle) {
+			await sqs.send(
+				new ChangeMessageVisibilityCommand({
+					QueueUrl: queueUrl,
+					ReceiptHandle: message.ReceiptHandle,
+					VisibilityTimeout: override.visibilityTimeoutSeconds,
+				}),
+			);
+		}
 
 		if (override?.ack === "upfront") {
 			await ackMessageUpfront({ sqs, message, job });

--- a/server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts
+++ b/server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts
@@ -8,11 +8,19 @@ const calls = {
 	clearPending: 0,
 	keepPending: [] as number[],
 	failureWebhook: 0,
+	lockTtlMs: [] as number[],
 };
 const state = { lockContention: true, preflightBlocked: false };
 
 mock.module("@/external/redis/utils/lockUtils/withLock.js", () => ({
-	withLock: async ({ fn }: { fn: () => Promise<void> }) => {
+	withLock: async ({
+		fn,
+		ttlMs,
+	}: {
+		fn: () => Promise<void>;
+		ttlMs?: number;
+	}) => {
+		if (ttlMs != null) calls.lockTtlMs.push(ttlMs);
 		if (state.lockContention) throw { code: ErrCode.LockAlreadyExists };
 		return fn();
 	},
@@ -77,6 +85,7 @@ beforeEach(() => {
 	calls.clearPending = 0;
 	calls.keepPending = [];
 	calls.failureWebhook = 0;
+	calls.lockTtlMs = [];
 	state.lockContention = true;
 	state.preflightBlocked = false;
 });
@@ -102,6 +111,7 @@ test("auto-topup lock retry preserves burst suppression", async () => {
 	expect(calls.clearPending).toBe(0);
 	expect(calls.keepPending).toEqual([10 * 60 * 1000]);
 	expect(calls.failureWebhook).toBe(0);
+	expect(calls.lockTtlMs).toEqual([5 * 60 * 1000]);
 });
 
 test("auto-topup purchase limit preserves burst suppression", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Same-message SQS redelivery could start a second auto-top-up while the first was still in Stripe. The billing lock is a Redis `SET NX` with a TTL — it is not held until `executeAutoTopup` returns. At 60s the key expires, preflight still sees `0/1` this month (`recordAutoTopupAttempt` runs after Stripe), and a second invoice gets created.

## What

- Auto-top-up `withLock` TTL: **60s → 5 minutes**
- On receive, extend that AutoTopUp message's SQS visibility to **3 hours** (`ChangeMessageVisibility`) so the 30s queue default cannot redeliver mid-charge

The worker's 25s processing timeout is unchanged. If the handler is abandoned, the message stays hidden for 3 hours; the in-flight function can still finish under the 5-minute lock. A later redelivery should see `1/1` or balance above threshold and skip.

Lock-contention retries of the **same** message now wait up to 3 hours instead of ~30s.

## Test plan

- [x] Auto-top-up `withLock` TTL is 5 minutes
- [ ] Worker `ChangeMessageVisibility` for `JobName.AutoTopUp` only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecef442c-3fa9-4b1f-a257-4859e8a6dbbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecef442c-3fa9-4b1f-a257-4859e8a6dbbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate auto top-ups by holding the billing lock for 5 minutes and extending SQS visibility for `AutoTopUp` jobs to 3 hours. Previously a 60s lock and 30s visibility allowed the same message to redeliver mid-charge.

- Set `withLock` TTL in `autoTopup` to 5 minutes; tests assert the 5m TTL via the `withLock` mock.
- Add `visibilityTimeoutSeconds` to job overrides and set `JobName.AutoTopUp` to 3 hours; the worker calls SQS `ChangeMessageVisibility` on receipt.
- Make `JobOverride` fields optional to support partial overrides.
- Operational: an in-flight auto-top-up message can remain invisible for up to 3 hours; no migrations required.

<sup>Written for commit ad3bd569bd83d8d7b368c14f4050dfad2e6b22f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

