### PR TITLE
fix: keep pino out of the eve agent bundle

### DIFF
--- a/apps/leaf/src/internal/autumnMcp/client.ts
+++ b/apps/leaf/src/internal/autumnMcp/client.ts
@@ -1,33 +1,16 @@
-import { isSecretKeyPrefix } from "@autumn/auth";
 import { type AppEnv, ms } from "@autumn/shared";
 import { MCPClient } from "@mastra/mcp";
 import { env } from "../../lib/env.js";
 import { logger } from "../../lib/logger.js";
 import { createTtlCache } from "../../lib/ttlCache.js";
 import { autumnMcpErrorText } from "./errorResult.js";
+import { autumnMcpHeaders } from "./headers.js";
 
 type AutumnTool = {
 	execute?: (
 		args: Record<string, unknown>,
 		...rest: unknown[]
 	) => Promise<unknown>;
-};
-
-export const autumnMcpHeaders = ({
-	appEnv,
-	token,
-}: {
-	appEnv: AppEnv;
-	token: string;
-}) => {
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${token}`,
-		"x-autumn-environment": appEnv,
-	};
-	if (isSecretKeyPrefix({ token })) {
-		headers["secret-key"] = token;
-	}
-	return headers;
 };
 
 const withAuthFetch =

--- a/apps/leaf/src/internal/autumnMcp/headers.ts
+++ b/apps/leaf/src/internal/autumnMcp/headers.ts
@@ -1,0 +1,21 @@
+import { isSecretKeyPrefix } from "@autumn/auth";
+import type { AppEnv } from "@autumn/shared";
+
+/** Import-light on purpose: the eve agent bundle pulls this file, and its
+ * transitive graph must stay free of node-only deps (pino et al). */
+export const autumnMcpHeaders = ({
+	appEnv,
+	token,
+}: {
+	appEnv: AppEnv;
+	token: string;
+}) => {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${token}`,
+		"x-autumn-environment": appEnv,
+	};
+	if (isSecretKeyPrefix({ token })) {
+		headers["secret-key"] = token;
+	}
+	return headers;
+};

--- a/apps/leaf/src/internal/autumnMcp/rpcClient.ts
+++ b/apps/leaf/src/internal/autumnMcp/rpcClient.ts
@@ -1,5 +1,5 @@
 import type { AppEnv } from "@autumn/shared";
-import { autumnMcpHeaders } from "./client.js";
+import { autumnMcpHeaders } from "./headers.js";
 
 export type JsonValue =
 	| string


### PR DESCRIPTION
Hotfix: leaf fails to boot in the deployed image — eve's authored-module cache can't resolve `pino`:

```
ResolveMessage: Cannot find package 'pino' from '/app/apps/leaf/node_modules/.cache/eve/authored-modules/….mjs'
```

**Root cause:** `rpcClient.ts` — the deliberately import-light bridge the eve agent bundle uses — imports `autumnMcpHeaders` from `client.ts`, and `client.ts` gained a `src/lib/logger` import (observability boundary logging) → `@autumn/logging` → `pino`. The authored-module bundle externalizes `pino`, which isn't resolvable from the cache path in the image.

**Fix:** extract `autumnMcpHeaders` into a dependency-light `headers.ts` (only `@autumn/auth` + a type); `rpcClient` and `client` both import it from there. No dependency changes, no behavior changes.

**Verified:** BFS over the agent import closure (75 files) shows zero `@autumn/logging`/`lib/logger` reachability after the fix (was: 1 path via client.ts); `rpcClient` bundles standalone at 2.85 KB with zero pino references.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the transitive `pino` dependency from the eve agent bundle to fix Leaf boot failures in the deployed image. Previously `rpcClient` imported `client.ts` which pulled `@autumn/logging` → `pino`, and the authored-module cache couldn’t resolve it; now the headers helper lives in a dependency-light module.

- Moves `autumnMcpHeaders` from `client.ts` to `headers.ts` (imports only `@autumn/auth` and a type from `@autumn/shared`); updates imports in `client.ts` and `rpcClient.ts`.
- Agent import graph no longer reaches `@autumn/logging`/`pino`; authored-module bundle excludes `pino`, removing the cache resolution error at boot.
- No runtime behavior or dependency changes.

<sup>Written for commit 41b50f2c158bfca131c8961dfa4493c266aab3c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

