### PR TITLE
fix(setup): refresh Capy skills and Stripe CLI

### DIFF
--- a/scripts/setup/CAPY_README.md
+++ b/scripts/setup/CAPY_README.md
@@ -10,8 +10,8 @@ Configure this repository under **Settings → Project → Dev environment**:
 
 | Lifecycle | Command | Responsibility |
 | --- | --- | --- |
-| Initialize | `bash scripts/setup/capy-init.sh` | installs workspace dependencies and `neonctl`, then pulls the Autumn and Trigger.dev infrastructure images for snapshot reuse |
-| Update after checkout | `bun install --frozen-lockfile` | reconciles dependencies when a reused or snapshotted VM checks out another commit |
+| Initialize | `bash scripts/setup/capy-init.sh` | installs workspace dependencies, refreshes repo-pinned AI skills in `.agents/skills/`, installs `neonctl` and the pinned Stripe CLI, then pulls the Autumn and Trigger.dev infrastructure images for snapshot reuse |
+| Update after checkout | `bash scripts/setup/capy-init.sh` | re-runs the same deterministic refresh so reused or snapshotted VMs pick up pinned skills and tooling after checkout |
 | Startup | `bash scripts/setup/capy-startup.sh` | idempotently starts local infrastructure, provisions or resumes the VM's Neon branch, applies pending migrations and SQL functions, and writes local env files |
 | App | `bun capy` | runs Startup if needed, ensures emulate/portless are live, and starts the app in a detached tmux session |
 
@@ -38,7 +38,8 @@ Setup command or repository file.
 Optional integration variables such as `STRIPE_SANDBOX_SECRET_KEY`,
 `STRIPE_SANDBOX_WEBHOOK_SECRET`, `STRIPE_SANDBOX_CLIENT_ID`,
 `ANTHROPIC_API_KEY`, `RESEND_API_KEY`, `POSTHOG_API_KEY`, and
-`SLACK_BOT_TOKEN` pass through when configured.
+`SLACK_BOT_TOKEN` pass through when configured. `STRIPE_SANDBOX_SECRET_KEY`
+authenticates the Stripe CLI without interactive login.
 
 ## Runtime services
 

--- a/scripts/setup/capy-init.sh
+++ b/scripts/setup/capy-init.sh
@@ -19,6 +19,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$REPO_ROOT/scripts/setup/dw.compose.yml"
 TRIGGER_COMPOSE_FILE="$REPO_ROOT/scripts/setup/trigger.compose.yml"
 . "$SCRIPT_DIR/capy-trigger-image.sh"
+. "$SCRIPT_DIR/install-stripe-cli.sh"
 
 command -v bun >/dev/null 2>&1 || die "bun is required"
 docker info >/dev/null 2>&1 || die "Docker Engine is required (use a Capy v2 VM)"
@@ -66,6 +67,25 @@ command -v neonctl >/dev/null 2>&1 || command -v neon >/dev/null 2>&1 || \
   die "neonctl installation did not put a binary on PATH"
 log "neonctl ready"
 log "psql ready"
+
+# Sync the repo-pinned AI submodule, install its deps, and refresh repo skills.
+log "initializing ai submodule"
+git -C "$REPO_ROOT" submodule update --init --recursive
+if [ -f "$REPO_ROOT/ai/package.json" ]; then
+  log "installing ai deps"
+  ( cd "$REPO_ROOT/ai" && bun install --frozen-lockfile )
+  log "syncing repo skills from ai"
+  ( cd "$REPO_ROOT/ai" && bun sync )
+  if [ ! -f "$REPO_ROOT/.agents/skills/tdd/SKILL.md" ]; then
+    die "bun sync did not write .agents/skills/tdd/SKILL.md"
+  fi
+  log "repo skills ready at .agents/skills"
+fi
+
+log "installing Stripe CLI (stripe listen → localhost webhooks)"
+install_stripe_cli "[capy-init]"
+command -v stripe >/dev/null 2>&1 || die "stripe installation did not put a binary on PATH"
+stripe version >/dev/null
 
 # Bun workspace deps. Frozen-lockfile so a stale node_modules from a
 # Capy snapshot is repaired without churn.

--- a/scripts/setup/cursor-cloud/cursor-ai.test.sh
+++ b/scripts/setup/cursor-cloud/cursor-ai.test.sh
@@ -81,6 +81,91 @@ count="$(grep -c 'environments: \[cloud\]' "$tmp/user-skills/tdd/SKILL.md" || tr
 [[ "$count" == "1" ]] || fail "mark-skills should be idempotent, got $count"
 pass "mark-skills adds environments: [cloud] once"
 
+# --- Stripe helper refreshes mismatched installs and keeps exact matches ----
+stripe_tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp" "$stripe_tmp"' EXIT
+mkdir -p "$stripe_tmp/bin" "$stripe_tmp/src-1.33.0" "$stripe_tmp/src-1.34.0"
+cat >"$stripe_tmp/src-1.33.0/stripe" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = version ]; then
+	echo "Stripe version 1.33.0"
+else
+	echo "stripe stub"
+fi
+SH
+chmod +x "$stripe_tmp/src-1.33.0/stripe"
+( cd "$stripe_tmp/src-1.33.0" && tar -czf "$stripe_tmp/stripe_1.33.0_linux_x86_64.tar.gz" stripe )
+cat >"$stripe_tmp/src-1.34.0/stripe" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = version ]; then
+	echo "Stripe version 1.34.0"
+else
+	echo "stripe stub"
+fi
+SH
+chmod +x "$stripe_tmp/src-1.34.0/stripe"
+( cd "$stripe_tmp/src-1.34.0" && tar -czf "$stripe_tmp/stripe_1.34.0_linux_x86_64.tar.gz" stripe )
+cat >"$stripe_tmp/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+args=("$@")
+out=""
+for ((i=0; i<$#; i++)); do
+	if [ "${args[i]}" = "-o" ]; then
+		out="${args[i+1]}"
+		break
+	fi
+done
+cp "$STRIPE_ARCHIVE" "$out"
+SH
+chmod +x "$stripe_tmp/bin/curl"
+cat >"$stripe_tmp/bin/tar" <<'SH'
+#!/usr/bin/env bash
+exec /usr/bin/tar "$@"
+SH
+chmod +x "$stripe_tmp/bin/tar"
+cat >"$stripe_tmp/bin/install" <<'SH'
+#!/usr/bin/env bash
+exec /usr/bin/install "$@"
+SH
+chmod +x "$stripe_tmp/bin/install"
+cat >"$stripe_tmp/bin/sudo" <<'SH'
+#!/usr/bin/env bash
+exec "$@"
+SH
+chmod +x "$stripe_tmp/bin/sudo"
+source "$ROOT/scripts/setup/install-stripe-cli.sh"
+old_target="$stripe_tmp/stripe"
+cat >"$old_target" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = version ]; then
+	echo "Stripe version 1.33.0"
+else
+	echo "old stripe"
+fi
+SH
+chmod +x "$old_target"
+PATH="$stripe_tmp/bin:$PATH" STRIPE_ARCHIVE="$stripe_tmp/stripe_1.33.0_linux_x86_64.tar.gz" install_stripe_cli "[test]" "$old_target" 1.33.0
+[[ "$("$old_target" version)" == "Stripe version 1.33.0" ]] || fail "same-version stripe should stay in place"
+cat >"$old_target" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = version ]; then
+	echo "Stripe version 0.99.0"
+else
+	echo "old stripe"
+fi
+SH
+chmod +x "$old_target"
+PATH="$stripe_tmp/bin:$PATH" STRIPE_ARCHIVE="$stripe_tmp/stripe_1.34.0_linux_x86_64.tar.gz" install_stripe_cli "[test]" "$old_target" 1.34.0
+[[ "$("$old_target" version)" == "Stripe version 1.34.0" ]] || fail "mismatched stripe should be replaced"
+pass "stripe helper refreshes mismatched installs"
+
+# --- stripe version parser handles edge cases -------------------------------
+[[ "$(parse_stripe_version "Stripe version 11.22.33")" == "11.22.33" ]] || fail "parser must keep a two-digit major"
+parser_output=$'Stripe version 1.33.0\nGo version go1.22.5'
+[[ "$(parse_stripe_version "$parser_output")" == "1.33.0" ]] || fail "parser must stop at first semver"
+pass "stripe parser extracts the first semantic version"
+
 if grep -q 'repositoryDependencies' "$ROOT/.cursor/environment.json"; then
 	fail "environment.json must not declare useautumn/ai as a sibling repo — it is a submodule"
 fi

--- a/scripts/setup/cursor-cloud/install.sh
+++ b/scripts/setup/cursor-cloud/install.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/../../.."
 log() { echo "[cursor-cloud-install] $*"; }
+. scripts/setup/install-stripe-cli.sh
 
 export CLOUD_AGENT=1
 export DW_HEADLESS=1
@@ -38,13 +39,13 @@ fi
 log "bun $($BUN --version) at $BUN"
 
 log "init ai submodule (skills + MCP sync source)"
-git submodule update --init --recursive
+git -C . submodule update --init --recursive
 
 # Copy skills before apt / workspace install. Cloud freezes available_skills
 # when the first chat starts; JIT agents often open that chat mid-install.
 if [ -f ai/package.json ]; then
 	log "ai deps + bun ai sync --copy (skills into ~/.cursor/skills)"
-	(cd ai && "$BUN" install)
+	(cd ai && "$BUN" install --frozen-lockfile)
 	"$BUN" ai/src/cli.ts sync --copy
 	"$BUN" scripts/setup/cursor-cloud/cursorCloud.ts mark-skills
 	if [ ! -f "${HOME}/.cursor/skills/tdd/SKILL.md" ]; then
@@ -60,23 +61,8 @@ bash scripts/setup/agent-bootstrap.sh
 log "workspace install"
 "$BUN" install --frozen-lockfile
 
-if [ ! -x /usr/local/bin/stripe ]; then
-	log "installing Stripe CLI (stripe listen → localhost webhooks)"
-	arch="$(uname -m)"
-	case "$arch" in
-		x86_64) stripe_arch="x86_64" ;;
-		aarch64|arm64) stripe_arch="arm64" ;;
-		*) stripe_arch="x86_64" ;;
-	esac
-	tmp="$(mktemp -d)"
-	stripe_ver="1.33.0"
-	curl -fsSL -o "$tmp/stripe.tar.gz" \
-		"https://github.com/stripe/stripe-cli/releases/download/v${stripe_ver}/stripe_${stripe_ver}_linux_${stripe_arch}.tar.gz"
-	tar -xzf "$tmp/stripe.tar.gz" -C "$tmp"
-	sudo install -m 0755 "$tmp/stripe" /usr/local/bin/stripe
-	rm -rf "$tmp"
-	stripe version
-fi
+log "installing Stripe CLI (stripe listen → localhost webhooks)"
+install_stripe_cli "[cursor-cloud-install]"
 
 if [ ! -x /usr/local/bin/cloudflared ]; then
 	log "installing cloudflared (per-service public hosts)"

--- a/scripts/setup/install-stripe-cli.sh
+++ b/scripts/setup/install-stripe-cli.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+parse_stripe_version() {
+	local output="$1"
+	printf '%s\n' "$output" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true
+}
+
+install_stripe_cli() {
+	local log_prefix="${1:-[setup]}"
+	local target="${2:-/usr/local/bin/stripe}"
+	local stripe_ver="${3:-1.33.0}"
+
+	if [ -x "$target" ]; then
+		local current_version current_output
+		current_output="$("$target" version 2>/dev/null || true)"
+		current_version="$(parse_stripe_version "$current_output")"
+		if [ "$current_version" = "$stripe_ver" ]; then
+			return 0
+		fi
+		echo "$log_prefix replacing Stripe CLI ${current_version:-unknown} with $stripe_ver at $target"
+	fi
+
+	local arch stripe_arch tmp tmp_target
+	arch="$(uname -m)"
+	case "$arch" in
+		x86_64) stripe_arch="x86_64" ;;
+		aarch64|arm64) stripe_arch="arm64" ;;
+		*) stripe_arch="x86_64" ;;
+	esac
+
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "$tmp"' RETURN
+	curl -fsSL -o "$tmp/stripe.tar.gz" \
+		"https://github.com/stripe/stripe-cli/releases/download/v${stripe_ver}/stripe_${stripe_ver}_linux_${stripe_arch}.tar.gz"
+	tar -xzf "$tmp/stripe.tar.gz" -C "$tmp"
+	tmp_target="$tmp/stripe"
+
+	if [ "$EUID" -eq 0 ]; then
+		install -m 0755 "$tmp_target" "$target"
+	elif [ -w "$(dirname "$target")" ]; then
+		install -m 0755 "$tmp_target" "$target"
+	else
+		command -v sudo >/dev/null 2>&1 || {
+			echo "$log_prefix ERROR: sudo is required to install Stripe CLI into $target" >&2
+			return 1
+		}
+		sudo install -m 0755 "$tmp_target" "$target"
+	fi
+
+	"$target" version
+}


### PR DESCRIPTION
## Summary
- initialize the repository-pinned `ai` submodule during Capy setup, install its locked dependencies, and run `cd ai && bun sync`
- verify Capy's preferred `.agents/skills` output before completing Initialize or Update-after-checkout
- install the pinned Stripe CLI through a shared idempotent installer reused by Capy and Cursor Cloud
- document the identical Capy Initialize/Update command and API-key authentication for `stripe listen`

## Verification
- `bash -n scripts/setup/capy-init.sh scripts/setup/cursor-cloud/install.sh scripts/setup/install-stripe-cli.sh`
- `git diff --check`
- `cd ai && bun install --frozen-lockfile && bun sync`
- `test -f .agents/skills/tdd/SKILL.md`
- `scripts/setup/cursor-cloud/cursor-ai.test.sh` (targeted cursor setup coverage passed; unrelated DW helper checks require the unavailable `unit-test-org` fixture in the isolated task workspace)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Capy setup deterministic by refreshing repo-pinned skills and enforcing a pinned `stripe` CLI version. Previously Update-after-checkout ran only `bun install`; now both Initialize and Update run `scripts/setup/capy-init.sh`, and the installer replaces mismatched `stripe` versions to prevent drift.

- `scripts/setup/capy-init.sh`: syncs the `ai` submodule, installs locked deps, runs `bun sync` to refresh `.agents/skills`, verifies `tdd/SKILL.md`, and installs `stripe` via a shared version-enforcing helper (default v1.33.0).
- `scripts/setup/cursor-cloud/install.sh` and tests: reuse the shared installer, lock `ai` installs, fix the submodule call, and add tests that preserve exact matches and replace mismatched `stripe` versions (plus a robust version parser).
- `scripts/setup/install-stripe-cli.sh` and docs: architecture-aware, idempotent installer that enforces the configured version and prompts for `sudo` if needed; `CAPY_README` documents a single Initialize/Update command and non-interactive `stripe listen` via `STRIPE_SANDBOX_SECRET_KEY`.

**Rollout**
- Replace any “Update after checkout” steps with `bash scripts/setup/capy-init.sh`.
- Set `STRIPE_SANDBOX_SECRET_KEY` locally to use `stripe listen` without interactive login.
- If `/usr/local/bin` is not writable, the installer will prompt for `sudo`.

<sup>Written for commit 15092ba33983f7320bb074ec74bc4ae332d9609d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes Capy and Cursor Cloud setup consistently refresh repository-pinned skills and install the pinned Stripe CLI.
- **[Bug fixes]** The shared Stripe installer now checks the existing CLI version and replaces mismatched installations.
- **[Improvements]** Capy initializes the AI submodule, installs its locked dependencies, synchronizes skills, and verifies the expected output.
- **[Improvements]** Cursor Cloud and Capy reuse the same Stripe CLI installation path, while setup documentation now describes the shared lifecycle command and API-key authentication.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/setup/install-stripe-cli.sh | Adds a shared, architecture-aware installer that verifies the existing Stripe CLI version before reusing it. |
| scripts/setup/capy-init.sh | Initializes pinned AI tooling, synchronizes skills, validates generated output, and installs the Stripe CLI. |
| scripts/setup/cursor-cloud/install.sh | Reuses the shared Stripe installer and enforces the AI submodule lockfile. |
| scripts/setup/cursor-cloud/cursor-ai.test.sh | Adds coverage for replacing mismatched Stripe CLI versions and parsing version output. |
| scripts/setup/CAPY_README.md | Documents the unified Capy initialization/update process and Stripe API-key authentication. |

<sub>Reviews (2): Last reviewed commit: ["fix(setup): refresh capy skills and stri..."](https://github.com/useautumn/autumn/commit/15092ba33983f7320bb074ec74bc4ae332d9609d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55654302)</sub>

<!-- /greptile_comment -->