### PR TITLE
fix(capy): bootstrap test organization during provisioning

### DIFF
--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -372,6 +372,11 @@ function writeEnvFiles(
 		// Login flow that works without external services: dev `sendOTPEmail`
 		// prints the OTP to the server log. The README documents this path.
 		NODE_ENV: "development",
+		TESTS_ORG: "unit-test-org",
+		TESTS_ORG_ID: "org_2sWv2S8LJ9iaTjLI6UtNsfL88Kt",
+		AUTUMN_TEST_BASE_URL: serverUrl,
+		AUTUMN_TEST_VITE_URL: viteUrl,
+		CACHE_V2_DRAGONFLY_PUBLIC_URL: redisUrl,
 	};
 
 	const viteEnv: Record<string, string> = {
@@ -390,6 +395,28 @@ function writeEnvFiles(
 	log(`wrote .env.local for server/, vite/, apps/checkout/`);
 	log(`  server: ${serverUrl}`);
 	log(`  vite:   ${viteUrl}`);
+}
+
+function runSetupTest(args: string[], databaseUrl: string): void {
+	log(`running setup-test ${args.join(" ")}`);
+	const result = Bun.spawnSync(
+		["bun", "scripts/setup/setup-test.ts", ...args],
+		{
+			cwd: PROJECT_ROOT,
+			env: {
+				...process.env,
+				DATABASE_URL: databaseUrl,
+				DATABASE_CRITICAL_URL: databaseUrl,
+			},
+			stdout: "inherit",
+			stderr: "inherit",
+		},
+	);
+	if (result.exitCode !== 0) {
+		fatal(
+			`setup-test ${args.join(" ")} exited with code ${result.exitCode ?? 1}`,
+		);
+	}
 }
 
 function triggerCompose(args: string[]) {
@@ -564,7 +591,10 @@ function ensureNeonAuth(): void {
 	}
 }
 
-function ensureNeonBranch(machineId: string, state: State | null): State {
+function ensureNeonBranch(
+	machineId: string,
+	state: State | null,
+): { state: State; created: boolean } {
 	const branchName = deriveBranchName(machineId);
 
 	// Branch already provisioned in state file and still exists on Neon →
@@ -574,7 +604,10 @@ function ensureNeonBranch(machineId: string, state: State | null): State {
 		if (existing) {
 			log(`reusing existing Neon branch ${branchName} (${state.branchId})`);
 			const pooledUrl = connectionString(branchName, { pooled: true });
-			return { ...state, databaseUrl: pooledUrl };
+			return {
+				state: { ...state, databaseUrl: pooledUrl },
+				created: false,
+			};
 		}
 		log(
 			`state references ${branchName} but Neon no longer has it — reprovisioning`,
@@ -588,11 +621,14 @@ function ensureNeonBranch(machineId: string, state: State | null): State {
 		log(`adopting existing Neon branch ${branchName} (${existingByName.id})`);
 		const pooledUrl = connectionString(branchName, { pooled: true });
 		return {
-			machineId,
-			branchName,
-			branchId: existingByName.id,
-			databaseUrl: pooledUrl,
-			createdAt: state?.createdAt ?? Date.now(),
+			state: {
+				machineId,
+				branchName,
+				branchId: existingByName.id,
+				databaseUrl: pooledUrl,
+				createdAt: state?.createdAt ?? Date.now(),
+			},
+			created: false,
 		};
 	}
 
@@ -604,11 +640,14 @@ function ensureNeonBranch(machineId: string, state: State | null): State {
 	const branch = createBranch(branchName, NEON_TEMPLATE_BRANCH);
 	const pooledUrl = connectionString(branchName, { pooled: true });
 	return {
-		machineId,
-		branchName,
-		branchId: branch.id,
-		databaseUrl: pooledUrl,
-		createdAt: Date.now(),
+		state: {
+			machineId,
+			branchName,
+			branchId: branch.id,
+			databaseUrl: pooledUrl,
+			createdAt: Date.now(),
+		},
+		created: true,
 	};
 }
 
@@ -637,7 +676,7 @@ async function main(): Promise<void> {
 	// 2. Neon auth + branch + migrations.
 	ensureNeonAuth();
 	const priorState = loadState();
-	const nextState = ensureNeonBranch(machineId, priorState);
+	const { state: nextState, created } = ensureNeonBranch(machineId, priorState);
 	if (!nextState.branchName) fatal("provisioning produced no branchName");
 	const directUrl = connectionString(nextState.branchName, { pooled: false });
 	applyCommittedMigrations(nextState.branchName, directUrl);
@@ -664,7 +703,14 @@ async function main(): Promise<void> {
 		trigger.accessToken,
 	);
 
-	log("capy provision complete — run `bun dev` to start the stack");
+	if (created) {
+		runSetupTest(["--yes"], directUrl);
+	}
+	runSetupTest(["--ensure-key"], directUrl);
+
+	log(
+		`capy provision complete — run \`bun capy\` to start the stack (fresh=${created})`,
+	);
 }
 
 await main();


### PR DESCRIPTION
## Summary
- seed the canonical unit test organization after provisioning a fresh Capy Neon branch
- repair the test organization API key on every Capy startup using the existing setup script
- write the non-secret test organization, local test URL, and Dragonfly environment values needed by `./run.sh`

## Validation
- `bun -F @autumn/scripts ts`
- `bunx biome check scripts/capy/provision.ts`
- `git diff --check`

Full Docker, Neon, and test lifecycle verification is intentionally left for a fresh Capy session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps the canonical test organization during Capy provisioning and ensures its API key stays valid, so local tests run without manual setup. Also writes required test env values and standardizes the startup instruction.

- Writes env values: TESTS_ORG, TESTS_ORG_ID, AUTUMN_TEST_BASE_URL, AUTUMN_TEST_VITE_URL, CACHE_V2_DRAGONFLY_PUBLIC_URL.
- Provisioning now runs `scripts/setup/setup-test.ts`: seeds on first branch create (`--yes`), always repairs API key (`--ensure-key`). Idempotent.
- `ensureNeonBranch` returns `{ state, created }`; `created` gates initial seeding.
- Final log now instructs `bun capy` to start the stack.

<sup>Written for commit ab19521950bc19a51f41c07fbea401369c40146f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR provisions the canonical unit-test organization and Capy test environment values, then refreshes its API key on startup. The recovery path still fails for older or adopted branches where the organization has never been seeded.

- **Bug fixes:** Seeds the canonical unit-test organization when creating a fresh Capy Neon branch and refreshes its API key during provisioning.
- **Improvements:** Writes the test organization, local test URLs, and Dragonfly URL into the generated server environment.
- **Bug fixes:** Updates the completion message to direct developers to `bun capy`.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until reused and adopted Neon branches can bootstrap a missing test organization instead of aborting provisioning.

The always-run key repair assumes the test organization exists, but full setup is skipped for reused and adopted branches, leaving older Capy environments unable to start.

**Files Needing Attention:** scripts/capy/provision.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/provision.ts | Adds Capy test environment values and organization setup, but gates missing-organization recovery on newly creating the Neon branch. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Provision Capy] --> B{Neon branch created now?}
    B -->|Yes| C[Run full test-org setup]
    B -->|No: reused or adopted| D[Skip full setup]
    C --> E[Repair test-org API key]
    D --> E
    E --> F{Test organization exists?}
    F -->|Yes| G[Provisioning completes]
    F -->|No| H[Key repair throws and provisioning aborts]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/capy/provision.ts:706-709
**Reused branches skip organization bootstrap**

When Capy reuses or adopts a Neon branch without the test organization, `created` is false, so provisioning skips `--yes` and runs the key-only repair against a missing organization, causing provisioning to abort.

```suggestion
	runSetupTest(["--ensure"], directUrl);
	runSetupTest(["--ensure-key"], directUrl);
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: bootstrap Capy test organization"](https://github.com/useautumn/autumn/commit/ab19521950bc19a51f41c07fbea401369c40146f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55618225)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->