### PR TITLE
fix(export): read totalCount from customer count query object

### DIFF
--- a/vite/src/views/customers2/components/export/CustomerExportOverview.tsx
+++ b/vite/src/views/customers2/components/export/CustomerExportOverview.tsx
@@ -32,12 +32,14 @@ function OverviewRow({
 
 export function CustomerExportOverview({
 	exportTotalCount,
+	isCountApproximate,
 	isCountLoading,
 	isFilteredExport,
 	columnsAction,
 	scopeRow,
 }: {
 	exportTotalCount: number | undefined;
+	isCountApproximate: boolean;
 	isCountLoading: boolean;
 	isFilteredExport: boolean;
 	columnsAction: ReactNode;
@@ -52,7 +54,7 @@ export function CustomerExportOverview({
 					<span className="tabular-nums">
 						{exportTotalCount === undefined
 							? "All customers"
-							: `${exportTotalCount.toLocaleString()} ${exportTotalCount === 1 ? "customer" : "customers"}`}
+							: `${isCountApproximate ? "~" : ""}${exportTotalCount.toLocaleString()} ${exportTotalCount === 1 ? "customer" : "customers"}`}
 					</span>
 				)}
 			</OverviewRow>

--- a/vite/src/views/customers2/components/export/CustomerExportSheet.tsx
+++ b/vite/src/views/customers2/components/export/CustomerExportSheet.tsx
@@ -32,6 +32,7 @@ export function CustomerExportSheet({
 		handleOpenChange,
 		hasActiveFilters,
 		hasFilters,
+		isExportCountApproximate,
 		isExportCountLoading,
 		isExportsInitialError,
 		isExportsLoading,
@@ -63,6 +64,7 @@ export function CustomerExportSheet({
 										{(field) => (
 											<CustomerExportOverview
 												exportTotalCount={exportTotalCount}
+												isCountApproximate={isExportCountApproximate}
 												isCountLoading={isExportCountLoading}
 												isFilteredExport={isFilteredExport}
 												columnsAction={

--- a/vite/src/views/customers2/components/export/useCustomerExportSheet.ts
+++ b/vite/src/views/customers2/components/export/useCustomerExportSheet.ts
@@ -166,8 +166,10 @@ export function useCustomerExportSheet({
 		countQuery.isPending ||
 		countQuery.isFetching ||
 		countQuery.isPlaceholderData;
-	const exportTotalCount =
+	const exportCountData =
 		isExportCountLoading || countQuery.isError ? undefined : countQuery.data;
+	const exportTotalCount = exportCountData?.totalCount ?? undefined;
+	const isExportCountApproximate = exportCountData?.approximate ?? false;
 	const hasNothingToExport = exportTotalCount === 0;
 
 	const handleOpenChange = (nextOpen: boolean) => {
@@ -187,6 +189,7 @@ export function useCustomerExportSheet({
 		handleOpenChange,
 		hasActiveFilters,
 		hasFilters,
+		isExportCountApproximate,
 		isExportCountLoading,
 		submitBlockedReason: getSubmitBlockedReason({
 			activeExport,


### PR DESCRIPTION
## Problem

The Export customers sheet shows **"[object Object] customers"**:

`useCustomerCountQuery` changed its return shape from a bare `number` to `{ totalCount, approximate }` in 0cf53ffef (balance-filter count fix). That commit updated `useCusSearchQuery` and `CustomerListSearchBar`, but the export sheet was missed — `useCustomerExportSheet` still assigned `countQuery.data` (now an object) into `exportTotalCount`, so `CustomerExportOverview` rendered `Object.prototype.toLocaleString()`.

Side effect: `hasNothingToExport = exportTotalCount === 0` could never be true, so the "There are no customers to export" submit guard was dead.

## Fix

- Unwrap `countQuery.data?.totalCount` in `useCustomerExportSheet`, restoring the count display and the empty-list guard
- Surface `approximate` as a `~` prefix on the count, matching what `CustomerListSearchBar` does with the same data

## Why CI didn't catch it

`vite`'s `ts` script runs plain `tsc --noEmit` against the solution-style `tsconfig.json` (`"files": []` + references), which type-checks nothing — it would need `tsc -b`. Running the real check (`tsc -p tsconfig.app.json --noEmit`) reports ~1000 pre-existing errors repo-wide, so fixing the script is left as a separate effort. These three files are clean under the real check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the export customers count by reading `totalCount` from the query result and indicating approximate counts. Previously the sheet treated the count result as a number, rendering “[object Object] customers” and disabling the “no customers to export” guard; now it unwraps the count, prefixes “~” when approximate, and restores the guard.

- Unwrap `countQuery.data?.totalCount` and `approximate` in `useCustomerExportSheet`.
- Pass `isExportCountApproximate` to `CustomerExportOverview` and render the “~” prefix for approximate counts.
- `hasNothingToExport` now correctly uses the unwrapped count.

<sup>Written for commit 16d7eacd4f07da5f319c9a3771fd0b55c50b9ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

