### PR TITLE
feat(migrations): match plan-item filters on live included grants

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -87,7 +87,10 @@ const useLocalAuthUrls = viteAppEnv === "dev" && !isProductionMode;
 const LOCAL_MISC_CACHE_URL = "redis://localhost:6379";
 const LOCAL_CACHE_V2_URL = "redis://localhost:6380";
 const useLocalMiscCache =
-	viteAppEnv === "dev" && !isProductionMode && worktreeNum === 1;
+	viteAppEnv === "dev" &&
+	!isProductionMode &&
+	worktreeNum === 1 &&
+	!process.env.CACHE_V2_DRAGONFLY_URL;
 const localUrl = (value: string | undefined, fallback: string) =>
 	value && !value.includes(".useautumn.com") ? value : fallback;
 const AUTUMN_API_URL = useLocalAuthUrls

--- a/scripts/dw/helpers/compose.ts
+++ b/scripts/dw/helpers/compose.ts
@@ -39,9 +39,8 @@ function composeEnv(worktreeNum: number): Record<string, string> {
 
 export function ensureComposeStack(
 	worktreeNum: number,
-	branchName: string | undefined,
+	_branchName: string | undefined,
 ): void {
-	if (worktreeNum === 1 && !branchName) return;
 	if (!dockerComposeAvailable()) {
 		log("docker compose not available; skipping infra stack");
 		return;
@@ -81,9 +80,8 @@ function composeDown(project: string, extra: string[] = []): number {
 
 export function removeComposeStack(
 	worktreeNum: number,
-	branchName: string | undefined,
+	_branchName: string | undefined,
 ): void {
-	if (worktreeNum === 1 && !branchName) return;
 	const project = composeProjectName(worktreeNum);
 	if (composeDown(project, ["-v"]) === 0) {
 		log(`removed compose stack ${project}`);

--- a/scripts/dw/helpers/env-files.ts
+++ b/scripts/dw/helpers/env-files.ts
@@ -97,6 +97,7 @@ export function provisionedInfraEnv(
 		REDIS_URL: redisUrl,
 		MISC_CACHE_DRAGONFLY_PUBLIC_URL: redisUrl,
 		CACHE_V2_DRAGONFLY_URL: redisUrl,
+		CACHE_V2_DRAGONFLY_PUBLIC_URL: redisUrl,
 		DYNAMODB_ENDPOINT: `http://localhost:${dynamoDbPortFor(worktreeNum)}`,
 		SQS_QUEUE_URL: queueUrl("autumn.fifo"),
 		SQS_QUEUE_URL_V2: queueUrl("autumn.fifo"),

--- a/scripts/dw/helpers/ports.test.ts
+++ b/scripts/dw/helpers/ports.test.ts
@@ -2,12 +2,26 @@ import { describe, expect, test } from "bun:test";
 import {
 	appPortsFor,
 	checkoutPortFor,
+	dragonflyPortFor,
+	dynamoDbPortFor,
+	elasticMqPortFor,
 	EMULATE_PORT,
 	leafPortFor,
 	ngrokApiPortFor,
 	serverPortFor,
 	vitePortFor,
 } from "./ports.ts";
+
+describe("compose ports", () => {
+	test("worktree 1 does not publish onto bun d 6379/8000", () => {
+		expect(dragonflyPortFor(1)).not.toBe(6379);
+		expect(dragonflyPortFor(1)).not.toBe(6380);
+		expect(dynamoDbPortFor(1)).not.toBe(8000);
+		expect(dragonflyPortFor(2)).toBe(6479);
+		expect(elasticMqPortFor(2)).toBe(9424);
+		expect(dynamoDbPortFor(2)).toBe(8100);
+	});
+});
 
 describe("appPortsFor", () => {
 	test("recycles app servers only — not cloudflared or emulate", () => {

--- a/scripts/dw/helpers/ports.ts
+++ b/scripts/dw/helpers/ports.ts
@@ -1,23 +1,31 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { MAX_WORKTREE } from "../constants.ts";
 import type { WorktreeAliases } from "../types.ts";
 import { log, sh } from "./shell.ts";
 
 const PORTLESS_PROXY_PORT_FILE = join(homedir(), ".portless", "proxy.port");
 
+/** bun d owns 6379/6380/8000. wt-1 compose sits past slot 50. */
+const worktree1ComposeSlot = MAX_WORKTREE + 1;
+
+function composeSlot(worktreeNum: number): number {
+	return worktreeNum === 1 ? worktree1ComposeSlot : worktreeNum;
+}
+
 export function dragonflyPortFor(worktreeNum: number): number {
-	return 6379 + (worktreeNum - 1) * 100;
+	return 6379 + (composeSlot(worktreeNum) - 1) * 100;
 }
 
 export function elasticMqPortFor(worktreeNum: number): number {
-	return 9324 + (worktreeNum - 1) * 100;
+	return 9324 + (composeSlot(worktreeNum) - 1) * 100;
 }
 
 // DynamoDB Local's default port. Base 8000 never collides with the server's
 // 8080 base: 8000 + k*100 and 8080 + k*100 stay 80 apart for every worktree.
 export function dynamoDbPortFor(worktreeNum: number): number {
-	return 8000 + (worktreeNum - 1) * 100;
+	return 8000 + (composeSlot(worktreeNum) - 1) * 100;
 }
 
 export function serverPortFor(worktreeNum: number): number {

--- a/scripts/dw/helpers/start.ts
+++ b/scripts/dw/helpers/start.ts
@@ -33,6 +33,7 @@ function applyLocalInfra(
 	const next = { ...env };
 	const infra = provisionedInfraEnv(worktreeNum);
 	Object.assign(next, infra);
+	delete next.MISC_CACHE_DRAGONFLY_PRIVATE_URL;
 	for (const key of Object.keys(next)) {
 		if (key.includes("SQS_QUEUE_URL") && !(key in infra)) delete next[key];
 	}

--- a/scripts/tw/worker/boot.ts
+++ b/scripts/tw/worker/boot.ts
@@ -296,13 +296,15 @@ const main = async (): Promise<void> => {
 	const repoRoot = process.cwd();
 	const serverPort = resolveServerPort();
 
-	const { TEST_ORG_CONFIG } = await import(
-		"../../setupTestUtils/createTestOrg.js"
-	);
-	const orgId =
-		process.env.ORG_ID && process.env.ORG_ID.length > 0
-			? process.env.ORG_ID
-			: TEST_ORG_CONFIG.id;
+	// ORG_ID is always injected at fork. Do not import createTestOrg here —
+	// that pulls initLogger → @autumn/logging before a stale-warm bun install
+	// can link newly added workspace packages.
+	const orgId = process.env.ORG_ID;
+	if (!orgId) {
+		throw new Error(
+			"[tw-boot] ORG_ID is required — the orchestrator must inject the test org id",
+		);
+	}
 
 	const stripeAccountId = process.env.STRIPE_ACCOUNT_ID;
 	if (!stripeAccountId) {

--- a/scripts/tw/worker/freestyleBoot.ts
+++ b/scripts/tw/worker/freestyleBoot.ts
@@ -50,13 +50,12 @@ const resolveServerPort = (): number => {
 const main = async (): Promise<void> => {
 	const serverPort = resolveServerPort();
 
-	const { TEST_ORG_CONFIG } = await import(
-		"../../setupTestUtils/createTestOrg.js"
-	);
-	const orgId =
-		process.env.ORG_ID && process.env.ORG_ID.length > 0
-			? process.env.ORG_ID
-			: TEST_ORG_CONFIG.id;
+	const orgId = process.env.ORG_ID;
+	if (!orgId) {
+		throw new Error(
+			"[tw-fsboot] ORG_ID is required — the orchestrator must inject the test org id",
+		);
+	}
 
 	const stripeAccountId = process.env.STRIPE_ACCOUNT_ID;
 	if (!stripeAccountId) {

--- a/server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts
+++ b/server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts
@@ -3,12 +3,47 @@ import {
 	type CustomizePlanV1,
 	type Feature,
 	type FullCusProduct,
+	type FullCustomerEntitlement,
+	type FullProduct,
+	type SharedContext,
 	findCustomerEntitlementByFeature,
 	findFeatureById,
 	isBooleanFeature,
+	keepAddEntitlementPricesForLiveRemoves,
 } from "@autumn/shared";
+import { planItemV1ToPriceAndEnt } from "@shared/api/products/items/mappers/planItemV1ToPriceAndEnt";
+import { planItemFilterMatchesCustomerPair } from "@shared/api/products/items/utils/match";
 
-const isNoopAddItem = ({
+const addItemToEntitlementPrice = ({
+	ctx,
+	item,
+	fullProduct,
+}: {
+	ctx: SharedContext;
+	item: CreatePlanItemParamsV1;
+	fullProduct: Pick<FullProduct, "org_id" | "internal_id">;
+}) => {
+	const { newPrice, newEnt } = planItemV1ToPriceAndEnt({
+		ctx,
+		item,
+		orgId: fullProduct.org_id,
+		internalProductId: fullProduct.internal_id,
+		isCustom: true,
+	});
+	const feature = findFeatureById({
+		features: ctx.features,
+		featureId: item.feature_id,
+		errorOnNotFound: true,
+	});
+	if (!newEnt) return undefined;
+
+	return {
+		entitlement: { ...newEnt, feature },
+		price: newPrice ?? undefined,
+	};
+};
+
+const isBooleanAlreadyPresent = ({
 	item,
 	targetCustomerProduct,
 	features,
@@ -16,12 +51,11 @@ const isNoopAddItem = ({
 	item: CreatePlanItemParamsV1;
 	targetCustomerProduct: FullCusProduct;
 	features: Feature[];
-}): boolean => {
+}) => {
 	const feature = findFeatureById({
 		features,
 		featureId: item.feature_id,
 	});
-
 	if (!feature || !isBooleanFeature({ feature })) return false;
 
 	return Boolean(
@@ -33,24 +67,51 @@ const isNoopAddItem = ({
 };
 
 export const handleCustomizeNoopItems = ({
+	ctx,
 	customize,
 	targetCustomerProduct,
-	features,
+	deletedCustomerEntitlements,
+	fullProduct,
 }: {
+	ctx: SharedContext;
 	customize: CustomizePlanV1;
 	targetCustomerProduct: FullCusProduct;
-	features: Feature[];
+	deletedCustomerEntitlements: FullCustomerEntitlement[];
+	fullProduct: Pick<FullProduct, "org_id" | "internal_id">;
 }): {
 	addItems: CreatePlanItemParamsV1[];
 } => {
-	const addItems = (customize.add_items ?? []).filter(
-		(item) =>
-			!isNoopAddItem({
-				item,
-				targetCustomerProduct,
-				features,
-			}),
+	const addItems = customize.add_items ?? [];
+	const addEntitlementPrices = addItems.map((item) =>
+		addItemToEntitlementPrice({ ctx, item, fullProduct }),
 	);
 
-	return { addItems };
+	const pairable = addEntitlementPrices.filter(
+		(entitlementPrice) => entitlementPrice !== undefined,
+	);
+	const kept = new Set(
+		keepAddEntitlementPricesForLiveRemoves({
+			removeItems: customize.remove_items ?? [],
+			addEntitlementPrices: pairable,
+			removeFilterMatchedLive: ({ filter }) =>
+				deletedCustomerEntitlements.some((customerEntitlement) =>
+					planItemFilterMatchesCustomerPair({
+						filter,
+						customerEntitlement,
+					}),
+				),
+		}),
+	);
+
+	return {
+		addItems: addItems.filter((item, index) => {
+			const entitlementPrice = addEntitlementPrices[index];
+			if (entitlementPrice && !kept.has(entitlementPrice)) return false;
+			return !isBooleanAlreadyPresent({
+				item,
+				targetCustomerProduct,
+				features: ctx.features,
+			});
+		}),
+	};
 };

--- a/server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts
+++ b/server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts
@@ -4,7 +4,9 @@ import {
 	type Feature,
 	type FullCusProduct,
 	type FullCustomerEntitlement,
+	type FullCustomerPrice,
 	type FullProduct,
+	type PlanItemFilter,
 	type SharedContext,
 	findCustomerEntitlementByFeature,
 	findFeatureById,
@@ -13,6 +15,7 @@ import {
 } from "@autumn/shared";
 import { planItemV1ToPriceAndEnt } from "@shared/api/products/items/mappers/planItemV1ToPriceAndEnt";
 import { planItemFilterMatchesCustomerPair } from "@shared/api/products/items/utils/match";
+import { customerPriceToCustomerEntitlement } from "@shared/utils/cusPriceUtils/convertCustomerPrice/customerPriceToCustomerEntitlement";
 
 const addItemToEntitlementPrice = ({
 	ctx,
@@ -43,6 +46,42 @@ const addItemToEntitlementPrice = ({
 	};
 };
 
+const filterMatchedDeletedPair = ({
+	filter,
+	deletedCustomerPrices,
+	deletedCustomerEntitlements,
+}: {
+	filter: PlanItemFilter;
+	deletedCustomerPrices: FullCustomerPrice[];
+	deletedCustomerEntitlements: FullCustomerEntitlement[];
+}) => {
+	if (
+		deletedCustomerPrices.some((customerPrice) =>
+			planItemFilterMatchesCustomerPair({
+				filter,
+				customerPrice,
+				customerEntitlement: customerPriceToCustomerEntitlement({
+					customerPrice,
+					customerEntitlements: deletedCustomerEntitlements,
+				}),
+			}),
+		)
+	)
+		return true;
+
+	return deletedCustomerEntitlements.some((customerEntitlement) =>
+		planItemFilterMatchesCustomerPair({
+			filter,
+			customerEntitlement,
+			customerPrice: deletedCustomerPrices.find(
+				(customerPrice) =>
+					customerPrice.price.entitlement_id ===
+					customerEntitlement.entitlement.id,
+			),
+		}),
+	);
+};
+
 const isBooleanAlreadyPresent = ({
 	item,
 	targetCustomerProduct,
@@ -70,12 +109,14 @@ export const handleCustomizeNoopItems = ({
 	ctx,
 	customize,
 	targetCustomerProduct,
+	deletedCustomerPrices,
 	deletedCustomerEntitlements,
 	fullProduct,
 }: {
 	ctx: SharedContext;
 	customize: CustomizePlanV1;
 	targetCustomerProduct: FullCusProduct;
+	deletedCustomerPrices: FullCustomerPrice[];
 	deletedCustomerEntitlements: FullCustomerEntitlement[];
 	fullProduct: Pick<FullProduct, "org_id" | "internal_id">;
 }): {
@@ -94,12 +135,11 @@ export const handleCustomizeNoopItems = ({
 			removeItems: customize.remove_items ?? [],
 			addEntitlementPrices: pairable,
 			removeFilterMatchedLive: ({ filter }) =>
-				deletedCustomerEntitlements.some((customerEntitlement) =>
-					planItemFilterMatchesCustomerPair({
-						filter,
-						customerEntitlement,
-					}),
-				),
+				filterMatchedDeletedPair({
+					filter,
+					deletedCustomerPrices,
+					deletedCustomerEntitlements,
+				}),
 		}),
 	);
 

--- a/server/src/internal/billing/v2/setup/patch/setupPatchContext.ts
+++ b/server/src/internal/billing/v2/setup/patch/setupPatchContext.ts
@@ -187,9 +187,11 @@ export const setupPatchContext = ({
 	patchFullProduct.prices.push(...updateNewPrices, ...customPricePrices);
 
 	const { addItems: nonNoopAddItems } = handleCustomizeNoopItems({
+		ctx,
 		customize,
 		targetCustomerProduct: finalCustomerProduct,
-		features: ctx.features,
+		deletedCustomerEntitlements: deleteCustomerEntitlements,
+		fullProduct: patchFullProduct,
 	});
 
 	const { prices: customItemPrices, entitlements: customEntitlements } =

--- a/server/src/internal/billing/v2/setup/patch/setupPatchContext.ts
+++ b/server/src/internal/billing/v2/setup/patch/setupPatchContext.ts
@@ -190,6 +190,7 @@ export const setupPatchContext = ({
 		ctx,
 		customize,
 		targetCustomerProduct: finalCustomerProduct,
+		deletedCustomerPrices: deleteCustomerPrices,
 		deletedCustomerEntitlements: deleteCustomerEntitlements,
 		fullProduct: patchFullProduct,
 	});

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseEffectiveMigratableCustomize.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveLicenseMigrationTarget/licenseEffectiveMigratableCustomize.ts
@@ -2,6 +2,7 @@ import {
 	diffPlanV1,
 	type FullProductWithoutLicenses,
 	type LicenseCustomize,
+	PlanItemFilterPrecision,
 } from "@autumn/shared";
 import { toMigratableCustomize } from "@/internal/catalogV2/actions/buildMigrationDraft/toMigratableCustomize";
 import { fullProductToApiPlanV1Sync } from "@/internal/catalogV2/actions/buildPlanChange";
@@ -18,6 +19,7 @@ export const licenseEffectiveMigratableCustomize = ({
 		customize: diffPlanV1({
 			from: fullProductToApiPlanV1Sync({ product: fromProduct }),
 			to: fullProductToApiPlanV1Sync({ product: toProduct }),
+			filterPrecision: PlanItemFilterPrecision.IdentityAndIncluded,
 		}),
 	});
 	const { price, add_items, remove_items } = customize;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveOwnMigrationTarget.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/resolveOwnMigrationTarget.ts
@@ -1,6 +1,7 @@
 import {
 	diffPlanV1,
 	planDiffHasBillingChanges,
+	PlanItemFilterPrecision,
 	toBasePriceParams,
 	type UpdateCatalogParams,
 } from "@autumn/shared";
@@ -40,7 +41,11 @@ export const resolveOwnMigrationTarget = ({
 	const toPlan = fullProductToApiPlanV1Sync({ product: nextFullProduct });
 
 	const customize = toMigratableCustomize({
-		customize: diffPlanV1({ from: fromPlan, to: toPlan }),
+		customize: diffPlanV1({
+			from: fromPlan,
+			to: toPlan,
+			filterPrecision: PlanItemFilterPrecision.IdentityAndIncluded,
+		}),
 	});
 	if (Object.keys(customize).length === 0) return null;
 

--- a/server/src/internal/migrations/v2/batchOperations/actions/removeLicenseEntitlementsForPage/removeLicenseEntitlementRows.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/removeLicenseEntitlementsForPage/removeLicenseEntitlementRows.ts
@@ -50,6 +50,10 @@ export const removeLicenseEntitlementRows = async ({
 			? sql``
 			: sql`AND COALESCE(definition.interval, ${EntInterval.Lifetime}) = ${filter.interval}
 				AND COALESCE(definition.interval_count, 1) = ${filter.interval_count ?? 1}`;
+	const includedCondition =
+		filter.included === undefined
+			? sql``
+			: sql`AND definition.allowance = ${filter.included}`;
 
 	const removed = await db.execute<{
 		id: string;
@@ -78,6 +82,7 @@ export const removeLicenseEntitlementRows = async ({
 				AND definition.id = target.entitlement_id
 				AND definition.feature_id = ${filter.feature_id}
 				${intervalCondition}
+				${includedCondition}
 				AND assignment.internal_customer_id = page.internal_customer_id
 				AND assignment.internal_entity_id IS NOT NULL
 				AND assignment.status IN (${sqlList({ values: [...MIGRATABLE_STATUSES] })})

--- a/server/src/internal/migrations/v2/batchOperations/actions/utils/resolveFilterEntitlementIds.ts
+++ b/server/src/internal/migrations/v2/batchOperations/actions/utils/resolveFilterEntitlementIds.ts
@@ -27,8 +27,12 @@ export const entitlementPriceFilterSql = ({
 		filter.interval_count === undefined
 			? sql``
 			: sql`AND COALESCE(definition.interval_count, 1) = ${filter.interval_count}`;
+	const included =
+		filter.included === undefined
+			? sql``
+			: sql`AND definition.allowance = ${filter.included}`;
 
-	return sql`${featureId} ${interval} ${intervalCount}`;
+	return sql`${featureId} ${interval} ${intervalCount} ${included}`;
 };
 
 /** Distinct live entitlement ids whose compiled filter matches.

--- a/server/src/internal/migrations/v2/batchOperations/compute/transitions/planItemFilterToEntitlementPriceFilter.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/transitions/planItemFilterToEntitlementPriceFilter.ts
@@ -25,6 +25,9 @@ export const planItemFilterToEntitlementPriceFilter = ({
 	} else if (filter.interval_count !== undefined) {
 		compiled.interval_count = filter.interval_count;
 	}
+	if (filter.included !== undefined) {
+		compiled.included = filter.included;
+	}
 
 	return compiled;
 };

--- a/server/src/internal/migrations/v2/batchOperations/compute/transitions/resolveTargetFullProduct.ts
+++ b/server/src/internal/migrations/v2/batchOperations/compute/transitions/resolveTargetFullProduct.ts
@@ -35,6 +35,12 @@ const matchesRemoveFilter = ({
 	) {
 		return false;
 	}
+	if (
+		filter.included !== undefined &&
+		entitlement.allowance !== filter.included
+	) {
+		return false;
+	}
 	return true;
 };
 

--- a/server/src/internal/migrations/v2/batchOperations/types/entitlementPriceFilter.ts
+++ b/server/src/internal/migrations/v2/batchOperations/types/entitlementPriceFilter.ts
@@ -15,6 +15,7 @@ export const EntitlementPriceFilterSchema = z.object({
 	interval: z.nativeEnum(EntInterval).optional(),
 	interval_count: z.number().int().positive().optional(),
 	billing_method: z.nativeEnum(BillingMethod).optional(),
+	included: z.number().optional(),
 });
 
 export type EntitlementPriceFilter = z.infer<
@@ -55,6 +56,13 @@ export const entitlementPriceFilterMatchesEntitlementPrice = ({
 	if (
 		filter.interval_count !== undefined &&
 		(entitlement.interval_count ?? 1) !== filter.interval_count
+	) {
+		return false;
+	}
+
+	if (
+		filter.included !== undefined &&
+		entitlement.allowance !== filter.included
 	) {
 		return false;
 	}

--- a/server/src/internal/migrations/v2/webhookDelivery/utils/queueMigrationWebhooks.ts
+++ b/server/src/internal/migrations/v2/webhookDelivery/utils/queueMigrationWebhooks.ts
@@ -51,11 +51,7 @@ export const queueMigrationWebhooks = async ({
 			records: batch,
 		};
 
-		const missingLocalTriggerBranch =
-			process.env.NODE_ENV !== "production" &&
-			!process.env.TRIGGER_DEV_BRANCH?.trim();
-		// Tests inherit the DEV key but not the local worker's preview branch.
-		if (!isTriggerConfigured() || missingLocalTriggerBranch) {
+		if (!isTriggerConfigured()) {
 			await sendMigrationWebhooks({ ctx, payload });
 			continue;
 		}

--- a/server/src/trigger/configureTrigger.ts
+++ b/server/src/trigger/configureTrigger.ts
@@ -20,13 +20,17 @@ if (process.env.TRIGGER_SERVER_SECRET_KEY) {
 		// Must match `bunx trigger.dev dev --branch` from scripts/dev.ts —
 		// otherwise local triggers land on `default` while the worker listens
 		// on the isolated branch and never receives them.
-		...(previewBranch && previewBranch !== "default"
-			? { previewBranch }
-			: {}),
+		...(previewBranch && previewBranch !== "default" ? { previewBranch } : {}),
 	});
 }
 
-/** Whether autumn's trigger.dev key is configured — check THIS, never
- * `TRIGGER_SECRET_KEY` (that name belongs to autumn-cloud). */
-export const isTriggerConfigured = (): boolean =>
-	Boolean(process.env.TRIGGER_SERVER_SECRET_KEY);
+/** True when we can enqueue onto autumn's Trigger project.
+ * Workers inject `TRIGGER_SECRET_KEY`; local/non-prod also needs `TRIGGER_DEV_BRANCH`. */
+export const isTriggerConfigured = (): boolean => {
+	const hasAutumnKey = Boolean(process.env.TRIGGER_SERVER_SECRET_KEY);
+	const hasInjectedKey = Boolean(process.env.TRIGGER_SECRET_KEY);
+	if (!hasAutumnKey && !hasInjectedKey) return false;
+
+	if (process.env.NODE_ENV === "production") return true;
+	return Boolean(process.env.TRIGGER_DEV_BRANCH?.trim());
+};

--- a/server/tests/_groups/temp.ts
+++ b/server/tests/_groups/temp.ts
@@ -1,18 +1,13 @@
 import type { TestGroup } from "./types";
 
 const activeTempPaths: string[] = [
-	"integration/billing/migrations-v2/batch-migrations/licenses/batch-license-customize-priced-base-item.test.ts",
-	"integration/billing/migrations-v2/batch-migrations/licenses/batch-license-released-seat-pool-repoint.test.ts",
-	"integration/billing/migrations-v2/batch-migrations/licenses/list-distinct-license-entitlements-for-page.test.ts",
-	"integration/billing/migrations-v2/batch-migrations/licenses/batch-license-over-allocated-pool.test.ts",
-	"integration/billing/migrations-v2/batch-migrations/replace-items/batch-replace-item-events-webhooks.test.ts",
-	"integration/billing/migrations-v2/batch-migrations/remove-items/batch-delete-item-events-webhooks.test.ts",
-	"integration/billing/migrations-v2/batch-migrations/version-repoint/events/version-repoint-webhooks-cache.test.ts",
+	"integration/billing/migrations-v2/batch-migrations/version-repoint/parity/version-repoint-parity-trial.test.ts",
+	"integration/billing/migrations-v2/batch-migrations/version-repoint/parity/version-repoint-parity-add-remove-replace.test.ts",
 ];
 
 export const temp: TestGroup = {
 	name: "temp",
-	description: "Remaining batch-migration integration failures",
+	description: "This round: parity-trial + parity-add-remove-replace",
 	tier: "domain",
 	paths: activeTempPaths,
 	maxConcurrency: 2,

--- a/server/tests/_groups/temp.ts
+++ b/server/tests/_groups/temp.ts
@@ -1,13 +1,17 @@
 import type { TestGroup } from "./types";
 
 const activeTempPaths: string[] = [
-	"integration/billing/migrations-v2/batch-migrations/version-repoint/parity/version-repoint-parity-trial.test.ts",
-	"integration/billing/migrations-v2/batch-migrations/version-repoint/parity/version-repoint-parity-add-remove-replace.test.ts",
+	"integration/billing/migrations-v2/update-plan-operation/feature-quantity-strategy/round-to-lowest-price-topology.test.ts",
+	"integration/billing/migrations-v2/update-plan-operation/feature-quantity-strategy/round-to-lowest-price-below-cheapest-tier.test.ts",
+	"integration/billing/migrations-v2/update-plan-operation/feature-quantity-strategy/end-to-end-multi-feature-isolation.test.ts",
+	"integration/billing/migrations-v2/update-plan-operation/feature-quantity-strategy/base-tier-bump-regression.test.ts",
+	"integration/billing/migrations-v2/update-plan-operation/feature-quantity-strategy/round-to-lowest-price-baseline.test.ts",
+	"integration/billing/migrations-v2/update-plan-operation/feature-quantity-strategy/end-to-end-multi-entity-schedule-usage.test.ts",
 ];
 
 export const temp: TestGroup = {
 	name: "temp",
-	description: "This round: parity-trial + parity-add-remove-replace",
+	description: "This round: FQS update_plan failures after included-filter pairing",
 	tier: "domain",
 	paths: activeTempPaths,
 	maxConcurrency: 2,

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/in-place/batch-in-place-catalog-migrate.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/in-place/batch-in-place-catalog-migrate.test.ts
@@ -1,0 +1,465 @@
+/**
+ * In-place catalog edit (disable_version) then batch-migrate attached customers.
+ *
+ * Dashboard flow: rewrite the live version, keep existing rows on the retired
+ * entitlement, then run the auto-draft so customers catch up.
+ *
+ * Contract:
+ *   mixed/replace: 100/mo → 200/mo, used 3 → remaining 197, one messages row,
+ *     no leftover 100 row, dashboard survives
+ *   delete: drop messages/mo → zero messages rows, dashboard survives
+ *   add: keep 100/mo, add words once → original messages row + one words row
+ *
+ * C14 (catalog already 30, live 10 → remaining 27) lives in
+ * batch-replace-item-in-place.test.ts — not duplicated here.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiCustomerV5,
+	MigrationItemRunStatus,
+	type UpdatePlanParamsV2Input,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import {
+	type PollableExpectParams,
+	pollableCustomerExpect,
+} from "@tests/utils/pollableCustomerExpect";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { runMigrationInChunks } from "@/internal/migrations/v2/run/runMigrationInChunks.js";
+import { generateId } from "@/utils/genUtils.js";
+import {
+	expectCustomerEntitlementRowCount,
+	expectMigrationItemRunStatus,
+	type ScenarioCtx,
+} from "../batchTestUtils";
+import {
+	expectReplacedFeatureRowCorrect,
+	setScopedFeatureBalance,
+} from "../paidRowTestUtils";
+import { expectBatchLane } from "../version-repoint/utils/versionRepointTestUtils";
+
+const MESSAGES_INCLUDED = 100;
+const NEW_MESSAGES_INCLUDED = 200;
+const CONSUMED = 3;
+const WORDS_INCLUDED = 50;
+
+const dashboardAndMessages = [
+	itemsV2.dashboard(),
+	itemsV2.monthlyMessages(),
+] as const;
+
+type InPlaceItems = UpdatePlanParamsV2Input["items"];
+
+const expectBalanceAbsent = pollableCustomerExpect({
+	fetchCustomer: ({
+		customerId,
+		autumn,
+	}: PollableExpectParams<ApiCustomerV5> & { featureId: string }) =>
+		autumn!.customers.get<ApiCustomerV5>(customerId!),
+	assert: ({
+		customer,
+		featureId,
+	}: PollableExpectParams<ApiCustomerV5> & {
+		customer: ApiCustomerV5;
+		featureId: string;
+	}) => {
+		expect(customer.balances[featureId]).toBeUndefined();
+	},
+});
+
+const seedAttachedPlan = async ({
+	customerId,
+	otherCustomerId,
+	planId,
+}: {
+	customerId: string;
+	otherCustomerId: string;
+	planId: string;
+}) => {
+	const plan = products.base({
+		id: planId,
+		items: [
+			items.dashboard(),
+			items.monthlyMessages({ includedUsage: MESSAGES_INCLUDED }),
+		],
+	});
+
+	const scenario = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.otherCustomers([{ id: otherCustomerId }]),
+			s.products({ list: [plan] }),
+		],
+		actions: [
+			s.parallel(
+				s.billing.attach({ productId: plan.id }),
+				s.billing.attach({
+					customerId: otherCustomerId,
+					productId: plan.id,
+				}),
+			),
+		],
+	});
+
+	return { ...scenario, plan, customerIds: [customerId, otherCustomerId] };
+};
+
+const updatePlanInPlace = async ({
+	autumn,
+	planId,
+	items: nextItems,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+	items: InPlaceItems;
+}) => {
+	const body: UpdatePlanParamsV2Input = {
+		plan_id: planId,
+		disable_version: true,
+		migration: { draft: true },
+		items: nextItems,
+	};
+	const response = (await autumn.post("/plans.update", body)) as {
+		migration?: { id: string };
+		migrations?: { id: string }[];
+	};
+	const migrationId = response.migrations?.[0]?.id ?? response.migration?.id;
+	if (!migrationId) throw new Error(`expected a catalog draft for ${planId}`);
+	return migrationId;
+};
+
+const runCatalogDraft = async ({
+	ctx,
+	migrationId,
+}: {
+	ctx: ScenarioCtx;
+	migrationId: string;
+}) => {
+	const [migration] = await migrationRepo.get({ ctx, id: migrationId });
+	if (!migration) throw new Error(`Migration ${migrationId} not found`);
+	const migrationRunId = generateId("mrun");
+	const result = await runMigrationInChunks({
+		ctx,
+		migration,
+		migrationRunId,
+		dryRun: false,
+	});
+	return { migration, migrationRunId, result };
+};
+
+const expectRowCounts = async ({
+	ctx,
+	customerIds,
+	planId,
+	counts,
+}: {
+	ctx: ScenarioCtx;
+	customerIds: string[];
+	planId: string;
+	counts: Partial<Record<TestFeature, number>>;
+}) => {
+	for (const customerId of customerIds) {
+		for (const [featureId, count] of Object.entries(counts) as [
+			TestFeature,
+			number,
+		][]) {
+			await expectCustomerEntitlementRowCount({
+				ctx,
+				customerId,
+				planId,
+				featureId,
+				count,
+			});
+		}
+	}
+};
+
+const expectSucceededRuns = async ({
+	ctx,
+	migrationInternalId,
+	migrationRunId,
+	customerIds,
+}: {
+	ctx: ScenarioCtx;
+	migrationInternalId: string;
+	migrationRunId: string;
+	customerIds: string[];
+}) => {
+	for (const customerId of customerIds) {
+		await expectMigrationItemRunStatus({
+			ctx,
+			migrationInternalId,
+			migrationRunId,
+			customerId,
+			status: MigrationItemRunStatus.Succeeded,
+		});
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("in-place catalog: 100→200 then migrate carries remaining, no duplicate messages")}`,
+	async () => {
+		const customerId = "batch-inplace-replace";
+		const otherCustomerId = "batch-inplace-replace-b";
+		const { ctx, autumnV2_3, plan, customerIds } = await seedAttachedPlan({
+			customerId,
+			otherCustomerId,
+			planId: "batch-inplace-replace-plan",
+		});
+
+		const beforeByCustomer = new Map(
+			await Promise.all(
+				customerIds.map(async (id) => {
+					const before = await setScopedFeatureBalance({
+						ctx,
+						customerId: id,
+						featureId: TestFeature.Messages,
+						balance: MESSAGES_INCLUDED - CONSUMED,
+					});
+					return [id, before] as const;
+				}),
+			),
+		);
+
+		const migrationId = await updatePlanInPlace({
+			autumn: autumnV2_3,
+			planId: plan.id,
+			items: [
+				itemsV2.dashboard(),
+				itemsV2.monthlyMessages({ included: NEW_MESSAGES_INCLUDED }),
+			],
+		});
+
+		await expectRowCounts({
+			ctx,
+			customerIds,
+			planId: plan.id,
+			counts: { [TestFeature.Messages]: 1, [TestFeature.Dashboard]: 1 },
+		});
+		await expectBalanceCorrect({
+			customerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			remaining: MESSAGES_INCLUDED - CONSUMED,
+			usage: CONSUMED,
+			granted: MESSAGES_INCLUDED,
+			planId: plan.id,
+			breakdownCount: 1,
+		});
+
+		const { migration, migrationRunId, result } = await runCatalogDraft({
+			ctx,
+			migrationId,
+		});
+		expectBatchLane({ result });
+		await expectSucceededRuns({
+			ctx,
+			migrationInternalId: migration.internal_id,
+			migrationRunId,
+			customerIds,
+		});
+
+		const remaining = NEW_MESSAGES_INCLUDED - CONSUMED;
+		for (const id of customerIds) {
+			const before = beforeByCustomer.get(id);
+			if (!before) throw new Error(`missing before-row for ${id}`);
+			await expectReplacedFeatureRowCorrect({
+				ctx,
+				customerId: id,
+				featureId: TestFeature.Messages,
+				beforeRowId: before.id,
+				beforeEntitlementId: before.entitlement_id,
+				balance: remaining,
+			});
+			await expectCustomerProducts({
+				customerId: id,
+				autumn: autumnV2_3,
+				active: [plan.id],
+			});
+			await expectBalanceCorrect({
+				customerId: id,
+				autumn: autumnV2_3,
+				featureId: TestFeature.Messages,
+				remaining,
+				usage: CONSUMED,
+				granted: NEW_MESSAGES_INCLUDED,
+				planId: plan.id,
+				breakdownCount: 1,
+			});
+			const customer = await autumnV2_3.customers.get<ApiCustomerV5>(id);
+			expectFlagCorrect({
+				customer,
+				featureId: TestFeature.Dashboard,
+				planId: plan.id,
+			});
+		}
+		await expectRowCounts({
+			ctx,
+			customerIds,
+			planId: plan.id,
+			counts: { [TestFeature.Messages]: 1, [TestFeature.Dashboard]: 1 },
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("in-place catalog: delete messages then migrate drops the row, no leftover")}`,
+	async () => {
+		const customerId = "batch-inplace-delete";
+		const otherCustomerId = "batch-inplace-delete-b";
+		const { ctx, autumnV2_3, plan, customerIds } = await seedAttachedPlan({
+			customerId,
+			otherCustomerId,
+			planId: "batch-inplace-delete-plan",
+		});
+
+		const migrationId = await updatePlanInPlace({
+			autumn: autumnV2_3,
+			planId: plan.id,
+			items: [itemsV2.dashboard()],
+		});
+
+		await expectRowCounts({
+			ctx,
+			customerIds,
+			planId: plan.id,
+			counts: { [TestFeature.Messages]: 1, [TestFeature.Dashboard]: 1 },
+		});
+
+		const { migration, migrationRunId, result } = await runCatalogDraft({
+			ctx,
+			migrationId,
+		});
+		expectBatchLane({ result });
+		await expectSucceededRuns({
+			ctx,
+			migrationInternalId: migration.internal_id,
+			migrationRunId,
+			customerIds,
+		});
+
+		await expectRowCounts({
+			ctx,
+			customerIds,
+			planId: plan.id,
+			counts: { [TestFeature.Messages]: 0, [TestFeature.Dashboard]: 1 },
+		});
+		for (const id of customerIds) {
+			await expectCustomerProducts({
+				customerId: id,
+				autumn: autumnV2_3,
+				active: [plan.id],
+			});
+			await expectBalanceAbsent({
+				customerId: id,
+				autumn: autumnV2_3,
+				featureId: TestFeature.Messages,
+			});
+			const customer = await autumnV2_3.customers.get<ApiCustomerV5>(id);
+			expectFlagCorrect({
+				customer,
+				featureId: TestFeature.Dashboard,
+				planId: plan.id,
+			});
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("in-place catalog: add words then migrate keeps 100/mo and adds words once")}`,
+	async () => {
+		const customerId = "batch-inplace-add";
+		const otherCustomerId = "batch-inplace-add-b";
+		const { ctx, autumnV2_3, plan, customerIds } = await seedAttachedPlan({
+			customerId,
+			otherCustomerId,
+			planId: "batch-inplace-add-plan",
+		});
+
+		const migrationId = await updatePlanInPlace({
+			autumn: autumnV2_3,
+			planId: plan.id,
+			items: [
+				...dashboardAndMessages,
+				itemsV2.monthlyWords({ included: WORDS_INCLUDED }),
+			],
+		});
+
+		await expectRowCounts({
+			ctx,
+			customerIds,
+			planId: plan.id,
+			counts: {
+				[TestFeature.Messages]: 1,
+				[TestFeature.Dashboard]: 1,
+				[TestFeature.Words]: 0,
+			},
+		});
+
+		const { migration, migrationRunId, result } = await runCatalogDraft({
+			ctx,
+			migrationId,
+		});
+		expectBatchLane({ result });
+		await expectSucceededRuns({
+			ctx,
+			migrationInternalId: migration.internal_id,
+			migrationRunId,
+			customerIds,
+		});
+
+		await expectRowCounts({
+			ctx,
+			customerIds,
+			planId: plan.id,
+			counts: {
+				[TestFeature.Messages]: 1,
+				[TestFeature.Dashboard]: 1,
+				[TestFeature.Words]: 1,
+			},
+		});
+		for (const id of customerIds) {
+			await expectCustomerProducts({
+				customerId: id,
+				autumn: autumnV2_3,
+				active: [plan.id],
+			});
+			await expectBalanceCorrect({
+				customerId: id,
+				autumn: autumnV2_3,
+				featureId: TestFeature.Messages,
+				remaining: MESSAGES_INCLUDED,
+				usage: 0,
+				granted: MESSAGES_INCLUDED,
+				planId: plan.id,
+				breakdownCount: 1,
+			});
+			await expectBalanceCorrect({
+				customerId: id,
+				autumn: autumnV2_3,
+				featureId: TestFeature.Words,
+				remaining: WORDS_INCLUDED,
+				usage: 0,
+				granted: WORDS_INCLUDED,
+				planId: plan.id,
+				breakdownCount: 1,
+			});
+			const customer = await autumnV2_3.customers.get<ApiCustomerV5>(id);
+			expectFlagCorrect({
+				customer,
+				featureId: TestFeature.Dashboard,
+				planId: plan.id,
+			});
+		}
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/in-place/batch-in-place-included-filter.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/in-place/batch-in-place-included-filter.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Dashboard catalogV2 existing-version draft: 100→200 must rewrite the
+ * catalog grant and leave a customized 1k row alone.
+ *
+ * Contract (C2): catalog 100 → remaining 197 after consume 3; custom 1k
+ * untouched (same entitlement id and balance). Draft remove_items carry
+ * included: 100.
+ *
+ * Wildcard rewrite of 1k stays in batch-replace-item-custom-definitions.test.ts.
+ */
+
+import { expect, test } from "bun:test";
+import { ResetInterval, type UpdateCatalogResponse } from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { runMigrationInChunks } from "@/internal/migrations/v2/run/runMigrationInChunks.js";
+import { generateId } from "@/utils/genUtils.js";
+import {
+	expectFeatureRowUnchanged,
+	expectReplacedFeatureRowCorrect,
+	repointToCustomEntitlement,
+	setScopedFeatureBalance,
+} from "../paidRowTestUtils";
+import { expectBatchLane } from "../version-repoint/utils/versionRepointTestUtils";
+
+const CATALOG_ALLOWANCE = 100;
+const CUSTOM_1K_ALLOWANCE = 1000;
+const NEW_ALLOWANCE = 200;
+const CONSUMED = 3;
+
+test.concurrent(
+	`${chalk.yellowBright("in-place catalog: 100→200 draft spares a custom 1k row")}`,
+	async () => {
+		const catalogCustomerId = "batch-inplace-included-catalog";
+		const custom1kCustomerId = "batch-inplace-included-1k";
+		const plan = products.base({
+			id: "batch-inplace-included-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId: catalogCustomerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: custom1kCustomerId }]),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.parallel(
+					s.billing.attach({ productId: plan.id }),
+					s.billing.attach({
+						customerId: custom1kCustomerId,
+						productId: plan.id,
+					}),
+				),
+			],
+		});
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: CUSTOM_1K_ALLOWANCE },
+		});
+		await setScopedFeatureBalance({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+
+		const catalogBefore = await setScopedFeatureBalance({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CATALOG_ALLOWANCE - CONSUMED,
+		});
+		const custom1kBefore = await setScopedFeatureBalance({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+
+		const response = (await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: plan.id,
+					migration: { draft: true },
+					items: [
+						itemsV2.dashboard(),
+						itemsV2.monthlyMessages({ included: NEW_ALLOWANCE }),
+					],
+				},
+			],
+		})) as UpdateCatalogResponse;
+		const migrationId = response.migrations?.[0]?.id;
+		expect(migrationId).toBeDefined();
+
+		const [migration] = await migrationRepo.get({ ctx, id: migrationId });
+		expect(migration).toBeDefined();
+		const updatePlan = migration!.operations?.customer?.find(
+			(operation) => operation.type === "update_plan",
+		);
+		expect(updatePlan?.customize?.remove_items).toEqual([
+			{
+				feature_id: TestFeature.Messages,
+				interval: ResetInterval.Month,
+				interval_count: 1,
+				included: CATALOG_ALLOWANCE,
+			},
+		]);
+
+		const migrationRunId = generateId("mrun");
+		const result = await runMigrationInChunks({
+			ctx,
+			migration: migration!,
+			migrationRunId,
+			dryRun: false,
+		});
+		expectBatchLane({ result });
+
+		await expectReplacedFeatureRowCorrect({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: catalogBefore.id,
+			beforeEntitlementId: catalogBefore.entitlement_id,
+			balance: NEW_ALLOWANCE - CONSUMED,
+		});
+		await expectFeatureRowUnchanged({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: custom1kBefore.id,
+			beforeEntitlementId: custom1kBefore.entitlement_id,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+		await expectBalanceCorrect({
+			customerId: custom1kCustomerId,
+			autumn: autumnV2_3,
+			featureId: TestFeature.Messages,
+			granted: CUSTOM_1K_ALLOWANCE,
+			remaining: CUSTOM_1K_ALLOWANCE,
+			usage: 0,
+			planId: plan.id,
+			breakdownCount: 1,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/licenses/batch-license-item-included-filter.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/licenses/batch-license-item-included-filter.test.ts
@@ -1,0 +1,300 @@
+/**
+ * License customize replace with included: 100 rewrites catalog-shaped seat
+ * grants and leaves a customized 1k seat alone.
+ *
+ * Contract (L1 execute): assignment at 100 → 200 with consumption carried;
+ * assignment at 1k untouched.
+ * Unmatched 100→200 + leftover boolean: 1k seat spared, dashboard lands.
+ *
+ * Catalog draft stamp for the same delta lives in
+ * catalog-v2/plans/migrations/licenses/included-filter-drafts.test.ts.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	customerEntitlements,
+	entitlements,
+} from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { setupLicenseUpdateScenario } from "@tests/integration/licenses/billing/update/setupLicenseUpdateScenario";
+import { getLicenseDbState } from "@tests/integration/licenses/licenseTestUtils";
+import {
+	expectLicenseAssignmentFeaturePresent,
+	expectLicenseAssignmentMessagesCorrect,
+} from "@tests/integration/licenses/utils/expectLicenseAssignmentMessagesCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { pollUntil } from "@tests/utils/genUtils";
+import chalk from "chalk";
+import { and, eq, inArray } from "drizzle-orm";
+import { generateId } from "@/utils/genUtils.js";
+
+const SEAT_MESSAGES = 100;
+const CUSTOM_1K_ALLOWANCE = 1000;
+const NEW_SEAT_MESSAGES = 200;
+const INCLUDED_SEATS = 1;
+const ATTACHED_SEATS = 3;
+const ASSIGNED_SEATS = 2;
+const CONSUMED = 60;
+
+const repointAssignmentToCustomAllowance = async ({
+	db,
+	customerProductId,
+	allowance,
+}: {
+	db: Parameters<typeof getLicenseDbState>[0]["db"];
+	customerProductId: string;
+	allowance: number;
+}) => {
+	const [row] = await db
+		.select()
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.customer_product_id, customerProductId),
+				eq(customerEntitlements.feature_id, TestFeature.Messages),
+			),
+		);
+	if (!row) throw new Error(`expected messages row on ${customerProductId}`);
+
+	const [definition] = await db
+		.select()
+		.from(entitlements)
+		.where(eq(entitlements.id, row.entitlement_id));
+	if (!definition) throw new Error("expected entitlement definition");
+
+	const customId = generateId("ent");
+	await db.insert(entitlements).values({
+		...definition,
+		id: customId,
+		is_custom: true,
+		allowance,
+	});
+	await db
+		.update(customerEntitlements)
+		.set({ entitlement_id: customId, balance: allowance })
+		.where(eq(customerEntitlements.id, row.id));
+};
+
+test(`${chalk.yellowBright("batch-license-customize: included 100 rewrites catalog seats and spares 1k")}`, async () => {
+	const customerId = "batch-item-included-customer";
+	const idPrefix = "batch-item-included";
+
+	const scenario = await setupLicenseUpdateScenario({
+		customerId,
+		idPrefix,
+		seatItems: [items.monthlyMessages({ includedUsage: SEAT_MESSAGES })],
+		includedSeats: INCLUDED_SEATS,
+		attachedSeats: ATTACHED_SEATS,
+	});
+	await scenario.assignSeats({ count: ASSIGNED_SEATS });
+
+	const { ctx, autumnV2_3, parent, devSeat } = scenario;
+	const { assignments } = await getLicenseDbState({ db: ctx.db, customerId });
+	const liveAssignments = assignments.filter(
+		(assignment) => assignment.internal_entity_id,
+	);
+	expect(liveAssignments).toHaveLength(ASSIGNED_SEATS);
+
+	const catalogAssignmentId = liveAssignments[0]!.id;
+	const custom1kAssignmentId = liveAssignments[1]!.id;
+
+	await ctx.db
+		.update(customerEntitlements)
+		.set({ balance: SEAT_MESSAGES - CONSUMED })
+		.where(eq(customerEntitlements.customer_product_id, catalogAssignmentId));
+
+	await repointAssignmentToCustomAllowance({
+		db: ctx.db,
+		customerProductId: custom1kAssignmentId,
+		allowance: CUSTOM_1K_ALLOWANCE,
+	});
+
+	const { result } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_3,
+		migrationId: `${idPrefix}-migration`,
+		filter: { customer: { plan: { plan_id: parent.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: parent.id, custom: false },
+					customize: {
+						upsert_licenses: [
+							{
+								license_plan_id: devSeat.id,
+								customize: {
+									add_items: [
+										itemsV2.monthlyMessages({ included: NEW_SEAT_MESSAGES }),
+									],
+									remove_items: [
+										{
+											feature_id: TestFeature.Messages,
+											interval: BillingInterval.Month,
+											interval_count: 1,
+											included: SEAT_MESSAGES,
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+
+	expect(result?.lane).toBe("batch");
+
+	const readAssignmentBalance = async ({
+		customerProductId,
+	}: {
+		customerProductId: string;
+	}) => {
+		const [row] = await ctx.db
+			.select({
+				balance: customerEntitlements.balance,
+				entitlementId: customerEntitlements.entitlement_id,
+			})
+			.from(customerEntitlements)
+			.where(
+				and(
+					eq(customerEntitlements.customer_product_id, customerProductId),
+					eq(customerEntitlements.feature_id, TestFeature.Messages),
+				),
+			);
+		return row;
+	};
+
+	const catalogConverged = await pollUntil({
+		fetch: () => readAssignmentBalance({ customerProductId: catalogAssignmentId }),
+		until: (row) => row?.balance === NEW_SEAT_MESSAGES - CONSUMED,
+		timeoutMs: 15_000,
+		intervalMs: 250,
+	});
+	expect(catalogConverged?.balance).toBe(NEW_SEAT_MESSAGES - CONSUMED);
+
+	const custom1k = await readAssignmentBalance({
+		customerProductId: custom1kAssignmentId,
+	});
+	expect(custom1k?.balance).toBe(CUSTOM_1K_ALLOWANCE);
+
+	const allRows = await ctx.db
+		.select({ featureId: customerEntitlements.feature_id })
+		.from(customerEntitlements)
+		.where(
+			inArray(
+				customerEntitlements.customer_product_id,
+				liveAssignments.map((assignment) => assignment.id),
+			),
+		);
+	expect(
+		allRows.filter((row) => row.featureId === TestFeature.Messages),
+	).toHaveLength(ASSIGNED_SEATS);
+});
+
+test(`${chalk.yellowBright("batch-license-customize: unmatched 100→200 still adds boolean on 1k seat")}`, async () => {
+	const customerId = "batch-item-included-leftover";
+	const idPrefix = "batch-item-leftover";
+
+	const scenario = await setupLicenseUpdateScenario({
+		customerId,
+		idPrefix,
+		seatItems: [items.monthlyMessages({ includedUsage: SEAT_MESSAGES })],
+		includedSeats: INCLUDED_SEATS,
+		attachedSeats: ATTACHED_SEATS,
+	});
+	await scenario.assignSeats({ count: ASSIGNED_SEATS });
+
+	const { ctx, autumnV2_3, parent, devSeat } = scenario;
+	const { assignments } = await getLicenseDbState({ db: ctx.db, customerId });
+	const liveAssignments = assignments.filter(
+		(assignment) => assignment.internal_entity_id,
+	);
+	expect(liveAssignments).toHaveLength(ASSIGNED_SEATS);
+
+	const catalogAssignmentId = liveAssignments[0]!.id;
+	const custom1kAssignmentId = liveAssignments[1]!.id;
+
+	await repointAssignmentToCustomAllowance({
+		db: ctx.db,
+		customerProductId: custom1kAssignmentId,
+		allowance: CUSTOM_1K_ALLOWANCE,
+	});
+
+	const [custom1kBefore] = await ctx.db
+		.select({ entitlementId: customerEntitlements.entitlement_id })
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.customer_product_id, custom1kAssignmentId),
+				eq(customerEntitlements.feature_id, TestFeature.Messages),
+			),
+		);
+
+	const { result } = await runChunkedMigration({
+		ctx,
+		migrationClient: autumnV2_3,
+		migrationId: `${idPrefix}-migration`,
+		filter: { customer: { plan: { plan_id: parent.id, custom: false } } },
+		operations: {
+			customer: [
+				{
+					type: "update_plan",
+					plan_filter: { plan_id: parent.id, custom: false },
+					customize: {
+						upsert_licenses: [
+							{
+								license_plan_id: devSeat.id,
+								customize: {
+									add_items: [
+										itemsV2.monthlyMessages({ included: NEW_SEAT_MESSAGES }),
+										itemsV2.dashboard(),
+									],
+									remove_items: [
+										{
+											feature_id: TestFeature.Messages,
+											interval: BillingInterval.Month,
+											interval_count: 1,
+											included: SEAT_MESSAGES,
+										},
+									],
+								},
+							},
+						],
+					},
+				},
+			],
+		},
+		noBillingChanges: true,
+	});
+	expect(result?.lane).toBe("batch");
+
+	await expectLicenseAssignmentMessagesCorrect({
+		ctx,
+		customerProductId: catalogAssignmentId,
+		featureId: TestFeature.Messages,
+		balance: NEW_SEAT_MESSAGES,
+	});
+	await expectLicenseAssignmentMessagesCorrect({
+		ctx,
+		customerProductId: custom1kAssignmentId,
+		featureId: TestFeature.Messages,
+		balance: CUSTOM_1K_ALLOWANCE,
+		entitlementId: custom1kBefore?.entitlementId,
+	});
+	await expectLicenseAssignmentFeaturePresent({
+		ctx,
+		customerProductId: custom1kAssignmentId,
+		featureId: TestFeature.Dashboard,
+	});
+	await expectLicenseAssignmentFeaturePresent({
+		ctx,
+		customerProductId: catalogAssignmentId,
+		featureId: TestFeature.Dashboard,
+	});
+});

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/mixed-items/batch-item-month-vs-lifetime.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/mixed-items/batch-item-month-vs-lifetime.test.ts
@@ -1,0 +1,257 @@
+/**
+ * A month filter must not touch a lifetime sibling of the same feature.
+ *
+ * Contract:
+ *   remove month → monthly row gone, lifetime row unchanged
+ *   replace month → monthly rewritten, lifetime row unchanged
+ *   C5 add month beside lifetime → sibling monthly row, lifetime kept
+ *
+ * Month-vs-quarter lives in the *-interval-narrowing tests; do not duplicate it.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	customerEntitlements,
+	customerProducts,
+	customers,
+	EntInterval,
+	entitlements,
+	ResetInterval,
+} from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import { expectCustomerEntitlementRowCount, type ScenarioCtx } from "../batchTestUtils";
+import { expectBatchLane } from "../version-repoint/utils/versionRepointTestUtils";
+
+const MONTHLY_INCLUDED = 100;
+const LIFETIME_INCLUDED = 50;
+const REPLACED_MONTHLY = 200;
+const ADDED_MONTHLY = 80;
+
+const readMessageRows = async ({
+	ctx,
+	customerId,
+}: {
+	ctx: ScenarioCtx;
+	customerId: string;
+}) =>
+	ctx.db
+		.select({
+			id: customerEntitlements.id,
+			entitlementId: customerEntitlements.entitlement_id,
+			balance: customerEntitlements.balance,
+			interval: entitlements.interval,
+		})
+		.from(customerEntitlements)
+		.innerJoin(
+			entitlements,
+			eq(entitlements.id, customerEntitlements.entitlement_id),
+		)
+		.innerJoin(
+			customerProducts,
+			eq(customerProducts.id, customerEntitlements.customer_product_id),
+		)
+		.innerJoin(
+			customers,
+			eq(customers.internal_id, customerProducts.internal_customer_id),
+		)
+		.where(
+			and(
+				eq(customers.org_id, ctx.org.id),
+				eq(customers.env, ctx.env),
+				eq(customers.id, customerId),
+				eq(customerEntitlements.feature_id, TestFeature.Messages),
+			),
+		);
+
+const isLifetimeInterval = (interval: string | null) =>
+	interval === null || interval === EntInterval.Lifetime;
+
+const splitCadence = (
+	rows: Awaited<ReturnType<typeof readMessageRows>>,
+) => ({
+	monthly: rows.find((row) => row.interval === EntInterval.Month),
+	lifetime: rows.find((row) => isLifetimeInterval(row.interval)),
+});
+
+test.concurrent(
+	`${chalk.yellowBright("batch delete: a month filter leaves the lifetime sibling")}`,
+	async () => {
+		const customerId = "batch-del-month-keep-life";
+		const plan = products.base({
+			id: "batch-del-month-keep-life-plan",
+			items: [
+				items.monthlyMessages({ includedUsage: MONTHLY_INCLUDED }),
+				items.lifetimeMessages({ includedUsage: LIFETIME_INCLUDED }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		const before = splitCadence(await readMessageRows({ ctx, customerId }));
+		expect(before.monthly).toBeDefined();
+		expect(before.lifetime).toBeDefined();
+		if (!before.monthly || !before.lifetime) {
+			throw new Error("Expected monthly and lifetime message rows");
+		}
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-del-month-keep-life-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id, custom: false },
+						customize: {
+							remove_items: [
+								{
+									feature_id: TestFeature.Messages,
+									interval: ResetInterval.Month,
+								},
+							],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		const after = splitCadence(await readMessageRows({ ctx, customerId }));
+		expect(after.monthly).toBeUndefined();
+		expect(after.lifetime).toEqual(before.lifetime);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: a month filter leaves the lifetime sibling")}`,
+	async () => {
+		const customerId = "batch-rep-month-keep-life";
+		const plan = products.base({
+			id: "batch-rep-month-keep-life-plan",
+			items: [
+				items.monthlyMessages({ includedUsage: MONTHLY_INCLUDED }),
+				items.lifetimeMessages({ includedUsage: LIFETIME_INCLUDED }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		const before = splitCadence(await readMessageRows({ ctx, customerId }));
+		expect(before.monthly).toBeDefined();
+		expect(before.lifetime).toBeDefined();
+		if (!before.monthly || !before.lifetime) {
+			throw new Error("Expected monthly and lifetime message rows");
+		}
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-rep-month-keep-life-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id, custom: false },
+						customize: {
+							remove_items: [
+								{
+									feature_id: TestFeature.Messages,
+									interval: ResetInterval.Month,
+								},
+							],
+							add_items: [
+								itemsV2.monthlyMessages({ included: REPLACED_MONTHLY }),
+							],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		const after = splitCadence(await readMessageRows({ ctx, customerId }));
+		expect(after.monthly).toMatchObject({
+			id: before.monthly.id,
+			balance: REPLACED_MONTHLY,
+		});
+		expect(after.monthly?.entitlementId).not.toBe(before.monthly.entitlementId);
+		expect(after.lifetime).toEqual(before.lifetime);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch add: month beside lifetime inserts a sibling")}`,
+	async () => {
+		const customerId = "batch-add-month-beside-life";
+		const plan = products.base({
+			id: "batch-add-month-beside-life-plan",
+			items: [items.lifetimeMessages({ includedUsage: LIFETIME_INCLUDED })],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		const before = splitCadence(await readMessageRows({ ctx, customerId }));
+		expect(before.lifetime).toBeDefined();
+		expect(before.monthly).toBeUndefined();
+		if (!before.lifetime) {
+			throw new Error("Expected a lifetime message row");
+		}
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-add-month-beside-life-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id, custom: false },
+						customize: {
+							add_items: [
+								itemsV2.monthlyMessages({ included: ADDED_MONTHLY }),
+							],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		const after = splitCadence(await readMessageRows({ ctx, customerId }));
+		expect(after.lifetime).toEqual(before.lifetime);
+		expect(after.monthly?.balance).toBe(ADDED_MONTHLY);
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			count: 2,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/mixed-items/batch-item-paid-different-allowance.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/mixed-items/batch-item-paid-different-allowance.test.ts
@@ -1,0 +1,209 @@
+/**
+ * C4: a paid row with a different allowance than the catalog is untouchable
+ * on the batch lane (rowIsUnpaidSql), for both remove and replace.
+ *
+ * Same-allowance paid rows stay in batch-*-item-paid-rows.test.ts.
+ */
+
+import { expect, test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { expectCustomerEntitlementRowCount } from "../batchTestUtils";
+import {
+	attachSyntheticPaidPrice,
+	expectCustomerPriceSurvives,
+	readScopedFeatureRow,
+	repointToCustomEntitlement,
+	setScopedFeatureBalance,
+} from "../paidRowTestUtils";
+import { expectBatchLane } from "../version-repoint/utils/versionRepointTestUtils";
+
+const CATALOG_ALLOWANCE = 100;
+const PAID_ALLOWANCE = 200;
+
+const paidDifferentSetup = async ({
+	catalogCustomerId,
+	paidCustomerId,
+	planId,
+}: {
+	catalogCustomerId: string;
+	paidCustomerId: string;
+	planId: string;
+}) => {
+	const plan = products.base({
+		id: planId,
+		items: [
+			items.dashboard(),
+			items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE }),
+		],
+	});
+
+	const { ctx, autumnV2_3 } = await initScenario({
+		customerId: catalogCustomerId,
+		setup: [
+			s.customer({ testClock: false }),
+			s.otherCustomers([{ id: paidCustomerId }]),
+			s.products({ list: [plan] }),
+		],
+		actions: [
+			s.parallel(
+				s.billing.attach({ productId: plan.id }),
+				s.billing.attach({
+					customerId: paidCustomerId,
+					productId: plan.id,
+				}),
+			),
+		],
+	});
+
+	await repointToCustomEntitlement({
+		ctx,
+		customerId: paidCustomerId,
+		featureId: TestFeature.Messages,
+		overrides: { allowance: PAID_ALLOWANCE },
+	});
+	await setScopedFeatureBalance({
+		ctx,
+		customerId: paidCustomerId,
+		featureId: TestFeature.Messages,
+		balance: PAID_ALLOWANCE,
+	});
+	const paid = await attachSyntheticPaidPrice({
+		ctx,
+		customerId: paidCustomerId,
+		featureId: TestFeature.Messages,
+	});
+	const paidBefore = await readScopedFeatureRow({
+		ctx,
+		customerId: paidCustomerId,
+		featureId: TestFeature.Messages,
+	});
+
+	return { ctx, autumnV2_3, planId: plan.id, paid, paidBefore };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("batch delete: a paid different-allowance row is never removed")}`,
+	async () => {
+		const catalogCustomerId = "batch-del-paid-diff-catalog";
+		const paidCustomerId = "batch-del-paid-diff-200";
+		const { ctx, autumnV2_3, planId, paid, paidBefore } =
+			await paidDifferentSetup({
+				catalogCustomerId,
+				paidCustomerId,
+				planId: "batch-del-paid-diff-plan",
+			});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-del-paid-diff-migration",
+			filter: { customer: { plan: { plan_id: planId, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: planId, custom: false },
+						customize: {
+							remove_items: [
+								{
+									feature_id: TestFeature.Messages,
+									interval: ResetInterval.Month,
+								},
+							],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId: catalogCustomerId,
+			planId,
+			featureId: TestFeature.Messages,
+			count: 0,
+		});
+
+		const paidAfter = await readScopedFeatureRow({
+			ctx,
+			customerId: paidCustomerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(paidAfter.id).toBe(paidBefore.id);
+		expect(paidAfter.entitlement_id).toBe(paidBefore.entitlement_id);
+		expect(paidAfter.balance).toBe(PAID_ALLOWANCE);
+		await expectCustomerPriceSurvives({
+			ctx,
+			customerPriceId: paid.customerPriceId,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: a paid different-allowance row is never rewritten")}`,
+	async () => {
+		const catalogCustomerId = "batch-rep-paid-diff-catalog";
+		const paidCustomerId = "batch-rep-paid-diff-200";
+		const { ctx, autumnV2_3, planId, paid, paidBefore } =
+			await paidDifferentSetup({
+				catalogCustomerId,
+				paidCustomerId,
+				planId: "batch-rep-paid-diff-plan",
+			});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-rep-paid-diff-migration",
+			filter: { customer: { plan: { plan_id: planId, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: planId, custom: false },
+						customize: {
+							add_items: [itemsV2.monthlyMessages({ included: 30 })],
+							remove_items: [
+								{
+									feature_id: TestFeature.Messages,
+									interval: ResetInterval.Month,
+								},
+							],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		const catalogAfter = await readScopedFeatureRow({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(catalogAfter.balance).toBe(30);
+
+		const paidAfter = await readScopedFeatureRow({
+			ctx,
+			customerId: paidCustomerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(paidAfter.id).toBe(paidBefore.id);
+		expect(paidAfter.entitlement_id).toBe(paidBefore.entitlement_id);
+		expect(paidAfter.balance).toBe(PAID_ALLOWANCE);
+		await expectCustomerPriceSurvives({
+			ctx,
+			customerPriceId: paid.customerPriceId,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/paidRowTestUtils.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/paidRowTestUtils.ts
@@ -3,6 +3,7 @@ import {
 	BillWhen,
 	BillingInterval,
 	BillingType,
+	type EntInterval,
 	customerEntitlements,
 	customerPrices,
 	customerProducts,
@@ -13,7 +14,7 @@ import {
 	products as productsTable,
 	PriceType,
 } from "@autumn/shared";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { generateId } from "@/utils/genUtils.js";
 import type { ScenarioCtx } from "./batchTestUtils";
 
@@ -23,10 +24,12 @@ export const readScopedFeatureRow = async ({
 	ctx,
 	customerId,
 	featureId,
+	interval,
 }: {
 	ctx: ScenarioCtx;
 	customerId: string;
 	featureId: string;
+	interval?: EntInterval | null;
 }) => {
 	const [result] = await ctx.db
 		.select({ row: customerEntitlements })
@@ -39,12 +42,21 @@ export const readScopedFeatureRow = async ({
 			customersTable,
 			eq(customerProducts.internal_customer_id, customersTable.internal_id),
 		)
+		.innerJoin(
+			entitlements,
+			eq(customerEntitlements.entitlement_id, entitlements.id),
+		)
 		.where(
 			and(
 				eq(customersTable.org_id, ctx.org.id),
 				eq(customersTable.env, ctx.env),
 				eq(customersTable.id, customerId),
 				eq(customerEntitlements.feature_id, featureId),
+				interval === undefined
+					? undefined
+					: interval === null
+						? isNull(entitlements.interval)
+						: eq(entitlements.interval, interval),
 			),
 		);
 	if (!result) {
@@ -260,6 +272,7 @@ export const expectReplacedFeatureRowCorrect = async ({
 	beforeRowId,
 	beforeEntitlementId,
 	balance,
+	interval,
 }: {
 	ctx: ScenarioCtx;
 	customerId: string;
@@ -267,11 +280,45 @@ export const expectReplacedFeatureRowCorrect = async ({
 	beforeRowId: string;
 	beforeEntitlementId: string;
 	balance: number;
+	interval?: EntInterval | null;
 }) => {
-	const after = await readScopedFeatureRow({ ctx, customerId, featureId });
+	const after = await readScopedFeatureRow({
+		ctx,
+		customerId,
+		featureId,
+		interval,
+	});
 	expect(after.id, `expected in-place replace for ${customerId}`).toBe(
 		beforeRowId,
 	);
 	expect(after.entitlement_id).not.toBe(beforeEntitlementId);
+	expect(after.balance).toBe(balance);
+};
+
+export const expectFeatureRowUnchanged = async ({
+	ctx,
+	customerId,
+	featureId,
+	beforeRowId,
+	beforeEntitlementId,
+	balance,
+	interval,
+}: {
+	ctx: ScenarioCtx;
+	customerId: string;
+	featureId: string;
+	beforeRowId: string;
+	beforeEntitlementId: string;
+	balance: number;
+	interval?: EntInterval | null;
+}) => {
+	const after = await readScopedFeatureRow({
+		ctx,
+		customerId,
+		featureId,
+		interval,
+	});
+	expect(after.id, `expected spared row for ${customerId}`).toBe(beforeRowId);
+	expect(after.entitlement_id).toBe(beforeEntitlementId);
 	expect(after.balance).toBe(balance);
 };

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/remove-items/batch-delete-item-included-filter.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/remove-items/batch-delete-item-included-filter.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Filter-mode delete with included: 100 drops catalog-shaped 100/mo rows
+ * and leaves a customized 1k grant.
+ *
+ * Contract (B3): catalog 100 gone; 1k remains. Dashboard survives.
+ *
+ * Wildcard (every live allowance) stays in batch-delete-item-custom-rows.test.ts.
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { expectCustomerEntitlementRowCount } from "../batchTestUtils";
+import {
+	expectFeatureRowUnchanged,
+	repointToCustomEntitlement,
+	setScopedFeatureBalance,
+} from "../paidRowTestUtils";
+import { expectBatchLane } from "../version-repoint/utils/versionRepointTestUtils";
+
+const CATALOG_ALLOWANCE = 100;
+const CUSTOM_1K_ALLOWANCE = 1000;
+
+test.concurrent(
+	`${chalk.yellowBright("batch delete: included 100 drops catalog 100 and spares custom 1k")}`,
+	async () => {
+		const catalogCustomerId = "batch-del-included-catalog";
+		const custom1kCustomerId = "batch-del-included-1k";
+		const plan = products.base({
+			id: "batch-del-included-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId: catalogCustomerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: custom1kCustomerId }]),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.parallel(
+					s.billing.attach({ productId: plan.id }),
+					s.billing.attach({
+						customerId: custom1kCustomerId,
+						productId: plan.id,
+					}),
+				),
+			],
+		});
+		const planId = plan.id;
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: CUSTOM_1K_ALLOWANCE },
+		});
+		const custom1kBefore = await setScopedFeatureBalance({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-del-included-migration",
+			filter: { customer: { plan: { plan_id: planId, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: planId, custom: false },
+						customize: {
+							remove_items: [
+								{
+									feature_id: TestFeature.Messages,
+									interval: ResetInterval.Month,
+									included: CATALOG_ALLOWANCE,
+								},
+							],
+						},
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId: catalogCustomerId,
+			planId,
+			featureId: TestFeature.Messages,
+			count: 0,
+		});
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId: catalogCustomerId,
+			planId,
+			featureId: TestFeature.Dashboard,
+			count: 1,
+		});
+		await expectFeatureRowUnchanged({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: custom1kBefore.id,
+			beforeEntitlementId: custom1kBefore.entitlement_id,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId: custom1kCustomerId,
+			planId,
+			featureId: TestFeature.Dashboard,
+			count: 1,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/replace-items/batch-replace-item-in-place.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/replace-items/batch-replace-item-in-place.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Filter-replace uses the live row's grant, not a catalog from→to diff.
+ *
+ * Contract:
+ *   C14: catalog already 30, customer still on retired 10, consumed 3
+ *        → remaining 27 (not left at 7, not reset to 30)
+ *   C1b: already on the minted 30 id, consumed 3 → remaining 27, no extra credits
+ *   C8 / C1b': live definition already matches incoming 200, different id
+ *        → repoint, remaining stays 140 (consumed 60 of 200)
+ */
+
+import { expect, test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { expectCustomerEntitlementRowCount } from "../batchTestUtils";
+import {
+	expectReplacedFeatureRowCorrect,
+	readScopedFeatureRow,
+	repointToCustomEntitlement,
+	setScopedFeatureBalance,
+} from "../paidRowTestUtils";
+import { expectBatchLane } from "../version-repoint/utils/versionRepointTestUtils";
+
+const replaceMessagesMonth = ({
+	planId,
+	included,
+}: {
+	planId: string;
+	included: number;
+}) => ({
+	customer: [
+		{
+			type: "update_plan" as const,
+			plan_filter: { plan_id: planId, custom: false },
+			customize: {
+				remove_items: [
+					{
+						feature_id: TestFeature.Messages,
+						interval: ResetInterval.Month,
+					},
+				],
+				add_items: [itemsV2.monthlyMessages({ included })],
+			},
+		},
+	],
+});
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: in-place catalog 30 still carries live 10 → remaining 27")}`,
+	async () => {
+		const customerId = "batch-replace-inplace-10to30";
+		const plan = products.base({
+			id: "batch-replace-inplace-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: 30 }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: 10 },
+		});
+		const before = await setScopedFeatureBalance({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			balance: 7,
+		});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-replace-inplace-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: replaceMessagesMonth({ planId: plan.id, included: 30 }),
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		await expectReplacedFeatureRowCorrect({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: before.id,
+			beforeEntitlementId: before.entitlement_id,
+			balance: 27,
+		});
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			count: 1,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: already at minted 30 applies no extra credits")}`,
+	async () => {
+		const customerId = "batch-replace-already-at-30";
+		const plan = products.base({
+			id: "batch-replace-already-30-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: 30 }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		const before = await setScopedFeatureBalance({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			balance: 27,
+		});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-replace-already-30-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: replaceMessagesMonth({ planId: plan.id, included: 30 }),
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		const after = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(after.id).toBe(before.id);
+		expect(after.balance).toBe(27);
+		await expectCustomerEntitlementRowCount({
+			ctx,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			count: 1,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: already-at-200 different id repoints with no extra credits")}`,
+	async () => {
+		const customerId = "batch-replace-already-200";
+		const plan = products.base({
+			id: "batch-replace-already-200-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: 100 }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [plan] })],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: 200 },
+		});
+		const before = await setScopedFeatureBalance({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			balance: 140,
+		});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-replace-already-200-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: replaceMessagesMonth({ planId: plan.id, included: 200 }),
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		await expectReplacedFeatureRowCorrect({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: before.id,
+			beforeEntitlementId: before.entitlement_id,
+			balance: 140,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/batch-migrations/replace-items/batch-replace-item-included-filter.test.ts
+++ b/server/tests/integration/billing/migrations-v2/batch-migrations/replace-items/batch-replace-item-included-filter.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Filter-mode replace with included: 100 rewrites catalog-shaped 100/mo
+ * grants and leaves a customized 1k row alone.
+ *
+ * Contract:
+ *   B2 catalog 100 + custom 1k — 100→200 with live Δ; 1k untouched
+ *   B5 two custom 100s (different ids) + 1k — both 100s rewrite; 1k spared
+ *   B6 replay B2 — no extra credits; 1k still 1k
+ *   unmatched replace + leftover adds: 1k monthly spared; dashboard + lifetime land
+ *
+ * Wildcard (omit included) stays in batch-replace-item-custom-definitions.test.ts.
+ * Paid skip stays in batch-replace-item-paid-rows.test.ts.
+ */
+
+import { expect, test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import {
+	expectUnmatchedReplaceLeftoversCorrect,
+	unmatchedReplaceLeftoverCustomize,
+} from "@tests/integration/billing/migrations-v2/utils/expectUnmatchedReplaceLeftoversCorrect";
+import { runChunkedMigration } from "@tests/integration/billing/migrations-v2/utils/runChunkedMigration";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	expectFeatureRowUnchanged,
+	expectReplacedFeatureRowCorrect,
+	readScopedFeatureRow,
+	repointToCustomEntitlement,
+	setScopedFeatureBalance,
+} from "../paidRowTestUtils";
+import { expectBatchLane } from "../version-repoint/utils/versionRepointTestUtils";
+
+const CATALOG_ALLOWANCE = 100;
+const CUSTOM_1K_ALLOWANCE = 1000;
+const REPLACEMENT_ALLOWANCE = 200;
+const GRANT_DELTA = REPLACEMENT_ALLOWANCE - CATALOG_ALLOWANCE;
+const CONSUMED = 3;
+
+const includedCatalogRemove = {
+	feature_id: TestFeature.Messages,
+	interval: ResetInterval.Month,
+	included: CATALOG_ALLOWANCE,
+};
+
+const replaceTo200 = {
+	add_items: [itemsV2.monthlyMessages({ included: REPLACEMENT_ALLOWANCE })],
+	remove_items: [includedCatalogRemove],
+};
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: included 100 rewrites catalog 100 and spares custom 1k")}`,
+	async () => {
+		const catalogCustomerId = "batch-replace-included-catalog";
+		const custom1kCustomerId = "batch-replace-included-1k";
+		const plan = products.base({
+			id: "batch-replace-included-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId: catalogCustomerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: custom1kCustomerId }]),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.parallel(
+					s.billing.attach({ productId: plan.id }),
+					s.billing.attach({
+						customerId: custom1kCustomerId,
+						productId: plan.id,
+					}),
+				),
+			],
+		});
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: CUSTOM_1K_ALLOWANCE },
+		});
+
+		const catalogBefore = await setScopedFeatureBalance({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CATALOG_ALLOWANCE - CONSUMED,
+		});
+		const custom1kBefore = await setScopedFeatureBalance({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-replace-included-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id, custom: false },
+						customize: replaceTo200,
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		await expectReplacedFeatureRowCorrect({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: catalogBefore.id,
+			beforeEntitlementId: catalogBefore.entitlement_id,
+			balance: catalogBefore.balance + GRANT_DELTA,
+		});
+		await expectFeatureRowUnchanged({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: custom1kBefore.id,
+			beforeEntitlementId: custom1kBefore.entitlement_id,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: included 100 rewrites two custom 100s and spares 1k")}`,
+	async () => {
+		const custom100A = "batch-replace-included-100-a";
+		const custom100B = "batch-replace-included-100-b";
+		const custom1kCustomerId = "batch-replace-included-100-1k";
+		const plan = products.base({
+			id: "batch-replace-included-group-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId: custom100A,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: custom100B }, { id: custom1kCustomerId }]),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.parallel(
+					s.billing.attach({ productId: plan.id }),
+					s.billing.attach({
+						customerId: custom100B,
+						productId: plan.id,
+					}),
+					s.billing.attach({
+						customerId: custom1kCustomerId,
+						productId: plan.id,
+					}),
+				),
+			],
+		});
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom100A,
+			featureId: TestFeature.Messages,
+		});
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom100B,
+			featureId: TestFeature.Messages,
+		});
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: CUSTOM_1K_ALLOWANCE },
+		});
+
+		const [beforeA, beforeB, before1k] = await Promise.all([
+			setScopedFeatureBalance({
+				ctx,
+				customerId: custom100A,
+				featureId: TestFeature.Messages,
+				balance: CATALOG_ALLOWANCE,
+			}),
+			setScopedFeatureBalance({
+				ctx,
+				customerId: custom100B,
+				featureId: TestFeature.Messages,
+				balance: CATALOG_ALLOWANCE,
+			}),
+			setScopedFeatureBalance({
+				ctx,
+				customerId: custom1kCustomerId,
+				featureId: TestFeature.Messages,
+				balance: CUSTOM_1K_ALLOWANCE,
+			}),
+		]);
+		expect(beforeA.entitlement_id).not.toBe(beforeB.entitlement_id);
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-replace-included-group-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id, custom: false },
+						customize: replaceTo200,
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		for (const [customerId, before] of [
+			[custom100A, beforeA],
+			[custom100B, beforeB],
+		] as const) {
+			await expectReplacedFeatureRowCorrect({
+				ctx,
+				customerId,
+				featureId: TestFeature.Messages,
+				beforeRowId: before.id,
+				beforeEntitlementId: before.entitlement_id,
+				balance: CATALOG_ALLOWANCE + GRANT_DELTA,
+			});
+		}
+		await expectFeatureRowUnchanged({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: before1k.id,
+			beforeEntitlementId: before1k.entitlement_id,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: replaying included 100 credits the catalog delta once")}`,
+	async () => {
+		const catalogCustomerId = "batch-replace-included-replay-catalog";
+		const custom1kCustomerId = "batch-replace-included-replay-1k";
+		const plan = products.base({
+			id: "batch-replace-included-replay-plan",
+			items: [
+				items.dashboard(),
+				items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE }),
+			],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId: catalogCustomerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.otherCustomers([{ id: custom1kCustomerId }]),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.parallel(
+					s.billing.attach({ productId: plan.id }),
+					s.billing.attach({
+						customerId: custom1kCustomerId,
+						productId: plan.id,
+					}),
+				),
+			],
+		});
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: CUSTOM_1K_ALLOWANCE },
+		});
+
+		const catalogBefore = await setScopedFeatureBalance({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CATALOG_ALLOWANCE - CONSUMED,
+		});
+		const custom1kBefore = await setScopedFeatureBalance({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+
+		const runReplace = ({ migrationId }: { migrationId: string }) =>
+			runChunkedMigration({
+				ctx,
+				migrationClient: autumnV2_3,
+				migrationId,
+				filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+				operations: {
+					customer: [
+						{
+							type: "update_plan" as const,
+							plan_filter: { plan_id: plan.id, custom: false },
+							customize: replaceTo200,
+						},
+					],
+				},
+				noBillingChanges: true,
+			});
+
+		const firstRun = await runReplace({
+			migrationId: "batch-replace-included-replay-first",
+		});
+		expectBatchLane({ result: firstRun.result });
+
+		const afterFirst = await readScopedFeatureRow({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(afterFirst.balance).toBe(catalogBefore.balance + GRANT_DELTA);
+
+		const replay = await runReplace({
+			migrationId: "batch-replace-included-replay-second",
+		});
+		expectBatchLane({ result: replay.result });
+
+		const afterReplay = await readScopedFeatureRow({
+			ctx,
+			customerId: catalogCustomerId,
+			featureId: TestFeature.Messages,
+		});
+		expect(afterReplay.id).toBe(afterFirst.id);
+		expect(afterReplay.balance).toBe(afterFirst.balance);
+
+		await expectFeatureRowUnchanged({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			beforeRowId: custom1kBefore.id,
+			beforeEntitlementId: custom1kBefore.entitlement_id,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("batch replace: unmatched 100→200 still adds boolean and lifetime")}`,
+	async () => {
+		const custom1kCustomerId = "batch-replace-unmatched-leftover-1k";
+		const plan = products.base({
+			id: "batch-replace-unmatched-leftover-plan",
+			items: [items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE })],
+		});
+
+		const { ctx, autumnV2_3 } = await initScenario({
+			customerId: custom1kCustomerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await repointToCustomEntitlement({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			overrides: { allowance: CUSTOM_1K_ALLOWANCE },
+		});
+		const beforeMonthly = await setScopedFeatureBalance({
+			ctx,
+			customerId: custom1kCustomerId,
+			featureId: TestFeature.Messages,
+			balance: CUSTOM_1K_ALLOWANCE,
+		});
+
+		const { result } = await runChunkedMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: "batch-replace-unmatched-leftover-migration",
+			filter: { customer: { plan: { plan_id: plan.id, custom: false } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id, custom: false },
+						customize: unmatchedReplaceLeftoverCustomize(),
+					},
+				],
+			},
+			noBillingChanges: true,
+		});
+		expectBatchLane({ result });
+
+		await expectUnmatchedReplaceLeftoversCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId: custom1kCustomerId,
+			planId: plan.id,
+			beforeMonthly,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-included-filter.test.ts
+++ b/server/tests/integration/billing/migrations-v2/update-plan-operation/customize/update-plan-op-included-filter.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Per-customer update_plan honors included on remove_items. The important
+ * case is a row that does NOT match the filter and must stay put.
+ *
+ * Contract:
+ *   custom 1k + filter included: 100 → row and grant unchanged
+ *   catalog 100 + filter included: 100 → 200, same cusEnt row
+ *   paid overage included 50 → 100 migrates; included 200 with filter 50 does not
+ *   unmatched 100→200 + leftover boolean/lifetime: 1k spared, leftovers land
+ */
+
+import { test } from "bun:test";
+import {
+	ResetInterval,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { readScopedFeatureRow } from "@tests/integration/billing/migrations-v2/batch-migrations/paidRowTestUtils";
+import { expectIncludedFilterOutcomeCorrect } from "@tests/integration/billing/migrations-v2/utils/expectIncludedFilterOutcomeCorrect";
+import {
+	expectUnmatchedReplaceLeftoversCorrect,
+	unmatchedReplaceLeftoverCustomize,
+} from "@tests/integration/billing/migrations-v2/utils/expectUnmatchedReplaceLeftoversCorrect";
+import { runUpdatePlanMigration } from "@tests/integration/billing/migrations-v2/utils/runUpdatePlanMigration";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+const CATALOG_ALLOWANCE = 100;
+const CUSTOM_1K_ALLOWANCE = 1000;
+const REPLACEMENT_ALLOWANCE = 200;
+const PAID_INCLUDED = 50;
+const PAID_CUSTOM = 200;
+const PAID_REPLACEMENT = 100;
+
+const includedReplace = ({
+	fromIncluded,
+	toIncluded,
+	paid = false,
+}: {
+	fromIncluded: number;
+	toIncluded: number;
+	paid?: boolean;
+}) => ({
+	remove_items: [
+		{
+			feature_id: TestFeature.Messages,
+			interval: ResetInterval.Month,
+			included: fromIncluded,
+		},
+	],
+	add_items: [
+		paid
+			? { ...itemsV2.consumableMessages({ amount: 0.1 }), included: toIncluded }
+			: itemsV2.monthlyMessages({ included: toIncluded }),
+	],
+});
+
+const customizeGrant = ({
+	included,
+	paid = false,
+}: {
+	included: number;
+	paid?: boolean;
+}): UpdateSubscriptionV1ParamsInput["customize"] => ({
+	remove_items: [
+		{ feature_id: TestFeature.Messages, interval: ResetInterval.Month },
+	],
+	add_items: [
+		paid
+			? { ...itemsV2.consumableMessages({ amount: 0.1 }), included }
+			: itemsV2.monthlyMessages({ included }),
+	],
+});
+
+test.concurrent(
+	`${chalk.yellowBright("per-customer included filter: 1k custom row is not migrated")}`,
+	async () => {
+		const customerId = "mig-included-spare-1k";
+		const plan = products.base({
+			id: "mig-included-spare-1k-plan",
+			items: [items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: customizeGrant({ included: CUSTOM_1K_ALLOWANCE }),
+		});
+
+		const before = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: plan.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id },
+						customize: includedReplace({
+							fromIncluded: CATALOG_ALLOWANCE,
+							toIncluded: REPLACEMENT_ALLOWANCE,
+						}),
+					},
+				],
+			},
+			runOnServer: false,
+			noBillingChanges: true,
+		});
+
+		await expectCustomerProducts({
+			customerId,
+			autumn: autumnV2_3,
+			active: [plan.id],
+		});
+		await expectIncludedFilterOutcomeCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			before,
+			granted: CUSTOM_1K_ALLOWANCE,
+			spared: true,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("per-customer included filter: catalog 100 migrates to 200")}`,
+	async () => {
+		const customerId = "mig-included-match-100";
+		const plan = products.base({
+			id: "mig-included-match-100-plan",
+			items: [items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		const before = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: plan.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id },
+						customize: includedReplace({
+							fromIncluded: CATALOG_ALLOWANCE,
+							toIncluded: REPLACEMENT_ALLOWANCE,
+						}),
+					},
+				],
+			},
+			runOnServer: false,
+			noBillingChanges: true,
+		});
+
+		await expectIncludedFilterOutcomeCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			before,
+			granted: REPLACEMENT_ALLOWANCE,
+			spared: false,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("per-customer included filter: paid overage 50 migrates, 200 does not")}`,
+	async () => {
+		const matchCustomerId = "mig-included-paid-match";
+		const spareCustomerId = "mig-included-paid-spare";
+		const plan = products.pro({
+			id: "mig-included-paid-plan",
+			items: [items.consumableMessages({ includedUsage: PAID_INCLUDED })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId: matchCustomerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.otherCustomers([{ id: spareCustomerId, paymentMethod: "success" }]),
+				s.products({ list: [plan] }),
+			],
+			actions: [
+				s.parallel(
+					s.billing.attach({ productId: plan.id }),
+					s.billing.attach({
+						customerId: spareCustomerId,
+						productId: plan.id,
+					}),
+				),
+			],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: spareCustomerId,
+			plan_id: plan.id,
+			customize: customizeGrant({ included: PAID_CUSTOM, paid: true }),
+		});
+
+		const matchBefore = await readScopedFeatureRow({
+			ctx,
+			customerId: matchCustomerId,
+			featureId: TestFeature.Messages,
+		});
+		const spareBefore = await readScopedFeatureRow({
+			ctx,
+			customerId: spareCustomerId,
+			featureId: TestFeature.Messages,
+		});
+
+		const paidOp = {
+			type: "update_plan" as const,
+			plan_filter: { plan_id: plan.id },
+			customize: includedReplace({
+				fromIncluded: PAID_INCLUDED,
+				toIncluded: PAID_REPLACEMENT,
+				paid: true,
+			}),
+		};
+
+		for (const customerId of [matchCustomerId, spareCustomerId]) {
+			await runUpdatePlanMigration({
+				ctx,
+				migrationClient: autumnV2_3,
+				migrationId: `${customerId}-mig`,
+				customerId,
+				filter: { customer: { plan: { plan_id: plan.id } } },
+				operations: { customer: [paidOp] },
+				runOnServer: false,
+			});
+		}
+
+		await expectIncludedFilterOutcomeCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId: matchCustomerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			before: matchBefore,
+			granted: PAID_REPLACEMENT,
+			spared: false,
+		});
+		await expectIncludedFilterOutcomeCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId: spareCustomerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			before: spareBefore,
+			granted: PAID_CUSTOM,
+			spared: true,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("per-customer included filter: unmatched 100→200 still adds boolean and lifetime")}`,
+	async () => {
+		const customerId = "mig-included-leftover-1k";
+		const plan = products.base({
+			id: "mig-included-leftover-1k-plan",
+			items: [items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: customizeGrant({ included: CUSTOM_1K_ALLOWANCE }),
+		});
+
+		const beforeMonthly = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+
+		await runUpdatePlanMigration({
+			ctx,
+			migrationClient: autumnV2_3,
+			migrationId: `${customerId}-mig`,
+			customerId,
+			filter: { customer: { plan: { plan_id: plan.id } } },
+			operations: {
+				customer: [
+					{
+						type: "update_plan",
+						plan_filter: { plan_id: plan.id },
+						customize: unmatchedReplaceLeftoverCustomize(),
+					},
+				],
+			},
+			runOnServer: false,
+			noBillingChanges: true,
+		});
+
+		await expectUnmatchedReplaceLeftoversCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId,
+			planId: plan.id,
+			beforeMonthly,
+		});
+	},
+);

--- a/server/tests/integration/billing/migrations-v2/utils/expectFilterLiveDefinitionCorrect.ts
+++ b/server/tests/integration/billing/migrations-v2/utils/expectFilterLiveDefinitionCorrect.ts
@@ -1,0 +1,120 @@
+import type { BillingChangeResponse } from "@autumn/shared";
+import { expectBillingUpdatedCorrect } from "@tests/integration/billing/autumn-webhooks/utils/expectBillingUpdatedWebhook";
+import {
+	type CustomerProductsUpdatedPayload,
+	expectProductsUpdatedCorrect,
+} from "@tests/integration/billing/autumn-webhooks/utils/expectProductsUpdatedWebhook";
+import { expectPreviewBalanceChange } from "@tests/integration/billing/migrations-v2/update-plan-operation/previews/expectMigrationPreviewCorrect";
+import type { ScenarioCtx } from "../batch-migrations/batchTestUtils";
+import {
+	expectMigrationEventBillingPlanChangesEqual,
+	expectMigrationItemEventCorrect,
+	type MigrationItemEvents,
+} from "./expectMigrationItemEvent";
+
+type ItemChangeExpectation = {
+	action: "created" | "deleted";
+	featureId: string;
+	included?: number;
+};
+
+type BalanceExpectation = {
+	featureId: string;
+	granted: number;
+	remaining: number;
+	usage: number;
+	previousGranted: number;
+	previousRemaining: number;
+};
+
+/** One customer's filter-mode stamp: live from-definition on item_changes
+ * and billing.updated, plus remaining after the grant delta when replacing. */
+export const expectFilterLiveDefinitionCorrect = async ({
+	ctx,
+	events,
+	billingUpdated,
+	productsUpdated,
+	customerId,
+	planId,
+	itemChanges,
+	balance,
+	absentFeatureIds,
+	flagChanges,
+}: {
+	ctx: ScenarioCtx;
+	events: MigrationItemEvents | null;
+	billingUpdated: BillingChangeResponse | null;
+	productsUpdated?: CustomerProductsUpdatedPayload["data"] | null;
+	customerId: string;
+	planId: string;
+	itemChanges: ItemChangeExpectation[];
+	balance?: BalanceExpectation;
+	absentFeatureIds?: string[];
+	flagChanges?: { action: "created" | "deleted"; featureId: string }[];
+}) => {
+	expectBillingUpdatedCorrect({
+		data: billingUpdated,
+		customerId,
+		entityId: null,
+		planChanges: [{ planId, itemChanges }],
+	});
+
+	if (productsUpdated !== undefined) {
+		expectProductsUpdatedCorrect({
+			data: productsUpdated,
+			customerId,
+			planId,
+			entityId: null,
+			...(absentFeatureIds
+				? { absentFeatureIds }
+				: balance
+					? {
+							features: [
+								{
+									featureId: balance.featureId,
+									balance: balance.remaining,
+								},
+							],
+						}
+					: {}),
+		});
+	}
+
+	if (!events) return;
+
+	await expectMigrationItemEventCorrect({
+		ctx,
+		events,
+		customerId,
+		status: "succeeded",
+		planChangeActions: ["updated"],
+		planChangePlanIds: [planId],
+		itemChanges,
+		balanceFeatureIds: balance ? [balance.featureId] : [],
+		...(flagChanges ? { flagChanges } : {}),
+	});
+
+	const preview = await expectMigrationEventBillingPlanChangesEqual({
+		ctx,
+		events,
+		customerId,
+		billingUpdated,
+	});
+
+	if (!balance) return;
+
+	expectPreviewBalanceChange({
+		preview,
+		featureId: balance.featureId,
+		balance: {
+			granted: balance.granted,
+			remaining: balance.remaining,
+			usage: balance.usage,
+			unlimited: false,
+		},
+		previousAttributes: {
+			granted: balance.previousGranted,
+			remaining: balance.previousRemaining,
+		},
+	});
+};

--- a/server/tests/integration/billing/migrations-v2/utils/expectIncludedFilterOutcomeCorrect.ts
+++ b/server/tests/integration/billing/migrations-v2/utils/expectIncludedFilterOutcomeCorrect.ts
@@ -1,0 +1,64 @@
+import { expect } from "bun:test";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { ScenarioCtx } from "../batch-migrations/batchTestUtils";
+import {
+	expectFeatureRowUnchanged,
+	readScopedFeatureRow,
+} from "../batch-migrations/paidRowTestUtils";
+
+/** Spare: same cusEnt row and definition. Match: new definition, new grant. */
+export const expectIncludedFilterOutcomeCorrect = async ({
+	ctx,
+	autumn,
+	customerId,
+	planId,
+	featureId,
+	before,
+	granted,
+	remaining,
+	usage = 0,
+	spared,
+}: {
+	ctx: ScenarioCtx;
+	autumn: AutumnInt;
+	customerId: string;
+	planId: string;
+	featureId: string;
+	before: { id: string; entitlement_id: string };
+	granted: number;
+	remaining?: number;
+	usage?: number;
+	spared: boolean;
+}) => {
+	const balance = remaining ?? granted;
+	if (spared) {
+		await expectFeatureRowUnchanged({
+			ctx,
+			customerId,
+			featureId,
+			beforeRowId: before.id,
+			beforeEntitlementId: before.entitlement_id,
+			balance,
+		});
+	} else {
+		const after = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId,
+		});
+		expect(after.entitlement_id).not.toBe(before.entitlement_id);
+		expect(after.balance).toBe(balance);
+	}
+
+	await expectBalanceCorrect({
+		customerId,
+		autumn,
+		featureId,
+		granted,
+		remaining: balance,
+		usage,
+		planId,
+		breakdownCount: 1,
+	});
+};

--- a/server/tests/integration/billing/migrations-v2/utils/expectUnmatchedReplaceLeftoversCorrect.ts
+++ b/server/tests/integration/billing/migrations-v2/utils/expectUnmatchedReplaceLeftoversCorrect.ts
@@ -1,0 +1,101 @@
+import {
+	type ApiCustomerV5,
+	EntInterval,
+	ResetInterval,
+} from "@autumn/shared";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { expectFlagCorrect } from "@tests/integration/utils/expectFlagCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { ScenarioCtx } from "../batch-migrations/batchTestUtils";
+import { expectFeatureRowUnchanged } from "../batch-migrations/paidRowTestUtils";
+
+export const CATALOG_MESSAGES = 100;
+export const CUSTOM_1K_MESSAGES = 1000;
+export const REPLACEMENT_MESSAGES = 200;
+export const LIFETIME_MESSAGES = 50;
+
+export const unmatchedReplaceLeftoverCustomize = ({
+	fromIncluded = CATALOG_MESSAGES,
+	toIncluded = REPLACEMENT_MESSAGES,
+	lifetimeIncluded = LIFETIME_MESSAGES,
+}: {
+	fromIncluded?: number;
+	toIncluded?: number;
+	lifetimeIncluded?: number;
+} = {}) => ({
+	remove_items: [
+		{
+			feature_id: TestFeature.Messages,
+			interval: ResetInterval.Month,
+			included: fromIncluded,
+		},
+	],
+	add_items: [
+		itemsV2.monthlyMessages({ included: toIncluded }),
+		itemsV2.dashboard(),
+		{
+			feature_id: TestFeature.Messages,
+			included: lifetimeIncluded,
+			reset: { interval: ResetInterval.OneOff },
+		},
+	],
+});
+
+/** 1k monthly spared; leftover boolean + lifetime still land. */
+export const expectUnmatchedReplaceLeftoversCorrect = async ({
+	ctx,
+	autumn,
+	customerId,
+	planId,
+	beforeMonthly,
+	monthlyGranted = CUSTOM_1K_MESSAGES,
+	lifetimeGranted = LIFETIME_MESSAGES,
+}: {
+	ctx: ScenarioCtx;
+	autumn: AutumnInt;
+	customerId: string;
+	planId: string;
+	beforeMonthly: { id: string; entitlement_id: string };
+	monthlyGranted?: number;
+	lifetimeGranted?: number;
+}) => {
+	await expectFeatureRowUnchanged({
+		ctx,
+		customerId,
+		featureId: TestFeature.Messages,
+		beforeRowId: beforeMonthly.id,
+		beforeEntitlementId: beforeMonthly.entitlement_id,
+		balance: monthlyGranted,
+		interval: EntInterval.Month,
+	});
+
+	await expectBalanceCorrect({
+		customerId,
+		autumn,
+		featureId: TestFeature.Messages,
+		granted: monthlyGranted + lifetimeGranted,
+		remaining: monthlyGranted + lifetimeGranted,
+		usage: 0,
+		planId,
+		breakdownCount: 2,
+		breakdown: {
+			[ResetInterval.Month]: {
+				included_grant: monthlyGranted,
+				remaining: monthlyGranted,
+			},
+			[ResetInterval.OneOff]: {
+				included_grant: lifetimeGranted,
+				remaining: lifetimeGranted,
+			},
+		},
+	});
+
+	const customer = await autumn.customers.get<ApiCustomerV5>(customerId);
+	expectFlagCorrect({
+		customer,
+		featureId: TestFeature.Dashboard,
+		planId,
+	});
+};

--- a/server/tests/integration/billing/update-subscription/custom-plan-patch/patch-item-filter-included.test.ts
+++ b/server/tests/integration/billing/update-subscription/custom-plan-patch/patch-item-filter-included.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Per-customer subscriptions.update honors included on remove_items.
+ * The important case is a row that does NOT match the filter and must stay put.
+ *
+ * Contract:
+ *   P1 custom 1k + filter included: 100 → 1k kept, one messages row
+ *   P2 omitted included still rewrites 1k → 200 (wildcard)
+ *   P3 paid overage at 200 + filter included: 50 → 200 kept
+ *   unmatched 100→200 + leftover boolean/lifetime: 1k spared, leftovers land
+ */
+
+import { test } from "bun:test";
+import {
+	ResetInterval,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { readScopedFeatureRow } from "@tests/integration/billing/migrations-v2/batch-migrations/paidRowTestUtils";
+import { expectIncludedFilterOutcomeCorrect } from "@tests/integration/billing/migrations-v2/utils/expectIncludedFilterOutcomeCorrect";
+import {
+	expectUnmatchedReplaceLeftoversCorrect,
+	unmatchedReplaceLeftoverCustomize,
+} from "@tests/integration/billing/migrations-v2/utils/expectUnmatchedReplaceLeftoversCorrect";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+
+const CATALOG_ALLOWANCE = 100;
+const CUSTOM_1K_ALLOWANCE = 1000;
+const REPLACEMENT_ALLOWANCE = 200;
+const PAID_INCLUDED = 50;
+const PAID_CUSTOM = 200;
+
+const wildcardRemove = {
+	feature_id: TestFeature.Messages,
+	interval: ResetInterval.Month,
+};
+
+const includedCatalogRemove = {
+	...wildcardRemove,
+	included: CATALOG_ALLOWANCE,
+};
+
+const customizeToGrant = ({
+	included,
+	paid = false,
+}: {
+	included: number;
+	paid?: boolean;
+}): UpdateSubscriptionV1ParamsInput["customize"] => ({
+	remove_items: [wildcardRemove],
+	add_items: [
+		paid
+			? { ...itemsV2.consumableMessages({ amount: 0.1 }), included }
+			: itemsV2.monthlyMessages({ included }),
+	],
+});
+
+const updateSubscriptionAllowingNoop = async ({
+	autumn,
+	params,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	params: UpdateSubscriptionV1ParamsInput;
+}) => {
+	try {
+		await autumn.subscriptions.update<UpdateSubscriptionV1ParamsInput>(params);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!message.includes("identical to the current subscription")) throw error;
+	}
+};
+
+test.concurrent(
+	`${chalk.yellowBright("patch item filters: included 100 does not migrate a custom 1k row")}`,
+	async () => {
+		const customerId = "patch-filter-included-spare-1k";
+		const plan = products.base({
+			id: "patch-filter-included-spare",
+			items: [items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: customizeToGrant({ included: CUSTOM_1K_ALLOWANCE }),
+		});
+
+		const before = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+
+		await updateSubscriptionAllowingNoop({
+			autumn: autumnV2_3,
+			params: {
+				customer_id: customerId,
+				plan_id: plan.id,
+				customize: {
+					remove_items: [includedCatalogRemove],
+					add_items: [
+						itemsV2.monthlyMessages({ included: REPLACEMENT_ALLOWANCE }),
+					],
+				},
+			},
+		});
+
+		await expectCustomerProducts({
+			customerId,
+			autumn: autumnV2_3,
+			active: [plan.id],
+		});
+		await expectIncludedFilterOutcomeCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			before,
+			granted: CUSTOM_1K_ALLOWANCE,
+			spared: true,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("patch item filters: omitted included still rewrites a custom 1k row")}`,
+	async () => {
+		const customerId = "patch-filter-included-wildcard-1k";
+		const plan = products.base({
+			id: "patch-filter-included-wild",
+			items: [items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: customizeToGrant({ included: CUSTOM_1K_ALLOWANCE }),
+		});
+
+		const before = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: {
+				remove_items: [wildcardRemove],
+				add_items: [
+					itemsV2.monthlyMessages({ included: REPLACEMENT_ALLOWANCE }),
+				],
+			},
+		});
+
+		await expectIncludedFilterOutcomeCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			before,
+			granted: REPLACEMENT_ALLOWANCE,
+			spared: false,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("patch item filters: included 50 does not migrate a paid 200 overage row")}`,
+	async () => {
+		const customerId = "patch-filter-included-paid-spare";
+		const plan = products.pro({
+			id: "patch-filter-included-paid",
+			items: [items.consumableMessages({ includedUsage: PAID_INCLUDED })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success", testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: customizeToGrant({ included: PAID_CUSTOM, paid: true }),
+		});
+
+		const before = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+
+		await updateSubscriptionAllowingNoop({
+			autumn: autumnV2_3,
+			params: {
+				customer_id: customerId,
+				plan_id: plan.id,
+				customize: {
+					remove_items: [
+						{
+							feature_id: TestFeature.Messages,
+							interval: ResetInterval.Month,
+							included: PAID_INCLUDED,
+						},
+					],
+					add_items: [
+						{
+							...itemsV2.consumableMessages({ amount: 0.1 }),
+							included: CATALOG_ALLOWANCE,
+						},
+					],
+				},
+			},
+		});
+
+		await expectIncludedFilterOutcomeCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId,
+			planId: plan.id,
+			featureId: TestFeature.Messages,
+			before,
+			granted: PAID_CUSTOM,
+			spared: true,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("patch item filters: unmatched 100→200 still adds boolean and lifetime")}`,
+	async () => {
+		const customerId = "patch-filter-unmatched-leftover";
+		const plan = products.base({
+			id: "patch-filter-unmatched-leftover",
+			items: [items.monthlyMessages({ includedUsage: CATALOG_ALLOWANCE })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [plan] }),
+			],
+			actions: [s.billing.attach({ productId: plan.id })],
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: customizeToGrant({ included: CUSTOM_1K_ALLOWANCE }),
+		});
+
+		const beforeMonthly = await readScopedFeatureRow({
+			ctx,
+			customerId,
+			featureId: TestFeature.Messages,
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerId,
+			plan_id: plan.id,
+			customize: unmatchedReplaceLeftoverCustomize(),
+		});
+
+		await expectUnmatchedReplaceLeftoversCorrect({
+			ctx,
+			autumn: autumnV2_3,
+			customerId,
+			planId: plan.id,
+			beforeMonthly,
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -844,6 +844,7 @@ Seed via DB `customer_licenses.plan_license_id`. `seedVersionableCustomer` is th
 | Customize existing link → updated + nested core `plan_change` | ✓ `license-changes-customize.test.ts` |
 | New customized link → created, no nested `plan_change` | ✓ `license-changes-customize.test.ts` |
 | Name + included compose on one `plan_change` | ✓ `license-changes-customize.test.ts` |
+| After `new_version` + license customize add Dashboard, later `preview_update` parses and echoes the overlay | ✓ `license-changes-customize.test.ts` |
 | In-batch pin → updated freeze, no nested `plan_change` | ✓ `license-changes-follow.test.ts` |
 | In-batch propagate → updated + nested item `plan_change` | ✓ `license-changes-follow.test.ts` |
 | Child `new_version` + pin → `previous_attributes.version` | ✓ `license-changes-follow.test.ts` |

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-customize.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-customize.test.ts
@@ -5,6 +5,8 @@
  *   - customize on an existing link → updated + nested core plan_change
  *   - new link with customize → created, no nested plan_change
  *   - parent name + included compose onto one plan_change
+ *   - after new_version + license customize, a later preview_update parses
+ *     and echoes the overlay (Dashboard) on latest
  */
 
 import { test } from "bun:test";
@@ -19,6 +21,11 @@ import {
 	parsePlanPreview,
 } from "../../preview/utils/expectPlanPreview.js";
 import {
+	expectLatestPlanVersion,
+	expectLicenseLinkCorrect,
+} from "../utils/expectLicenseLinkCorrect.js";
+import {
+	dashboardItem,
 	messagesItem,
 	seedLinkedChildParent,
 	withCatalogPlans,
@@ -205,6 +212,74 @@ test.concurrent(
 						customize: {
 							upsert_licenses: [{ license_plan_id: childId, included: 5 }],
 						},
+					},
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license_changes: preview after versioned license customize")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lc_vrcust_p");
+		const childId = uniqueTestId("cv2_lc_vrcust_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: parentId,
+							versioning: "new_version",
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: { add_items: [dashboardItem()] },
+								},
+							],
+						},
+					],
+				});
+
+				await expectLatestPlanVersion({ ctx, planId: parentId, version: 2 });
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 2,
+					licensePlanId: childId,
+					included: 2,
+					customized: true,
+					entitlements: [{ feature_id: TestFeature.Dashboard }],
+				});
+
+				const preview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: [{ plan_id: parentId }],
+					}),
+				);
+				expectPlanPreviewRowCorrect({
+					preview,
+					expected: {
+						planId: parentId,
+						action: "none",
+						licenses: [
+							{
+								license_plan_id: childId,
+								version: 1,
+								included: 2,
+								prepaid_only: true,
+							},
+						],
 					},
 				});
 			},

--- a/server/tests/integration/catalog-v2/plans/migrations/billing-flag.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/billing-flag.test.ts
@@ -224,6 +224,7 @@ test.concurrent(
 											feature_id: TestFeature.Messages,
 											interval: ResetInterval.Month,
 											interval_count: 1,
+											included: 100,
 										},
 									],
 									add_items: [

--- a/server/tests/integration/catalog-v2/plans/migrations/customize-buckets.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/customize-buckets.test.ts
@@ -56,6 +56,7 @@ const messagesCustomize = ({
 			feature_id: TestFeature.Messages,
 			interval: fromInterval,
 			interval_count: 1,
+			included: 100,
 		},
 	],
 	add_items: [
@@ -389,6 +390,7 @@ test.concurrent(
 											feature_id: fromId,
 											interval: ResetInterval.Month,
 											interval_count: 1,
+											included: 100,
 										},
 									],
 									add_items: [

--- a/server/tests/integration/catalog-v2/plans/migrations/customize-lanes.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/customize-lanes.test.ts
@@ -200,6 +200,7 @@ test.concurrent(
 											billing_method: BillingMethod.Prepaid,
 											interval: BillingInterval.Month,
 											interval_count: 1,
+											included: 0,
 										},
 									],
 								},
@@ -336,6 +337,7 @@ test.concurrent(
 											feature_id: TestFeature.Messages,
 											interval: ResetInterval.Month,
 											interval_count: 1,
+											included: 100,
 										},
 									],
 									add_items: [

--- a/server/tests/integration/catalog-v2/plans/migrations/filter-collapse.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/filter-collapse.test.ts
@@ -37,6 +37,7 @@ const messagesCustomize = ({ included }: { included: number }) => ({
 			feature_id: TestFeature.Messages,
 			interval: ResetInterval.Month,
 			interval_count: 1,
+			included: 100,
 		},
 	],
 	add_items: [

--- a/server/tests/integration/catalog-v2/plans/migrations/included-filter-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/included-filter-drafts.test.ts
@@ -1,9 +1,12 @@
 /**
- * catalogV2.update — migration drafts for in-place existing versioning.
+ * catalogV2.update draft generators stamp included on remove_items when the
+ * from-item is a numbered grant (filterPrecision IdentityAndIncluded).
  *
- * Contract:
- *   existing + migratable item diff + versionable customers → one version-pinned draft
- *   omitted migration / no customers / name-only → no draft
+ * Contract (C1): in-place 100→500 writes remove_items[0].included === 100.
+ *
+ * Red (current): draft remove filter is feature+interval only.
+ * Green (after): the same draft also carries included: 100 so a 1k custom
+ * row is not a candidate.
  */
 
 import { expect, test } from "bun:test";
@@ -28,32 +31,22 @@ const messagesItem = ({ included }: { included: number }) => ({
 	reset: { interval: ResetInterval.Month },
 });
 
-const seedPlan = async ({
-	autumn,
-	planId,
-}: {
-	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
-	planId: string;
-}) => {
-	await autumn.catalogV2.update({
-		plans: [
-			{
-				plan_id: planId,
-				name: "Draft Plan",
-				items: [messagesItem({ included: 100 })],
-			},
-		],
-	});
-};
-
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 migration: existing item update with customers creates a version-pinned draft")}`,
+	`${chalk.yellowBright("catalogV2 migration: 100→500 draft stamps included: 100 on remove_items")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
-		const planId = uniqueTestId("cv2_mig_ex");
+		const planId = uniqueTestId("cv2_mig_inc");
 		await deleteDbPlans({ ctx, planIds: [planId] });
 		try {
-			await seedPlan({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Included Filter Plan",
+						items: [messagesItem({ included: 100 })],
+					},
+				],
+			});
 			await seedVersionableCustomer({ ctx, planId, version: 1 });
 
 			const response = await autumnV2_3.catalogV2.update({
@@ -121,60 +114,6 @@ test.concurrent(
 		} finally {
 			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
 			await deleteDbPlans({ ctx, planIds: [planId] });
-		}
-	},
-);
-
-test.concurrent(
-	`${chalk.yellowBright("catalogV2 migration: omitted draft flag / no customers / name-only → no draft")}`,
-	async () => {
-		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
-		const withCustomers = uniqueTestId("cv2_mig_omit");
-		const noCustomers = uniqueTestId("cv2_mig_noc");
-		const nameOnly = uniqueTestId("cv2_mig_name");
-		const planIds = [withCustomers, noCustomers, nameOnly];
-		await deleteDbPlans({ ctx, planIds });
-		try {
-			await seedPlan({ autumn: autumnV2_3, planId: withCustomers });
-			await seedPlan({ autumn: autumnV2_3, planId: noCustomers });
-			await seedPlan({ autumn: autumnV2_3, planId: nameOnly });
-			await seedVersionableCustomer({ ctx, planId: withCustomers, version: 1 });
-			await seedVersionableCustomer({ ctx, planId: nameOnly, version: 1 });
-
-			const omitted = await autumnV2_3.catalogV2.update({
-				plans: [
-					{
-						plan_id: withCustomers,
-						items: [messagesItem({ included: 500 })],
-					},
-				],
-			});
-			expect(omitted.migrations ?? []).toHaveLength(0);
-
-			const emptyCustomers = await autumnV2_3.catalogV2.update({
-				plans: [
-					{
-						plan_id: noCustomers,
-						items: [messagesItem({ included: 500 })],
-						migration: { draft: true },
-					},
-				],
-			});
-			expect(emptyCustomers.migrations ?? []).toHaveLength(0);
-
-			const renamed = await autumnV2_3.catalogV2.update({
-				plans: [
-					{
-						plan_id: nameOnly,
-						name: "Renamed",
-						migration: { draft: true },
-					},
-				],
-			});
-			expect(renamed.migrations ?? []).toHaveLength(0);
-		} finally {
-			await cleanupPlanCustomerRefs({ ctx, planIds });
-			await deleteDbPlans({ ctx, planIds });
 		}
 	},
 );

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/included-filter-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/included-filter-drafts.test.ts
@@ -1,0 +1,244 @@
+/**
+ * catalogV2.update drafts stamp included on nested license remove filters
+ * (licenseEffectiveMigratableCustomize).
+ *
+ * Contract:
+ *   propagate child 100→200 → upsert_licenses remove included: 100
+ *   two parents, same from-grant → one $or op still carries included: 100
+ *   declared overlay 100→200 → nested included: 100
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	messagesItem,
+	messagesOverride,
+	seedLinkedChildParent,
+	withCatalogPlans,
+} from "../../licenses/utils/seedLicensePlans.js";
+import { seedVersionableCustomer } from "../utils/seedVersionableCustomer.js";
+import {
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	orVersionPinnedFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "./utils/expectLicenseMigrationDrafts.js";
+
+const CATALOG_ALLOWANCE = 100;
+const NEW_ALLOWANCE = 200;
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: child 100→200 stamps included: 100 on nested remove")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_inc_c");
+		const parentId = uniqueTestId("cv2_ml_inc_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					childItems: [messagesItem(CATALOG_ALLOWANCE)],
+				});
+				await seedVersionableCustomer({ ctx, planId: parentId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: parentId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(NEW_ALLOWANCE)],
+							propagate: { license_parents: [{ plan_id: parentId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: parentId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [parentId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: {
+										remove_items: [
+											{
+												feature_id: TestFeature.Messages,
+												interval: ResetInterval.Month,
+												interval_count: 1,
+												included: CATALOG_ALLOWANCE,
+											},
+										],
+										add_items: [
+											{
+												feature_id: TestFeature.Messages,
+												included: NEW_ALLOWANCE,
+												unlimited: false,
+												reset: { interval: ResetInterval.Month },
+											},
+										],
+									},
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: two propagate parents collapse with included: 100")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_inc_2p_c");
+		const teamId = uniqueTestId("cv2_ml_inc_2p_t");
+		const scaleId = uniqueTestId("cv2_ml_inc_2p_s");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, teamId, scaleId],
+			run: async () => {
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							name: "Seat",
+							items: [messagesItem(CATALOG_ALLOWANCE)],
+						},
+						{
+							plan_id: teamId,
+							name: "Team",
+							licenses: [{ license_plan_id: childId, included: 2 }],
+						},
+						{
+							plan_id: scaleId,
+							name: "Scale",
+							licenses: [{ license_plan_id: childId, included: 2 }],
+						},
+					],
+				});
+				await seedVersionableCustomer({ ctx, planId: teamId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: scaleId, version: 1 });
+
+				const planFilter = orVersionPinnedFilter({
+					branches: [{ planId: teamId }, { planId: scaleId }],
+				});
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(NEW_ALLOWANCE)],
+							propagate: {
+								license_parents: [
+									{ plan_id: teamId },
+									{ plan_id: scaleId },
+								],
+							},
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: teamId, versions: [1] },
+							{ plan_id: scaleId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [teamId, scaleId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({
+										included: NEW_ALLOWANCE,
+										fromIncluded: CATALOG_ALLOWANCE,
+									}),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 license-drafts: declared overlay 100→200 stamps nested included: 100")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const childId = uniqueTestId("cv2_ml_inc_dec_c");
+		const parentId = uniqueTestId("cv2_ml_inc_dec_t");
+		await withCatalogPlans({
+			ctx,
+			planIds: [childId, parentId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					customize: messagesOverride(CATALOG_ALLOWANCE),
+				});
+				await seedVersionableCustomer({ ctx, planId: parentId, version: 1 });
+
+				const planFilter = versionPinnedFilter({ planId: parentId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: parentId,
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: messagesOverride(NEW_ALLOWANCE),
+								},
+							],
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: parentId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [parentId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								parentLicenseOp({
+									planFilter,
+									childId,
+									customize: messagesItemDelta({
+										included: NEW_ALLOWANCE,
+										fromIncluded: CATALOG_ALLOWANCE,
+									}),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-seats-direct-and-overlay-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/propagated/propagate-seats-direct-and-overlay-drafts.test.ts
@@ -219,7 +219,10 @@ test.concurrent(
 								parentLicenseOp({
 									planFilter,
 									childId,
-									customize: messagesItemDelta({ included: 1000 }),
+									customize: messagesItemDelta({
+										included: 1000,
+										fromIncluded: 500,
+									}),
 								}),
 							],
 						},

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/utils/expectLicenseMigrationDrafts.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/utils/expectLicenseMigrationDrafts.ts
@@ -23,12 +23,20 @@ import {
 } from "../../utils/expectMigrationDrafts.js";
 import type { CatalogV2Client } from "../../../licenses/utils/seedLicensePlans.js";
 
-export const messagesItemDelta = ({ included }: { included: number }) => ({
+/** Catalog draft generators stamp the from-item grant on remove. Default 10 matches `messagesItem(10)`. */
+export const messagesItemDelta = ({
+	included,
+	fromIncluded = 10,
+}: {
+	included: number;
+	fromIncluded?: number;
+}) => ({
 	remove_items: [
 		{
 			feature_id: TestFeature.Messages,
 			interval: ResetInterval.Month,
 			interval_count: 1,
+			included: fromIncluded,
 		},
 	],
 	add_items: [
@@ -54,14 +62,17 @@ export const dashboardRemoveCustomize = {
 /** Delete Messages and add Words — same replace across every child. */
 export const messagesToWordsDelta = ({
 	included = 100,
+	fromIncluded = 10,
 }: {
 	included?: number;
+	fromIncluded?: number;
 } = {}) => ({
 	remove_items: [
 		{
 			feature_id: TestFeature.Messages,
 			interval: ResetInterval.Month,
 			interval_count: 1,
+			included: fromIncluded,
 		},
 	],
 	add_items: [

--- a/server/tests/integration/catalog-v2/plans/migrations/variants/conflict-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/variants/conflict-drafts.test.ts
@@ -2,13 +2,13 @@
  * catalogV2.update — preview conflicts never block or omit a variant draft.
  *
  * Contract:
- *   follow 100→150 vs 200 lists value_divergence; draft customize is 150
+ *   follow 100→150 vs 200 lists value_divergence; from-grant splits the ops
  *   follow + declare 300 → two ops (150 vs 300); explicit swallows the list
- *   license follow 100→150 vs 200 stamps license_plan_id; one $or upsert_licenses op
+ *   license follow 100→150 vs 200 stamps license_plan_id; from-grant splits
  *   license follow + declare 300 → two upsert_licenses ops (150 vs 300)
  *   pin lists the clash and still omits the variant op
  *   license pin lists license_plan_id and omits the variant license op
- *   both lanes: plan-body + Seat clash → one $or item op + one $or license op
+ *   both lanes: plan-body + Seat clash → two item ops + two license ops
  */
 
 import { test } from "bun:test";
@@ -88,9 +88,8 @@ test.concurrent(
 					},
 				});
 
-				const planFilter = orVersionPinnedFilter({
-					branches: [{ planId: baseId }, { planId: variantId }],
-				});
+				const baseFilter = versionPinnedFilter({ planId: baseId });
+				const variantFilter = versionPinnedFilter({ planId: variantId });
 				await expectLicenseDraftCase({
 					autumn: autumnV2_3,
 					ctx,
@@ -105,11 +104,27 @@ test.concurrent(
 						{
 							planIds: [baseId, variantId],
 							noBillingChanges: true,
-							filter: { customer: { plan: planFilter } },
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [{ planId: baseId }, { planId: variantId }],
+									}),
+								},
+							},
 							operations: [
 								childItemOp({
-									planFilter,
-									customize: messagesItemDelta({ included: 150 }),
+									planFilter: baseFilter,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
+								}),
+								childItemOp({
+									planFilter: variantFilter,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 200,
+									}),
 								}),
 							],
 						},
@@ -198,11 +213,17 @@ test.concurrent(
 							operations: [
 								childItemOp({
 									planFilter: baseFilter,
-									customize: messagesItemDelta({ included: 150 }),
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
 								}),
 								childItemOp({
 									planFilter: variantFilter,
-									customize: messagesItemDelta({ included: 300 }),
+									customize: messagesItemDelta({
+										included: 300,
+										fromIncluded: 200,
+									}),
 								}),
 							],
 						},
@@ -269,10 +290,8 @@ test.concurrent(
 					},
 				});
 
-				const planFilter = orVersionPinnedFilter({
-					branches: [{ planId: baseId }, { planId: variantId }],
-				});
-				const messages150 = messagesItemDelta({ included: 150 });
+				const baseFilter = versionPinnedFilter({ planId: baseId });
+				const variantFilter = versionPinnedFilter({ planId: variantId });
 				await expectLicenseDraftCase({
 					autumn: autumnV2_3,
 					ctx,
@@ -288,12 +307,29 @@ test.concurrent(
 							planIds: [baseId, variantId],
 							omitPlanIds: [childId],
 							noBillingChanges: true,
-							filter: { customer: { plan: planFilter } },
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [{ planId: baseId }, { planId: variantId }],
+									}),
+								},
+							},
 							operations: [
 								parentLicenseOp({
-									planFilter,
+									planFilter: baseFilter,
 									childId,
-									customize: messages150,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
+								}),
+								parentLicenseOp({
+									planFilter: variantFilter,
+									childId,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 200,
+									}),
 								}),
 							],
 						},
@@ -361,7 +397,10 @@ test.concurrent(
 							operations: [
 								childItemOp({
 									planFilter: baseFilter,
-									customize: messagesItemDelta({ included: 150 }),
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
 								}),
 							],
 						},
@@ -462,12 +501,18 @@ test.concurrent(
 								parentLicenseOp({
 									planFilter: versionPinnedFilter({ planId: baseId }),
 									childId,
-									customize: messagesItemDelta({ included: 150 }),
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
 								}),
 								parentLicenseOp({
 									planFilter: versionPinnedFilter({ planId: variantId }),
 									childId,
-									customize: messagesItemDelta({ included: 300 }),
+									customize: messagesItemDelta({
+										included: 300,
+										fromIncluded: 200,
+									}),
 								}),
 							],
 						},
@@ -549,7 +594,10 @@ test.concurrent(
 								parentLicenseOp({
 									planFilter: baseFilter,
 									childId,
-									customize: messagesItemDelta({ included: 150 }),
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
 								}),
 							],
 						},
@@ -561,7 +609,7 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 variants drafts: both lanes draft the item $or and two license ops")}`,
+	`${chalk.yellowBright("catalogV2 variants drafts: both lanes draft two item ops and two license ops")}`,
 	async () => {
 		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
 		const baseId = uniqueTestId("cv2_var_dr_cf_both");
@@ -618,10 +666,8 @@ test.concurrent(
 					},
 				});
 
-				const planFilter = orVersionPinnedFilter({
-					branches: [{ planId: baseId }, { planId: variantId }],
-				});
-				const messages150 = messagesItemDelta({ included: 150 });
+				const baseFilter = versionPinnedFilter({ planId: baseId });
+				const variantFilter = versionPinnedFilter({ planId: variantId });
 				await expectLicenseDraftCase({
 					autumn: autumnV2_3,
 					ctx,
@@ -637,16 +683,43 @@ test.concurrent(
 							planIds: [baseId, variantId],
 							omitPlanIds: [childId],
 							noBillingChanges: true,
-							filter: { customer: { plan: planFilter } },
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [{ planId: baseId }, { planId: variantId }],
+									}),
+								},
+							},
 							operations: [
 								childItemOp({
-									planFilter,
-									customize: messages150,
+									planFilter: baseFilter,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
+								}),
+								childItemOp({
+									planFilter: variantFilter,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 200,
+									}),
 								}),
 								parentLicenseOp({
-									planFilter,
+									planFilter: baseFilter,
 									childId,
-									customize: messages150,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
+								}),
+								parentLicenseOp({
+									planFilter: variantFilter,
+									childId,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 200,
+									}),
 								}),
 							],
 						},

--- a/server/tests/integration/catalog-v2/plans/migrations/variants/included-filter-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/variants/included-filter-drafts.test.ts
@@ -1,0 +1,312 @@
+/**
+ * catalogV2.update variant drafts stamp included on remove_items (own
+ * IdentityAndIncluded diff). Same from-grant still collapses with the stamp.
+ *
+ * Contract:
+ *   follow 100→150 on base+variant both at 100 → one $or op, included: 100
+ *   follow 100 vs 200 → 150 splits; each op carries its from-grant
+ *   declared variant 200→300 stamps included: 200
+ *   license overlay follow 100 vs 200 → 150 stamps nested included
+ */
+
+import { test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../utils/seedVersionableCustomer.js";
+import {
+	childItemOp,
+	expectLicenseDraftCase,
+	messagesItemDelta,
+	orVersionPinnedFilter,
+	parentLicenseOp,
+	versionPinnedFilter,
+} from "../licenses/utils/expectLicenseMigrationDrafts.js";
+import {
+	messagesItem,
+	withCatalogPlans,
+} from "../../licenses/utils/seedLicensePlans.js";
+import {
+	seedBaseVariantWithChildLicense,
+	seedBaseWithVariant,
+} from "../../variants/utils/seedVariantPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants drafts: follow 100→150 stamps included: 100 on the collapsed $or")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_inc_same");
+		const variantId = uniqueTestId("cv2_var_inc_same_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+					variantMessages: 100,
+				});
+				await seedVersionableCustomer({ ctx, planId: baseId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+
+				const planFilter = orVersionPinnedFilter({
+					branches: [{ planId: baseId }, { planId: variantId }],
+				});
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: baseId,
+							items: [messagesItem(150)],
+							propagate: { variants: [{ plan_id: variantId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: baseId, versions: [1] },
+							{ plan_id: variantId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [baseId, variantId],
+							noBillingChanges: true,
+							filter: { customer: { plan: planFilter } },
+							operations: [
+								childItemOp({
+									planFilter,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants drafts: follow 100 vs 200 → 150 stamps each from-grant")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_inc_split");
+		const variantId = uniqueTestId("cv2_var_inc_split_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				await seedVersionableCustomer({ ctx, planId: baseId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+
+				const baseFilter = versionPinnedFilter({ planId: baseId });
+				const variantFilter = versionPinnedFilter({ planId: variantId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: baseId,
+							items: [messagesItem(150)],
+							propagate: { variants: [{ plan_id: variantId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: baseId, versions: [1] },
+							{ plan_id: variantId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [baseId, variantId],
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [{ planId: baseId }, { planId: variantId }],
+									}),
+								},
+							},
+							operations: [
+								childItemOp({
+									planFilter: baseFilter,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
+								}),
+								childItemOp({
+									planFilter: variantFilter,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 200,
+									}),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants drafts: declared 200→300 stamps included: 200")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_inc_dec");
+		const variantId = uniqueTestId("cv2_var_inc_dec_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+
+				const variantFilter = versionPinnedFilter({ planId: variantId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: baseId,
+							variants: [
+								{
+									variant_plan_id: variantId,
+									customize: {
+										remove_items: [{ feature_id: TestFeature.Messages }],
+										add_items: [messagesItem(300)],
+									},
+								},
+							],
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [[{ plan_id: variantId, versions: [1] }]],
+					expected: [
+						{
+							planIds: [variantId],
+							omitPlanIds: [baseId],
+							noBillingChanges: true,
+							filter: { customer: { plan: variantFilter } },
+							operations: [
+								childItemOp({
+									planFilter: variantFilter,
+									customize: messagesItemDelta({
+										included: 300,
+										fromIncluded: 200,
+									}),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants drafts: license overlay follow stamps nested included 100 vs 200")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_inc_lic");
+		const variantId = uniqueTestId("cv2_var_inc_lic_eu");
+		const childId = uniqueTestId("cv2_var_inc_lic_seat");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId, childId],
+			run: async () => {
+				await seedBaseVariantWithChildLicense({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+					childId,
+				});
+				await seedVersionableCustomer({ ctx, planId: baseId, version: 1 });
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+
+				const baseFilter = versionPinnedFilter({ planId: baseId });
+				const variantFilter = versionPinnedFilter({ planId: variantId });
+				await expectLicenseDraftCase({
+					autumn: autumnV2_3,
+					ctx,
+					plans: [
+						{
+							plan_id: baseId,
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: {
+										remove_items: [{ feature_id: TestFeature.Messages }],
+										add_items: [messagesItem(150)],
+									},
+								},
+							],
+							propagate: { variants: [{ plan_id: variantId }] },
+							migration: { draft: true },
+						},
+					],
+					responsePlans: [
+						[
+							{ plan_id: baseId, versions: [1] },
+							{ plan_id: variantId, versions: [1] },
+						],
+					],
+					expected: [
+						{
+							planIds: [baseId, variantId],
+							omitPlanIds: [childId],
+							noBillingChanges: true,
+							filter: {
+								customer: {
+									plan: orVersionPinnedFilter({
+										branches: [{ planId: baseId }, { planId: variantId }],
+									}),
+								},
+							},
+							operations: [
+								parentLicenseOp({
+									planFilter: baseFilter,
+									childId,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 100,
+									}),
+								}),
+								parentLicenseOp({
+									planFilter: variantFilter,
+									childId,
+									customize: messagesItemDelta({
+										included: 150,
+										fromIncluded: 200,
+									}),
+								}),
+							],
+						},
+					],
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/migrations/variants/variant-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/variants/variant-drafts.test.ts
@@ -195,7 +195,10 @@ test.concurrent(
 							operations: [
 								childItemOp({
 									planFilter: variantFilter,
-									customize: messagesItemDelta({ included: 300 }),
+									customize: messagesItemDelta({
+										included: 300,
+										fromIncluded: 200,
+									}),
 								}),
 							],
 						},

--- a/server/tests/integration/catalog-v2/plans/migrations/versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/versioning-drafts.test.ts
@@ -35,6 +35,7 @@ const messagesCustomize = ({ included }: { included: number }) => ({
 			feature_id: TestFeature.Messages,
 			interval: ResetInterval.Month,
 			interval_count: 1,
+			included: 100,
 		},
 	],
 	add_items: [
@@ -212,6 +213,7 @@ test.concurrent(
 											feature_id: TestFeature.Messages,
 											interval: ResetInterval.Month,
 											interval_count: 1,
+											included: 200,
 										},
 									],
 									add_items: [

--- a/server/tests/integration/crud/plans/diffing/diffPlanV1.test.ts
+++ b/server/tests/integration/crud/plans/diffing/diffPlanV1.test.ts
@@ -290,4 +290,35 @@ describe("diffPlanV1 — popfly start vs start_annual", () => {
 			expect.arrayContaining(to.items),
 		);
 	});
+
+	test("default 100→200 remove filter does not stamp included", () => {
+		const from = makePlan({
+			items: [
+				{
+					feature_id: "messages",
+					included: 100,
+					unlimited: false,
+					reset: { interval: ResetInterval.Month },
+					price: null,
+				},
+			],
+		});
+		const to = makePlan({
+			items: [{ ...from.items[0]!, included: 200 }],
+		});
+
+		const diff = diffPlanV1({ from, to });
+		expect(diff.remove_items).toEqual([
+			{
+				feature_id: "messages",
+				interval: ResetInterval.Month,
+				interval_count: 1,
+			},
+		]);
+		expect(diff.remove_items?.[0]).not.toHaveProperty("included");
+		expect(diff.add_items?.[0]).toMatchObject({
+			feature_id: "messages",
+			included: 200,
+		});
+	});
 });

--- a/server/tests/integration/licenses/utils/expectLicenseAssignmentMessagesCorrect.ts
+++ b/server/tests/integration/licenses/utils/expectLicenseAssignmentMessagesCorrect.ts
@@ -1,0 +1,59 @@
+import { expect } from "bun:test";
+import { customerEntitlements } from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+/** One assignment's live messages grant: same definition when spared. */
+export const expectLicenseAssignmentMessagesCorrect = async ({
+	ctx,
+	customerProductId,
+	featureId,
+	balance,
+	entitlementId,
+}: {
+	ctx: AutumnContext;
+	customerProductId: string;
+	featureId: string;
+	balance: number;
+	entitlementId?: string;
+}) => {
+	const [row] = await ctx.db
+		.select({
+			balance: customerEntitlements.balance,
+			entitlementId: customerEntitlements.entitlement_id,
+		})
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.customer_product_id, customerProductId),
+				eq(customerEntitlements.feature_id, featureId),
+			),
+		);
+
+	expect(row, `expected ${featureId} on ${customerProductId}`).toBeDefined();
+	expect(row!.balance).toBe(balance);
+	if (entitlementId !== undefined) {
+		expect(row!.entitlementId).toBe(entitlementId);
+	}
+};
+
+export const expectLicenseAssignmentFeaturePresent = async ({
+	ctx,
+	customerProductId,
+	featureId,
+}: {
+	ctx: AutumnContext;
+	customerProductId: string;
+	featureId: string;
+}) => {
+	const [row] = await ctx.db
+		.select({ id: customerEntitlements.id })
+		.from(customerEntitlements)
+		.where(
+			and(
+				eq(customerEntitlements.customer_product_id, customerProductId),
+				eq(customerEntitlements.feature_id, featureId),
+			),
+		);
+	expect(row, `expected ${featureId} on ${customerProductId}`).toBeDefined();
+};

--- a/server/tests/perf/batch-migrations/probes/probeReplaceGroupFanout.ts
+++ b/server/tests/perf/batch-migrations/probes/probeReplaceGroupFanout.ts
@@ -1,0 +1,657 @@
+/**
+ * Times the new filter-replace hot path against the DEV DB: candidate SELECT
+ * (join entitlements AS definition) + N applyReplacePatches groups per page.
+ *
+ * Average = 1 grant-delta group (everyone on the same live def).
+ * Limit    = many groups on one 5k-customer page (concurrency 50).
+ * Also times filter-delete (one-shot) and mixed (delete then replace).
+ *
+ * Writes run inside a rolled-back transaction. Seed is isolated (plangrp).
+ *
+ *   infisical run --env=dev --recursive -- bun tests/perf/batch-migrations/probes/probeReplaceGroupFanout.ts
+ *   infisical run --env=dev --recursive -- bun tests/perf/batch-migrations/probes/probeReplaceGroupFanout.ts --groups 1,100,1000
+ *   infisical run --env=dev --recursive -- bun tests/perf/batch-migrations/probes/probeReplaceGroupFanout.ts --explain
+ *   infisical run --env=dev --recursive -- bun tests/perf/batch-migrations/probes/probeReplaceGroupFanout.ts --cleanup
+ */
+
+import {
+	AllowanceType,
+	CusProductStatus,
+	EntInterval,
+	type EntitlementWithFeature,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { buildAddCandidateRowsQuery } from "@/internal/migrations/v2/batchOperations/actions/addCustomerEntitlementsForPage/selectAddCandidateRows.js";
+import { deleteCustomerEntitlementRows } from "@/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/deleteCustomerEntitlementRows.js";
+import {
+	buildRemoveCandidateRowsQuery,
+	selectRemoveCandidateRows,
+} from "@/internal/migrations/v2/batchOperations/actions/removeCustomerEntitlementsForPage/selectRemoveCandidateRows.js";
+import {
+	applyReplacePatches,
+	type ReplaceRow,
+} from "@/internal/migrations/v2/batchOperations/actions/replaceCustomerEntitlementsForPage/applyReplacePatches.js";
+import {
+	buildReplaceCandidateRowsQuery,
+	selectReplaceCandidateRows,
+} from "@/internal/migrations/v2/batchOperations/actions/replaceCustomerEntitlementsForPage/selectReplaceCandidateRows.js";
+import { groupFilterReplaceRows } from "@/internal/migrations/v2/batchOperations/actions/utils/groupFilterReplaceRows.js";
+import { BATCH_MIGRATION_PATCH_GROUP_CONCURRENCY } from "@/internal/migrations/v2/batchOperations/execute/utils/batchMigrationExecutionConstants.js";
+import { mapWithConcurrency } from "@/internal/migrations/v2/batchOperations/execute/utils/mapWithConcurrency.js";
+import { buildOperationScope } from "@/internal/migrations/v2/batchOperations/scope/operationScope.js";
+import { generateId } from "@/utils/genUtils.js";
+import { getBenchContext } from "../utils/benchContext.js";
+import {
+	BENCH_PLANREP_PREFIXES,
+	ensureBenchPlanItemProduct,
+} from "../utils/seedBenchPlanItems.js";
+
+const PREFIXES = {
+	productId: "bench-plangrp",
+	customerId: "bench-plangrp-c-",
+	internalCustomer: "cus_bench_plangrp_",
+	customerProduct: "cp_bench_plangrp_",
+	entitlement: "ce_bench_plangrp_",
+	wordsEntitlement: "ce_bench_plangrp_w_",
+	fromEntitlement: "ent_bench_plangrp_from_",
+	wordsFromEntitlement: "ent_bench_plangrp_words_",
+	toEntitlement: "ent_bench_plangrp_to",
+};
+
+const PAGE_SIZE = 5000;
+const TO_ALLOWANCE = 10_000;
+const APPROX_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+const parseArgs = () => {
+	const args = process.argv.slice(2);
+	const get = (flag: string) => {
+		const index = args.indexOf(flag);
+		return index === -1 ? undefined : args[index + 1];
+	};
+	const groups = (get("--groups") ?? "1,10,100,1000")
+		.split(",")
+		.map((value) => Number(value.trim()))
+		.filter((value) => value > 0);
+	return {
+		customers: Number(get("--customers") ?? String(PAGE_SIZE)),
+		groups,
+		cleanup: args.includes("--cleanup"),
+		explain: args.includes("--explain"),
+	};
+};
+
+const printPlan = ({ title, plan }: { title: string; plan: unknown }) => {
+	const rows = (
+		Array.isArray(plan) ? plan : ((plan as { rows?: unknown[] }).rows ?? [])
+	) as Record<string, string>[];
+	console.log("");
+	console.log(`── ${title} ${"─".repeat(Math.max(58 - title.length, 0))}`);
+	for (const row of rows) {
+		console.log(Object.values(row)[0]);
+	}
+};
+
+const explainMs = (plan: unknown): number | undefined => {
+	const rows = (
+		Array.isArray(plan) ? plan : ((plan as { rows?: unknown[] }).rows ?? [])
+	) as Record<string, string>[];
+	for (const row of rows) {
+		const line = Object.values(row)[0];
+		const match = /Execution Time: ([0-9.]+) ms/.exec(line);
+		if (match) return Number(match[1]);
+	}
+	return undefined;
+};
+
+const cleanupFanout = async ({ db }: { db: DrizzleCli }) => {
+	await db.execute(sql`
+		DELETE FROM customer_entitlements
+		WHERE id LIKE ${`${PREFIXES.entitlement}%`}
+	`);
+	await db.execute(sql`
+		DELETE FROM customer_products
+		WHERE id LIKE ${`${PREFIXES.customerProduct}%`}
+	`);
+	await db.execute(sql`
+		DELETE FROM customers
+		WHERE internal_id LIKE ${`${PREFIXES.internalCustomer}%`}
+	`);
+	await db.execute(sql`
+		DELETE FROM entitlements
+		WHERE id LIKE ${`${PREFIXES.fromEntitlement}%`}
+			OR id LIKE ${`${PREFIXES.wordsFromEntitlement}%`}
+			OR id = ${PREFIXES.toEntitlement}
+	`);
+};
+
+const seedFanout = async ({
+	db,
+	orgId,
+	env,
+	internalProductId,
+	internalFeatureId,
+	featureId,
+	wordsInternalFeatureId,
+	wordsFeatureId,
+	customers,
+	groupCount,
+	startsAt,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: string;
+	internalProductId: string;
+	internalFeatureId: string;
+	featureId: string;
+	wordsInternalFeatureId: string;
+	wordsFeatureId: string;
+	customers: number;
+	groupCount: number;
+	startsAt: number;
+}) => {
+	await db.execute(sql`
+		INSERT INTO entitlements (
+			id, created_at, org_id, internal_product_id, internal_feature_id,
+			feature_id, allowance_type, allowance, interval, interval_count, is_custom
+		)
+		SELECT
+			${PREFIXES.fromEntitlement} || i,
+			${startsAt},
+			${orgId},
+			${internalProductId},
+			${internalFeatureId},
+			${featureId},
+			${AllowanceType.Fixed},
+			10 + i,
+			${EntInterval.Month},
+			1,
+			true
+		FROM GENERATE_SERIES(1, ${groupCount}) AS i
+		ON CONFLICT (id) DO NOTHING
+	`);
+
+	await db.execute(sql`
+		INSERT INTO entitlements (
+			id, created_at, org_id, internal_product_id, internal_feature_id,
+			feature_id, allowance_type, allowance, interval, interval_count, is_custom
+		)
+		VALUES (
+			${PREFIXES.toEntitlement},
+			${startsAt},
+			${orgId},
+			${internalProductId},
+			${internalFeatureId},
+			${featureId},
+			${AllowanceType.Fixed},
+			${TO_ALLOWANCE},
+			${EntInterval.Month},
+			1,
+			true
+		)
+		ON CONFLICT (id) DO NOTHING
+	`);
+
+	const series = sql`GENERATE_SERIES(1, ${customers}) AS i`;
+	await db.execute(sql`
+		INSERT INTO customers (
+			internal_id, id, org_id, env, created_at, name, email
+		)
+		SELECT
+			${PREFIXES.internalCustomer} || i,
+			${PREFIXES.customerId} || i,
+			${orgId},
+			${env},
+			${startsAt},
+			'bench plan grp',
+			''
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+	await db.execute(sql`
+		INSERT INTO customer_products (
+			id, internal_customer_id, internal_product_id, created_at, status,
+			starts_at, is_custom, product_id, customer_id, options
+		)
+		SELECT
+			${PREFIXES.customerProduct} || i,
+			${PREFIXES.internalCustomer} || i,
+			${internalProductId},
+			${startsAt},
+			${CusProductStatus.Active},
+			${startsAt},
+			false,
+			${PREFIXES.productId},
+			${PREFIXES.customerId} || i,
+			'{}'::jsonb[]
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, customer_id, unlimited, balance,
+			created_at, reset_cycle_anchor, next_reset_at, usage_allowed,
+			separate_interval, adjustment, additional_balance, cache_version
+		)
+		SELECT
+			${PREFIXES.entitlement} || i,
+			${PREFIXES.customerProduct} || i,
+			${PREFIXES.fromEntitlement} || ((i - 1) % ${groupCount} + 1),
+			${PREFIXES.internalCustomer} || i,
+			${internalFeatureId},
+			${featureId},
+			${PREFIXES.customerId} || i,
+			false,
+			40,
+			${startsAt},
+			${startsAt},
+			${startsAt} + ${APPROX_MONTH_MS}::bigint,
+			false,
+			false,
+			0,
+			0,
+			0
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+
+	await db.execute(sql`
+		INSERT INTO entitlements (
+			id, created_at, org_id, internal_product_id, internal_feature_id,
+			feature_id, allowance_type, allowance, interval, interval_count, is_custom
+		)
+		SELECT
+			${PREFIXES.wordsFromEntitlement} || i,
+			${startsAt},
+			${orgId},
+			${internalProductId},
+			${wordsInternalFeatureId},
+			${wordsFeatureId},
+			${AllowanceType.Fixed},
+			50 + i,
+			${EntInterval.Month},
+			1,
+			true
+		FROM GENERATE_SERIES(1, ${groupCount}) AS i
+		ON CONFLICT (id) DO NOTHING
+	`);
+	await db.execute(sql`
+		INSERT INTO customer_entitlements (
+			id, customer_product_id, entitlement_id, internal_customer_id,
+			internal_feature_id, feature_id, customer_id, unlimited, balance,
+			created_at, reset_cycle_anchor, next_reset_at, usage_allowed,
+			separate_interval, adjustment, additional_balance, cache_version
+		)
+		SELECT
+			${PREFIXES.wordsEntitlement} || i,
+			${PREFIXES.customerProduct} || i,
+			${PREFIXES.wordsFromEntitlement} || ((i - 1) % ${groupCount} + 1),
+			${PREFIXES.internalCustomer} || i,
+			${wordsInternalFeatureId},
+			${wordsFeatureId},
+			${PREFIXES.customerId} || i,
+			false,
+			40,
+			${startsAt},
+			${startsAt},
+			${startsAt} + ${APPROX_MONTH_MS}::bigint,
+			false,
+			false,
+			0,
+			0,
+			0
+		FROM ${series}
+		ON CONFLICT DO NOTHING
+	`);
+};
+
+const main = async () => {
+	const { customers, groups, cleanup, explain } = parseArgs();
+	const { ctx, org } = await getBenchContext();
+	const { db } = ctx;
+	const messages = ctx.features.find(
+		(feature) => feature.id === TestFeature.Messages,
+	);
+	const words = ctx.features.find((feature) => feature.id === TestFeature.Words);
+	if (!messages || !words) throw new Error("bench: messages/words missing");
+
+	const cleanupStarted = Date.now();
+	await cleanupFanout({ db });
+	console.log(`probe: cleanup ${Date.now() - cleanupStarted}ms`);
+	if (cleanup) process.exit(0);
+
+	const { internalProductId } = await ensureBenchPlanItemProduct({
+		db,
+		orgId: org.id,
+		env: ctx.env,
+		internalFeatureId: messages.internal_id,
+		featureId: TestFeature.Messages,
+		productId: PREFIXES.productId,
+		name: "Bench Plan Group Fanout",
+		allowance: 100,
+	});
+	const scope = buildOperationScope({
+		internalProductId,
+		isCustom: false,
+	});
+	const filter = {
+		feature_id: TestFeature.Messages,
+		interval: EntInterval.Month,
+		interval_count: 1,
+	};
+
+	const leftoverPage = (
+		await db.execute<{ internal_id: string }>(sql`
+			SELECT internal_id FROM customers
+			WHERE internal_id LIKE ${`${BENCH_PLANREP_PREFIXES.internalCustomer}%`}
+			ORDER BY internal_id
+			LIMIT ${PAGE_SIZE}
+		`)
+	).map((row) => row.internal_id);
+
+	if (leftoverPage.length > 0) {
+		const leftoverEntitlement = (
+			await db.execute<{ entitlement_id: string }>(sql`
+				SELECT ce.entitlement_id
+				FROM customer_entitlements ce
+				WHERE ce.id LIKE ${`${BENCH_PLANREP_PREFIXES.entitlement}%`}
+				LIMIT 1
+			`)
+		)[0]?.entitlement_id;
+		if (leftoverEntitlement) {
+			const leftoverPlan = await db.execute(sql`
+				EXPLAIN (ANALYZE, BUFFERS)
+				${buildReplaceCandidateRowsQuery({
+					internalCustomerIds: leftoverPage,
+					scope: buildOperationScope({
+						internalProductId: (
+							await db.execute<{ internal_product_id: string }>(sql`
+								SELECT internal_product_id FROM customer_products
+								WHERE id LIKE ${`${BENCH_PLANREP_PREFIXES.customerProduct}%`}
+								LIMIT 1
+							`)
+						)[0].internal_product_id,
+						isCustom: false,
+					}),
+					entitlement: {
+						id: leftoverEntitlement,
+						interval: EntInterval.Month,
+						interval_count: 1,
+						internal_feature_id: messages.internal_id,
+						feature: messages,
+					} as EntitlementWithFeature,
+					filter,
+					excludeEntitlementId: "ent_bench_exclude_none",
+					features: ctx.features,
+					includeAnchorSources: true,
+					limit: 10_000,
+				})}
+			`);
+			printPlan({
+				title: `replace SELECT leftover planrep n=${leftoverPage.length}`,
+				plan: leftoverPlan,
+			});
+		}
+	} else {
+		console.log("probe: no leftover bench-plan-replace rows — skip 5k leftover EXPLAIN");
+	}
+
+	const toEntitlement = {
+		id: PREFIXES.toEntitlement,
+		created_at: Date.now(),
+		org_id: org.id,
+		internal_product_id: internalProductId,
+		internal_feature_id: messages.internal_id,
+		feature_id: TestFeature.Messages,
+		allowance_type: AllowanceType.Fixed,
+		allowance: TO_ALLOWANCE,
+		interval: EntInterval.Month,
+		interval_count: 1,
+		is_custom: true,
+		feature: messages,
+	} as EntitlementWithFeature;
+
+	const wordsEntitlement = {
+		id: generateId("ent"),
+		interval: EntInterval.Month,
+		interval_count: 1,
+		internal_feature_id: words.internal_id,
+		feature_id: words.id,
+		feature: words,
+	} as EntitlementWithFeature;
+
+	for (const groupCount of groups) {
+		console.log("");
+		console.log(
+			`══ groups=${groupCount} customers=${customers} concurrency=${BATCH_MIGRATION_PATCH_GROUP_CONCURRENCY} ${"═".repeat(12)}`,
+		);
+
+		await cleanupFanout({ db });
+		const seedStarted = Date.now();
+		await seedFanout({
+			db,
+			orgId: org.id,
+			env: ctx.env,
+			internalProductId,
+			internalFeatureId: messages.internal_id,
+			featureId: TestFeature.Messages,
+			wordsInternalFeatureId: words.internal_id,
+			wordsFeatureId: TestFeature.Words,
+			customers,
+			groupCount,
+			startsAt: Date.now(),
+		});
+		await db.execute(sql`ANALYZE customer_entitlements`);
+		await db.execute(sql`ANALYZE entitlements`);
+		console.log(`probe: seed+analyze ${Date.now() - seedStarted}ms`);
+
+		const pageCustomers = (
+			await db.execute<{ internal_id: string }>(sql`
+				SELECT internal_id FROM customers
+				WHERE internal_id LIKE ${`${PREFIXES.internalCustomer}%`}
+				ORDER BY internal_id
+				LIMIT ${customers}
+			`)
+		).map((row) => row.internal_id);
+
+		const replaceQuery = buildReplaceCandidateRowsQuery({
+			internalCustomerIds: pageCustomers,
+			scope,
+			entitlement: toEntitlement,
+			filter,
+			excludeEntitlementId: PREFIXES.toEntitlement,
+			features: ctx.features,
+			includeAnchorSources: true,
+			limit: 10_000,
+		});
+		const replaceExplain = await db.execute(
+			sql`EXPLAIN (ANALYZE, BUFFERS) ${replaceQuery}`,
+		);
+		if (explain) {
+			printPlan({
+				title: `replace SELECT groups=${groupCount}`,
+				plan: replaceExplain,
+			});
+		}
+
+		const addQuery = buildAddCandidateRowsQuery({
+			internalCustomerIds: pageCustomers,
+			scope,
+			entitlement: wordsEntitlement,
+			includeAnchorSources: true,
+			limit: 10_000,
+		});
+		const addExplain = await db.execute(
+			sql`EXPLAIN (ANALYZE, BUFFERS) ${addQuery}`,
+		);
+		if (explain) {
+			printPlan({
+				title: `add SELECT (words already live → skip) groups=${groupCount}`,
+				plan: addExplain,
+			});
+		}
+
+		const wordsFilter = {
+			feature_id: TestFeature.Words,
+			interval: EntInterval.Month,
+			interval_count: 1,
+		};
+		const deleteQuery = buildRemoveCandidateRowsQuery({
+			internalCustomerIds: pageCustomers,
+			scope,
+			filter: wordsFilter,
+			limit: 10_000,
+		});
+		const deleteExplain = await db.execute(
+			sql`EXPLAIN (ANALYZE, BUFFERS) ${deleteQuery}`,
+		);
+		if (explain) {
+			printPlan({
+				title: `delete SELECT groups=${groupCount}`,
+				plan: deleteExplain,
+			});
+		}
+
+		const selectStarted = Date.now();
+		const candidates = await selectReplaceCandidateRows({
+			db,
+			internalCustomerIds: pageCustomers,
+			scope,
+			entitlement: toEntitlement,
+			filter,
+			excludeEntitlementId: PREFIXES.toEntitlement,
+			features: ctx.features,
+			includeAnchorSources: true,
+			limit: 10_000,
+		});
+		const selectMs = Date.now() - selectStarted;
+
+		const groupStarted = Date.now();
+		const grouped = groupFilterReplaceRows({
+			rows: candidates.map(
+				(candidate): ReplaceRow => ({
+					...candidate,
+					resetCycleAnchor: candidate.liveNextResetAt,
+					nextResetAt: candidate.liveNextResetAt,
+				}),
+			),
+			toEntitlement,
+		});
+		const groupMs = Date.now() - groupStarted;
+
+		let replaceMs = 0;
+		let updated = 0;
+		try {
+			await db.transaction(async (tx) => {
+				const replaceStarted = Date.now();
+				const patched = await mapWithConcurrency({
+					items: grouped,
+					concurrency: BATCH_MIGRATION_PATCH_GROUP_CONCURRENCY,
+					run: (group) =>
+						applyReplacePatches({
+							db: tx as unknown as DrizzleCli,
+							rows: group.rows,
+							scope,
+							toEntitlement,
+							customerEntitlementPatch: group.patch,
+						}),
+				});
+				replaceMs = Date.now() - replaceStarted;
+				updated = patched.reduce((sum, result) => sum + result.rows, 0);
+				throw new Error("probe: intentional rollback");
+			});
+		} catch (error) {
+			if (!(error instanceof Error && error.message.includes("intentional"))) {
+				throw error;
+			}
+		}
+
+		const waves = Math.ceil(
+			grouped.length / BATCH_MIGRATION_PATCH_GROUP_CONCURRENCY,
+		);
+		console.log(
+			`probe: replace select ${selectMs}ms (${candidates.length} rows)  group ${groupMs}ms (${grouped.length} groups, ${waves} waves)  apply ${replaceMs}ms (${updated} updates)  page ${selectMs + groupMs + replaceMs}ms`,
+		);
+		console.log(
+			`probe: EXPLAIN replace ${explainMs(replaceExplain) ?? "?"}ms  add ${explainMs(addExplain) ?? "?"}ms  delete ${explainMs(deleteExplain) ?? "?"}ms`,
+		);
+
+		const removeSelectStarted = Date.now();
+		const removeCandidates = await selectRemoveCandidateRows({
+			db,
+			internalCustomerIds: pageCustomers,
+			scope,
+			filter: wordsFilter,
+			features: ctx.features,
+			limit: 10_000,
+		});
+		const removeSelectMs = Date.now() - removeSelectStarted;
+
+		let deleteMs = 0;
+		let deleted = 0;
+		try {
+			await db.transaction(async (tx) => {
+				const deleteStarted = Date.now();
+				const ids = await deleteCustomerEntitlementRows({
+					db: tx as unknown as DrizzleCli,
+					customerEntitlementIds: removeCandidates.map(
+						(row) => row.customerEntitlementId,
+					),
+					scope,
+				});
+				deleteMs = Date.now() - deleteStarted;
+				deleted = ids.length;
+				throw new Error("probe: intentional rollback");
+			});
+		} catch (error) {
+			if (!(error instanceof Error && error.message.includes("intentional"))) {
+				throw error;
+			}
+		}
+		console.log(
+			`probe: delete select ${removeSelectMs}ms (${removeCandidates.length} rows)  delete ${deleteMs}ms (${deleted} rows, 1 statement)`,
+		);
+
+		let mixedMs = 0;
+		try {
+			await db.transaction(async (tx) => {
+				const mixedStarted = Date.now();
+				await deleteCustomerEntitlementRows({
+					db: tx as unknown as DrizzleCli,
+					customerEntitlementIds: removeCandidates.map(
+						(row) => row.customerEntitlementId,
+					),
+					scope,
+				});
+				await mapWithConcurrency({
+					items: grouped,
+					concurrency: BATCH_MIGRATION_PATCH_GROUP_CONCURRENCY,
+					run: (group) =>
+						applyReplacePatches({
+							db: tx as unknown as DrizzleCli,
+							rows: group.rows,
+							scope,
+							toEntitlement,
+							customerEntitlementPatch: group.patch,
+						}),
+				});
+				mixedMs = Date.now() - mixedStarted;
+				throw new Error("probe: intentional rollback");
+			});
+		} catch (error) {
+			if (!(error instanceof Error && error.message.includes("intentional"))) {
+				throw error;
+			}
+		}
+		console.log(
+			`probe: mixed (delete words + replace messages ${grouped.length} groups) ${mixedMs}ms`,
+		);
+	}
+
+	await cleanupFanout({ db });
+	process.exit(0);
+};
+
+await main();

--- a/server/tests/scenarios/migrations/batch/11-in-place-replace-messages-scenario.test.ts
+++ b/server/tests/scenarios/migrations/batch/11-in-place-replace-messages-scenario.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Dashboard in-place catalog rewrite: messages 100/mo → 200, then the
+ * auto-drafted migration. Seed stays on the old catalog; the customize op is
+ * the same replace the dashboard draft would run.
+ */
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import chalk from "chalk";
+import { presentScenario } from "./utils/presentScenario";
+import { seedMigrationCast } from "./utils/seedMigrationCast";
+
+const ID_PREFIX = "mq11";
+const SCENARIO_FILE =
+	"tests/scenarios/migrations/batch/11-in-place-replace-messages-scenario.test.ts";
+
+test(`${chalk.yellowBright("SEED: in-place 100→200 mixed replace")}`, async () => {
+	const cast = await seedMigrationCast({
+		idPrefix: ID_PREFIX,
+		planVersions: [
+			[itemsV2.dashboard(), itemsV2.monthlyMessages({ included: 100 })],
+		],
+		members: [
+			{
+				role: "catalog",
+				usage: [{ featureId: TestFeature.Messages, value: 60 }],
+				note: "40/100 left — remaining should become 140 after the +100 credit",
+			},
+			{
+				role: "unused",
+				note: "100/100 left — remaining should become 200",
+			},
+		],
+	});
+
+	await presentScenario({
+		title: "in-place 100→200 mixed replace",
+		cast,
+		scenarioFile: SCENARIO_FILE,
+		migrations: [
+			{
+				id: `${ID_PREFIX}-migration`,
+				filter: { customer: { plan: { plan_id: cast.parent.id } } },
+				operations: {
+					customer: [
+						{
+							type: "update_plan",
+							plan_filter: { plan_id: cast.parent.id },
+							customize: {
+								remove_items: [
+									{
+										feature_id: TestFeature.Messages,
+										interval: ResetInterval.Month,
+									},
+								],
+								add_items: [itemsV2.monthlyMessages({ included: 200 })],
+							},
+						},
+					],
+				},
+				no_billing_changes: true,
+			},
+		],
+		expectation: {
+			lane: "batch",
+			notes: [
+				"run this drafted customize op, OR skip it: in the dashboard, in-place edit the plan (disable_version / all_versions) messages 100→200, then run the auto-drafted migration",
+				`${ID_PREFIX}-catalog: messages 40/100 becomes 140/200 — remaining += 100, one messages row, no leftover 100+200`,
+				`${ID_PREFIX}-unused: messages 100/100 becomes 200/200`,
+				`${TestFeature.Dashboard} is untouched on both customers`,
+				`seed/reset from server/: ./run.sh $(pwd)/${SCENARIO_FILE}`,
+			],
+		},
+	});
+});

--- a/server/tests/scenarios/migrations/batch/12-in-place-delete-messages-scenario.test.ts
+++ b/server/tests/scenarios/migrations/batch/12-in-place-delete-messages-scenario.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Dashboard in-place: drop messages/mo from the live catalog, then migrate.
+ * Dashboard stays on the plan so you can see something survived after the row
+ * is gone.
+ */
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import chalk from "chalk";
+import { presentScenario } from "./utils/presentScenario";
+import { seedMigrationCast } from "./utils/seedMigrationCast";
+
+const ID_PREFIX = "mq12";
+const SCENARIO_FILE =
+	"tests/scenarios/migrations/batch/12-in-place-delete-messages-scenario.test.ts";
+
+test(`${chalk.yellowBright("SEED: in-place delete messages")}`, async () => {
+	const cast = await seedMigrationCast({
+		idPrefix: ID_PREFIX,
+		planVersions: [
+			[itemsV2.dashboard(), itemsV2.monthlyMessages({ included: 100 })],
+		],
+		members: [
+			{
+				role: "catalog",
+				usage: [{ featureId: TestFeature.Messages, value: 60 }],
+				note: "40/100 left — the messages row should disappear entirely",
+			},
+			{
+				role: "unused",
+				note: "full 100 — also gone after migrate; dashboard stays",
+			},
+		],
+	});
+
+	await presentScenario({
+		title: "in-place delete messages",
+		cast,
+		scenarioFile: SCENARIO_FILE,
+		migrations: [
+			{
+				id: `${ID_PREFIX}-migration`,
+				filter: { customer: { plan: { plan_id: cast.parent.id } } },
+				operations: {
+					customer: [
+						{
+							type: "update_plan",
+							plan_filter: { plan_id: cast.parent.id },
+							customize: {
+								remove_items: [
+									{
+										feature_id: TestFeature.Messages,
+										interval: ResetInterval.Month,
+									},
+								],
+							},
+						},
+					],
+				},
+				no_billing_changes: true,
+			},
+		],
+		expectation: {
+			lane: "batch",
+			notes: [
+				"run this drafted customize op, OR skip it: in the dashboard, in-place remove messages/mo (disable_version / all_versions), then run the auto-drafted migration",
+				`${ID_PREFIX}-catalog and ${ID_PREFIX}-unused: messages row is gone — no leftover 100/mo`,
+				`${TestFeature.Dashboard} stays on both customers so the plan still has something`,
+				`seed/reset from server/: ./run.sh $(pwd)/${SCENARIO_FILE}`,
+			],
+		},
+	});
+});

--- a/server/tests/scenarios/migrations/batch/13-in-place-add-item-scenario.test.ts
+++ b/server/tests/scenarios/migrations/batch/13-in-place-add-item-scenario.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Dashboard in-place: add words onto a 100/mo + dashboard catalog, then
+ * migrate. Messages must stay; words must appear once, not as a duplicate add.
+ */
+import { test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import chalk from "chalk";
+import { presentScenario } from "./utils/presentScenario";
+import { seedMigrationCast } from "./utils/seedMigrationCast";
+
+const ID_PREFIX = "mq13";
+const SCENARIO_FILE =
+	"tests/scenarios/migrations/batch/13-in-place-add-item-scenario.test.ts";
+
+test(`${chalk.yellowBright("SEED: in-place add an item")}`, async () => {
+	const cast = await seedMigrationCast({
+		idPrefix: ID_PREFIX,
+		planVersions: [
+			[itemsV2.dashboard(), itemsV2.monthlyMessages({ included: 100 })],
+		],
+		members: [
+			{
+				role: "catalog",
+				usage: [{ featureId: TestFeature.Messages, value: 60 }],
+				note: "40/100 left — messages stay; words should appear once at 50",
+			},
+			{
+				role: "unused",
+				note: "full 100 messages — still there after words is added",
+			},
+		],
+	});
+
+	await presentScenario({
+		title: "in-place add an item",
+		cast,
+		scenarioFile: SCENARIO_FILE,
+		migrations: [
+			{
+				id: `${ID_PREFIX}-migration`,
+				filter: { customer: { plan: { plan_id: cast.parent.id } } },
+				operations: {
+					customer: [
+						{
+							type: "update_plan",
+							plan_filter: { plan_id: cast.parent.id },
+							customize: {
+								add_items: [itemsV2.monthlyWords({ included: 50 })],
+							},
+						},
+					],
+				},
+				no_billing_changes: true,
+			},
+		],
+		expectation: {
+			lane: "batch",
+			notes: [
+				"run this drafted customize op, OR skip it: in the dashboard, in-place add words (disable_version / all_versions), then run the auto-drafted migration",
+				`${ID_PREFIX}-catalog: messages stays 40/100 — not reset, not duplicated`,
+				`${ID_PREFIX}-unused: messages stays 100/100`,
+				`both customers gain one ${TestFeature.Words} 50/mo row — no duplicate add`,
+				`${TestFeature.Dashboard} is untouched`,
+				`seed/reset from server/: ./run.sh $(pwd)/${SCENARIO_FILE}`,
+			],
+		},
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/compute-patch-product-transition.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/compute-patch-product-transition.test.ts
@@ -1,0 +1,311 @@
+/**
+ * computePatchProductTransition is a customize lowerer, not a product diff.
+ * Catalog products are identity (repoint) only; item ops come from
+ * removeItems + minted addEntitlementPrices.
+ *
+ * Contract:
+ *   1. In-place customize: catalog ents ignored; sparse month filter + minted 30 → one replace
+ *   2. Remove only → removed filter
+ *   3. Add only → added minted row
+ *   4. Two features → independent ops
+ *   5. Mismatched interval → remove + add, not replace
+ *   6. Distinct from/to ids + replace → customerProduct repoint
+ *   7. Same internal_id → customerProduct undefined
+ *   8. Sibling cadence → replace the monthly filter only
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	EntInterval,
+	type EntitlementPrice,
+	type EntitlementWithFeature,
+	type Feature,
+	FeatureType,
+	type FullProductWithoutLicenses,
+	ResetInterval,
+} from "@autumn/shared";
+import { computePatchProductOperations } from "@/internal/migrations/v2/batchOperations/compute/operations/computePatchProductOperations.js";
+import { computePatchProductTransition } from "@/internal/migrations/v2/batchOperations/compute/transitions/computePatchProductTransition.js";
+
+const messagesFeature = {
+	internal_id: "feat_messages",
+	id: "messages",
+	type: FeatureType.Metered,
+} as unknown as Feature;
+
+const dashboardFeature = {
+	internal_id: "feat_dashboard",
+	id: "dashboard",
+	type: FeatureType.Boolean,
+} as unknown as Feature;
+
+const messagesEnt = ({
+	id = "ent_messages",
+	interval = EntInterval.Month,
+	intervalCount = 1,
+	allowance = 100,
+}: {
+	id?: string;
+	interval?: EntInterval | null;
+	intervalCount?: number;
+	allowance?: number;
+} = {}): EntitlementWithFeature =>
+	({
+		id,
+		created_at: 0,
+		internal_product_id: "prod_pro",
+		internal_feature_id: messagesFeature.internal_id,
+		feature_id: messagesFeature.id,
+		allowance_type: AllowanceType.Fixed,
+		allowance,
+		interval,
+		interval_count: intervalCount,
+		feature: messagesFeature,
+	}) as unknown as EntitlementWithFeature;
+
+const dashboardEnt = ({
+	id = "ent_dashboard",
+}: {
+	id?: string;
+} = {}): EntitlementWithFeature =>
+	({
+		id,
+		created_at: 0,
+		internal_product_id: "prod_pro",
+		internal_feature_id: dashboardFeature.internal_id,
+		feature_id: dashboardFeature.id,
+		allowance_type: null,
+		allowance: null,
+		interval: null,
+		feature: dashboardFeature,
+	}) as unknown as EntitlementWithFeature;
+
+const catalogProduct = ({
+	internalId,
+	entitlements = [],
+}: {
+	internalId: string;
+	entitlements?: EntitlementWithFeature[];
+}): FullProductWithoutLicenses =>
+	({
+		id: "pro",
+		internal_id: internalId,
+		entitlements,
+		prices: [],
+	}) as unknown as FullProductWithoutLicenses;
+
+const asEntitlementPrice = (
+	entitlement: EntitlementWithFeature,
+): EntitlementPrice => ({ entitlement }) satisfies EntitlementPrice;
+
+const monthMessagesFilter = {
+	feature_id: "messages",
+	interval: ResetInterval.Month,
+};
+
+const compiledMonthMessagesFilter = {
+	feature_id: "messages",
+	interval: EntInterval.Month,
+	interval_count: 1,
+};
+
+describe("computePatchProductTransition", () => {
+	test("in-place customize ignores catalog entitlements and pairs as one replace", () => {
+		const alreadyRewritten = messagesEnt({
+			id: "ent_catalog_rewritten",
+			allowance: 30,
+		});
+		const minted = messagesEnt({ id: "ent_messages_new", allowance: 30 });
+		const product = catalogProduct({
+			internalId: "prod_pro",
+			entitlements: [alreadyRewritten],
+		});
+
+		const result = computePatchProductTransition({
+			fromProduct: product,
+			toProduct: product,
+			removeItems: [monthMessagesFilter],
+			addEntitlementPrices: [asEntitlementPrice(minted)],
+		});
+
+		expect(result.replaced).toHaveLength(1);
+		expect(result.replaced[0]?.from).toEqual(compiledMonthMessagesFilter);
+		expect(result.replaced[0]?.to.entitlement.id).toBe("ent_messages_new");
+		expect(result.replaced[0]?.to.entitlement.allowance).toBe(30);
+		expect(result.added).toHaveLength(0);
+		expect(result.removed).toHaveLength(0);
+		expect(result.customerProduct).toBeUndefined();
+	});
+
+	test("remove only yields a removed filter", () => {
+		const result = computePatchProductTransition({
+			removeItems: [monthMessagesFilter],
+			addEntitlementPrices: [],
+		});
+
+		expect(result.removed).toEqual([{ filter: compiledMonthMessagesFilter }]);
+		expect(result.replaced).toHaveLength(0);
+		expect(result.added).toHaveLength(0);
+	});
+
+	test("add only yields the minted row", () => {
+		const minted = messagesEnt({ id: "ent_messages_new", allowance: 30 });
+
+		const result = computePatchProductTransition({
+			addEntitlementPrices: [asEntitlementPrice(minted)],
+		});
+
+		expect(result.added).toHaveLength(1);
+		expect(result.added[0]?.entitlement.id).toBe("ent_messages_new");
+		expect(result.replaced).toHaveLength(0);
+		expect(result.removed).toHaveLength(0);
+	});
+
+	test("two features lower independently", () => {
+		const mintedMessages = messagesEnt({
+			id: "ent_messages_new",
+			allowance: 30,
+		});
+		const mintedDashboard = dashboardEnt({ id: "ent_dashboard_new" });
+
+		const result = computePatchProductTransition({
+			removeItems: [monthMessagesFilter],
+			addEntitlementPrices: [
+				asEntitlementPrice(mintedMessages),
+				asEntitlementPrice(mintedDashboard),
+			],
+		});
+
+		expect(result.replaced).toHaveLength(1);
+		expect(result.replaced[0]?.from).toEqual(compiledMonthMessagesFilter);
+		expect(result.replaced[0]?.to.entitlement.id).toBe("ent_messages_new");
+		expect(result.added.map((price) => price.entitlement.id)).toEqual([
+			"ent_dashboard_new",
+		]);
+		expect(result.removed).toHaveLength(0);
+	});
+
+	test("mismatched interval is remove plus add, not a replace", () => {
+		const mintedQuarterly = messagesEnt({
+			id: "ent_quarterly_new",
+			interval: EntInterval.Month,
+			intervalCount: 3,
+			allowance: 90,
+		});
+		const monthlyFilter = {
+			feature_id: "messages",
+			interval: ResetInterval.Month,
+			interval_count: 1,
+		};
+
+		const result = computePatchProductTransition({
+			removeItems: [monthlyFilter],
+			addEntitlementPrices: [asEntitlementPrice(mintedQuarterly)],
+		});
+
+		expect(result.removed).toEqual([{ filter: compiledMonthMessagesFilter }]);
+		expect(result.added).toHaveLength(1);
+		expect(result.added[0]?.entitlement.id).toBe("ent_quarterly_new");
+		expect(result.replaced).toHaveLength(0);
+	});
+
+	test("customize and version returns a replace and a customer-product repoint", () => {
+		const minted = messagesEnt({ id: "ent_messages_new", allowance: 30 });
+		const fromProduct = catalogProduct({
+			internalId: "prod_pro_v1",
+			entitlements: [messagesEnt({ allowance: 100 })],
+		});
+		const toProduct = catalogProduct({
+			internalId: "prod_pro_v2",
+			entitlements: [minted],
+		});
+
+		const result = computePatchProductTransition({
+			fromProduct,
+			toProduct,
+			removeItems: [monthMessagesFilter],
+			addEntitlementPrices: [asEntitlementPrice(minted)],
+		});
+
+		expect(result.replaced).toHaveLength(1);
+		expect(result.replaced[0]?.from).toEqual(compiledMonthMessagesFilter);
+		expect(result.replaced[0]?.to.entitlement.id).toBe("ent_messages_new");
+		expect(result.added).toHaveLength(0);
+		expect(result.removed).toHaveLength(0);
+		expect(result.customerProduct).toEqual({
+			fromInternalProductId: "prod_pro_v1",
+			toInternalProductId: "prod_pro_v2",
+		});
+	});
+
+	test("same internal_id leaves customerProduct undefined", () => {
+		const minted = messagesEnt({ id: "ent_messages_new", allowance: 30 });
+		const product = catalogProduct({ internalId: "prod_pro" });
+
+		const result = computePatchProductTransition({
+			fromProduct: product,
+			toProduct: product,
+			removeItems: [monthMessagesFilter],
+			addEntitlementPrices: [asEntitlementPrice(minted)],
+		});
+
+		expect(result.customerProduct).toBeUndefined();
+		expect(result.replaced).toHaveLength(1);
+	});
+
+	test("sibling cadence replaces only the matched monthly filter", () => {
+		const monthly = messagesEnt({ id: "ent_monthly" });
+		const quarterly = messagesEnt({ id: "ent_quarterly", intervalCount: 3 });
+		const mintedMonthly = messagesEnt({
+			id: "ent_monthly_new",
+			allowance: 200,
+		});
+		const monthlyFilter = {
+			feature_id: "messages",
+			interval: ResetInterval.Month,
+			interval_count: 1,
+		};
+
+		const result = computePatchProductTransition({
+			fromProduct: catalogProduct({
+				internalId: "prod_pro",
+				entitlements: [monthly, quarterly],
+			}),
+			toProduct: catalogProduct({
+				internalId: "prod_pro",
+				entitlements: [monthly, quarterly],
+			}),
+			removeItems: [monthlyFilter],
+			addEntitlementPrices: [asEntitlementPrice(mintedMonthly)],
+		});
+
+		expect(result.replaced).toHaveLength(1);
+		expect(result.replaced[0]?.from).toEqual(compiledMonthMessagesFilter);
+		expect(result.replaced[0]?.to.entitlement.id).toBe("ent_monthly_new");
+		expect(result.added).toHaveLength(0);
+		expect(result.removed).toHaveLength(0);
+	});
+
+	test("lowering the transition emits filter replace ops", () => {
+		const minted = messagesEnt({ id: "ent_messages_new", allowance: 30 });
+		const patchTransition = computePatchProductTransition({
+			removeItems: [monthMessagesFilter],
+			addEntitlementPrices: [asEntitlementPrice(minted)],
+		});
+		const operations = computePatchProductOperations({
+			patchTransition,
+			licenseLinks: [],
+		});
+
+		expect(operations.replaceEntitlements).toEqual([
+			expect.objectContaining({
+				by: "filter",
+				from: compiledMonthMessagesFilter,
+			}),
+		]);
+		expect(
+			operations.replaceEntitlements[0]?.entitlementPrice.entitlement.id,
+		).toBe("ent_messages_new");
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/customer-entitlement-patch-key.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/customer-entitlement-patch-key.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AllowanceType,
+	EntInterval,
+	type EntitlementWithFeature,
+	type Feature,
+	FeatureType,
+} from "@autumn/shared";
+import {
+	customerEntitlementPatchKey,
+	groupFilterReplaceRows,
+} from "@/internal/migrations/v2/batchOperations/actions/utils/groupFilterReplaceRows.js";
+
+const messagesFeature = {
+	internal_id: "feat_messages",
+	id: "messages",
+	type: FeatureType.Metered,
+} as unknown as Feature;
+
+const messagesEnt = ({
+	id,
+	allowance,
+}: {
+	id: string;
+	allowance: number;
+}): EntitlementWithFeature =>
+	({
+		id,
+		created_at: 0,
+		internal_product_id: "prod_pro",
+		internal_feature_id: messagesFeature.internal_id,
+		feature_id: messagesFeature.id,
+		allowance_type: AllowanceType.Fixed,
+		allowance,
+		interval: EntInterval.Month,
+		interval_count: 1,
+		rollover: null,
+		entity_feature_id: null,
+		pooled: false,
+		feature: messagesFeature,
+	}) as unknown as EntitlementWithFeature;
+
+describe("customerEntitlementPatchKey", () => {
+	test("empty patch is keep on both columns", () => {
+		expect(customerEntitlementPatchKey({ patch: {} })).toBe(
+			"balance:keep|unlimited:keep",
+		);
+	});
+
+	test("increment encodes type and amount", () => {
+		expect(
+			customerEntitlementPatchKey({
+				patch: { balance: { type: "increment", amount: 20 } },
+			}),
+		).toBe("balance:increment:20|unlimited:keep");
+	});
+
+	test("set encodes type and amount", () => {
+		expect(
+			customerEntitlementPatchKey({
+				patch: { balance: { type: "set", amount: 30 } },
+			}),
+		).toBe("balance:set:30|unlimited:keep");
+	});
+
+	test("unlimited null is distinct from keep", () => {
+		expect(customerEntitlementPatchKey({ patch: { unlimited: null } })).toBe(
+			"balance:keep|unlimited:null",
+		);
+		expect(customerEntitlementPatchKey({ patch: {} })).not.toBe(
+			customerEntitlementPatchKey({ patch: { unlimited: null } }),
+		);
+	});
+
+	test("unlimited true and false are distinct from keep and null", () => {
+		const keep = customerEntitlementPatchKey({ patch: {} });
+		const asNull = customerEntitlementPatchKey({ patch: { unlimited: null } });
+		const asTrue = customerEntitlementPatchKey({ patch: { unlimited: true } });
+		const asFalse = customerEntitlementPatchKey({
+			patch: { unlimited: false },
+		});
+
+		expect(asTrue).toBe("balance:keep|unlimited:true");
+		expect(asFalse).toBe("balance:keep|unlimited:false");
+		expect(new Set([keep, asNull, asTrue, asFalse]).size).toBe(4);
+	});
+});
+
+describe("groupFilterReplaceRows", () => {
+	test("two 10/mo defs with different ids share one increment:20 group", () => {
+		const to = messagesEnt({ id: "ent_minted_30", allowance: 30 });
+		const groups = groupFilterReplaceRows({
+			rows: [
+				{ liveDefinition: messagesEnt({ id: "ent_custom_a", allowance: 10 }) },
+				{ liveDefinition: messagesEnt({ id: "ent_custom_b", allowance: 10 }) },
+			],
+			toEntitlement: to,
+		});
+
+		expect(groups).toHaveLength(1);
+		expect(customerEntitlementPatchKey({ patch: groups[0].patch })).toBe(
+			"balance:increment:20|unlimited:keep",
+		);
+		expect(groups[0].rows).toHaveLength(2);
+		expect(groups[0].rows.map((row) => row.liveDefinition?.id)).toEqual([
+			"ent_custom_a",
+			"ent_custom_b",
+		]);
+	});
+
+	test("two 100/mo defs with different ids share one increment:-70 group", () => {
+		const to = messagesEnt({ id: "ent_minted_30", allowance: 30 });
+		const groups = groupFilterReplaceRows({
+			rows: [
+				{ liveDefinition: messagesEnt({ id: "ent_custom_a", allowance: 100 }) },
+				{ liveDefinition: messagesEnt({ id: "ent_custom_b", allowance: 100 }) },
+			],
+			toEntitlement: to,
+		});
+
+		expect(groups).toHaveLength(1);
+		expect(customerEntitlementPatchKey({ patch: groups[0].patch })).toBe(
+			"balance:increment:-70|unlimited:keep",
+		);
+		expect(groups[0].rows).toHaveLength(2);
+		expect(groups[0].rows.map((row) => row.liveDefinition?.id)).toEqual([
+			"ent_custom_a",
+			"ent_custom_b",
+		]);
+	});
+
+	test("same-allowance different ids stay one group; a different allowance splits", () => {
+		const to = messagesEnt({ id: "ent_minted_30", allowance: 30 });
+		const groups = groupFilterReplaceRows({
+			rows: [
+				{ liveDefinition: messagesEnt({ id: "ent_100_a", allowance: 100 }) },
+				{ liveDefinition: messagesEnt({ id: "ent_100_b", allowance: 100 }) },
+				{ liveDefinition: messagesEnt({ id: "ent_10", allowance: 10 }) },
+			],
+			toEntitlement: to,
+		});
+
+		expect(groups).toHaveLength(2);
+		const groupedByKey = new Map(
+			groups.map((group) => [
+				customerEntitlementPatchKey({ patch: group.patch }),
+				group.rows.map((row) => row.liveDefinition?.id),
+			]),
+		);
+		expect(groupedByKey.get("balance:increment:-70|unlimited:keep")).toEqual([
+			"ent_100_a",
+			"ent_100_b",
+		]);
+		expect(groupedByKey.get("balance:increment:20|unlimited:keep")).toEqual([
+			"ent_10",
+		]);
+	});
+
+	test("different live allowances split into separate groups", () => {
+		const to = messagesEnt({ id: "ent_minted_30", allowance: 30 });
+		const groups = groupFilterReplaceRows({
+			rows: [
+				{ liveDefinition: messagesEnt({ id: "ent_100", allowance: 100 }) },
+				{ liveDefinition: messagesEnt({ id: "ent_10", allowance: 10 }) },
+			],
+			toEntitlement: to,
+		});
+
+		expect(groups).toHaveLength(2);
+		expect(
+			new Set(
+				groups.map((group) => customerEntitlementPatchKey({ patch: group.patch })),
+			).size,
+		).toBe(2);
+	});
+
+	test("already on minted id is omitted, not grouped", () => {
+		const to = messagesEnt({ id: "ent_minted_30", allowance: 30 });
+		const groups = groupFilterReplaceRows({
+			rows: [
+				{ liveDefinition: to },
+				{ liveDefinition: messagesEnt({ id: "ent_custom", allowance: 10 }) },
+			],
+			toEntitlement: to,
+		});
+
+		expect(groups).toHaveLength(1);
+		expect(groups[0].rows).toHaveLength(1);
+		expect(groups[0].rows[0].liveDefinition?.id).toBe("ent_custom");
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/to-removed-item.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/to-removed-item.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CusProductStatus,
+	EntInterval,
+	type EntitlementWithFeature,
+	type Feature,
+	FeatureType,
+} from "@autumn/shared";
+import { toRemovedItem } from "@/internal/migrations/v2/batchOperations/actions/utils/toRemovedItem.js";
+
+const messagesFeature = {
+	internal_id: "fea_messages_internal",
+	id: "messages",
+	type: FeatureType.Metered,
+	name: "Messages",
+} as Feature;
+
+const entitlement = ({
+	id,
+	allowance,
+}: {
+	id: string;
+	allowance: number;
+}): EntitlementWithFeature =>
+	({
+		id,
+		internal_feature_id: messagesFeature.internal_id,
+		feature_id: messagesFeature.id,
+		feature: messagesFeature,
+		allowance,
+		interval: EntInterval.Month,
+		interval_count: 1,
+		allowance_type: "fixed",
+	}) as unknown as EntitlementWithFeature;
+
+const row = {
+	internalCustomerId: "cus_1",
+	customerProductId: "cp_1",
+	entityId: null,
+	liveBalance: 80,
+	liveNextResetAt: 1_800_000_000_000,
+	status: CusProductStatus.Active,
+	startsAt: 1_700_000_000_000,
+	canceledAt: null,
+	endedAt: null,
+	trialEndsAt: null,
+};
+
+describe("toRemovedItem", () => {
+	test("stamps the row's live definition, not a shared catalog entitlement", () => {
+		const live = entitlement({ id: "ent_custom_200", allowance: 200 });
+		const catalog = entitlement({ id: "ent_catalog_100", allowance: 100 });
+		const item = toRemovedItem({
+			row,
+			planId: "pro",
+			fromEntitlement: live,
+		});
+
+		expect(item.entitlement).toBe(live);
+		expect(item.entitlement).not.toBe(catalog);
+		expect(item.entitlement.allowance).toBe(200);
+		expect(item.granted).toBe(200);
+		expect(item.remaining).toBe(80);
+		expect(item.featureId).toBe("messages");
+	});
+});

--- a/server/tests/unit/migrations-v2/batch-operations/update-plan-op-eligibility.test.ts
+++ b/server/tests/unit/migrations-v2/batch-operations/update-plan-op-eligibility.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { BillingInterval, BillingMethod } from "@autumn/shared";
-import { checkUpdatePlanOpEligibility } from "@/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanOpEligibility.js";
+import { BillingInterval, BillingMethod, ResetInterval } from "@autumn/shared";
+import {
+	checkUpdatePlanOpEligibility,
+	isModifyInPlaceOnly,
+} from "@/internal/migrations/v2/batchOperations/compute/guards/checkUpdatePlanOpEligibility.js";
 
 describe("checkUpdatePlanOpEligibility", () => {
 	test("version-only with no add_items or remove_items is not batch-lowered", () => {
@@ -141,5 +144,27 @@ describe("checkUpdatePlanOpEligibility", () => {
 		expect(rejections.map((rejection) => rejection.code)).toContain(
 			"priced_add_item",
 		);
+	});
+
+	test("included on a remove filter does not break in-place match keys", () => {
+		expect(
+			isModifyInPlaceOnly({
+				addItems: [
+					{
+						feature_id: "messages",
+						included: 200,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+				removeItems: [
+					{
+						feature_id: "messages",
+						interval: ResetInterval.Month,
+						interval_count: 1,
+						included: 100,
+					},
+				],
+			}),
+		).toBe(true);
 	});
 });

--- a/server/tests/unit/shared/customizeToKey.test.ts
+++ b/server/tests/unit/shared/customizeToKey.test.ts
@@ -200,6 +200,45 @@ describe("customizeToKey", () => {
 		});
 	});
 
+	describe("remove_items filter — included (grant stamp)", () => {
+		test("omitted is a wildcard; 0 vs 100 vs omitted all differ", () => {
+			expectSame(
+				customize({ remove_items: [{ feature_id: "messages" }] }),
+				customize({
+					remove_items: [{ feature_id: "messages", included: 100 }],
+				}),
+				false,
+			);
+			expectSame(
+				customize({
+					remove_items: [{ feature_id: "messages", included: 100 }],
+				}),
+				customize({
+					remove_items: [{ feature_id: "messages", included: 200 }],
+				}),
+				false,
+			);
+			expectSame(
+				customize({
+					remove_items: [{ feature_id: "messages", included: 0 }],
+				}),
+				customize({
+					remove_items: [{ feature_id: "messages", included: 100 }],
+				}),
+				false,
+			);
+			expectSame(
+				customize({
+					remove_items: [{ feature_id: "messages", included: 100 }],
+				}),
+				customize({
+					remove_items: [{ feature_id: "messages", included: 100 }],
+				}),
+				true,
+			);
+		});
+	});
+
 	describe("remove_items filter — interval (unset collapses)", () => {
 		test("unset vs a real interval differ; equal intervals are same", () => {
 			expectSame(

--- a/server/tests/unit/shared/diffPlanV1.filterPrecision.test.ts
+++ b/server/tests/unit/shared/diffPlanV1.filterPrecision.test.ts
@@ -1,0 +1,153 @@
+/**
+ * PlanItemFilterPrecision: IdentityAndIncluded stamps grant onto remove
+ * filters. Default Identity stays a cadence wildcard.
+ *
+ * Contract:
+ *   D1 default 100→200 — remove has no included
+ *   D2 IdentityAndIncluded 100→200 — remove included: 100, add 200, same match key
+ *   D3 boolean / unlimited + flag — no included on the filter
+ *   D4 planItemFiltersEqual treats omitted vs 100 as different
+ *
+ * included is a live-row dimension. It must not enter composeMatchKey /
+ * planItemFilterMatchKey or 100/mo will fail to pair with add 200.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type ApiPlanV1,
+	AppEnv,
+	planItemFilterMatchKey,
+	PlanItemFilterPrecision,
+	ResetInterval,
+} from "@autumn/shared";
+import { planItemFiltersEqual } from "@autumn/shared/utils/planV1Utils/diff/comparePlanItems.js";
+import { diffPlanV1 } from "@autumn/shared/utils/planV1Utils/diff/diffPlanV1.js";
+
+const plan = (overrides: Partial<ApiPlanV1>): ApiPlanV1 =>
+	({
+		id: "pro",
+		name: "Pro",
+		description: null,
+		group: null,
+		version: 1,
+		add_on: false,
+		auto_enable: false,
+		price: null,
+		items: [],
+		created_at: 1,
+		env: AppEnv.Sandbox,
+		archived: false,
+		base_variant_id: null,
+		config: { ignore_past_due: false },
+		metadata: {},
+		...overrides,
+	}) as ApiPlanV1;
+
+const monthlyMessages = ({ included }: { included: number }) => ({
+	feature_id: "messages",
+	included,
+	unlimited: false,
+	reset: { interval: ResetInterval.Month },
+	price: null,
+});
+
+const from100 = plan({ items: [monthlyMessages({ included: 100 })] });
+const to200 = plan({ items: [monthlyMessages({ included: 200 })] });
+
+const identityAndIncludedDiff = () =>
+	diffPlanV1({
+		from: from100,
+		to: to200,
+		filterPrecision: PlanItemFilterPrecision.IdentityAndIncluded,
+	});
+
+describe("diffPlanV1 filterPrecision", () => {
+	test("D1: default 100→200 omit included on the remove filter", () => {
+		const diff = diffPlanV1({ from: from100, to: to200 });
+
+		expect(diff.remove_items).toEqual([
+			{
+				feature_id: "messages",
+				interval: ResetInterval.Month,
+				interval_count: 1,
+			},
+		]);
+		expect(diff.add_items?.[0]).toMatchObject({
+			feature_id: "messages",
+			included: 200,
+		});
+	});
+
+	test("D2: IdentityAndIncluded stamps included: 100 and keeps the identity key", () => {
+		const diff = identityAndIncludedDiff();
+
+		expect(diff.remove_items).toEqual([
+			{
+				feature_id: "messages",
+				interval: ResetInterval.Month,
+				interval_count: 1,
+				included: 100,
+			},
+		]);
+		expect(diff.add_items?.[0]).toMatchObject({
+			feature_id: "messages",
+			included: 200,
+		});
+
+		const stamped = {
+			feature_id: "messages",
+			interval: ResetInterval.Month,
+			interval_count: 1,
+			included: 100,
+		};
+		expect(planItemFilterMatchKey(stamped)).toBe(
+			planItemFilterMatchKey({
+				feature_id: "messages",
+				interval: ResetInterval.Month,
+				interval_count: 1,
+			}),
+		);
+	});
+
+	test("D3: boolean and unlimited removes never stamp included", () => {
+		const booleanItem = {
+			feature_id: "dashboard",
+		} as ApiPlanV1["items"][number];
+		const booleanDiff = diffPlanV1({
+			from: plan({ items: [booleanItem] }),
+			to: plan({ items: [] }),
+			filterPrecision: PlanItemFilterPrecision.IdentityAndIncluded,
+		});
+		expect(booleanDiff.remove_items).toEqual([{ feature_id: "dashboard" }]);
+
+		const unlimitedItem = {
+			feature_id: "messages",
+			unlimited: true,
+			reset: { interval: ResetInterval.Month },
+			price: null,
+		} as ApiPlanV1["items"][number];
+		const unlimitedDiff = diffPlanV1({
+			from: plan({ items: [unlimitedItem] }),
+			to: plan({ items: [] }),
+			filterPrecision: PlanItemFilterPrecision.IdentityAndIncluded,
+		});
+		expect(unlimitedDiff.remove_items?.[0]).not.toHaveProperty("included");
+	});
+
+	test("D4: planItemFiltersEqual treats omitted included as not equal to 100", () => {
+		const identity = {
+			feature_id: "messages",
+			interval: ResetInterval.Month,
+			interval_count: 1,
+		};
+		expect(
+			planItemFiltersEqual(identity, { ...identity, included: 100 }),
+		).toBe(false);
+		expect(
+			planItemFiltersEqual(
+				{ ...identity, included: 100 },
+				{ ...identity, included: 100 },
+			),
+		).toBe(true);
+	});
+});

--- a/server/tests/unit/shared/pairRemovedAndAddedPlanItems.test.ts
+++ b/server/tests/unit/shared/pairRemovedAndAddedPlanItems.test.ts
@@ -1,0 +1,707 @@
+/**
+ * pairRemovedAndAddedPlanItems: per-remove best unclaimed matching add.
+ *
+ * Algorithm: walk removes in order. For each filter, among unclaimed adds that
+ * match every specified field, pick the highest-precision candidate (ties:
+ * first in add-list order). Claim that add index. Unclaimed removes → removed;
+ * unclaimed adds → leftoverAdds.
+ *
+ * Feature-only filters match every cadence of that feature; month filters do
+ * not match lifetime. billing_method on the filter does not claim a free add
+ * (same as planItemFilterMatchesCustomerPair / composeMatchKey).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	BillWhen,
+	BillingMethod,
+	EntInterval,
+	type EntitlementPrice,
+	type PlanItemFilter,
+	ResetInterval,
+	keepAddEntitlementPricesForLiveRemoves,
+	pairRemovedAndAddedPlanItems,
+} from "@autumn/shared";
+import { entitlements } from "@tests/utils/fixtures/db/entitlements";
+import { features } from "@tests/utils/fixtures/db/features";
+import { prices } from "@tests/utils/fixtures/db/prices";
+
+const seatsFeature = features.create({
+	id: "seats",
+	internalId: "feat_internal_seats",
+	name: "Seats",
+});
+
+const messages = ({
+	id,
+	interval = EntInterval.Month,
+	intervalCount = 1,
+	allowance = 100,
+	priced = false,
+	billWhen,
+}: {
+	id: string;
+	interval?: EntInterval | null;
+	intervalCount?: number;
+	allowance?: number;
+	priced?: boolean;
+	billWhen?: BillWhen;
+}): EntitlementPrice =>
+	entitlements.buildPricePair({
+		entitlement: entitlements.buildWithFeature({
+			id,
+			feature_id: "messages",
+			interval,
+			interval_count: intervalCount,
+			allowance,
+		}),
+		price: priced
+			? prices.buildUsage({
+					overrides: { id: `price_${id}`, entitlement_id: id },
+					configOverrides: billWhen ? { bill_when: billWhen } : {},
+				})
+			: undefined,
+	});
+
+const seats = ({
+	id,
+	interval = EntInterval.Month,
+	allowance = 5,
+}: {
+	id: string;
+	interval?: EntInterval | null;
+	allowance?: number;
+}): EntitlementPrice =>
+	entitlements.buildPricePair({
+		entitlement: entitlements.buildWithFeature({
+			id,
+			feature_id: "seats",
+			internal_feature_id: seatsFeature.internal_id,
+			feature: seatsFeature,
+			interval,
+			allowance,
+		}),
+	});
+
+const monthMessagesFilter = ({
+	intervalCount,
+	billingMethod,
+}: {
+	intervalCount?: number;
+	billingMethod?: BillingMethod;
+} = {}): PlanItemFilter => ({
+	feature_id: "messages",
+	interval: ResetInterval.Month,
+	...(intervalCount !== undefined ? { interval_count: intervalCount } : {}),
+	...(billingMethod !== undefined ? { billing_method: billingMethod } : {}),
+});
+
+const ids = (adds: EntitlementPrice[]) =>
+	adds.map((add) => add.entitlement.id);
+
+const expectPairing = ({
+	removeItems,
+	addEntitlementPrices,
+	replacedToIds,
+	removedFilters,
+	leftoverAddIds,
+}: {
+	removeItems: PlanItemFilter[];
+	addEntitlementPrices: EntitlementPrice[];
+	replacedToIds?: string[];
+	removedFilters?: PlanItemFilter[];
+	leftoverAddIds?: string[];
+}) => {
+	const result = pairRemovedAndAddedPlanItems({
+		removeItems,
+		addEntitlementPrices,
+	});
+	expect(result.replaced.map((row) => row.to.entitlement.id)).toEqual(
+		replacedToIds ?? [],
+	);
+	expect(result.replaced.map((row) => row.from)).toEqual(
+		(replacedToIds ?? []).map((_, index) => removeItems[index]!),
+	);
+	expect(result.removed.map((row) => row.filter)).toEqual(removedFilters ?? []);
+	expect(ids(result.leftoverAdds)).toEqual(leftoverAddIds ?? []);
+};
+
+describe("pairRemovedAndAddedPlanItems", () => {
+	describe("cadence / interval", () => {
+		test("10 msgs/mo remove vs 30 lifetime + 20 msgs/mo add: replace 20/mo, leftover 30 lifetime", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const lifetime30 = messages({
+				id: "ent_lifetime_30",
+				interval: EntInterval.Lifetime,
+				allowance: 30,
+			});
+			const month20 = messages({
+				id: "ent_month_20",
+				interval: EntInterval.Month,
+				allowance: 20,
+			});
+
+			for (const addEntitlementPrices of [
+				[lifetime30, month20],
+				[month20, lifetime30],
+			]) {
+				expectPairing({
+					removeItems: [remove],
+					addEntitlementPrices,
+					replacedToIds: ["ent_month_20"],
+					leftoverAddIds: ["ent_lifetime_30"],
+				});
+			}
+		});
+
+		test("month remove vs lifetime add only: no replace (interval specified, lifetime does not match)", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const lifetime30 = messages({
+				id: "ent_lifetime_30",
+				interval: EntInterval.Lifetime,
+				allowance: 30,
+			});
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [lifetime30],
+				removedFilters: [remove],
+				leftoverAddIds: ["ent_lifetime_30"],
+			});
+		});
+
+		test("null-interval add is lifetime and does not match a month filter", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const unsetLifetime = messages({
+				id: "ent_unset_lifetime",
+				interval: null,
+				allowance: 30,
+			});
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [unsetLifetime],
+				removedFilters: [remove],
+				leftoverAddIds: ["ent_unset_lifetime"],
+			});
+		});
+
+		test("one_off remove vs lifetime + month: claims lifetime not month, regardless of add order", () => {
+			const remove: PlanItemFilter = {
+				feature_id: "messages",
+				interval: ResetInterval.OneOff,
+			};
+			const lifetime = messages({
+				id: "ent_lifetime",
+				interval: EntInterval.Lifetime,
+			});
+			const month = messages({ id: "ent_month", interval: EntInterval.Month });
+
+			for (const addEntitlementPrices of [
+				[month, lifetime],
+				[lifetime, month],
+			]) {
+				expectPairing({
+					removeItems: [remove],
+					addEntitlementPrices,
+					replacedToIds: ["ent_lifetime"],
+					leftoverAddIds: ["ent_month"],
+				});
+			}
+		});
+
+		test("month remove vs year add: no replace", () => {
+			const remove = monthMessagesFilter();
+			const year = messages({ id: "ent_year", interval: EntInterval.Year });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [year],
+				removedFilters: [remove],
+				leftoverAddIds: ["ent_year"],
+			});
+		});
+
+		test("feature-only remove vs [lifetime, month]: first-in-list (lifetime) because precision ties", () => {
+			const remove: PlanItemFilter = { feature_id: "messages" };
+			const lifetime = messages({
+				id: "ent_lifetime",
+				interval: EntInterval.Lifetime,
+			});
+			const month = messages({ id: "ent_month", interval: EntInterval.Month });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [lifetime, month],
+				replacedToIds: ["ent_lifetime"],
+				leftoverAddIds: ["ent_month"],
+			});
+		});
+
+		test("feature-only remove vs [month, lifetime]: first-in-list (month) because precision ties", () => {
+			const remove: PlanItemFilter = { feature_id: "messages" };
+			const lifetime = messages({
+				id: "ent_lifetime",
+				interval: EntInterval.Lifetime,
+			});
+			const month = messages({ id: "ent_month", interval: EntInterval.Month });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [month, lifetime],
+				replacedToIds: ["ent_month"],
+				leftoverAddIds: ["ent_lifetime"],
+			});
+		});
+	});
+
+	describe("interval_count", () => {
+		test("interval_count 1 vs 3 (monthly vs quarterly): no cross-claim", () => {
+			const monthlyFilter = monthMessagesFilter({ intervalCount: 1 });
+			const quarterly = messages({
+				id: "ent_quarterly",
+				interval: EntInterval.Month,
+				intervalCount: 3,
+			});
+
+			expectPairing({
+				removeItems: [monthlyFilter],
+				addEntitlementPrices: [quarterly],
+				removedFilters: [monthlyFilter],
+				leftoverAddIds: ["ent_quarterly"],
+			});
+		});
+
+		test("two removes and two adds at count 1 vs 3: each claims its own count", () => {
+			const monthlyFilter = monthMessagesFilter({ intervalCount: 1 });
+			const quarterlyFilter = monthMessagesFilter({ intervalCount: 3 });
+			const monthly = messages({
+				id: "ent_monthly",
+				intervalCount: 1,
+			});
+			const quarterly = messages({
+				id: "ent_quarterly",
+				intervalCount: 3,
+			});
+
+			for (const addEntitlementPrices of [
+				[quarterly, monthly],
+				[monthly, quarterly],
+			]) {
+				const result = pairRemovedAndAddedPlanItems({
+					removeItems: [monthlyFilter, quarterlyFilter],
+					addEntitlementPrices,
+				});
+				expect(result.replaced).toHaveLength(2);
+				expect(result.replaced[0]?.from).toEqual(monthlyFilter);
+				expect(result.replaced[0]?.to.entitlement.id).toBe("ent_monthly");
+				expect(result.replaced[1]?.from).toEqual(quarterlyFilter);
+				expect(result.replaced[1]?.to.entitlement.id).toBe("ent_quarterly");
+				expect(result.removed).toEqual([]);
+				expect(result.leftoverAdds).toEqual([]);
+			}
+		});
+
+		test("filter omits interval_count: month matches count 1 and 3, first unclaimed add wins", () => {
+			const remove = monthMessagesFilter();
+			const monthly = messages({ id: "ent_monthly", intervalCount: 1 });
+			const quarterly = messages({ id: "ent_quarterly", intervalCount: 3 });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [quarterly, monthly],
+				replacedToIds: ["ent_quarterly"],
+				leftoverAddIds: ["ent_monthly"],
+			});
+		});
+
+		test("unset interval_count on the add equals 1", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const unsetCount = messages({ id: "ent_unset_count" });
+			unsetCount.entitlement.interval_count = null as unknown as number;
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [unsetCount],
+				replacedToIds: ["ent_unset_count"],
+			});
+		});
+	});
+
+	describe("feature", () => {
+		test("different feature_id never pairs", () => {
+			const remove = monthMessagesFilter();
+			const seatsAdd = seats({ id: "ent_seats" });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [seatsAdd],
+				removedFilters: [remove],
+				leftoverAddIds: ["ent_seats"],
+			});
+		});
+
+		test("two features, two removes, two adds: independent replaces", () => {
+			const messagesFilter = monthMessagesFilter();
+			const seatsFilter: PlanItemFilter = {
+				feature_id: "seats",
+				interval: ResetInterval.Month,
+			};
+			const messagesAdd = messages({ id: "ent_messages_new" });
+			const seatsAdd = seats({ id: "ent_seats_new" });
+
+			const result = pairRemovedAndAddedPlanItems({
+				removeItems: [messagesFilter, seatsFilter],
+				addEntitlementPrices: [seatsAdd, messagesAdd],
+			});
+			expect(result.replaced).toHaveLength(2);
+			expect(result.replaced[0]?.from).toEqual(messagesFilter);
+			expect(result.replaced[0]?.to.entitlement.id).toBe("ent_messages_new");
+			expect(result.replaced[1]?.from).toEqual(seatsFilter);
+			expect(result.replaced[1]?.to.entitlement.id).toBe("ent_seats_new");
+			expect(result.removed).toEqual([]);
+			expect(result.leftoverAdds).toEqual([]);
+		});
+
+		test("one remove two adds same feature: one replace + leftover add", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const first = messages({ id: "ent_first", allowance: 20 });
+			const second = messages({ id: "ent_second", allowance: 40 });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [first, second],
+				replacedToIds: ["ent_first"],
+				leftoverAddIds: ["ent_second"],
+			});
+		});
+	});
+
+	describe("billing_method", () => {
+		test("prepaid filter vs free (no price) add: must not claim", () => {
+			const remove = monthMessagesFilter({
+				intervalCount: 1,
+				billingMethod: BillingMethod.Prepaid,
+			});
+			const free = messages({ id: "ent_free", allowance: 20 });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [free],
+				removedFilters: [remove],
+				leftoverAddIds: ["ent_free"],
+			});
+		});
+
+		test("prepaid filter vs prepaid add: replace", () => {
+			const remove = monthMessagesFilter({
+				intervalCount: 1,
+				billingMethod: BillingMethod.Prepaid,
+			});
+			const prepaid = messages({
+				id: "ent_prepaid",
+				priced: true,
+				billWhen: BillWhen.InAdvance,
+			});
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [prepaid],
+				replacedToIds: ["ent_prepaid"],
+			});
+		});
+
+		test("prepaid vs usage_based do not cross-claim", () => {
+			const prepaidFilter = monthMessagesFilter({
+				intervalCount: 1,
+				billingMethod: BillingMethod.Prepaid,
+			});
+			const usageFilter = monthMessagesFilter({
+				intervalCount: 1,
+				billingMethod: BillingMethod.UsageBased,
+			});
+			const prepaid = messages({
+				id: "ent_prepaid",
+				priced: true,
+				billWhen: BillWhen.InAdvance,
+			});
+			const usage = messages({
+				id: "ent_usage",
+				priced: true,
+				billWhen: BillWhen.EndOfPeriod,
+			});
+
+			expectPairing({
+				removeItems: [prepaidFilter],
+				addEntitlementPrices: [usage],
+				removedFilters: [prepaidFilter],
+				leftoverAddIds: ["ent_usage"],
+			});
+			expectPairing({
+				removeItems: [usageFilter],
+				addEntitlementPrices: [prepaid],
+				removedFilters: [usageFilter],
+				leftoverAddIds: ["ent_prepaid"],
+			});
+
+			const result = pairRemovedAndAddedPlanItems({
+				removeItems: [prepaidFilter, usageFilter],
+				addEntitlementPrices: [usage, prepaid],
+			});
+			expect(result.replaced[0]?.to.entitlement.id).toBe("ent_prepaid");
+			expect(result.replaced[1]?.to.entitlement.id).toBe("ent_usage");
+			expect(result.removed).toEqual([]);
+			expect(result.leftoverAdds).toEqual([]);
+		});
+
+		test("filter without billing_method still claims a free add", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const free = messages({ id: "ent_free" });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [free],
+				replacedToIds: ["ent_free"],
+			});
+		});
+
+		test("filter without billing_method claims a priced add when it is the only match", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const prepaid = messages({
+				id: "ent_prepaid",
+				priced: true,
+				billWhen: BillWhen.InAdvance,
+			});
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [prepaid],
+				replacedToIds: ["ent_prepaid"],
+			});
+		});
+	});
+
+	describe("claim / order", () => {
+		test("claimed add cannot be taken by a later remove", () => {
+			const first = monthMessagesFilter({ intervalCount: 1 });
+			const second = monthMessagesFilter({ intervalCount: 1 });
+			const only = messages({ id: "ent_only" });
+
+			expectPairing({
+				removeItems: [first, second],
+				addEntitlementPrices: [only],
+				replacedToIds: ["ent_only"],
+				removedFilters: [second],
+			});
+		});
+
+		test("feature-only remove vs [month, lifetime] claims month; later lifetime remove gets leftover lifetime", () => {
+			const featureOnly: PlanItemFilter = { feature_id: "messages" };
+			const lifetimeFilter: PlanItemFilter = {
+				feature_id: "messages",
+				interval: ResetInterval.OneOff,
+			};
+			const month = messages({ id: "ent_month", interval: EntInterval.Month });
+			const lifetime = messages({
+				id: "ent_lifetime",
+				interval: EntInterval.Lifetime,
+			});
+
+			const result = pairRemovedAndAddedPlanItems({
+				removeItems: [featureOnly, lifetimeFilter],
+				addEntitlementPrices: [month, lifetime],
+			});
+			expect(result.replaced[0]?.from).toEqual(featureOnly);
+			expect(result.replaced[0]?.to.entitlement.id).toBe("ent_month");
+			expect(result.replaced[1]?.from).toEqual(lifetimeFilter);
+			expect(result.replaced[1]?.to.entitlement.id).toBe("ent_lifetime");
+		});
+
+		test("month remove picks month add even when lifetime is listed first; later one_off remove gets lifetime", () => {
+			const monthFilter = monthMessagesFilter({ intervalCount: 1 });
+			const lifetimeFilter: PlanItemFilter = {
+				feature_id: "messages",
+				interval: ResetInterval.OneOff,
+			};
+			const lifetime = messages({
+				id: "ent_lifetime",
+				interval: EntInterval.Lifetime,
+			});
+			const month = messages({ id: "ent_month", interval: EntInterval.Month });
+
+			const result = pairRemovedAndAddedPlanItems({
+				removeItems: [monthFilter, lifetimeFilter],
+				addEntitlementPrices: [lifetime, month],
+			});
+			expect(result.replaced[0]?.from).toEqual(monthFilter);
+			expect(result.replaced[0]?.to.entitlement.id).toBe("ent_month");
+			expect(result.replaced[1]?.from).toEqual(lifetimeFilter);
+			expect(result.replaced[1]?.to.entitlement.id).toBe("ent_lifetime");
+			expect(result.removed).toEqual([]);
+			expect(result.leftoverAdds).toEqual([]);
+		});
+
+		test("more removes than adds: leftover removes stay removed", () => {
+			const first = monthMessagesFilter({ intervalCount: 1 });
+			const second: PlanItemFilter = { feature_id: "seats" };
+			const third: PlanItemFilter = { feature_id: "dashboard" };
+			const only = messages({ id: "ent_only" });
+
+			expectPairing({
+				removeItems: [first, second, third],
+				addEntitlementPrices: [only],
+				replacedToIds: ["ent_only"],
+				removedFilters: [second, third],
+			});
+		});
+
+		test("more adds than removes: leftover adds stay leftover", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const month = messages({ id: "ent_month" });
+			const extra = messages({
+				id: "ent_year",
+				interval: EntInterval.Year,
+			});
+			const seatsAdd = seats({ id: "ent_seats" });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [extra, month, seatsAdd],
+				replacedToIds: ["ent_month"],
+				leftoverAddIds: ["ent_year", "ent_seats"],
+			});
+		});
+
+		test("empty remove list leaves every add leftover", () => {
+			const month = messages({ id: "ent_month" });
+
+			expectPairing({
+				removeItems: [],
+				addEntitlementPrices: [month],
+				leftoverAddIds: ["ent_month"],
+			});
+		});
+
+		test("empty add list leaves every remove removed", () => {
+			const remove = monthMessagesFilter();
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [],
+				removedFilters: [remove],
+			});
+		});
+
+		test("empty remove list and empty add list yield empty buckets", () => {
+			expectPairing({
+				removeItems: [],
+				addEntitlementPrices: [],
+			});
+		});
+	});
+
+	describe("included", () => {
+		test("M7: remove included 100 still pairs with add 200 at the same cadence", () => {
+			const remove = {
+				...monthMessagesFilter({ intervalCount: 1 }),
+				included: 100,
+			};
+			const month200 = messages({
+				id: "ent_month_200",
+				allowance: 200,
+			});
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [month200],
+				replacedToIds: ["ent_month_200"],
+			});
+		});
+	});
+
+	describe("sparse vs full filters", () => {
+		test("{ feature_id } still pairs with a month add", () => {
+			const remove: PlanItemFilter = { feature_id: "messages" };
+			const month = messages({ id: "ent_month" });
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [month],
+				replacedToIds: ["ent_month"],
+			});
+		});
+
+		test("{ feature_id, interval: month, interval_count: 1 } does not pair with quarterly", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const quarterly = messages({
+				id: "ent_quarterly",
+				intervalCount: 3,
+			});
+
+			expectPairing({
+				removeItems: [remove],
+				addEntitlementPrices: [quarterly],
+				removedFilters: [remove],
+				leftoverAddIds: ["ent_quarterly"],
+			});
+		});
+	});
+
+	describe("inputs are not mutated", () => {
+		test("remove and add arrays keep length, order, and object identity", () => {
+			const remove = monthMessagesFilter({ intervalCount: 1 });
+			const lifetime = messages({
+				id: "ent_lifetime",
+				interval: EntInterval.Lifetime,
+			});
+			const month = messages({ id: "ent_month" });
+			const removeItems = [remove];
+			const addEntitlementPrices = [lifetime, month];
+
+			const result = pairRemovedAndAddedPlanItems({
+				removeItems,
+				addEntitlementPrices,
+			});
+
+			expect(removeItems).toHaveLength(1);
+			expect(removeItems[0]).toBe(remove);
+			expect(addEntitlementPrices).toEqual([lifetime, month]);
+			expect(addEntitlementPrices[0]).toBe(lifetime);
+			expect(addEntitlementPrices[1]).toBe(month);
+			expect(result.replaced[0]?.to).toBe(month);
+			expect(result.leftoverAdds[0]).toBe(lifetime);
+		});
+	});
+});
+
+describe("keepAddEntitlementPricesForLiveRemoves", () => {
+	test("drops the paired replace add when the remove missed; leftover adds stay", () => {
+		const month = messages({ id: "ent_month_200", allowance: 200 });
+		const lifetime = messages({
+			id: "ent_lifetime",
+			interval: EntInterval.Lifetime,
+			allowance: 50,
+		});
+		const kept = keepAddEntitlementPricesForLiveRemoves({
+			removeItems: [monthMessagesFilter()],
+			addEntitlementPrices: [month, lifetime],
+			removeFilterMatchedLive: () => false,
+		});
+		expect(ids(kept)).toEqual(["ent_lifetime"]);
+	});
+
+	test("keeps the paired replace add when the remove hit live", () => {
+		const month = messages({ id: "ent_month_200", allowance: 200 });
+		const lifetime = messages({
+			id: "ent_lifetime",
+			interval: EntInterval.Lifetime,
+			allowance: 50,
+		});
+		const kept = keepAddEntitlementPricesForLiveRemoves({
+			removeItems: [monthMessagesFilter()],
+			addEntitlementPrices: [month, lifetime],
+			removeFilterMatchedLive: () => true,
+		});
+		expect(ids(kept)).toEqual(["ent_month_200", "ent_lifetime"]);
+	});
+});

--- a/shared/api/products/items/filter/planItemFilter.ts
+++ b/shared/api/products/items/filter/planItemFilter.ts
@@ -1,4 +1,5 @@
 import { BillingMethod } from "@api/products/components/billingMethod";
+import { IncludedUsageParamsSchema } from "@api/products/items/crud/createPlanItemParamsV1";
 import { BillingInterval } from "@models/productModels/intervals/billingInterval";
 import { ResetInterval } from "@models/productModels/intervals/resetInterval";
 import { z } from "zod/v4";
@@ -22,6 +23,10 @@ export const PlanItemFilterSchema = z
 		interval_count: z.number().int().positive().optional().meta({
 			description:
 				"Match items with this interval_count. Disambiguates between items that share an interval but differ in count.",
+		}),
+		included: IncludedUsageParamsSchema.optional().meta({
+			description:
+				"Match items whose grant equals this included usage. Omitted is a wildcard.",
 		}),
 	})
 	.refine(

--- a/shared/api/products/items/utils/match/planItemFilterMatchesCustomerPair.ts
+++ b/shared/api/products/items/utils/match/planItemFilterMatchesCustomerPair.ts
@@ -105,5 +105,10 @@ export const planItemFilterMatchesCustomerPair = ({
 		if (!priceMatches && !resetMatches) return false;
 	}
 
+	if (filter.included !== undefined) {
+		if (customerEntitlement?.entitlement.allowance !== filter.included)
+			return false;
+	}
+
 	return true;
 };

--- a/shared/utils/planV1Utils/convertCustomize/customizeToKey.ts
+++ b/shared/utils/planV1Utils/convertCustomize/customizeToKey.ts
@@ -1,3 +1,4 @@
+import type { PlanItemFilter } from "@api/products/items/filter/planItemFilter.js";
 import type { CustomizePlanLicense } from "@models/licenseModels/licenseModels";
 import { FreeTrialDuration } from "@models/productModels/freeTrialModels/freeTrialEnums";
 import { basePriceToKey } from "@utils/planV1Utils/convertCustomize/basePriceToKey";
@@ -10,6 +11,9 @@ import {
 const ABSENT = "";
 
 const sortedJoin = (keys: string[]): string => [...keys].sort().join(",");
+
+const removeItemToKey = (filter: PlanItemFilter): string =>
+	`${planItemFilterMatchKey(filter)}|included:${filter.included ?? ""}`;
 
 const priceToKey = ({
 	price,
@@ -64,7 +68,7 @@ export const customizeToKey = ({
 	[
 		`price:${priceToKey({ price: customize.price })}`,
 		`add_items:${sortedJoin((customize.add_items ?? []).map((item) => createPlanItemToKey({ item })))}`,
-		`remove_items:${sortedJoin((customize.remove_items ?? []).map(planItemFilterMatchKey))}`,
+		`remove_items:${sortedJoin((customize.remove_items ?? []).map(removeItemToKey))}`,
 		`free_trial:${freeTrialSegment({ freeTrial: customize.free_trial })}`,
 		`upsert_licenses:${sortedJoin((customize.upsert_licenses ?? []).map((license) => upsertLicenseToKey({ license })))}`,
 		`remove_licenses:${sortedJoin((customize.remove_licenses ?? []).map((entry) => entry.license_plan_id))}`,

--- a/shared/utils/planV1Utils/customize/index.ts
+++ b/shared/utils/planV1Utils/customize/index.ts
@@ -1,2 +1,3 @@
+export * from "./keepAddEntitlementPricesForLiveRemoves.js";
 export * from "./pairRemovedAndAddedPlanItems.js";
 export * from "./planItemFilterMatchesEntitlementPrice.js";

--- a/shared/utils/planV1Utils/customize/keepAddEntitlementPricesForLiveRemoves.ts
+++ b/shared/utils/planV1Utils/customize/keepAddEntitlementPricesForLiveRemoves.ts
@@ -1,0 +1,27 @@
+import type { PlanItemFilter } from "@api/products/items/filter/planItemFilter.js";
+import type { EntitlementPrice } from "@utils/productUtils/entitlementPriceUtils/entitlementPriceTypes.js";
+import { pairRemovedAndAddedPlanItems } from "./pairRemovedAndAddedPlanItems.js";
+
+/** Drop a paired replace-add when its remove filter did not hit a live row.
+ * Leftover adds (boolean, other cadence) always stay. */
+export const keepAddEntitlementPricesForLiveRemoves = ({
+	removeItems,
+	addEntitlementPrices,
+	removeFilterMatchedLive,
+}: {
+	removeItems: PlanItemFilter[];
+	addEntitlementPrices: EntitlementPrice[];
+	removeFilterMatchedLive: ({ filter }: { filter: PlanItemFilter }) => boolean;
+}): EntitlementPrice[] => {
+	const { replaced, leftoverAdds } = pairRemovedAndAddedPlanItems({
+		removeItems,
+		addEntitlementPrices,
+	});
+
+	return [
+		...replaced
+			.filter(({ from }) => removeFilterMatchedLive({ filter: from }))
+			.map(({ to }) => to),
+		...leftoverAdds,
+	];
+};

--- a/shared/utils/planV1Utils/diff/comparePlanItems.ts
+++ b/shared/utils/planV1Utils/diff/comparePlanItems.ts
@@ -174,7 +174,8 @@ export const planItemFiltersEqual = (
 		normalizeIntervalCount({
 			interval: b.interval,
 			intervalCount: b.interval_count,
-		});
+		}) &&
+	(a.included ?? null) === (b.included ?? null);
 
 /** Omitted and `[]` are the same empty list. Order does not matter. */
 export const arraysEqual = <T>({

--- a/shared/utils/planV1Utils/diff/diffPlanV1.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1.ts
@@ -153,6 +153,11 @@ export enum PlanItemMatchPrecision {
 	FeatureCadence = "feature_cadence",
 }
 
+export enum PlanItemFilterPrecision {
+	Identity = "identity",
+	IdentityAndIncluded = "identity_and_included",
+}
+
 export const buildPlanItemKey = ({
 	item,
 	matchPrecision = PlanItemMatchPrecision.FeatureBillingMethodCadence,
@@ -190,7 +195,13 @@ export const planItemFilterMatchKey = (filter: PlanItemFilter): string =>
 		},
 	)}`;
 
-const buildRemoveFilter = (item: ApiPlanItem): PlanItemFilter => {
+const buildRemoveFilter = ({
+	item,
+	filterPrecision,
+}: {
+	item: ApiPlanItem;
+	filterPrecision: PlanItemFilterPrecision;
+}): PlanItemFilter => {
 	const filter: PlanItemFilter = { feature_id: item.feature_id };
 	if (item.price?.billing_method !== undefined)
 		filter.billing_method = item.price.billing_method;
@@ -200,6 +211,14 @@ const buildRemoveFilter = (item: ApiPlanItem): PlanItemFilter => {
 	const intervalCount =
 		item.price?.interval_count ?? item.reset?.interval_count;
 	if (interval !== undefined) filter.interval_count = intervalCount ?? 1;
+	if (
+		filterPrecision === PlanItemFilterPrecision.IdentityAndIncluded &&
+		typeof item.included === "number" &&
+		item.unlimited !== true &&
+		(item.reset != null || item.price != null)
+	) {
+		filter.included = item.included;
+	}
 	return filter;
 };
 
@@ -261,10 +280,12 @@ export const diffPlanV1 = ({
 	from,
 	to,
 	includeAdds = false,
+	filterPrecision = PlanItemFilterPrecision.Identity,
 }: {
 	from: DiffablePlanV1;
 	to: DiffablePlanV1;
 	includeAdds?: boolean;
+	filterPrecision?: PlanItemFilterPrecision;
 }): DiffedCustomizePlanV1 => {
 	const diff: DiffedCustomizePlanV1 = {};
 
@@ -288,7 +309,7 @@ export const diffPlanV1 = ({
 	for (const fromItem of from.items) {
 		const toItem = toByKey.get(composeMatchKey(fromItem));
 		if (!toItem || !itemsEqual(fromItem, toItem)) {
-			removeItems.push(buildRemoveFilter(fromItem));
+			removeItems.push(buildRemoveFilter({ item: fromItem, filterPrecision }));
 		}
 	}
 	if (removeItems.length > 0) diff.remove_items = removeItems;

--- a/vite/src/views/migrations/migration/operations/RemoveItemRows.tsx
+++ b/vite/src/views/migrations/migration/operations/RemoveItemRows.tsx
@@ -4,6 +4,7 @@ import {
 	DropdownMenuContent,
 	DropdownMenuItem,
 	DropdownMenuTrigger,
+	Input,
 	Sheet,
 	SheetContent,
 } from "@autumn/ui";
@@ -17,8 +18,10 @@ import {
 	BillingMethodDropdown,
 	filterToProductItem,
 	getFilterSummary,
+	includedFilterInputValue,
 	INTERVAL_OPTIONS,
 	type ItemFilter,
+	setItemFilterIncluded,
 } from "./operationItemUtils";
 
 export function RemoveItemRows({
@@ -131,8 +134,8 @@ function RemoveItemSheetContent({
 						Remove Item
 					</h3>
 					<p className="text-xs text-tertiary-foreground">
-						Select a feature to remove from the plan. Use interval and billing
-						method to narrow the match.
+						Select a feature to remove from the plan. Use interval, included,
+						and billing method to narrow the match.
 					</p>
 				</div>
 
@@ -195,6 +198,41 @@ function RemoveItemSheetContent({
 						<p className="text-xs text-tertiary-foreground">
 							Narrow the match when the same feature appears at multiple
 							intervals.
+						</p>
+					</div>
+
+					<div className="flex flex-col gap-1.5">
+						<label className="text-xs font-medium text-foreground">
+							Included
+						</label>
+						<Input
+							type="number"
+							min={0}
+							placeholder="Any included"
+							value={includedFilterInputValue(draft.included)}
+							onChange={(event) => {
+								const raw = event.target.value.trim();
+								if (raw === "") {
+									setDraft(
+										setItemFilterIncluded({
+											filter: draft,
+											included: undefined,
+										}),
+									);
+									return;
+								}
+								const parsed = Number(raw);
+								if (!Number.isFinite(parsed)) return;
+								setDraft(
+									setItemFilterIncluded({
+										filter: draft,
+										included: parsed,
+									}),
+								);
+							}}
+						/>
+						<p className="text-xs text-tertiary-foreground">
+							Empty matches any grant. 0 matches a zero included grant.
 						</p>
 					</div>
 

--- a/vite/src/views/migrations/migration/operations/operationItemUtils.tsx
+++ b/vite/src/views/migrations/migration/operations/operationItemUtils.tsx
@@ -117,7 +117,26 @@ export interface ItemFilter {
 	feature_id?: string;
 	interval?: string;
 	billing_method?: string;
+	included?: number;
 }
+
+export const includedFilterInputValue = (
+	included: number | undefined,
+): string => (included === undefined ? "" : String(included));
+
+export const setItemFilterIncluded = ({
+	filter,
+	included,
+}: {
+	filter: ItemFilter;
+	included: number | undefined;
+}): ItemFilter => {
+	if (included === undefined) {
+		const { included: _included, ...rest } = filter;
+		return rest;
+	}
+	return { ...filter, included };
+};
 
 export function filterToProductItem(filter: ItemFilter): ProductItem {
 	return {
@@ -144,5 +163,6 @@ export function getFilterSummary(
 	const name = feature?.name || filter.feature_id || "Unconfigured";
 	const parts: string[] = [name];
 	if (filter.interval) parts.push(filter.interval);
+	if (filter.included !== undefined) parts.push(`${filter.included} included`);
 	return parts.join(" · ");
 }

--- a/vite/src/views/migrations/migration/shared/OperationsPreview.tsx
+++ b/vite/src/views/migrations/migration/shared/OperationsPreview.tsx
@@ -51,8 +51,9 @@ function EditedRow({
 	);
 }
 
-/** A removal is a filter (feature + optional interval/billing method), not a
- * concrete item, so it has no quantity — show the matched feature, not "0". */
+/** A removal is a filter (feature + optional interval / included / billing
+ * method), not a concrete item, so it has no quantity — show the matched
+ * feature, not "0". */
 function RemovedFilterRow({ filter }: { filter: ItemFilter }) {
 	const { features } = useFeaturesQuery();
 	return (

--- a/vite/tests/views/migrations/migration/operations/operationItemUtils.test.ts
+++ b/vite/tests/views/migrations/migration/operations/operationItemUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import type { Feature } from "@autumn/shared";
+import {
+	getFilterSummary,
+	includedFilterInputValue,
+	setItemFilterIncluded,
+} from "@/views/migrations/migration/operations/operationItemUtils";
+
+const features = [{ id: "messages", name: "Messages" }] as Feature[];
+
+describe("ItemFilter included", () => {
+	test("empty input is omitted; 0 is a real grant", () => {
+		expect(includedFilterInputValue(undefined)).toBe("");
+		expect(includedFilterInputValue(0)).toBe("0");
+		expect(includedFilterInputValue(100)).toBe("100");
+	});
+
+	test("clearing included drops the key instead of writing 0", () => {
+		expect(
+			setItemFilterIncluded({
+				filter: { feature_id: "messages", included: 0 },
+				included: undefined,
+			}),
+		).toEqual({ feature_id: "messages" });
+		expect(
+			setItemFilterIncluded({
+				filter: { feature_id: "messages" },
+				included: 0,
+			}),
+		).toEqual({ feature_id: "messages", included: 0 });
+	});
+
+	test("summary shows 0 included and hides omitted included", () => {
+		expect(getFilterSummary({ feature_id: "messages" }, features)).toBe(
+			"Messages",
+		);
+		expect(
+			getFilterSummary({ feature_id: "messages", included: 0 }, features),
+		).toBe("Messages · 0 included");
+		expect(
+			getFilterSummary({ feature_id: "messages", included: 100 }, features),
+		).toBe("Messages · 100 included");
+	});
+});


### PR DESCRIPTION
## Summary
- Catalog grant changes (e.g. 100→200) only rewrite live rows whose included allowance matches. Pairing ignores `included` so identity stays stable; live match ANDs it.
- Unmatched replace-adds are dropped so a custom 1k row is not duplicated; leftover adds (boolean, lifetime) still land.
- Also includes wt-1 compose port slots so local Dragonfly does not collide with `bun d`, a non-prod Trigger branch gate for inline webhook fallback, and the replace-group fanout probe.

## Test plan
- [ ] Catalog drafts stamp `included` and spare unmatched custom grants
- [ ] Batch replace/remove/update-plan/patch: spare 1k, apply leftovers, match 100→200
- [ ] License included-filter drafts + batch leftover dashboard
- [ ] Unit: `diffPlanV1` filter precision, `keepAddEntitlementPricesForLiveRemoves`

Stacked on #2963.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match plan‑item remove filters against live included grants so catalog edits and migrations don’t rewrite custom allowances. Old behavior matched by feature and cadence only; new behavior also requires the live allowance to equal the filter’s included value. Unmatched replace‑adds are dropped; prepaid replace‑adds are kept when the match depended on price.

- Diff/drafts: `diffPlanV1` adds `PlanItemFilterPrecision.IdentityAndIncluded`; catalog and license draft generators stamp remove filters with included for numbered grants; variants split ops by from‑grant when needed. Default diffs remain cadence‑only.
- Execution: batch and per‑customer paths AND included when matching live rows; month filters do not touch lifetime; paid rows with different allowances are skipped; drop replace‑adds whose remove did not hit a live row; keep prepaid replace‑adds when the remove matched via price.
- Matching/SQL: live match checks included; compiled entitlement‑price filters and SQL add allowance conditions; entitlement filters now carry included.
- UI: Remove Item supports an included filter and shows it in summaries; `customizeToKey` distinguishes omitted vs specified included without breaking add/remove pairing.
- Dev infra: worktree‑1 compose avoids `bun d`’s Dragonfly/DynamoDB ports; add `CACHE_V2_DRAGONFLY_PUBLIC_URL` and prefer existing `CACHE_V2_DRAGONFLY_URL` when set; `isTriggerConfigured()` requires a preview branch in non‑prod so tests fall back to inline webhooks; test workers require `ORG_ID` and avoid importing test orgs before workspace deps install.
- No schema changes. New unit/integration tests cover included filtering, month vs lifetime, paid‑row skips, pairing, and replace‑group fanout.

<sup>Written for commit 358b534758d4c317555b91bf7b661d799062bc8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes catalog and migration operations match the allowance on live grants, preventing catalog-shaped changes from overwriting customized grants.
- **[Bug fixes, API changes]** Adds `included` to plan-item removal filters and consistently applies it across migration matching, SQL selection, license operations, patch operations, and migration UI summaries.
- **[Bug fixes]** Retains replacement additions only when their paired removal matched live customer data, including prepaid items matched through their price.
- **[Improvements]** Adds focused migration, catalog, patch, license, UI, and pairing tests for included-allowance filtering and unmatched replacement behavior.
- **[Improvements]** Separates worktree infrastructure ports from the default development stack and adjusts local Trigger webhook fallback behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/planV1Utils/diff/diffPlanV1.ts | Adds selectable filter precision so generated migration removals can identify the original included allowance without changing item-pair identity. |
| shared/api/products/items/utils/match/planItemFilterMatchesCustomerPair.ts | Extends live customer item matching to require the requested included allowance when one is specified. |
| shared/utils/planV1Utils/customize/keepAddEntitlementPricesForLiveRemoves.ts | Coordinates paired replacement additions with removals that actually matched live customer data. |
| server/src/internal/billing/v2/setup/patch/handleCustomizeNoopItems.ts | Applies live-removal-aware replacement pruning to per-customer patch customization while retaining independent additions. |
| server/src/internal/migrations/v2/batchOperations/actions/utils/resolveFilterEntitlementIds.ts | Adds allowance matching to SQL-based entitlement selection for batch migrations. |
| server/src/internal/migrations/v2/batchOperations/actions/removeLicenseEntitlementsForPage/removeLicenseEntitlementRows.ts | Restricts license entitlement removals to definitions whose allowance matches the optional included filter. |
| server/src/trigger/configureTrigger.ts | Centralizes local and production Trigger availability checks, requiring a preview branch outside production. |
| scripts/dw/helpers/ports.ts | Moves worktree-one compose services to a dedicated high-numbered slot to avoid default development ports. |
| vite/src/views/migrations/migration/operations/RemoveItemRows.tsx | Adds included-allowance input and presentation support for migration removal operations. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Catalog or migration operation] --> B[Plan-item remove filter]
  B --> C{Live feature, interval, and included allowance match?}
  C -->|Yes| D[Remove or replace matching live grant]
  C -->|No| E[Preserve customized live grant]
  D --> F[Apply paired replacement addition]
  E --> G[Drop unmatched replacement addition]
  G --> H[Apply independent leftover additions]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(tw): install workspace deps before i..."](https://github.com/useautumn/autumn/commit/358b534758d4c317555b91bf7b661d799062bc8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55565954)</sub>

<!-- /greptile_comment -->