### PR TITLE
docs: replace entity feature IDs with licenses in entity-balances guides

### DIFF
--- a/apps/docs/mintlify/docs.json
+++ b/apps/docs/mintlify/docs.json
@@ -195,7 +195,9 @@
 								"group": "Licenses",
 								"pages": [
 									"api-reference/licenses/attachLicense",
-									"api-reference/licenses/releaseLicense"
+									"api-reference/licenses/releaseLicense",
+									"api-reference/licenses/listLicenses",
+									"api-reference/licenses/listLicenseAssignments"
 								]
 							}
 						]

--- a/apps/docs/mintlify/documentation/modelling-pricing/sub-entity-balances.mdx
+++ b/apps/docs/mintlify/documentation/modelling-pricing/sub-entity-balances.mdx
@@ -5,25 +5,32 @@ description: Grant individual usage limits to entities like users or workspaces 
 
 Sub-entity balances let you set usage limits that apply to each entity (user, workspace, project, etc.) individually under a parent customer. Instead of a single shared pool, each entity gets its own independent balance.
 
+You model this with a **license plan**: a plan that describes everything one entity gets. The parent plan offers a pool of those licenses, and you assign a license to an entity to hand it its own balance.
+
 > **Example** <br />
 > A team plan costs $30/seat/month. Each seat gets 50 AI meeting summaries per month. If a team has 5 users, each user has their own balance of 50 summaries — they can't use each other's allocation.
+
+## How it works
+
+```
+team plan  ──licenses: [{ seat, included: 1 }]──►  pool of seats
+                                                     │
+                                    licenses.attach  │  licenses.release
+                                                     ▼
+                              entity "user_alice"  ──►  own balance: 50 summaries/mo
+```
+
+The pool has a `granted` size (included seats plus any paid seats), a `usage` count (seats currently assigned), and a `remaining` count. Assigning a license consumes one seat; releasing gives it back.
 
 ## Setting up
 
 <Tabs>
 <Tab title="CLI">
 
-Create features for both the entity count (e.g., seats) and the per-entity feature (e.g., summaries). Then link them via `entityFeatureId` on the plan item:
+Create the feature each seat consumes, then a license plan holding what one seat gets. Link it from the parent plan via `licenses`:
 
 ```ts autumn.config.ts
 import { feature, item, plan } from 'atmn';
-
-export const seats = feature({
-  id: 'seats',
-  name: 'Seats',
-  type: 'metered',
-  consumable: false,
-});
 
 export const summaries = feature({
   id: 'summaries',
@@ -32,51 +39,52 @@ export const summaries = feature({
   consumable: true,
 });
 
-export const team = plan({
-  id: 'team',
-  name: 'Team',
+// Everything one seat gets, priced per seat.
+export const seat = plan({
+  id: 'seat',
+  name: 'Seat',
+  group: 'licenses',
   price: { amount: 30, interval: 'month' },
   items: [
-    item({
-      featureId: seats.id,
-      included: 1,
-      price: {
-        amount: 30,
-        interval: 'month',
-        billingUnits: 1,
-        billingMethod: 'usage_based',
-      },
-    }),
     item({
       featureId: summaries.id,
       included: 50,
       reset: { interval: 'month' },
-      entityFeatureId: seats.id,
     }),
+  ],
+});
+
+export const team = plan({
+  id: 'team',
+  name: 'Team',
+  licenses: [
+    { licensePlanId: seat.id, included: 1 },
   ],
 });
 ```
 
-The `entityFeatureId` links the summaries feature to the seats feature — each seat (entity) will receive its own balance of 50 summaries.
+`included: 1` means the Team plan comes with one free seat. Seats beyond that are paid at the license plan's own price.
 
 Push changes with `atmn push`.
+
+<Note>
+Give the license plan its own `group`. Attaching a plan replaces other plans in the same group, so a license plan sharing a group with its parent would knock the parent off.
+</Note>
 
 </Tab>
 <Tab title="Dashboard">
 
-1. Navigate to **Plans** and create or edit a plan
-2. Add the entity feature (e.g., "Seats") — this is the feature that counts entities
-3. Add the per-entity feature (e.g., "Meeting Summaries")
-4. Under **Advanced** for the per-entity feature, set **Entity Feature** to point to the entity feature (e.g., "Seats")
-5. Set the grant amount and reset interval for the per-entity feature
-6. Save the plan
+1. Navigate to **Plans** and create the license plan (e.g. "Seat") — give it its own group, its per-seat price, and the features one seat receives (e.g. 50 Meeting Summaries per month)
+2. Create or edit the parent plan (e.g. "Team")
+3. Under **Licenses**, add the Seat plan and set how many seats are **included**
+4. Save the plan
 
 </Tab>
 </Tabs>
 
-## Creating entities
+## Buying seats
 
-When a new team member joins, create an entity. This automatically increments the entity feature count (e.g., seats) and provisions the per-entity balance:
+Seats are bought on the parent plan. Pass `licenseQuantities` on attach — `quantity` is the **total** number of seats, including the plan's free `included` amount:
 
 <CodeGroup>
 
@@ -85,11 +93,13 @@ import { Autumn } from "autumn-js";
 
 const autumn = new Autumn({ secretKey: "am_sk_..." });
 
-await autumn.entities.create({
+await autumn.billing.attach({
   customerId: "org_123",
-  entityId: "user_alice",
-  featureId: "seats",
-  name: "Alice",
+  planId: "team",
+  licenseQuantities: [{
+    licensePlanId: "seat",
+    quantity: 5,
+  }],
 });
 ```
 
@@ -98,27 +108,79 @@ from autumn_sdk import Autumn
 
 autumn = Autumn("am_sk_...")
 
-await autumn.entities.create(
+await autumn.billing.attach(
     customer_id="org_123",
-    entity_id="user_alice",
-    feature_id="seats",
-    name="Alice",
+    plan_id="team",
+    license_quantities=[{
+        "license_plan_id": "seat",
+        "quantity": 5,
+    }],
 )
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/entities" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
-    "entity_id": "user_alice",
-    "feature_id": "seats",
-    "name": "Alice"
+    "plan_id": "team",
+    "license_quantities": [
+      { "license_plan_id": "seat", "quantity": 5 }
+    ]
   }'
 ```
 
 </CodeGroup>
+
+With 1 included seat and `quantity: 5`, the customer gets 5 seats and pays for 4 of them.
+
+## Assigning a license
+
+When a team member joins, assign them a license. This is what provisions their individual balance — creating an entity on its own does not:
+
+<CodeGroup>
+
+```typescript TypeScript
+await autumn.licenses.attach({
+  customerId: "org_123",
+  planId: "seat",
+  entities: [
+    { entityId: "user_alice", name: "Alice", featureId: "users" },
+  ],
+});
+```
+
+```python Python
+await autumn.licenses.attach(
+    customer_id="org_123",
+    plan_id="seat",
+    entities=[
+        {"entity_id": "user_alice", "name": "Alice", "feature_id": "users"},
+    ],
+)
+```
+
+```bash cURL
+curl -X POST "https://api.useautumn.com/v1/licenses.attach" \
+  -H "Authorization: Bearer am_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "org_123",
+    "plan_id": "seat",
+    "entities": [
+      { "entity_id": "user_alice", "name": "Alice", "feature_id": "users" }
+    ]
+  }'
+```
+
+</CodeGroup>
+
+`feature_id` is the entity type (e.g. a non-consumable `users` feature) and is required when the entity doesn't exist yet — Autumn creates it for you. You can pass several entities in one call.
+
+<Note>
+Assignment is idempotent. Re-assigning an entity that already holds an active license for the same plan succeeds without consuming another seat.
+</Note>
 
 ## Checking and tracking per entity
 
@@ -207,34 +269,53 @@ curl -X POST "https://api.useautumn.com/v1/track" \
 | **Customer-level** | Omit `entity_id` | Returns the total balance across all entities |
 
 <Note>
-When tracking at the customer level (without `entity_id`), usage is deducted from the first-created entity to keep entity-level totals in sync with the customer-level total.
+When tracking at the customer level (without `entity_id`), usage is deducted from the first-assigned entity to keep entity-level totals in sync with the customer-level total.
 </Note>
 
-## Deleting entities
+## Releasing a license
 
-When a team member leaves, delete the entity. This decrements the entity feature count and removes their balance:
+When a team member leaves, release their license. The seat returns to the pool and can be reassigned:
 
 <CodeGroup>
 
 ```typescript TypeScript
-await autumn.entities.delete({
+await autumn.licenses.release({
   customerId: "org_123",
-  entityId: "user_alice",
+  licensePlanId: "seat",
+  entityIds: ["user_alice"],
 });
 ```
 
 ```python Python
-await autumn.entities.delete(
+await autumn.licenses.release(
     customer_id="org_123",
-    entity_id="user_alice",
+    license_plan_id="seat",
+    entity_ids=["user_alice"],
 )
 ```
 
 ```bash cURL
-curl -X DELETE "https://api.useautumn.com/v1/entities/user_alice" \
+curl -X POST "https://api.useautumn.com/v1/licenses.release" \
+  -H "Authorization: Bearer am_sk_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "org_123",
+    "license_plan_id": "seat",
+    "entity_ids": ["user_alice"]
+  }'
+```
+
+</CodeGroup>
+
+`license_plan_id` is optional, and only needed to disambiguate when an entity holds licenses from more than one plan.
+
+## Inspecting seats
+
+[`licenses.list`](/api-reference/licenses/listLicenses) returns each pool with its `granted`, `usage`, and `remaining` seat counts. [`licenses.list_assignments`](/api-reference/licenses/listLicenseAssignments) returns which entities currently hold a license.
+
+```bash cURL
+curl -X POST "https://api.useautumn.com/v1/licenses.list" \
   -H "Authorization: Bearer am_sk_..." \
   -H "Content-Type: application/json" \
   -d '{ "customer_id": "org_123" }'
 ```
-
-</CodeGroup>

--- a/apps/docs/mintlify/examples/entity-balances.mdx
+++ b/apps/docs/mintlify/examples/entity-balances.mdx
@@ -7,6 +7,8 @@ Entities are a resource that lives under a parent customer, that can have it's o
 
 Entity-level balances let you set usage limits that apply to each entity (like users, workspaces, or projects) individually. Instead of a single shared pool, each entity gets their own balance.
 
+You model this with a **license plan**: a plan describing everything one entity gets. The parent plan offers a pool of those licenses, and you assign a license to an entity to give it its own balance.
+
 This is useful when you want to ensure fair usage across team members or isolate resource consumption per workspace.
 
 ## Example case
@@ -26,26 +28,29 @@ If a team has 8 users, they pay \$30 \times 8 = \$240/month, and each user gets 
 
 Create two features:
 
-1. **Seats** - A `metered` `non-consumable` feature to track team members
+1. **Seats** - A `metered` `non-consumable` feature identifying the entity type (team members)
 2. **Meeting Summaries** - A `metered` `consumable` feature for the number of meeting summaries generated
+
+</Step>
+
+<Step>
+#### Create the Seat License Plan
+
+Create a **Seat** plan holding everything one team member gets:
+
+1. A **\$30/month price**
+2. **Meeting Summaries**: 50 per month
+
+Give it its own group. Attaching a plan replaces other plans in the same group, so a license plan sharing a group with its parent would knock the parent off.
 
 </Step>
 
 <Step>
 #### Create Team Plan
 
-Create a Team plan with:
+Create a Team plan and, under **Licenses**, add the Seat plan with **0 included** seats.
 
-1. A **\$30/month base price**
-2. **Seats**: 1 included, then \$30/seat for additional (usage-based)
-3. **Meeting Summaries**: 50 per month, linked to the Seats feature as a **per-entity feature**, under "Advanced"
-
-The key configuration is setting the meeting summaries feature to point to "seats". When the entity is created, this creates a per-entity balance where each seat gets 50 summaries.
-
-<Frame>
-<img src="/assets/guides/entity-balances/team-light.png" className="block dark:hidden" />
-<img src="/assets/guides/entity-balances/team-dark.png" className="hidden dark:block" />
-</Frame>
+The Team plan now offers a pool of Seat licenses at \$30/month each. (Set **included** above 0 to give the plan some free seats.) A team member only receives their own 50 summaries once a license is assigned to them.
 
 </Step>
 </Steps>
@@ -108,7 +113,7 @@ curl --request POST \
 <Step>
 #### Create Initial Entity
 
-Create an entity for the admin user who is signing up. Since no plan is attached yet, this just registers the entity — no balance is granted yet. This should be done server-side for security.
+Create an entity for the admin user who is signing up. This just registers the entity — no balance is granted until a license is assigned to it. This should be done server-side for security.
 
 <CodeGroup>
 
@@ -159,15 +164,15 @@ curl -X POST "https://api.useautumn.com/v1/customers/org_123/entities" \
 </CodeGroup>
 
 <Note>
-Since no plan is attached yet, this entity exists but has no balances. Once the Team plan is attached, this entity will automatically receive its 50 meeting summaries.
+This entity exists but has no balances yet. It receives its 50 meeting summaries once you assign it a Seat license, a couple of steps below.
 </Note>
 
 </Step>
 
 <Step>
-#### Attach the Team Plan
+#### Attach the Team Plan and Buy Seats
 
-When the customer upgrades to Team, attach the plan. The checkout URL will show the \$30 base price.
+When the customer upgrades to Team, attach the plan. Pass `licenseQuantities` to say how many Seat licenses they want — `quantity` is the **total** number of seats, including any the plan includes for free.
 
 <CodeGroup>
 
@@ -178,12 +183,17 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-const { data } = await autumn.checkout({
-  customer_id: "org_123",
-  product_id: "team",
+// 4 seats at $30/month = $120/month
+const { data } = await autumn.billing.attach({
+  customerId: "org_123",
+  planId: "team",
+  licenseQuantities: [{
+    licensePlanId: "seat_license",
+    quantity: 4,
+  }],
 });
 
-if (data.url) {
+if (data.paymentUrl) {
   // Redirect to Stripe checkout
 }
 ```
@@ -195,12 +205,17 @@ from autumn import Autumn
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    response = await autumn.checkout(
+    # 4 seats at $30/month = $120/month
+    response = await autumn.billing.attach(
         customer_id="org_123",
-        product_id="team",
+        plan_id="team",
+        license_quantities=[{
+            "license_plan_id": "seat_license",
+            "quantity": 4,
+        }],
     )
-    
-    if response.url:
+
+    if response.payment_url:
         # Redirect to Stripe checkout
         pass
 
@@ -208,24 +223,29 @@ asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/checkout" \
+curl -X POST "https://api.useautumn.com/v1/billing.attach" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
     "customer_id": "org_123",
-    "product_id": "team"
+    "plan_id": "team",
+    "license_quantities": [
+      { "license_plan_id": "seat_license", "quantity": 4 }
+    ]
   }'
 ```
 
 </CodeGroup>
+
+<Note>
+Change the seat count later by attaching again with a new `quantity`. Autumn prorates the difference.
+</Note>
 </Step>
 
 <Step>
-#### Create Entities (Seats)
+#### Assign Seat Licenses
 
-When team members are added, create entities. This tracks seat usage and initializes their per-entity balance.
-
-This will also bill the customer a prorated amount for the seat price. You can configure this proration behavior (full vs prorated, immediately vs next cycle) in the "Advanced" section of the plan feature when editing the plan.
+When team members are added, assign each of them a Seat license. This is what gives them their own balance of 50 summaries. It consumes one seat from the pool bought in the previous step.
 
 <CodeGroup>
 
@@ -236,12 +256,16 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-// Create entities for team members
-await autumn.entities.create("org_123", [
-  { id: "user_alice", name: "Alice Smith", feature_id: "seats" },
-  { id: "user_bob", name: "Bob Jones", feature_id: "seats" },
-  { id: "user_charlie", name: "Charlie Brown", feature_id: "seats" },
-]);
+// Assign a seat to each team member
+await autumn.licenses.attach({
+  customerId: "org_123",
+  planId: "seat_license",
+  entities: [
+    { entityId: "user_alice", name: "Alice Smith", featureId: "seats" },
+    { entityId: "user_bob", name: "Bob Jones", featureId: "seats" },
+    { entityId: "user_charlie", name: "Charlie Brown", featureId: "seats" },
+  ],
+});
 ```
 
 ```python Python
@@ -251,34 +275,43 @@ from autumn import Autumn
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    # Create entities for team members
-    await autumn.features.create_entity(
+    # Assign a seat to each team member
+    await autumn.licenses.attach(
         customer_id="org_123",
-        id="user_alice",
-        name="Alice Smith",
-        feature_id="seats",
+        plan_id="seat_license",
+        entities=[
+            {"entity_id": "user_alice", "name": "Alice Smith", "feature_id": "seats"},
+            {"entity_id": "user_bob", "name": "Bob Jones", "feature_id": "seats"},
+            {"entity_id": "user_charlie", "name": "Charlie Brown", "feature_id": "seats"},
+        ],
     )
 
 asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X POST "https://api.useautumn.com/v1/customers/org_123/entities" \
+curl -X POST "https://api.useautumn.com/v1/licenses.attach" \
   -H "Authorization: Bearer am_sk_42424242" \
   -H "Content-Type: application/json" \
   -d '{
-    "id": "user_alice",
-    "name": "Alice Smith",
-    "feature_id": "seats"
+    "customer_id": "org_123",
+    "plan_id": "seat_license",
+    "entities": [
+      { "entity_id": "user_alice", "name": "Alice Smith", "feature_id": "seats" },
+      { "entity_id": "user_bob", "name": "Bob Jones", "feature_id": "seats" },
+      { "entity_id": "user_charlie", "name": "Charlie Brown", "feature_id": "seats" }
+    ]
   }'
 ```
 
 </CodeGroup>
 
 <Note>
-Creating an entity automatically increments the seat count. If you create 4 entities, your seat usage will be 4.
+`feature_id` is only required when the entity doesn't exist yet — Autumn creates it for you, so you can skip the separate entity-create call.
 
-After you create an entity, navigate to the Autumn customer page, and you will see it created at the top of the page.
+Assignment is idempotent: re-assigning someone who already holds an active Seat license succeeds without consuming another seat. If the pool has no seats left, the call errors — buy more seats first.
+
+After assigning, navigate to the Autumn customer page and you will see the entity and its balance.
 </Note>
 
 </Step>
@@ -492,11 +525,9 @@ The total is the sum of all entity balances (3 users × 50 = 150 included).
 </Step>
 
 <Step>
-#### Remove Entities
+#### Release Seat Licenses
 
-When a team member leaves, delete their entity. This decrements seat usage and removes their balance. 
-
-It will also create a pro-rated refund for the seat price. You can configure this proration behavior in the "Advanced" section of the plan feature when editing the plan.
+When a team member leaves, release their license. Their balance is removed and the seat returns to the pool, ready to be assigned to someone else.
 
 <CodeGroup>
 
@@ -507,8 +538,12 @@ const autumn = new Autumn({
   secretKey: 'am_sk_42424242',
 });
 
-// Remove Bob from the team
-await autumn.entities.delete("org_123", "user_bob");
+// Free up Bob's seat
+await autumn.licenses.release({
+  customerId: "org_123",
+  licensePlanId: "seat_license",
+  entityIds: ["user_bob"],
+});
 ```
 
 ```python Python
@@ -518,21 +553,33 @@ from autumn import Autumn
 autumn = Autumn("am_sk_42424242")
 
 async def main():
-    # Remove Bob from the team
-    await autumn.features.delete_entity("org_123", "user_bob")
+    # Free up Bob's seat
+    await autumn.licenses.release(
+        customer_id="org_123",
+        license_plan_id="seat_license",
+        entity_ids=["user_bob"],
+    )
 
 asyncio.run(main())
 ```
 
 ```bash cURL
-curl -X DELETE "https://api.useautumn.com/v1/customers/org_123/entities/user_bob" \
-  -H "Authorization: Bearer am_sk_42424242"
+curl -X POST "https://api.useautumn.com/v1/licenses.release" \
+  -H "Authorization: Bearer am_sk_42424242" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "org_123",
+    "license_plan_id": "seat_license",
+    "entity_ids": ["user_bob"]
+  }'
 ```
 
 </CodeGroup>
 
 <Note>
-Deleting an entity automatically decrements the seat count. The customer's total meeting summary balance will also decrease accordingly.
+Releasing a license frees the seat but does not change what the customer pays — they keep the 4 seats they bought. To stop paying for a seat, attach the Team plan again with a lower `quantity`; Autumn prorates the refund.
+
+`license_plan_id` is optional, and only needed to disambiguate when an entity holds licenses from more than one plan.
 </Note>
 
 </Step>
@@ -549,3 +596,5 @@ Entity-level balances are ideal when you want to:
 - Ensure fair usage across team members
 - Isolate consumption per workspace or project
 - Bill per-entity while providing entity-specific limits
+
+To see how many seats a customer has bought and used, call [`licenses.list`](/api-reference/licenses/listLicenses). To see who currently holds one, call [`licenses.list_assignments`](/api-reference/licenses/listLicenseAssignments).


### PR DESCRIPTION
`entity_feature_id` on plan items is now `internal: true`, and licenses are the public way to model per-entity balances. This rewrites both entity-balance guides around license plans.

## The model shift

```
OLD:  one plan
        item(summaries, included: 50, entityFeatureId: seats.id)
      entities.create(...)  ->  balance auto-granted

NEW:  seat plan  = its own plan, items: [summaries 50/mo], own price
      team plan  = licenses: [{ licensePlanId: 'seat', included: 1 }]
      licenses.attach({ customerId, planId, entities })  ->  balance granted
      licenses.release(...)                              ->  seat freed back to the pool
```

Three behavior changes called out in the prose, since they'll trip people migrating:

- Seats are **explicitly assigned**. Creating an entity no longer provisions a balance.
- Paid seats above `included` come from `licenseQuantities` on `billing.attach`.
- A **priced** license plan must be attached at customer level before it can be assigned to entities.

## Changes

- **`documentation/modelling-pricing/sub-entity-balances.mdx`** — rewritten. New sections for buying seats, assigning, releasing, and inspecting the pool. Check/track by `entity_id` is unchanged.
- **`examples/entity-balances.mdx`** — same shift applied to the walkthrough. "Create Entities (Seats)" → "Assign Seat Licenses", "Remove Entities" → "Release Seat Licenses", and the pricing setup now defines a separate Seat plan linked from Team.
- **`docs.json`** — added `listLicenses` and `listLicenseAssignments` to the Licenses nav group. Both pages already existed but were unreachable.

## Notes for review

- **A screenshot needs re-shooting.** `assets/guides/entity-balances/team-*.png` showed the old "Entity Feature under Advanced" config, so I dropped the `<Frame>`. It should come back pointed at the new Licenses UI.
- **Fixed a pre-existing math error.** The example claimed `$30 x 8 = $240`, but the plan also carried a $30 base price and 1 free seat. I made the Team plan 0-included and base-price-free so the stated math holds.
- **Left alone deliberately:** `api-reference/{core,balances}/check.mdx` and `api/api-reference/billing/attach.mdx` still mention `entity_feature_id`. The first two are generated from OpenAPI and will drop the field on the next generator run; the third is an orphan not referenced by `docs.json`.

`mint broken-links` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the entity-balances docs to model per-entity limits via license plans instead of `entity_feature_id`, which is now internal. Previously creating an entity auto‑granted a balance; now customers buy seats and you assign/release licenses to control per-entity balances.

- Old: plan items linked with `entity_feature_id`; creating an entity provisioned a balance.
- New: a seat is its own license plan; buy seats via `billing.attach` with `licenseQuantities`, assign to entities with `licenses.attach`, and free seats with `licenses.release`. A priced license plan must be attached at the customer level before assignment.

**Migration**
- Assign seats explicitly with `licenses.attach`; creating entities no longer grants balances.
- Pass `licenseQuantities` to `billing.attach` to set the total seat count (includes any plan-level included seats).
- Attach the seat license plan to the customer before assignment; give it its own `group` so it doesn’t replace the parent plan.

**Reviewer notes**
- Updated guides and examples to the license model; added `listLicenses` and `listLicenseAssignments` to the Licenses nav.
- Dropped an outdated screenshot; re-shoot against the Licenses UI.
- Some API reference pages still mention `entity_feature_id`; they will update on the next OpenAPI generation.

<sup>Written for commit 3d0b7414d0d80b6085929760fea967a594cf685f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the entity-balance documentation to teach license-based seat pools and exposes the existing license-listing references in navigation.
- **API changes, Improvements:** Replaces entity-feature-based provisioning with explicit license purchasing, assignment, release, and inspection examples.
- **Bug fixes, Improvements:** Corrects the walkthrough’s pricing model and explains included versus paid seat quantities.
- **Improvements:** Adds the license pool and assignment-list pages to the API-reference navigation.
</details>


<h3>Confidence Score: 4/5</h3>

The documentation should be corrected before merging because readers can create a Seat plan under one ID and then copy requests that reference the undefined `seat_license` ID.

The new walkthrough does not establish the identifier required by its billing, assignment, and release examples, making the documented end-to-end flow fail for a straightforward setup.

**Files Needing Attention:** apps/docs/mintlify/examples/entity-balances.mdx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/docs/mintlify/docs.json | Adds the two existing license-listing pages to the Licenses navigation group. |
| apps/docs/mintlify/documentation/modelling-pricing/sub-entity-balances.mdx | Rewrites the conceptual guide around license plans, explicit seat purchases, assignments, releases, and pool inspection with internally consistent identifiers. |
| apps/docs/mintlify/examples/entity-balances.mdx | Rewrites the walkthrough for license-based seats, but later requests rely on an unstated `seat_license` plan ID. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Team[Team plan] -->|licenseQuantities| Pool[Seat license pool]
  Pool -->|licenses.attach| Entity[Entity balance]
  Entity -->|licenses.release| Pool
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/docs/mintlify/examples/entity-balances.mdx:39
**Undefined seat plan identifier**

When a reader creates the Seat plan from this setup, no plan ID is specified, but the later billing and assignment examples reference `seat_license`, causing those requests to fail unless the reader happened to choose that ID.

```suggestion
Create a **Seat** plan with the ID `seat_license`, holding everything one team member gets:
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: replace entity feature IDs with li..."](https://github.com/useautumn/autumn/commit/3d0b7414d0d80b6085929760fea967a594cf685f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55604446)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)

<!-- /greptile_comment -->