### PR TITLE
fix: keep pino out of the eve agent bundle (dev)

### DIFF
--- a/apps/leaf/src/internal/autumnMcp/client.ts
+++ b/apps/leaf/src/internal/autumnMcp/client.ts
@@ -1,33 +1,16 @@
-import { isSecretKeyPrefix } from "@autumn/auth";
 import { type AppEnv, ms } from "@autumn/shared";
 import { MCPClient } from "@mastra/mcp";
 import { env } from "../../lib/env.js";
 import { logger } from "../../lib/logger.js";
 import { createTtlCache } from "../../lib/ttlCache.js";
 import { autumnMcpErrorText } from "./errorResult.js";
+import { autumnMcpHeaders } from "./headers.js";
 
 type AutumnTool = {
 	execute?: (
 		args: Record<string, unknown>,
 		...rest: unknown[]
 	) => Promise<unknown>;
-};
-
-export const autumnMcpHeaders = ({
-	appEnv,
-	token,
-}: {
-	appEnv: AppEnv;
-	token: string;
-}) => {
-	const headers: Record<string, string> = {
-		Authorization: `Bearer ${token}`,
-		"x-autumn-environment": appEnv,
-	};
-	if (isSecretKeyPrefix({ token })) {
-		headers["secret-key"] = token;
-	}
-	return headers;
 };
 
 const withAuthFetch =

--- a/apps/leaf/src/internal/autumnMcp/headers.ts
+++ b/apps/leaf/src/internal/autumnMcp/headers.ts
@@ -1,0 +1,21 @@
+import { isSecretKeyPrefix } from "@autumn/auth";
+import type { AppEnv } from "@autumn/shared";
+
+/** Import-light on purpose: the eve agent bundle pulls this file, and its
+ * transitive graph must stay free of node-only deps (pino et al). */
+export const autumnMcpHeaders = ({
+	appEnv,
+	token,
+}: {
+	appEnv: AppEnv;
+	token: string;
+}) => {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${token}`,
+		"x-autumn-environment": appEnv,
+	};
+	if (isSecretKeyPrefix({ token })) {
+		headers["secret-key"] = token;
+	}
+	return headers;
+};

--- a/apps/leaf/src/internal/autumnMcp/rpcClient.ts
+++ b/apps/leaf/src/internal/autumnMcp/rpcClient.ts
@@ -1,5 +1,5 @@
 import type { AppEnv } from "@autumn/shared";
-import { autumnMcpHeaders } from "./client.js";
+import { autumnMcpHeaders } from "./headers.js";
 
 export type JsonValue =
 	| string

--- a/apps/leaf/tests/unit/agent/agentBundleImports.test.ts
+++ b/apps/leaf/tests/unit/agent/agentBundleImports.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const LEAF_ROOT = resolve(import.meta.dir, "../../..");
+
+/** Externals that must never enter the eve agent bundle: they are transitive
+ * workspace deps the deployed image cannot resolve from the authored-modules
+ * cache, so a single import breaks leaf boot in production. */
+const FORBIDDEN_EXTERNALS = ["@autumn/logging", "pino", "@axiomhq/pino"];
+
+const tsFilesUnder = (dir: string): string[] =>
+	readdirSync(dir).flatMap((entry) => {
+		const path = resolve(dir, entry);
+		if (statSync(path).isDirectory()) return tsFilesUnder(path);
+		return path.endsWith(".ts") ? [path] : [];
+	});
+
+const resolveRelative = (fromFile: string, specifier: string) => {
+	const target = resolve(dirname(fromFile), specifier);
+	for (const candidate of [
+		target.replace(/\.js$/, ".ts"),
+		`${target}.ts`,
+		resolve(target, "index.ts"),
+	]) {
+		try {
+			statSync(candidate);
+			return candidate;
+		} catch {}
+	}
+	return null;
+};
+
+describe("agent bundle import closure", () => {
+	test("never reaches server-only logging deps", () => {
+		const queue = tsFilesUnder(resolve(LEAF_ROOT, "agent"));
+		const seen = new Set<string>();
+		const offenders: string[] = [];
+		while (queue.length) {
+			const file = queue.pop() as string;
+			if (seen.has(file)) continue;
+			seen.add(file);
+			const source = readFileSync(file, "utf8");
+			for (const match of source.matchAll(/from "([^"]+)"/g)) {
+				const specifier = match[1];
+				if (specifier.startsWith(".")) {
+					const resolved = resolveRelative(file, specifier);
+					if (resolved) queue.push(resolved);
+					continue;
+				}
+				if (
+					FORBIDDEN_EXTERNALS.some(
+						(name) => specifier === name || specifier.startsWith(`${name}/`),
+					)
+				) {
+					offenders.push(`${file.slice(LEAF_ROOT.length + 1)} -> ${specifier}`);
+				}
+			}
+		}
+		expect(seen.size).toBeGreaterThan(30);
+		expect(offenders).toEqual([]);
+	});
+});

--- a/apps/leaf/tests/unit/agent/agentBundleImports.test.ts
+++ b/apps/leaf/tests/unit/agent/agentBundleImports.test.ts
@@ -4,11 +4,6 @@ import { dirname, resolve } from "node:path";
 
 const LEAF_ROOT = resolve(import.meta.dir, "../../..");
 
-/** Externals that must never enter the eve agent bundle: they are transitive
- * workspace deps the deployed image cannot resolve from the authored-modules
- * cache, so a single import breaks leaf boot in production. */
-const FORBIDDEN_EXTERNALS = ["@autumn/logging", "pino", "@axiomhq/pino"];
-
 const tsFilesUnder = (dir: string): string[] =>
 	readdirSync(dir).flatMap((entry) => {
 		const path = resolve(dir, entry);
@@ -31,33 +26,48 @@ const resolveRelative = (fromFile: string, specifier: string) => {
 	return null;
 };
 
+const packageNameOf = (specifier: string) =>
+	specifier.startsWith("@")
+		? specifier.split("/").slice(0, 2).join("/")
+		: specifier.split("/")[0];
+
+/** The eve agent bundle resolves imports from a cache path where only leaf's
+ * OWN dependencies are guaranteed present — a transitive workspace dep (pino
+ * via @autumn/logging broke prod boot) resolves only by image-layout luck. */
 describe("agent bundle import closure", () => {
-	test("never reaches server-only logging deps", () => {
+	test("every runtime external is a declared leaf dependency", () => {
+		const manifest = JSON.parse(
+			readFileSync(resolve(LEAF_ROOT, "package.json"), "utf8"),
+		) as { dependencies?: Record<string, string> };
+		const declared = new Set(Object.keys(manifest.dependencies ?? {}));
 		const queue = tsFilesUnder(resolve(LEAF_ROOT, "agent"));
 		const seen = new Set<string>();
-		const offenders: string[] = [];
+		const offenders = new Set<string>();
 		while (queue.length) {
 			const file = queue.pop() as string;
 			if (seen.has(file)) continue;
 			seen.add(file);
 			const source = readFileSync(file, "utf8");
-			for (const match of source.matchAll(/from "([^"]+)"/g)) {
-				const specifier = match[1];
+			for (const match of source.matchAll(
+				/import\s+(type\s+)?[^;]*?from\s+"([^"]+)"/g,
+			)) {
+				const [, typeOnly, specifier] = match;
+				if (typeOnly) continue;
 				if (specifier.startsWith(".")) {
 					const resolved = resolveRelative(file, specifier);
 					if (resolved) queue.push(resolved);
 					continue;
 				}
-				if (
-					FORBIDDEN_EXTERNALS.some(
-						(name) => specifier === name || specifier.startsWith(`${name}/`),
-					)
-				) {
-					offenders.push(`${file.slice(LEAF_ROOT.length + 1)} -> ${specifier}`);
+				if (specifier.startsWith("node:")) continue;
+				const packageName = packageNameOf(specifier);
+				if (!declared.has(packageName)) {
+					offenders.add(
+						`${file.slice(LEAF_ROOT.length + 1)} -> ${packageName}`,
+					);
 				}
 			}
 		}
 		expect(seen.size).toBeGreaterThan(30);
-		expect(offenders).toEqual([]);
+		expect([...offenders].sort()).toEqual([]);
 	});
 });


### PR DESCRIPTION
Dev twin of #2976 (hotfix to main): `rpcClient` → `client.ts` → `lib/logger` → `pino` breaks leaf boot in deployed images (`Cannot find package 'pino'` from eve's authored-modules cache). Extracts `autumnMcpHeaders` into a dependency-light `headers.ts`; agent import closure verified logger-free. Identical content to #2976 so the next main↔dev sync merges clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps `pino` and other server-only logging deps out of the Eve agent bundle by moving `autumnMcpHeaders` into a lightweight `headers.ts`, preventing boot errors in deployed images. Previously `rpcClient` pulled headers via `client.ts` (which imported `logger` → `pino`); now both `rpcClient` and `client` import from `headers.ts`.

- `headers.ts` exports the same `autumnMcpHeaders` and only imports `@autumn/auth` and `@autumn/shared`.
- Adds `apps/leaf/tests/unit/agent/agentBundleImports.test.ts` to fail if the agent import closure includes `@autumn/logging`, `pino`, or `@axiomhq/pino`.
- Extends the test to assert all runtime externals in `apps/leaf/agent` are declared `dependencies` of `apps/leaf`.
- No behavior changes: header values and secret-key detection are unchanged; verify the agent bundle excludes `pino`.

<sup>Written for commit a20d434ce49c394559cf912e3469189ed48c0057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates MCP header construction from the server-oriented client module so Eve can load its agent bundle without pulling in Pino. It also adds a regression test for undeclared runtime dependencies in the agent import graph.
- **[Bug fixes]** Moves `autumnMcpHeaders` into a lightweight module and updates the RPC client to import it directly.
- **[Improvements]** Adds an agent-bundle dependency test to catch runtime imports that Leaf does not declare.
- **[API changes]** Removes the internal `autumnMcpHeaders` export from `client.ts` in favor of `headers.ts`.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/autumnMcp/client.ts | Imports the extracted header helper while retaining the server-side MCP client and logging behavior. |
| apps/leaf/src/internal/autumnMcp/headers.ts | Preserves authorization and environment header behavior in an import-light module. |
| apps/leaf/src/internal/autumnMcp/rpcClient.ts | Imports headers directly, removing the server logger path from the Eve agent dependency graph. |
| apps/leaf/tests/unit/agent/agentBundleImports.test.ts | Adds a regression check that runtime packages discovered from the agent source graph are declared Leaf dependencies. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Agent[Eve agent tools] --> RPC[rpcClient.ts]
  RPC --> Headers[headers.ts]
  Headers --> Auth["@autumn/auth"]
  Headers --> Shared["@autumn/shared types"]
  Client[client.ts] --> Headers
  Client --> Logger[Server logger / Pino]
  RPC -. no longer imports .-> Client
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test: 💍 assert agent-bundle externals a..."](https://github.com/useautumn/autumn/commit/a20d434ce49c394559cf912e3469189ed48c0057) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55625180)</sub>

**Context used:**

- Knowledge Base — [Leaf: Autumn's AI Agent Service](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/leaf-agent-app.md)

<!-- /greptile_comment -->