### PR TITLE
fix(auto-topup): 5m billing lock and 3h SQS visibility

### DIFF
--- a/server/src/internal/balances/autoTopUp/autoTopup.ts
+++ b/server/src/internal/balances/autoTopUp/autoTopup.ts
@@ -199,7 +199,7 @@ export const autoTopup = async ({
 				env,
 				customerId,
 			}),
-			ttlMs: 60_000,
+			ttlMs: ms.minutes(5),
 			errorMessage: `Another billing operation is already in progress for customer ${customerId}`,
 			fn: executeAutoTopup,
 		});

--- a/server/src/queue/initWorkers.ts
+++ b/server/src/queue/initWorkers.ts
@@ -1,7 +1,8 @@
 import "../sentry.js";
 
-import { ms, withTimeout } from "@autumn/shared";
+import { ms, seconds, withTimeout } from "@autumn/shared";
 import {
+	ChangeMessageVisibilityCommand,
 	DeleteMessageBatchCommand,
 	DeleteMessageCommand,
 	type Message,
@@ -61,11 +62,13 @@ const QUEUE_CAPACITY_RETRY_MS = 1_000;
 const DELETE_RETRY_DELAYS_MS = [100, 250, 500] as const;
 
 type JobOverride = {
-	ack: "upfront" | "always-after-processing";
-	dispatch: "inline" | "background";
+	ack?: "upfront" | "always-after-processing";
+	dispatch?: "inline" | "background";
 	/** Per-message bound. Omit for MESSAGE_TIMEOUT_MS; `null` runs unbounded,
 	 * which is only safe when the message is ACKed upfront. */
 	timeoutMs?: number | null;
+	/** Extend this message's SQS visibility after receive. Queue default is 30s. */
+	visibilityTimeoutSeconds?: number;
 };
 
 // Jobs with nonstandard acknowledgement or dispatch behavior. Inline dispatch
@@ -93,6 +96,11 @@ const JOB_OVERRIDES: Partial<Record<JobName, JobOverride>> = {
 		ack: "always-after-processing",
 		dispatch: "inline",
 		timeoutMs: BATCH_RESET_MESSAGE_TIMEOUT_MS,
+	},
+	// Hold this message past the 5-minute billing lock so the 30s queue
+	// visibility cannot redeliver while Stripe is still in flight.
+	[JobName.AutoTopUp]: {
+		visibilityTimeoutSeconds: seconds.hours(3),
 	},
 };
 
@@ -323,6 +331,16 @@ export const startPollingLoop = async ({
 
 		const job: SqsJob = JSON.parse(message.Body);
 		const override = getJobOverride(job.name);
+
+		if (override?.visibilityTimeoutSeconds != null && message.ReceiptHandle) {
+			await sqs.send(
+				new ChangeMessageVisibilityCommand({
+					QueueUrl: queueUrl,
+					ReceiptHandle: message.ReceiptHandle,
+					VisibilityTimeout: override.visibilityTimeoutSeconds,
+				}),
+			);
+		}
 
 		if (override?.ack === "upfront") {
 			await ackMessageUpfront({ sqs, message, job });

--- a/server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts
+++ b/server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts
@@ -8,11 +8,19 @@ const calls = {
 	clearPending: 0,
 	keepPending: [] as number[],
 	failureWebhook: 0,
+	lockTtlMs: [] as number[],
 };
 const state = { lockContention: true, preflightBlocked: false };
 
 mock.module("@/external/redis/utils/lockUtils/withLock.js", () => ({
-	withLock: async ({ fn }: { fn: () => Promise<void> }) => {
+	withLock: async ({
+		fn,
+		ttlMs,
+	}: {
+		fn: () => Promise<void>;
+		ttlMs?: number;
+	}) => {
+		if (ttlMs != null) calls.lockTtlMs.push(ttlMs);
 		if (state.lockContention) throw { code: ErrCode.LockAlreadyExists };
 		return fn();
 	},
@@ -77,6 +85,7 @@ beforeEach(() => {
 	calls.clearPending = 0;
 	calls.keepPending = [];
 	calls.failureWebhook = 0;
+	calls.lockTtlMs = [];
 	state.lockContention = true;
 	state.preflightBlocked = false;
 });
@@ -102,6 +111,7 @@ test("auto-topup lock retry preserves burst suppression", async () => {
 	expect(calls.clearPending).toBe(0);
 	expect(calls.keepPending).toEqual([10 * 60 * 1000]);
 	expect(calls.failureWebhook).toBe(0);
+	expect(calls.lockTtlMs).toEqual([5 * 60 * 1000]);
 });
 
 test("auto-topup purchase limit preserves burst suppression", async () => {

--- a/server/tests/unit/catalog/validateCatalogVariantUpdates.test.ts
+++ b/server/tests/unit/catalog/validateCatalogVariantUpdates.test.ts
@@ -15,6 +15,7 @@ const product = ({
 	({
 		id,
 		version,
+		active: true,
 		base_internal_product_id: baseInternalProductId,
 	}) as FullProduct;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Same-message SQS redelivery could start a second auto-top-up while the first was still in Stripe. The billing lock is a Redis `SET NX` with a TTL — it is not held until `executeAutoTopup` returns. At 60s the key expires, preflight still sees `0/1` this month (`recordAutoTopupAttempt` runs after Stripe), and a second invoice gets created.

Hotfix onto `main` only. Does not include other `dev` work.

## What

- Auto-top-up `withLock` TTL: **60s → 5 minutes**
- On receive, extend that AutoTopUp message's SQS visibility to **3 hours** (`ChangeMessageVisibility`) so the 30s queue default cannot redeliver mid-charge
- Catalog variant unit fixture now marks the base plan `active`, matching `validateCatalogVariantVersionTargets`

The worker's 25s processing timeout is unchanged. If the handler is abandoned, the message stays hidden for 3 hours; the in-flight function can still finish under the 5-minute lock. A later redelivery should see `1/1` or balance above threshold and skip.

Lock-contention retries of the **same** message now wait up to 3 hours instead of ~30s.

## Test plan

- [x] Auto-top-up `withLock` TTL is 5 minutes
- [x] `catalog variant updates must target the latest base version`
- [ ] Worker `ChangeMessageVisibility` for `JobName.AutoTopUp` only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecef442c-3fa9-4b1f-a257-4859e8a6dbbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecef442c-3fa9-4b1f-a257-4859e8a6dbbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate auto top-ups by extending the billing lock and SQS visibility. Previously: 60s Redis billing lock and 30s SQS visibility allowed the same message to re-run mid-Stripe charge; now: 5-minute lock and 3-hour visibility to hold the message until Stripe completes.

- Lock TTL: 60s → 5 minutes (`ttlMs: ms.minutes(5)`).
- SQS visibility for `JobName.AutoTopUp`: 30s queue default → 3 hours via `ChangeMessageVisibilityCommand` on receive (`visibilityTimeoutSeconds: seconds.hours(3)` from `@autumn/shared`).
- Scope: only affects `JobName.AutoTopUp`; worker processing timeout (25s) and ack behavior unchanged.
- Side effects: on crash, the message stays hidden for up to 3 hours; lock-contention retries of the same message may wait up to 3 hours instead of ~30s.
- Tests: integration test asserts the 5-minute lock TTL; catalog unit fixture marks the base plan `active` to match `validateCatalogVariantVersionTargets`.

<sup>Written for commit 795e9a34832b4939d89e5af4c2bdeb735e1b3a49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces duplicate auto-top-up risk by lengthening the customer billing lock and keeping received auto-top-up messages hidden from SQS for three hours.

- **Bug fixes:** Extends the auto-top-up Redis lock from one minute to five minutes.
- **Bug fixes:** Extends SQS visibility for auto-top-up messages to three hours before processing.
- **Improvements:** Updates lock-TTL coverage and corrects the catalog validation fixture.
- **Improvements:** Visibility-extension failures should be logged so stalled auto-top-ups can be diagnosed.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking observability gap when the new SQS visibility request fails.

The lock and visibility changes address concurrent redelivery, but a rejected visibility-extension request prevents that auto-top-up from running and is silently discarded by the batch-settlement diagnostics.

**Files Needing Attention:** server/src/queue/initWorkers.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/autoTopUp/autoTopup.ts | Extends the fixed auto-top-up billing lock to five minutes and adds a focused TTL assertion. |
| server/src/queue/initWorkers.ts | Adds per-job SQS visibility overrides for auto-top-ups, but failures in the new visibility request are silently retained for redelivery. |
| server/tests/integration/balances/auto-topup/auto-topup-lock-retry-suppression.test.ts | Verifies the new five-minute lock TTL while preserving existing suppression behavior. |
| server/tests/unit/catalog/validateCatalogVariantUpdates.test.ts | Marks the base-plan fixture active so it satisfies current catalog validation preconditions. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant SQS
  participant Worker
  participant Redis
  participant Stripe
  SQS->>Worker: Receive AutoTopUp
  Worker->>SQS: Set visibility to 3 hours
  Worker->>Redis: Acquire 5-minute billing lock
  Worker->>Stripe: Execute charge
  Stripe-->>Worker: Billing result
  Worker->>Redis: Record attempt and release lock
  Worker->>SQS: Delete message
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/queue/initWorkers.ts:335-343
**Visibility failures lack diagnostics**

A rejected `ChangeMessageVisibility` request prevents the auto-top-up from being processed, while the surrounding `Promise.allSettled` path silently leaves it for redelivery. Logging this rejection would make stalled auto-top-ups diagnosable, such as when the worker lacks the required permission.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(catalog): mark fixture base plan ac..."](https://github.com/useautumn/autumn/commit/795e9a34832b4939d89e5af4c2bdeb735e1b3a49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55548438)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->