### PR TITLE
fix(free-trial): free plans no longer report card_required true

### DIFF
--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -10,6 +10,7 @@ import {
 	type FullCustomer,
 	type FullProduct,
 	getProductItemDisplay,
+	isFreeProduct,
 	itemToBillingInterval,
 	itemToBillingIntervalCount,
 	productItemsToPlanItemsV1,
@@ -34,10 +35,14 @@ const getFreeTrialV2Response = ({
 }): ApiFreeTrialV2 | undefined => {
 	if (!product.free_trial) return undefined;
 
+	// Free plans have no card gate (attach branches on price count), so a stored
+	// `true` is inert and only misleads API consumers.
 	return ApiFreeTrialV2Schema.parse({
 		duration_type: product.free_trial.duration,
 		duration_length: product.free_trial.length,
-		card_required: product.free_trial.card_required ?? false,
+		card_required: isFreeProduct({ product })
+			? false
+			: (product.free_trial.card_required ?? false),
 		on_end: product.free_trial.on_end ?? null,
 	});
 };

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -10,7 +10,6 @@ import {
 	type FullCustomer,
 	type FullProduct,
 	getProductItemDisplay,
-	isFreeProduct,
 	itemToBillingInterval,
 	itemToBillingIntervalCount,
 	productItemsToPlanItemsV1,
@@ -24,6 +23,7 @@ import { buildApiPlanLicense } from "./buildApiPlanLicense.js";
 import { buildApiPlanVariant } from "./buildApiPlanVariant.js";
 import { buildCustomerEligibility } from "./buildCustomerEligibility.js";
 import { buildVariantDetails } from "./buildVariantDetails.js";
+import { resolveTrialCardRequired } from "./resolveTrialCardRequired.js";
 
 /**
  * Get free trial response in Plan V2 format
@@ -35,14 +35,10 @@ const getFreeTrialV2Response = ({
 }): ApiFreeTrialV2 | undefined => {
 	if (!product.free_trial) return undefined;
 
-	// Free plans have no card gate (attach branches on price count), so a stored
-	// `true` is inert and only misleads API consumers.
 	return ApiFreeTrialV2Schema.parse({
 		duration_type: product.free_trial.duration,
 		duration_length: product.free_trial.length,
-		card_required: isFreeProduct({ product })
-			? false
-			: (product.free_trial.card_required ?? false),
+		card_required: resolveTrialCardRequired({ product }),
 		on_end: product.free_trial.on_end ?? null,
 	});
 };

--- a/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
@@ -30,6 +30,7 @@ import { getItemType } from "../../product-items/productItemUtils/getItemType.js
 import { itemToPriceOrTiers } from "../../product-items/productItemUtils.js";
 import { mapToProductItems } from "../../productV2Utils.js";
 import { getAttachScenario } from "./getAttachScenario.js";
+import { resolveTrialCardRequired } from "./resolveTrialCardRequired.js";
 
 export const getProductItemResponse = ({
 	item,
@@ -96,11 +97,7 @@ const getFreeTrialResponse = async ({
 	fullCus?: FullCustomer;
 	attachScenario: AttachScenario;
 }) => {
-	// Free plans have no card gate (attach branches on price count), so a stored
-	// `true` is inert and only misleads API consumers.
-	const cardRequired = isFreeProduct({ product })
-		? false
-		: (product.free_trial?.card_required ?? false);
+	const cardRequired = resolveTrialCardRequired({ product });
 
 	if (!db) {
 		return product.free_trial

--- a/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getProductResponse.ts
@@ -96,7 +96,17 @@ const getFreeTrialResponse = async ({
 	fullCus?: FullCustomer;
 	attachScenario: AttachScenario;
 }) => {
-	if (!db) return product.free_trial;
+	// Free plans have no card gate (attach branches on price count), so a stored
+	// `true` is inert and only misleads API consumers.
+	const cardRequired = isFreeProduct({ product })
+		? false
+		: (product.free_trial?.card_required ?? false);
+
+	if (!db) {
+		return product.free_trial
+			? { ...product.free_trial, card_required: cardRequired }
+			: product.free_trial;
+	}
 
 	if (product.free_trial && fullCus) {
 		let trial = await getFreeTrialAfterFingerprint({
@@ -115,7 +125,7 @@ const getFreeTrialResponse = async ({
 			length: product.free_trial?.length,
 			unique_fingerprint: product.free_trial?.unique_fingerprint,
 			trial_available: notNullish(trial) ? true : false,
-			card_required: product.free_trial?.card_required,
+			card_required: cardRequired,
 		});
 	}
 
@@ -124,7 +134,7 @@ const getFreeTrialResponse = async ({
 			duration: product.free_trial?.duration,
 			length: product.free_trial?.length,
 			unique_fingerprint: product.free_trial?.unique_fingerprint,
-			card_required: product.free_trial?.card_required,
+			card_required: cardRequired,
 		});
 	}
 

--- a/server/src/internal/products/productUtils/productResponseUtils/resolveTrialCardRequired.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/resolveTrialCardRequired.ts
@@ -1,0 +1,14 @@
+import { type FullProduct, isFreeProduct } from "@autumn/shared";
+
+/**
+ * Free plans have no card gate (attach branches on price count), so a stored
+ * `true` is inert and only misleads API consumers.
+ */
+export const resolveTrialCardRequired = ({
+	product,
+}: {
+	product: FullProduct;
+}): boolean => {
+	if (isFreeProduct({ product })) return false;
+	return product.free_trial?.card_required ?? false;
+};

--- a/server/tests/unit/products/get-plan-response.test.ts
+++ b/server/tests/unit/products/get-plan-response.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { AppEnv, type FullProduct } from "@autumn/shared";
+import {
+	AppEnv,
+	BillingInterval,
+	type FreeTrial,
+	FreeTrialDuration,
+	type FullProduct,
+	type Price,
+	PriceType,
+} from "@autumn/shared";
 import { getPlanResponse } from "@/internal/products/productUtils/productResponseUtils/getPlanResponse.js";
 
 const baseProduct = {
@@ -27,6 +35,30 @@ const baseProduct = {
 	free_trial_ids: [],
 } satisfies Omit<FullProduct, "is_add_on" | "is_default">;
 
+const cardRequiredTrial = {
+	id: "ft_123",
+	duration: FreeTrialDuration.Day,
+	length: 7,
+	unique_fingerprint: false,
+	created_at: 1,
+	internal_product_id: "prod_internal",
+	is_custom: false,
+	card_required: true,
+} satisfies FreeTrial;
+
+const monthlyPrice = {
+	id: "price_123",
+	internal_product_id: "prod_internal",
+	proration_config: null,
+	config: {
+		type: PriceType.Fixed,
+		amount: 20,
+		interval: BillingInterval.Month,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+} satisfies Price;
+
 describe("getPlanResponse", () => {
 	test("normalizes null product booleans to DB defaults", async () => {
 		const response = await getPlanResponse({
@@ -40,5 +72,34 @@ describe("getPlanResponse", () => {
 
 		expect(response.add_on).toBe(false);
 		expect(response.auto_enable).toBe(false);
+	});
+
+	test("forces card_required off for a trial on a free plan", async () => {
+		const response = await getPlanResponse({
+			product: {
+				...baseProduct,
+				is_add_on: false,
+				is_default: false,
+				free_trial: cardRequiredTrial,
+			} as unknown as FullProduct,
+			features: [],
+		});
+
+		expect(response.free_trial?.card_required).toBe(false);
+	});
+
+	test("keeps card_required on for a trial on a paid plan", async () => {
+		const response = await getPlanResponse({
+			product: {
+				...baseProduct,
+				is_add_on: false,
+				is_default: false,
+				prices: [monthlyPrice],
+				free_trial: cardRequiredTrial,
+			} as unknown as FullProduct,
+			features: [],
+		});
+
+		expect(response.free_trial?.card_required).toBe(true);
 	});
 });

--- a/vite/src/views/products/plan/components/edit-plan-details/FreeTrialOption.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/FreeTrialOption.tsx
@@ -19,7 +19,11 @@ export const FreeTrialOption = () => {
 					onCheckedChange={(checked) =>
 						setProduct({
 							...product,
-							free_trial: checked ? (getDefaultFreeTrial() as FreeTrial) : null,
+							free_trial: checked
+								? (getDefaultFreeTrial({
+										planType: product.planType,
+									}) as FreeTrial)
+								: null,
 						})
 					}
 				/>

--- a/vite/src/views/products/plan/utils/getDefaultFreeTrial.ts
+++ b/vite/src/views/products/plan/utils/getDefaultFreeTrial.ts
@@ -3,8 +3,8 @@ import { FreeTrialDuration, type FrontendProduct } from "@autumn/shared";
 export const getDefaultFreeTrial = ({
 	planType,
 }: {
-	planType?: FrontendProduct["planType"];
-} = {}) => {
+	planType: FrontendProduct["planType"];
+}) => {
 	return {
 		length: 7,
 		unique_fingerprint: false,

--- a/vite/src/views/products/plan/utils/getDefaultFreeTrial.ts
+++ b/vite/src/views/products/plan/utils/getDefaultFreeTrial.ts
@@ -1,10 +1,14 @@
-import { FreeTrialDuration } from "@autumn/shared";
+import { FreeTrialDuration, type FrontendProduct } from "@autumn/shared";
 
-export const getDefaultFreeTrial = () => {
+export const getDefaultFreeTrial = ({
+	planType,
+}: {
+	planType?: FrontendProduct["planType"];
+} = {}) => {
 	return {
 		length: 7,
 		unique_fingerprint: false,
 		duration: FreeTrialDuration.Day,
-		card_required: true,
+		card_required: planType !== "free",
 	};
 };

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -13,6 +13,7 @@ import {
 	productItemsToPlanItemsV1,
 	productV2ToBasePrice,
 	productV2ToFeatureItems,
+	productV2ToFrontendProduct,
 	sortProductItems,
 } from "@autumn/shared";
 import { migrationUid } from "@/views/migrations/migration/shared/operationUtils";
@@ -53,11 +54,18 @@ export function frontendProductToApiPlanV1(
 			}
 		: null;
 
+	// Derived rather than read off `product.planType` so a plan toggled paid ->
+	// free can't smuggle through a stale `card_required: true`.
+	const { planType } = productV2ToFrontendProduct({ product });
+
 	const freeTrial: ApiPlanV1["free_trial"] = product.free_trial
 		? {
 				duration_type: product.free_trial.duration,
 				duration_length: product.free_trial.length,
-				card_required: product.free_trial.card_required ?? false,
+				card_required:
+					planType === "free"
+						? false
+						: (product.free_trial.card_required ?? false),
 				...(product.free_trial.on_end
 					? { on_end: product.free_trial.on_end }
 					: {}),

--- a/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
+++ b/vite/src/views/products/plan/versioning/buildMigrationDraft.ts
@@ -54,8 +54,8 @@ export function frontendProductToApiPlanV1(
 			}
 		: null;
 
-	// Derived rather than read off `product.planType` so a plan toggled paid ->
-	// free can't smuggle through a stale `card_required: true`.
+	// planType is derived from items; the stored planType field can be stale
+	// after item edits.
 	const { planType } = productV2ToFrontendProduct({ product });
 
 	const freeTrial: ApiPlanV1["free_trial"] = product.free_trial


### PR DESCRIPTION
## Problem

A free plan (zero prices) configured with a trial in the dashboard ends up stored and served with `free_trial.card_required: true`, while the dashboard never shows a card option for free plans — signup correctly never asks for a card, so the API response contradicts actual behavior.

Root causes:
- `getDefaultFreeTrial` seeded every trial with `card_required: true`, and the Card Required checkbox (`FreeTrialSection.tsx`) only renders for paid plans, so the seeded `true` was invisible and uneditable on free plans.
- The plan/product response builders passed the stored value straight through.

`card_required` is functionally inert for free plans — attach branches purely on price count (`handleAddProduct.ts`), so this is a data/response correctness fix with no behavior change at signup.

## Changes

**Write path (dashboard)**
- `getDefaultFreeTrial.ts` — seeds `card_required` by plan type instead of hardcoded `true`.
- `buildMigrationDraft.ts` — save payload forces `card_required: false` for free plans, deriving plan type from items (not the possibly-stale `planType` field) so paid→free toggles can't smuggle a stale `true`.

**Read path (server)**
- `getPlanResponse.ts` (v2 plan API) and `getProductResponse.ts` (legacy v0, incl. the no-`db` shortcut used by pricing table / check preview) — derive `card_required: false` via `isFreeProduct` when the plan has no prices. This corrects already-saved rows without a migration and keeps both APIs in agreement.

**Tests**
- `get-plan-response.test.ts` — free plan with stored `card_required: true` returns `false`; paid plan keeps `true`. Red/green verified against the old passthrough.

## Out of scope (deliberate)
- The Zod `.default(true)` on `FreeTrialParamsV0/V1Schema` — public API contract for paid plans.
- Attach/signup logic and customer-facing update-subscription/attach flows — untouched.

## Gates
- `bun ts` clean in server/ and vite/
- `bun test` — 87 vite + 128 server unit tests pass (incl. new regression tests)
- Pinned Biome clean on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Free-plan trials no longer report card_required: true in plan/product API responses. Previously the dashboard seeded true and APIs passed it through; now we always return false for free plans while preserving true for paid plans, with no signup flow change.

- Read path: v2 plan and legacy v0 product responses use resolveTrialCardRequired to force card_required: false for free plans (including the no-db path), correcting existing rows without a migration.
- Write path (dashboard): getDefaultFreeTrial now requires planType and seeds card_required by plan type; buildMigrationDraft forces false for free plans using planType derived from items (not a stale field).
- Tests: add regression tests covering free vs paid behavior.

**Rollout**
- No data migration; normalization happens on read.
- No changes to attach/signup logic or customer-facing flows.

<sup>Written for commit 816e3d344a2141ccdc9a666afd9807b575dfa81b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

