### PR TITLE
fix: retry queued tracks on subject view changes

### DIFF
--- a/server/src/internal/balances/idempotency/trackQueueIdempotency.ts
+++ b/server/src/internal/balances/idempotency/trackQueueIdempotency.ts
@@ -29,3 +29,21 @@ export const getRedisTrackFeatureIdempotencyKey = ({
 		redisKey: `{${customerId}}:${ctx.org.id}:${ctx.env}:idempotency:${hashedKey}`,
 	};
 };
+
+/** Carries partial multi-feature deduction results across an SQS redelivery so
+ *  completed features can still be mirrored to Postgres and included in the event. */
+export const getRedisTrackReplayStateKey = ({
+	ctx,
+	customerId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+}) => {
+	const hashedKey = hashIdempotencyKey(
+		`${getTrackQueueIdempotencyKey({ ctx })}:replay-state`,
+	);
+	return {
+		hashedKey,
+		redisKey: `{${customerId}}:${ctx.org.id}:${ctx.env}:idempotency:${hashedKey}`,
+	};
+};

--- a/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts
@@ -12,6 +12,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { triggerAutoTopUp } from "@/internal/balances/autoTopUp/triggerAutoTopUp.js";
 import {
 	getRedisTrackFeatureIdempotencyKey,
+	getRedisTrackReplayStateKey,
 	TRACK_V3_IDEMPOTENCY_TTL_MS,
 } from "@/internal/balances/idempotency/trackQueueIdempotency.js";
 import { fireTrackWebhooks } from "@/internal/balances/trackWebhooks/fireTrackWebhooks.js";
@@ -19,7 +20,7 @@ import { createAllocatedInvoice } from "@/internal/balances/utils/allocatedInvoi
 import { buildDeductFromSubjectBalancesKeys } from "@/internal/customers/cache/fullSubject/builders/buildDeductFromSubjectBalancesKeys.js";
 import { buildFullSubjectKey } from "@/internal/customers/cache/fullSubject/builders/buildFullSubjectKey.js";
 import { FULL_SUBJECT_CACHE_TTL_SECONDS } from "@/internal/customers/cache/fullSubject/config/fullSubjectCacheConfig.js";
-import { tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
+import { tryRedisRead, tryRedisWrite } from "@/utils/cacheUtils/cacheUtils.js";
 import type { DeductionOptions } from "../types/deductionTypes.js";
 import type { DeductionUpdate } from "../types/deductionUpdate.js";
 import type { FeatureDeduction } from "../types/featureDeduction.js";
@@ -41,6 +42,16 @@ import { normalizeDeductionSyncStateV2 } from "./normalizeDeductionSyncStateV2.j
 import { prepareDeductionOptionsV2 } from "./prepareDeductionOptionsV2.js";
 import { prepareFeatureDeductionV2 } from "./prepareFeatureDeductionV2.js";
 import { rollbackDeductionV2 } from "./rollbackDeductionV2.js";
+
+type RedisDeductionReplayState = {
+	updates: Record<string, DeductionUpdate>;
+	rolloverUpdates: Record<string, RolloverUpdate>;
+	mutationLogs: MutationLogItem[];
+	modifiedCusEntIdsByFeatureId: Record<string, string[]>;
+	usageWindowUpdates: Record<string, UsageWindowUpdate>;
+	usageWindowMutations: UsageWindowMutation[];
+	mutationLogCustomerEntitlements: FullCusEntWithFullCusProduct[];
+};
 
 export const executeRedisDeductionV2 = async ({
 	ctx,
@@ -123,6 +134,10 @@ export const executeRedisDeductionV2 = async ({
 		customerId,
 		entityId: fullSubject.entityId,
 	});
+	const targetRedis = redisInstance ?? ctx.redisV2;
+	const replayStateRedisKey = idempotencyKey
+		? getRedisTrackReplayStateKey({ ctx, customerId }).redisKey
+		: null;
 
 	// One timestamp for the whole operation: the resolver keys windows from it
 	// and Lua receives the same value, so they never disagree on the window.
@@ -134,6 +149,36 @@ export const executeRedisDeductionV2 = async ({
 			(customerEntitlement) => [customerEntitlement.id, customerEntitlement],
 		),
 	);
+	let replayStateLoaded = false;
+	const restoreReplayState = async (): Promise<void> => {
+		if (!replayStateRedisKey || replayStateLoaded) return;
+		replayStateLoaded = true;
+		const serializedReplayState = await tryRedisRead(
+			() => targetRedis.get(replayStateRedisKey),
+			targetRedis,
+		);
+		if (serializedReplayState) {
+			const replayState = JSON.parse(
+				serializedReplayState,
+			) as RedisDeductionReplayState;
+			allUpdates = replayState.updates;
+			allRolloverUpdates = replayState.rolloverUpdates;
+			allMutationLogs = replayState.mutationLogs;
+			allUsageWindowMutations = replayState.usageWindowMutations;
+			Object.assign(
+				allModifiedCusEntIdsByFeatureId,
+				replayState.modifiedCusEntIdsByFeatureId,
+			);
+			Object.assign(allUsageWindowUpdates, replayState.usageWindowUpdates);
+			for (const customerEntitlement of replayState.mutationLogCustomerEntitlements) {
+				mutationLogCustomerEntitlementById.set(
+					customerEntitlement.id,
+					customerEntitlement,
+				);
+			}
+			refreshedSubjectView = true;
+		}
+	};
 
 	for (
 		let deductionIndex = 0;
@@ -229,8 +274,6 @@ export const executeRedisDeductionV2 = async ({
 			debug: process.env.NODE_ENV !== "production",
 		};
 
-		const targetRedis = redisInstance ?? ctx.redisV2;
-
 		const result = await tryRedisWrite(
 			() =>
 				targetRedis.deductFromSubjectBalances(
@@ -289,11 +332,42 @@ export const executeRedisDeductionV2 = async ({
 			if (
 				resultJson.error === RedisDeductionErrorCode.DuplicateIdempotencyKey
 			) {
+				await restoreReplayState();
 				duplicateFeatureIds.push(deduction.feature.id);
 				ctx.logger.info(
 					`[executeRedisDeductionV2] Skipping already-applied feature ${deduction.feature.id} (duplicate idempotency key)`,
 				);
 				continue;
+			}
+
+			if (
+				resultJson.error === RedisDeductionErrorCode.SubjectViewChanged &&
+				replayStateRedisKey &&
+				(allMutationLogs.length > 0 ||
+					Object.keys(allModifiedCusEntIdsByFeatureId).length > 0 ||
+					Object.keys(allUsageWindowUpdates).length > 0)
+			) {
+				const replayState: RedisDeductionReplayState = {
+					updates: allUpdates,
+					rolloverUpdates: allRolloverUpdates,
+					mutationLogs: allMutationLogs,
+					modifiedCusEntIdsByFeatureId: allModifiedCusEntIdsByFeatureId,
+					usageWindowUpdates: allUsageWindowUpdates,
+					usageWindowMutations: allUsageWindowMutations,
+					mutationLogCustomerEntitlements: [
+						...mutationLogCustomerEntitlementById.values(),
+					],
+				};
+				await tryRedisWrite(
+					() =>
+						targetRedis.set(
+							replayStateRedisKey,
+							JSON.stringify(replayState),
+							"PX",
+							TRACK_V3_IDEMPOTENCY_TTL_MS,
+						),
+					targetRedis,
+				);
 			}
 
 			throw new RedisDeductionError({

--- a/server/src/queue/processMessage.ts
+++ b/server/src/queue/processMessage.ts
@@ -23,6 +23,10 @@ import { runUpdateBalanceV2 } from "@/internal/balances/updateBalance/v2/updateB
 import { refreshEntityAggregateCache } from "@/internal/balances/utils/refreshEntityAggregate/index.js";
 import { syncItemV4 } from "@/internal/balances/utils/sync/syncItemV4.js";
 import { syncItemV5 } from "@/internal/balances/utils/sync/syncItemV5.js";
+import {
+	RedisDeductionError,
+	RedisDeductionErrorCode,
+} from "@/internal/balances/utils/types/redisDeductionError.js";
 import { persistPublishedBalanceTransitions } from "@/internal/billing/v2/publish/persistPublishedBalanceTransitions.js";
 import { grantCheckoutReward } from "@/internal/billing/v2/workflows/grantCheckoutReward/grantCheckoutReward.js";
 import { sendProductsUpdated } from "@/internal/billing/v2/workflows/sendProductsUpdated/sendProductsUpdated.js";
@@ -84,9 +88,15 @@ export const shouldRetrySqsJobError = ({
 		// Signal jobs are meaningless without Redis: an unreachable Redis must
 		// leave the message in SQS for redelivery, not swallow-and-ack.
 		case JobName.SyncCustomerDirty:
-		case JobName.Track:
 		case JobName.UpdateBalance:
 			return isTransientDbError({ error }) || isTransientRedisError({ error });
+		case JobName.Track:
+			return (
+				isTransientDbError({ error }) ||
+				isTransientRedisError({ error }) ||
+				(error instanceof RedisDeductionError &&
+					error.code === RedisDeductionErrorCode.SubjectViewChanged)
+			);
 		// Finalize replays also redeliver while a dying attempt's claim marker
 		// clears — dropping one leaks the customer's reserved balance.
 		case JobName.FinalizeLock:

--- a/server/tests/unit/balances/track-v3/executeRedisDeductionV2-subject-view-refresh.test.ts
+++ b/server/tests/unit/balances/track-v3/executeRedisDeductionV2-subject-view-refresh.test.ts
@@ -1,3 +1,10 @@
+/**
+ * A subject-view transition can interrupt a multi-feature Track after an earlier
+ * feature already mutated Redis.
+ *
+ * Red: SQS redelivery skipped the completed feature and lost its sync/event data.
+ * Green: replay restores the accumulated result before finishing later features.
+ */
 import { afterAll, expect, mock, test } from "bun:test";
 import {
 	ApiVersion,
@@ -271,6 +278,115 @@ test("refreshes once and retries only the unfinished feature", async () => {
 	expect(projectedDeductions.map((deduction) => deduction.balance_id)).toEqual([
 		"feature_a_source",
 		"feature_b_target",
+	]);
+});
+
+test("restores successful feature side effects on a later queue delivery", async () => {
+	const sourceSubject = buildFullSubject({
+		epoch: 1,
+		featureAEntitlementId: "feature_a_source",
+		featureBEntitlementId: "feature_b_source",
+	});
+	const refreshedSubject = buildFullSubject({
+		epoch: 2,
+		featureAEntitlementId: "feature_a_refreshed",
+		featureBEntitlementId: "feature_b_refreshed",
+	});
+	const replaySubject = buildFullSubject({
+		epoch: 3,
+		featureAEntitlementId: "feature_a_replay",
+		featureBEntitlementId: "feature_b_replay",
+	});
+	const replayState = new Map<string, string>();
+	const redisResults = [
+		buildSuccessResult({
+			customerEntitlementId: "feature_a_source",
+			featureId: "feature_a",
+			balance: 9,
+		}),
+		JSON.stringify({ error: "SUBJECT_VIEW_CHANGED", feature_id: "feature_b" }),
+		JSON.stringify({ error: "SUBJECT_VIEW_CHANGED", feature_id: "feature_b" }),
+		JSON.stringify({
+			error: "DUPLICATE_IDEMPOTENCY_KEY",
+			feature_id: "feature_a",
+		}),
+		buildSuccessResult({
+			customerEntitlementId: "feature_b_replay",
+			featureId: "feature_b",
+			balance: 9,
+		}),
+	];
+	const redis = {
+		status: "ready",
+		get: async (key: string) => replayState.get(key) ?? null,
+		set: async (key: string, value: string) => {
+			replayState.set(key, value);
+			return "OK";
+		},
+		deductFromSubjectBalances: async () => redisResults.shift(),
+	} as unknown as Redis;
+	const ctx = {
+		org: { id: "org_123", config: {} },
+		env: AppEnv.Sandbox,
+		features: [featureA, featureB],
+		logger: {
+			info: mock(() => {}),
+			warn: mock(() => {}),
+			error: mock(() => {}),
+			debug: mock(() => {}),
+		},
+		id: "request_replay_123",
+		apiVersion: new ApiVersionClass(ApiVersion.V2_1),
+		skipCache: false,
+		redisV2: redis,
+	} as unknown as AutumnContext;
+	const featureDeductions: FeatureDeduction[] = [
+		{ feature: featureA, deduction: 1 },
+		{ feature: featureB, deduction: 1 },
+	];
+
+	await expect(
+		executeRedisDeductionV2({
+			ctx,
+			fullSubject: sourceSubject,
+			deductions: featureDeductions,
+			idempotencyKey: "track:request_replay_123",
+			redisInstance: redis,
+			expectedSubjectViewEpoch: 1,
+			refreshFullSubject: async () => refreshedSubject,
+		}),
+	).rejects.toMatchObject({ code: "SUBJECT_VIEW_CHANGED" });
+
+	expect(replayState.size).toBe(1);
+
+	const result = await executeRedisDeductionV2({
+		ctx,
+		fullSubject: replaySubject,
+		deductions: featureDeductions,
+		idempotencyKey: "track:request_replay_123",
+		redisInstance: redis,
+		expectedSubjectViewEpoch: 3,
+		refreshFullSubject: async () => replaySubject,
+	});
+
+	expect(
+		result.mutationLogs.map(
+			(mutationLog: MutationLogItem) => mutationLog.customer_entitlement_id,
+		),
+	).toEqual(["feature_a_source", "feature_b_replay"]);
+	expect(result.modifiedCusEntIdsByFeatureId).toEqual({
+		feature_a: ["feature_a_replay"],
+		feature_b: ["feature_b_replay"],
+	});
+
+	const projectedDeductions = projectMutationLogsToTrackDeductionsV2({
+		fullSubject: result.fullSubject,
+		mutationLogs: result.mutationLogs,
+		customerEntitlements: result.mutationLogCustomerEntitlements,
+	});
+	expect(projectedDeductions.map((deduction) => deduction.balance_id)).toEqual([
+		"feature_a_source",
+		"feature_b_replay",
 	]);
 });
 

--- a/server/tests/unit/queue/processMessage.test.ts
+++ b/server/tests/unit/queue/processMessage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { RedisUnavailableError } from "@/external/redis/utils/errors.js";
+import {
+	RedisDeductionError,
+	RedisDeductionErrorCode,
+} from "@/internal/balances/utils/types/redisDeductionError.js";
 import { JobName } from "@/queue/JobName.js";
 import { shouldRetrySqsJobError } from "@/queue/processMessage.js";
 
@@ -43,6 +47,18 @@ describe("shouldRetrySqsJobError", () => {
 				error: new RedisUnavailableError({
 					source: "runTrackV3",
 					reason: "timeout",
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("retries track jobs when the subject view changes", () => {
+		expect(
+			shouldRetrySqsJobError({
+				jobName: JobName.Track,
+				error: new RedisDeductionError({
+					message: "Subject view changed",
+					code: RedisDeductionErrorCode.SubjectViewChanged,
 				}),
 			}),
 		).toBe(true);


### PR DESCRIPTION
## Summary

- keep queued track jobs in SQS when Redis rejects a stale subject view
- add regression coverage for the retry classification

## Why

`SUBJECT_VIEW_CHANGED` is a transient concurrency signal. If the in-process subject refresh is invalidated again, the worker currently treats the error as permanent, ACKs the accepted async track, and drops it. Redelivery is safe because the epoch check runs before the idempotency claim, while per-feature idempotency protects any earlier deductions in a multi-feature request.

## Test plan

- `cd server && bun test tests/unit/queue/processMessage.test.ts` — 6 passed
- `cd server && bun ts` — passed
- `bunx biome check --write server/src/queue/processMessage.ts server/tests/unit/queue/processMessage.test.ts` — no changes; existing `SqsJob.data` warning only
- commit hooks: Knip and server typecheck passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries queued Track jobs when the subject view changes and preserves partial results across redelivery. Previously we ACKed and dropped the job; now we leave it in SQS and persist partial deductions so the replayed attempt resumes safely.

- Classifies `RedisDeductionErrorCode.SubjectViewChanged` as retryable for `JobName.Track`.
- Persists partial Track replay state in Redis (TTL `TRACK_V3_IDEMPOTENCY_TTL_MS`) via `getRedisTrackReplayStateKey`; restores it on redelivery and when a duplicate idempotency key is encountered.
- Keeps existing DB/Redis transient retry rules unchanged; other jobs unaffected.
- Adds unit tests for retry classification and replay-state restoration.

<sup>Written for commit 48e672b6d6c9d018d9ce4cd731b976920e2bcdaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes queued tracking jobs retry when a concurrent subject-view change interrupts processing, while retaining partial multi-feature results for the next delivery.

- **Bug fixes:** Classifies `SUBJECT_VIEW_CHANGED` as retryable for queued track jobs instead of acknowledging and dropping them.
- **Improvements, Bug fixes:** Stores partial Redis deduction results and restores them when already-completed features are encountered during redelivery.
- **Improvements:** Adds regression tests for retry classification and multi-feature replay behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the scope of this follow-up review.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/idempotency/trackQueueIdempotency.ts | Adds a customer-, organization-, environment-, and request-scoped Redis key for retaining partial queue replay state. |
| server/src/internal/balances/utils/deductionV2/executeRedisDeductionV2.ts | Persists partial multi-feature deduction results after a repeated subject-view conflict and restores them when redelivery encounters completed features. |
| server/src/queue/processMessage.ts | Treats subject-view changes from queued track jobs as retryable while preserving the existing retry behavior for other jobs. |
| server/tests/unit/balances/track-v3/executeRedisDeductionV2-subject-view-refresh.test.ts | Covers restoration of partial deduction effects across queue deliveries. |
| server/tests/unit/queue/processMessage.test.ts | Covers the new retry classification for subject-view changes. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant SQS
  participant Worker
  participant Redis
  participant Replay as Replay State
  participant Sync as Database/Event Sync
  SQS->>Worker: Deliver queued track
  Worker->>Redis: Deduct feature A
  Redis-->>Worker: Success
  Worker->>Redis: Deduct feature B
  Redis-->>Worker: SUBJECT_VIEW_CHANGED
  Worker->>Replay: Save feature A result
  Worker-->>SQS: Leave message for retry
  SQS->>Worker: Redeliver track
  Worker->>Redis: Deduct feature A
  Redis-->>Worker: Duplicate idempotency key
  Worker->>Replay: Restore feature A result
  Worker->>Redis: Deduct feature B
  Redis-->>Worker: Success
  Worker->>Sync: Mirror combined results
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: preserve partial track replay state"](https://github.com/useautumn/autumn/commit/48e672b6d6c9d018d9ce4cd731b976920e2bcdaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55621048)</sub>

**Context used:**

- Knowledge Base — [Queue, Cron, and Trigger.dev Background Work](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-queue-workers.md)
- Knowledge Base — [Idempotency Key Storage: Redis/DynamoDB Dual-Write](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/idempotency-keys.md)

<!-- /greptile_comment -->