### PR TITLE
Improve useautumn.com agent readiness

### DIFF
--- a/apps/leaf/src/mcp/auth/isPublicMcpDiscoveryRequest.ts
+++ b/apps/leaf/src/mcp/auth/isPublicMcpDiscoveryRequest.ts
@@ -1,0 +1,25 @@
+const PUBLIC_METHODS = new Set([
+	"initialize",
+	"notifications/initialized",
+	"ping",
+	"tools/list",
+]);
+
+const hasPublicMethod = (value: unknown) =>
+	typeof value === "object" &&
+	value !== null &&
+	"method" in value &&
+	typeof value.method === "string" &&
+	PUBLIC_METHODS.has(value.method);
+
+export const isPublicMcpDiscoveryRequest = async (request: Request) => {
+	if (request.method !== "POST") return false;
+
+	try {
+		const body: unknown = await request.clone().json();
+		const messages = Array.isArray(body) ? body : [body];
+		return messages.length > 0 && messages.every(hasPublicMethod);
+	} catch {
+		return false;
+	}
+};

--- a/apps/leaf/src/mcp/constants.ts
+++ b/apps/leaf/src/mcp/constants.ts
@@ -1,3 +1,5 @@
 export const MCP_PATH = "/mcp" as const;
+export const MCP_SERVER_CARD_PATH =
+	"/.well-known/mcp/server-card.json" as const;
 export const PROTECTED_RESOURCE_METADATA_PATH =
 	"/.well-known/oauth-protected-resource/mcp";

--- a/apps/leaf/src/mcp/handlers/handleMcp.ts
+++ b/apps/leaf/src/mcp/handlers/handleMcp.ts
@@ -1,12 +1,22 @@
 import { randomUUID } from "node:crypto";
 import type { createAutumnOperationsMCPServer } from "@autumn/mcp";
 import { RESPONSE_ALREADY_SENT } from "@hono/node-server/utils/response";
+import { isPublicMcpDiscoveryRequest } from "../auth/isPublicMcpDiscoveryRequest.js";
 import { OAuthHttpError } from "../auth/protectedResourceMetadata.js";
 import { buildAuthForRequest } from "../auth/resolveRequestAuth.js";
 import type { LeafMcpContext, McpRouteOptions } from "../types.js";
 
 type McpServer = ReturnType<typeof createAutumnOperationsMCPServer>;
 type McpAuth = Awaited<ReturnType<typeof buildAuthForRequest>>;
+
+const publicDiscoveryAuth = (options: McpRouteOptions): McpAuth => ({
+	apiKey: "public-discovery",
+	env: options["oauth-environment"],
+	principalId: "public:mcp-discovery",
+	resource: options.resourceUrl,
+	scopes: [],
+	serverURL: options["server-url"],
+});
 
 const setIncomingAuth = ({ c, auth }: { c: LeafMcpContext; auth: McpAuth }) => {
 	(c.env.incoming as typeof c.env.incoming & { auth?: McpAuth }).auth = auth;
@@ -41,13 +51,15 @@ export const createHandleMcp =
 	async (c: LeafMcpContext) => {
 		let auth: McpAuth;
 		try {
-			auth = await buildAuthForRequest({
-				headers: c.req.raw.headers,
-				db: options.db,
-				flags: options,
-				logger: options.logger,
-				resourceUrl: options.resourceUrl,
-			});
+			auth = (await isPublicMcpDiscoveryRequest(c.req.raw))
+				? publicDiscoveryAuth(options)
+				: await buildAuthForRequest({
+						headers: c.req.raw.headers,
+						db: options.db,
+						flags: options,
+						logger: options.logger,
+						resourceUrl: options.resourceUrl,
+					});
 		} catch (error) {
 			if (error instanceof OAuthHttpError) {
 				return oauthErrorResponse(c, error);

--- a/apps/leaf/src/mcp/mcpRouter.ts
+++ b/apps/leaf/src/mcp/mcpRouter.ts
@@ -1,7 +1,14 @@
-import { createAutumnOperationsMCPServer } from "@autumn/mcp";
+import {
+	createAutumnMcpServerCard,
+	createAutumnOperationsMCPServer,
+} from "@autumn/mcp";
 import type { HttpBindings } from "@hono/node-server";
 import { Hono } from "hono";
-import { MCP_PATH, PROTECTED_RESOURCE_METADATA_PATH } from "./constants.js";
+import {
+	MCP_PATH,
+	MCP_SERVER_CARD_PATH,
+	PROTECTED_RESOURCE_METADATA_PATH,
+} from "./constants.js";
 import { createHandleMcp } from "./handlers/handleMcp.js";
 import { createHandleProtectedResourceMetadata } from "./handlers/handleProtectedResourceMetadata.js";
 import type { McpRouteOptions } from "./types.js";
@@ -18,6 +25,12 @@ export const createMcpRouter = (options: McpRouteOptions) => {
 			options,
 		}),
 	);
+	router.get(MCP_SERVER_CARD_PATH, (c) => {
+		c.header("Cache-Control", "public, max-age=3600");
+		return c.json(
+			createAutumnMcpServerCard({ serverUrl: options.resourceUrl }),
+		);
+	});
 	router.all(
 		MCP_PATH,
 		createHandleMcp({

--- a/apps/leaf/tests/unit/mcp/public-discovery.test.ts
+++ b/apps/leaf/tests/unit/mcp/public-discovery.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { isPublicMcpDiscoveryRequest } from "../../../src/mcp/auth/isPublicMcpDiscoveryRequest.js";
+
+const requestFor = (body: unknown) =>
+	new Request("https://mcp.useautumn.com/mcp", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+
+describe("public MCP discovery", () => {
+	test.each(["initialize", "notifications/initialized", "ping", "tools/list"])(
+		"allows %s without credentials",
+		async (method) => {
+			expect(await isPublicMcpDiscoveryRequest(requestFor({ method }))).toBe(
+				true,
+			);
+		},
+	);
+
+	test("keeps tool calls behind authentication", async () => {
+		expect(
+			await isPublicMcpDiscoveryRequest(requestFor({ method: "tools/call" })),
+		).toBe(false);
+	});
+
+	test("rejects batches containing a protected method", async () => {
+		expect(
+			await isPublicMcpDiscoveryRequest(
+				requestFor([{ method: "tools/list" }, { method: "tools/call" }]),
+			),
+		).toBe(false);
+	});
+});

--- a/apps/website/app/about.md/route.ts
+++ b/apps/website/app/about.md/route.ts
@@ -1,0 +1,12 @@
+import { aboutContent, companyPageToMarkdown } from "@/lib/companyContent";
+
+export const dynamic = "force-static";
+
+export function GET() {
+	return new Response(
+		companyPageToMarkdown({ content: aboutContent, path: "/about" }),
+		{
+			headers: { "Content-Type": "text/markdown; charset=utf-8" },
+		},
+	);
+}

--- a/apps/website/app/about/page.tsx
+++ b/apps/website/app/about/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import CompanyPage from "@/components/company-page";
+import { aboutContent } from "@/lib/companyContent";
+
+export const metadata: Metadata = {
+	title: "About Autumn Billing",
+	description:
+		"About Autumn, the open-source billing infrastructure operated by Rebase, Inc.",
+	alternates: { canonical: "/about" },
+};
+
+export default function AboutPage() {
+	return <CompanyPage content={aboutContent} />;
+}

--- a/apps/website/app/contact.md/route.ts
+++ b/apps/website/app/contact.md/route.ts
@@ -1,0 +1,12 @@
+import { companyPageToMarkdown, contactContent } from "@/lib/companyContent";
+
+export const dynamic = "force-static";
+
+export function GET() {
+	return new Response(
+		companyPageToMarkdown({ content: contactContent, path: "/contact" }),
+		{
+			headers: { "Content-Type": "text/markdown; charset=utf-8" },
+		},
+	);
+}

--- a/apps/website/app/contact/page.tsx
+++ b/apps/website/app/contact/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import CompanyPage from "@/components/company-page";
+import { contactContent } from "@/lib/companyContent";
+
+export const metadata: Metadata = {
+	title: "Contact Autumn",
+	description:
+		"Official product, support, security, and privacy contact paths for Autumn and Rebase, Inc.",
+	alternates: { canonical: "/contact" },
+};
+
+export default function ContactPage() {
+	return <CompanyPage content={contactContent} />;
+}

--- a/apps/website/app/developers.md/route.ts
+++ b/apps/website/app/developers.md/route.ts
@@ -1,0 +1,12 @@
+import { companyPageToMarkdown, developersContent } from "@/lib/companyContent";
+
+export const dynamic = "force-static";
+
+export function GET() {
+	return new Response(
+		companyPageToMarkdown({ content: developersContent, path: "/developers" }),
+		{
+			headers: { "Content-Type": "text/markdown; charset=utf-8" },
+		},
+	);
+}

--- a/apps/website/app/developers/page.tsx
+++ b/apps/website/app/developers/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import CompanyPage from "@/components/company-page";
+import { developersContent } from "@/lib/companyContent";
+
+export const metadata: Metadata = {
+	title: "Autumn Developer Resources",
+	description:
+		"Autumn API docs, OpenAPI schema, OAuth metadata, SDKs, CLI, webhooks, and MCP server for developers and agents.",
+	alternates: { canonical: "/developers" },
+};
+
+export default function DevelopersPage() {
+	return <CompanyPage content={developersContent} />;
+}

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -21,7 +21,7 @@ const url = "https://useautumn.com";
 
 export const metadata: Metadata = {
 	title: {
-		default: "Billing Infrastructure for AI Startups | Autumn",
+		default: "Autumn Billing Infrastructure for AI Startups | useautumn.com",
 		template: "%s | Autumn",
 	},
 	description:
@@ -97,6 +97,8 @@ export default function RootLayout({ children }: LayoutProps) {
 			)}
 		>
 			<head>
+				<link rel="alternate" type="text/markdown" href="/home.md" />
+				<link rel="service-desc" type="application/yaml" href="/openapi.yml" />
 				<Reb2b />
 			</head>
 			<body className="min-h-full max-w-full overflow-x-clip overscroll-x-none flex flex-col">

--- a/apps/website/app/not-found.tsx
+++ b/apps/website/app/not-found.tsx
@@ -1,113 +1,68 @@
-"use client";
-import { motion } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
-import { IconArrowRightSmall } from "@/app/constant";
 import Navbar from "@/components/navbar";
 import type { PageStyle } from "@/lib/types";
+
+const RECOVERY_LINKS = [
+	{ label: "Home", href: "/" },
+	{ label: "Developer resources", href: "/developers" },
+	{ label: "Documentation", href: "https://docs.useautumn.com/welcome" },
+	{ label: "Sitemap", href: "/sitemap.xml" },
+	{ label: "llms.txt", href: "/llms.txt" },
+];
 
 export default function NotFound() {
 	return (
 		<div
-			className="w-full min-h-screen overflow-x-hidden overflow-y-auto bg-[#0f0f0f] flex flex-col"
+			className="flex min-h-dvh w-full flex-col overflow-x-hidden bg-[#0f0f0f]"
 			style={
 				{ "--page-pad": "max(2.5rem, calc((100vw - 1440px) / 2))" } as PageStyle
 			}
 		>
-			<div className="relative w-full px-4 md:px-(--page-pad) pt-5 flex-1 block">
-				<div className="absolute pointer-events-none top-0 bottom-0 left-4 md:left-(--page-pad) border-l border-[#292929] z-50" />
-				<div className="absolute pointer-events-none top-0 bottom-0 right-4 md:right-(--page-pad) border-r border-[#292929] z-50" />
-
+			<div className="relative flex w-full flex-1 flex-col px-4 pt-5 md:px-(--page-pad)">
 				<Navbar animateIntro={false} />
-
-				<div className="relative flex-1 w-full min-h-[calc(100vh-100px)] flex flex-col items-center justify-center -mt-[1px]">
-					<div className="absolute inset-0 w-full h-full z-0 overflow-hidden">
-						<motion.div
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							transition={{ duration: 1, ease: "easeOut" }}
-							className="absolute inset-0 w-full h-full"
-						>
-							<Image
-								src="/images/404.svg"
-								alt="404 Background City Base"
-								fill
-								className="object-cover object-center"
-								priority
-							/>
-						</motion.div>
-
-						<motion.div
-							initial={{ opacity: 0, display: "none" }}
-							animate={{
-								opacity: [0, 1, 0.8, 1, 0.6, 0],
-								display: ["block", "block", "block", "block", "block", "none"],
-								x: [0, -15, 20, -10, 15, 0],
-								y: [0, 8, -15, 5, -5, 0],
-								filter: [
-									"brightness(3) contrast(200%) hue-rotate(90deg)",
-									"brightness(2) contrast(300%) invert(30%)",
-									"brightness(1.5) contrast(150%) hue-rotate(-45deg)",
-									"brightness(3) contrast(200%) hue-rotate(180deg)",
-									"brightness(2) contrast(150%)",
-									"brightness(1)",
-								],
-								clipPath: [
-									"inset(10% 0% 60% 0%)",
-									"inset(20% 0% 30% 0%)",
-									"inset(80% 0% 5% 0%)",
-									"inset(40% 0% 40% 0%)",
-									"inset(5% 0% 80% 0%)",
-									"inset(0% 0% 0% 0%)",
-								],
-							}}
-							transition={{
-								duration: 0.45,
-								ease: "easeInOut",
-								delay: 0.1,
-								times: [0, 0.2, 0.6, 0.75, 0.9, 1],
-							}}
-							className="absolute inset-0 w-full h-full mix-blend-screen pointer-events-none z-10"
-						>
-							<Image
-								src="/images/404.svg"
-								alt="404 Background City Glitch"
-								fill
-								className="object-cover object-center scale-105"
-								priority
-							/>
-						</motion.div>
-					</div>
-
-					<div className="relative z-10 flex flex-col items-center justify-center w-full px-4 text-center mt-[-40px]">
+				<main className="relative flex min-h-[calc(100dvh-100px)] flex-1 items-center justify-center overflow-hidden border-x border-[#292929] px-4 text-center">
+					<Image
+						src="/images/404.svg"
+						alt=""
+						aria-hidden="true"
+						fill
+						sizes="100vw"
+						className="object-cover object-center"
+						priority
+					/>
+					<div className="relative z-10 flex max-w-2xl flex-col items-center">
 						<Image
 							src="/images/autumn-notfound.svg"
-							alt="Autumn Logo"
+							alt="Autumn"
 							width={64}
 							height={64}
-							className="w-[56px] h-[56px] md:w-[64px] md:h-[64px] mb-6"
+							className="mb-6 size-14 md:size-16"
 						/>
-
-						<h1 className="text-white text-[48px] md:text-[64px] font-normal tracking-[-3%] mb-3 font-sans leading-[1.1]">
+						<h1 className="text-balance text-5xl font-normal text-white md:text-6xl">
 							Page not found
 						</h1>
-
-						<p className="text-[#FFFFFF99] font-light text-[15px] md:text-[18px] mb-8 tracking-[-1%] text-center">
-							The page you are looking for doesn&apos;t exist or has been moved.
+						<p className="mt-4 text-pretty text-base leading-7 text-white/60 md:text-lg">
+							The page does not exist or has moved. People and agents can
+							recover through the site map, developer index, documentation, or
+							machine-readable llms.txt file.
 						</p>
-
-						<Link href="/">
-							<button className="group relative flex items-stretch justify-between transition-colors duration-300 bg-[#8752FA] hover:bg-[#7641E8] w-[200px] md:w-[210px] h-[48px] md:h-[54px] border border-[#8752FA]">
-								<span className="text-white text-[14px] md:text-[15px] pl-6 flex items-center font-sans tracking-[-1%]">
-									Back to home
-								</span>
-								<div className="flex items-center justify-center w-[36px] md:w-[40px] transition-colors duration-300 bg-white text-[#8752FA] m-1 md:m-1.5 shrink-0">
-									<IconArrowRightSmall className="w-4 h-4" />
-								</div>
-							</button>
-						</Link>
+						<nav aria-label="Page recovery" className="mt-8">
+							<ul className="flex flex-wrap justify-center gap-3">
+								{RECOVERY_LINKS.map((link) => (
+									<li key={link.href}>
+										<Link
+											className="inline-flex min-h-11 items-center border border-white/20 bg-black/70 px-4 text-sm text-white hover:bg-white hover:text-black"
+											href={link.href}
+										>
+											{link.label}
+										</Link>
+									</li>
+								))}
+							</ul>
+						</nav>
 					</div>
-				</div>
+				</main>
 			</div>
 		</div>
 	);

--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -3,6 +3,7 @@ import ElasticRecoil from "@/components/elastic-footer";
 import HomeSections from "@/components/home-sections";
 import JsonLd from "@/components/json-ld";
 import Navbar from "@/components/navbar";
+import { buildHomeMarkdown } from "@/lib/agentContent";
 import {
 	faqPageSchema,
 	organizationSchema,
@@ -23,6 +24,11 @@ export default function Home() {
 				{ "--page-pad": "max(2.5rem, calc((100vw - 1440px) / 2))" } as PageStyle
 			}
 		>
+			<noscript>
+				<pre className="mx-auto max-w-4xl whitespace-pre-wrap bg-black p-6 font-sans text-sm leading-6 text-white">
+					{buildHomeMarkdown()}
+				</pre>
+			</noscript>
 			<JsonLd
 				data={[
 					organizationSchema(),

--- a/apps/website/app/pricing.md/route.ts
+++ b/apps/website/app/pricing.md/route.ts
@@ -1,0 +1,9 @@
+import { buildPricingMarkdown } from "@/lib/agentContent";
+
+export const dynamic = "force-static";
+
+export function GET() {
+	return new Response(buildPricingMarkdown(), {
+		headers: { "Content-Type": "text/markdown; charset=utf-8" },
+	});
+}

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -7,6 +7,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
 	const staticRoutes: MetadataRoute.Sitemap = [
 		{ url: SITE_URL, changeFrequency: "weekly", priority: 1 },
 		{ url: `${SITE_URL}/pricing`, changeFrequency: "monthly", priority: 0.9 },
+		{
+			url: `${SITE_URL}/developers`,
+			changeFrequency: "monthly",
+			priority: 0.9,
+		},
+		{ url: `${SITE_URL}/about`, changeFrequency: "yearly", priority: 0.7 },
+		{ url: `${SITE_URL}/contact`, changeFrequency: "yearly", priority: 0.7 },
 		{ url: `${SITE_URL}/blog`, changeFrequency: "weekly", priority: 0.8 },
 		{ url: `${SITE_URL}/alog`, changeFrequency: "weekly", priority: 0.8 },
 		{ url: `${SITE_URL}/terms`, changeFrequency: "yearly", priority: 0.3 },

--- a/apps/website/components/company-page.tsx
+++ b/apps/website/components/company-page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import Footer from "@/components/footer";
+import Navbar from "@/components/navbar";
+import type { CompanyPageContent } from "@/lib/companyContent";
+import type { PageStyle } from "@/lib/types";
+
+export default function CompanyPage({
+	content,
+}: {
+	content: CompanyPageContent;
+}) {
+	return (
+		<div
+			className="min-h-dvh w-full overflow-x-clip bg-black text-white"
+			style={
+				{ "--page-pad": "max(2.5rem, calc((100vw - 1440px) / 2))" } as PageStyle
+			}
+		>
+			<div className="relative mx-auto w-full px-4 pt-5 md:px-(--page-pad)">
+				<Navbar />
+				<main className="border-x border-[#292929] bg-[#0f0f0f] px-6 py-16 sm:px-10 md:py-24 lg:px-20">
+					<div className="mx-auto max-w-3xl">
+						<h1 className="text-balance text-4xl font-medium sm:text-5xl">
+							{content.title}
+						</h1>
+						<p className="mt-6 text-pretty text-lg leading-8 text-white/70">
+							{content.intro}
+						</p>
+
+						<div className="mt-16 grid gap-12">
+							{content.sections.map((section) => (
+								<section key={section.title}>
+									<h2 className="text-balance text-2xl font-medium">
+										{section.title}
+									</h2>
+									<p className="mt-4 text-pretty leading-7 text-white/70">
+										{section.content}
+									</p>
+									{section.links && (
+										<ul className="mt-5 flex flex-wrap gap-x-6 gap-y-3">
+											{section.links.map((link) => (
+												<li key={link.href}>
+													<Link
+														className="text-[#b08aff] underline underline-offset-4"
+														href={link.href}
+													>
+														{link.label}
+													</Link>
+												</li>
+											))}
+										</ul>
+									)}
+								</section>
+							))}
+						</div>
+					</div>
+				</main>
+				<Footer />
+			</div>
+		</div>
+	);
+}

--- a/apps/website/components/footer.tsx
+++ b/apps/website/components/footer.tsx
@@ -12,32 +12,22 @@ type FooterColumn = {
 };
 
 const footerColumns: FooterColumn[] = [
-	// {
-	// 	title: "PRODUCT",
-	// 	links: [
-	// 		{ label: "FEATURES", href: "#" },
-	// 		{ label: "INTEGRATIONS", href: "#" },
-	// 		{ label: "PRICING", href: "#" },
-	// 		{ label: "CHANGELOG", href: "#" },
-	// 		{ label: "ROADMAP", href: "#" },
-	// 	],
-	// },
-	// {
-	// 	title: "COMPANY",
-	// 	links: [
-	// 		{ label: "OUR TEAM", href: "#" },
-	// 		{ label: "OUR VALUES", href: "/privacy" },
-	// 		{ label: "BLOG", href: "/blog" },
-	// 	],
-	// },
-	// {
-	// 	title: "RESOURCES",
-	// 	links: [
-	// 		{ label: "DOWNLOADS", href: "https://useautumn.com/" },
-	// 		{ label: "DOCUMENTATION", href: "https://docs.useautumn.com/welcome" },
-	// 		{ label: "CONTACT", href: "https://cal.com/ayrod/a?user=ayrod" },
-	// 	],
-	// },
+	{
+		title: "COMPANY",
+		links: [
+			{ label: "ABOUT", href: "/about" },
+			{ label: "CONTACT", href: "/contact" },
+			{ label: "BLOG", href: "/blog" },
+		],
+	},
+	{
+		title: "DEVELOPERS",
+		links: [
+			{ label: "RESOURCES", href: "/developers" },
+			{ label: "DOCUMENTATION", href: "https://docs.useautumn.com/welcome" },
+			{ label: "OPENAPI", href: "/openapi.yml" },
+		],
+	},
 ];
 
 export default function Footer() {
@@ -83,7 +73,14 @@ export default function Footer() {
 											<li key={link.href} className="group/strip">
 												<Link
 													href={link.href}
-													target="_blank"
+													target={
+														link.href.startsWith("http") ? "_blank" : undefined
+													}
+													rel={
+														link.href.startsWith("http")
+															? "noreferrer"
+															: undefined
+													}
 													className="group/strip flex items-center gap-3 text-[14px] font-mono uppercase tracking-[-1%] transition-colors duration-300"
 												>
 													<span className="w-1 h-1 bg-[#FFFFFF99] group-hover/strip:bg-white group-active/strip:bg-white transition-colors duration-300 shrink-0" />

--- a/apps/website/lib/agentContent.ts
+++ b/apps/website/lib/agentContent.ts
@@ -23,6 +23,17 @@ const PREFERRED_DOCS: Array<{ label: string; href: string }> = [
 	{ label: "Autumn docs", href: "https://docs.useautumn.com/welcome" },
 	{ label: "Quickstart", href: "https://docs.useautumn.com/quickstart" },
 	{ label: "API reference", href: "https://docs.useautumn.com/api-reference" },
+	{ label: "OpenAPI specification", href: `${SITE_URL}/openapi.yml` },
+	{
+		label: "OAuth 2.0 metadata",
+		href: `${SITE_URL}/.well-known/oauth-authorization-server`,
+	},
+	{ label: "MCP server", href: "https://mcp.useautumn.com/mcp" },
+	{
+		label: "MCP server card",
+		href: "https://mcp.useautumn.com/.well-known/mcp/server-card.json",
+	},
+	{ label: "Autumn CLI on npm", href: "https://www.npmjs.com/package/atmn" },
 ];
 
 const WHAT_AUTUMN_IS = [
@@ -32,6 +43,25 @@ const WHAT_AUTUMN_IS = [
 const WHAT_AUTUMN_IS_NOT = [
 	"Autumn is not a payment processor and does not replace Stripe; Stripe still holds the subscription and processes payments.",
 	"Autumn is not a pure usage-metering tool — it also enforces entitlements and feature access, not just end-of-month invoicing.",
+];
+const WHEN_TO_USE_AUTUMN = [
+	"Use Autumn when a software product needs subscriptions, usage-based pricing, prepaid credits, feature access, or a mix of those models on top of Stripe.",
+	"Use Autumn when pricing needs to live in versioned configuration instead of being duplicated across application code, Stripe objects, and webhook handlers.",
+	"Use Autumn when an agent needs to inspect or change a billing catalog, query customers and balances, preview a billing action, or reconcile subscription state through typed tools.",
+	"Do not use Autumn as a payment processor. Keep Stripe as the processor and source of payment details; Autumn coordinates the billing and entitlement state around it.",
+];
+const CORE_WORKFLOWS = [
+	"Define plans and features in the dashboard or in `autumn.config.ts`, then use the `atmn` CLI to preview and push the catalog.",
+	"Call `attach` when a customer starts, changes, or purchases a plan. Autumn creates or updates the corresponding Stripe resources and subscription state.",
+	"Call `check` before a gated action to read feature access or the remaining balance. Call `track` after usage so metered balances, credits, and overage billing stay synchronized.",
+	"Use the REST API or official TypeScript, Python, React, and framework SDKs for application code. Use the hosted MCP server for agent workflows that need typed discovery and actions.",
+];
+const AGENT_WORKFLOWS = [
+	"To answer a billing-state question, fetch the customer and relevant plan or balance first. Report the current subscription, entitlement, remaining balance, reset time, and any scheduled change instead of inferring state from Stripe objects alone.",
+	"To change a catalog, inspect the existing features and plans, build the complete desired update, and preview it before applying it. Treat migrations and destructive catalog writes as approval-gated actions.",
+	"To change a customer's billing, identify the customer and plan, preview the attach, update, cancellation, or one-off charge, explain immediate and next-cycle effects, and apply only after the user confirms the priced action.",
+	"For dates, use epoch milliseconds at the API boundary. For money, send major currency units such as 49 for $49; Autumn converts amounts only when it reaches a processor boundary that requires minor units.",
+	"For automation, prefer the typed OpenAPI schema, the headless `atmn` CLI, or the hosted MCP tools over scraping the dashboard. Authenticate application calls with an Autumn secret key and interactive agent connections with OAuth 2.0.",
 ];
 
 const stripHtml = (value: string) => value.replace(/<[^>]*>/g, "").trim();
@@ -156,9 +186,21 @@ export function buildLlmsTxt(): string {
 		"## What Autumn is not",
 		...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
 		"",
+		"## When to use Autumn",
+		...WHEN_TO_USE_AUTUMN.map((line) => `- ${line}`),
+		"",
+		"## Core workflow",
+		...CORE_WORKFLOWS.map((line) => `- ${line}`),
+		"",
+		"## Agent workflow",
+		...AGENT_WORKFLOWS.map((line) => `- ${line}`),
+		"",
 		"## Docs",
-		"For how the platform itself works, see the docs:",
+		"For product guidance, schemas, authentication, agent tools, and the CLI:",
 		...PREFERRED_DOCS.map((doc) => `- [${doc.label}](${doc.href})`),
+		"",
+		"## CLI",
+		"The official CLI is the [`atmn` package](https://www.npmjs.com/package/atmn). Run `npx atmn init`, `npx atmn pull`, or `npx atmn push --yes` for non-interactive agent and CI workflows.",
 		"",
 		"## Comparisons",
 		...alog.map((doc) => `- [${doc.title}](${mdUrl(doc)}): ${doc.summary}`),
@@ -182,8 +224,20 @@ export function buildHomeMarkdown(): string {
 		"## What Autumn is not",
 		...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
 		"",
+		"## When to use Autumn",
+		...WHEN_TO_USE_AUTUMN.map((line) => `- ${line}`),
+		"",
+		"## Core workflow",
+		...CORE_WORKFLOWS.map((line) => `- ${line}`),
+		"",
+		"## Agent workflow",
+		...AGENT_WORKFLOWS.map((line) => `- ${line}`),
+		"",
 		"## Learn more",
 		...PREFERRED_DOCS.map((doc) => `- [${doc.label}](${doc.href})`),
+		`- [Developer resources](${SITE_URL}/developers)`,
+		`- [About Autumn](${SITE_URL}/about)`,
+		`- [Contact Autumn](${SITE_URL}/contact)`,
 		`- [Blog](${SITE_URL}/blog)`,
 		`- [Comparisons](${SITE_URL}/alog)`,
 		"- [GitHub](https://github.com/useautumn/autumn)",
@@ -193,6 +247,18 @@ export function buildHomeMarkdown(): string {
 	];
 
 	return `${lines.join("\n").trim()}\n`;
+}
+
+export function buildPricingMarkdown(): string {
+	return [
+		"# Autumn Pricing",
+		"",
+		"Start free with 8K monthly billing volume. Pro starts at $375 per month for teams scaling usage-based pricing, with volume pricing available.",
+		"",
+		"- [View pricing](https://useautumn.com/pricing)",
+		"- [Contact Autumn](https://useautumn.com/contact)",
+		"",
+	].join("\n");
 }
 
 export function buildTermsMarkdown(): string {
@@ -242,6 +308,15 @@ export function buildLlmsFullTxt(): string {
 		"",
 		"## What Autumn is not",
 		...WHAT_AUTUMN_IS_NOT.map((line) => `- ${line}`),
+		"",
+		"## When to use Autumn",
+		...WHEN_TO_USE_AUTUMN.map((line) => `- ${line}`),
+		"",
+		"## Core workflow",
+		...CORE_WORKFLOWS.map((line) => `- ${line}`),
+		"",
+		"## Agent workflow",
+		...AGENT_WORKFLOWS.map((line) => `- ${line}`),
 		"",
 		"## Key links",
 		...PREFERRED_DOCS.map((doc) => `- ${doc.label}: ${doc.href}`),

--- a/apps/website/lib/companyContent.ts
+++ b/apps/website/lib/companyContent.ts
@@ -1,0 +1,162 @@
+import { SITE_URL } from "@/lib/seo";
+
+export type CompanyPageLink = { label: string; href: string };
+
+export type CompanyPageContent = {
+	title: string;
+	intro: string;
+	sections: Array<{
+		title: string;
+		content: string;
+		links?: CompanyPageLink[];
+	}>;
+};
+
+export const aboutContent: CompanyPageContent = {
+	title: "About Autumn",
+	intro:
+		"Autumn is open-source billing infrastructure for software companies. It gives product teams one place to define pricing, manage subscription state, meter usage, track credits, and enforce feature access while Stripe continues to process payments.",
+	sections: [
+		{
+			title: "Why we built it",
+			content:
+				"Billing logic spreads quickly. A new plan can require application flags, usage counters, Stripe products, checkout code, webhook handlers, and migration scripts. Autumn moves those decisions into a versioned catalog and a small API so a team can change pricing without rebuilding the same system for every product or contract.",
+		},
+		{
+			title: "What we operate",
+			content:
+				"Autumn maintains the billing and entitlement state around Stripe. Developers can attach plans, check access, track usage, issue credits, model prepaid and pay-as-you-go pricing, and keep customer state synchronized through the API, SDKs, CLI, dashboard, webhooks, and hosted MCP server.",
+		},
+		{
+			title: "Company",
+			content:
+				"Autumn is operated by Rebase, Inc., a Delaware corporation. The source code is available on GitHub, the API and product documentation are public, and the team works directly with developers building billing for AI and usage-based software products.",
+			links: [
+				{ label: "GitHub", href: "https://github.com/useautumn/autumn" },
+				{ label: "Documentation", href: "https://docs.useautumn.com/welcome" },
+			],
+		},
+	],
+};
+
+export const contactContent: CompanyPageContent = {
+	title: "Contact Autumn",
+	intro:
+		"Talk to the Autumn team about product questions, implementation help, security, privacy, or a billing architecture you are planning. The links below are the official contact paths for Rebase, Inc. (doing business as Autumn).",
+	sections: [
+		{
+			title: "Product and sales",
+			content:
+				"Email hey@useautumn.com for product questions, pricing, migration planning, enterprise requirements, or help deciding whether Autumn fits your billing model. Include your current stack, the pricing model you want to support, and whether you already use Stripe so the team can give you a concrete answer.",
+			links: [
+				{ label: "Email the team", href: "mailto:hey@useautumn.com" },
+				{ label: "Book a demo", href: "https://cal.com/ayrod" },
+			],
+		},
+		{
+			title: "Support and community",
+			content:
+				"For implementation questions, start with the documentation or ask in the Autumn Discord community. Public GitHub issues are the right place for reproducible bugs and feature requests that do not contain customer data, credentials, or other sensitive information.",
+			links: [
+				{ label: "Documentation", href: "https://docs.useautumn.com/welcome" },
+				{ label: "Discord", href: "https://discord.com/invite/STqxY92zuS" },
+				{
+					label: "GitHub issues",
+					href: "https://github.com/useautumn/autumn/issues",
+				},
+			],
+		},
+		{
+			title: "Security and privacy",
+			content:
+				"Email security@useautumn.com for security reports, privacy requests, or questions about how Autumn handles personal information. Do not include live secret keys or payment details in an initial message. Autumn's legal entity is Rebase, Inc., a Delaware corporation in the United States.",
+			links: [
+				{ label: "Security email", href: "mailto:security@useautumn.com" },
+				{ label: "Privacy policy", href: "/privacy" },
+			],
+		},
+	],
+};
+
+export const developersContent: CompanyPageContent = {
+	title: "Autumn Developer Resources",
+	intro:
+		"Build and automate usage-based billing with Autumn's public API, SDKs, OpenAPI schema, OAuth 2.0 authorization server, CLI, webhooks, and hosted MCP server. These are the canonical resources for application code, scripts, CI jobs, and AI agents.",
+	sections: [
+		{
+			title: "API and schemas",
+			content:
+				"The Autumn REST API exposes typed operations for customers, plans, features, balances, billing, events, referrals, and more. The OpenAPI 3.1 specification gives every operation a unique operation ID, description, request schema, and response schema so clients and function-calling agents can generate reliable calls.",
+			links: [
+				{
+					label: "API reference",
+					href: "https://docs.useautumn.com/api-reference",
+				},
+				{ label: "OpenAPI specification", href: "/openapi.yml" },
+				{
+					label: "OAuth metadata",
+					href: "/.well-known/oauth-authorization-server",
+				},
+			],
+		},
+		{
+			title: "SDKs and CLI",
+			content:
+				"Use the official SDKs in application code. For local development and automation, install the atmn CLI from npm or run it with npx. The CLI can initialize a versioned autumn.config.ts file, preview and push catalog changes, pull remote state, inspect customers and events, and emit JSON in headless environments.",
+			links: [
+				{ label: "Quickstart", href: "https://docs.useautumn.com/quickstart" },
+				{ label: "atmn on npm", href: "https://www.npmjs.com/package/atmn" },
+				{
+					label: "CLI source",
+					href: "https://github.com/useautumn/autumn/tree/dev/packages/atmn",
+				},
+			],
+		},
+		{
+			title: "Agents and webhooks",
+			content:
+				"Connect an agent to the hosted Streamable HTTP MCP server to inspect catalog and customer state or perform typed billing actions after OAuth authorization. Use webhooks for event-driven application updates. Agents should preview destructive billing or catalog changes before applying them.",
+			links: [
+				{
+					label: "MCP documentation",
+					href: "https://docs.useautumn.com/documentation/mcp",
+				},
+				{
+					label: "MCP server card",
+					href: "https://mcp.useautumn.com/.well-known/mcp/server-card.json",
+				},
+				{
+					label: "Webhook documentation",
+					href: "https://docs.useautumn.com/documentation/webhooks",
+				},
+			],
+		},
+	],
+};
+
+export function companyPageToMarkdown({
+	content,
+	path,
+}: {
+	content: CompanyPageContent;
+	path: string;
+}) {
+	const sections = content.sections.flatMap((section) => [
+		`## ${section.title}`,
+		"",
+		section.content,
+		...(section.links?.map((link) => `- [${link.label}](${link.href})`) ?? []),
+		"",
+	]);
+
+	return [
+		`# ${content.title}`,
+		"",
+		content.intro,
+		"",
+		...sections,
+		"---",
+		`Source: ${SITE_URL}${path}`,
+		"",
+	].join("\n");
+}

--- a/apps/website/lib/markdownRoutes.ts
+++ b/apps/website/lib/markdownRoutes.ts
@@ -2,8 +2,12 @@ export function markdownTargetFor(pathname: string): string | null {
 	const path = pathname.replace(/\/+$/, "") || "/";
 
 	if (path === "/") return "/home.md";
+	if (path === "/pricing") return "/pricing.md";
 	if (path === "/privacy") return "/privacy.md";
 	if (path === "/terms") return "/terms.md";
+	if (path === "/about") return "/about.md";
+	if (path === "/contact") return "/contact.md";
+	if (path === "/developers") return "/developers.md";
 	if (path === "/blog") return "/blog.md";
 	if (path === "/alog") return "/alog.md";
 

--- a/apps/website/lib/seo.ts
+++ b/apps/website/lib/seo.ts
@@ -28,11 +28,25 @@ export function organizationSchema() {
 		"@type": "Organization",
 		"@id": `${SITE_URL}/#organization`,
 		name: ORG_NAME,
+		legalName: "Rebase, Inc.",
+		alternateName: "Autumn Billing",
 		url: SITE_URL,
 		logo: LOGO_URL,
 		description:
 			"Billing infrastructure for AI startups: usage-based billing, credits, entitlements, and subscription state in one API.",
 		sameAs: SAME_AS,
+		contactPoint: {
+			"@type": "ContactPoint",
+			contactType: "sales and support",
+			email: "hey@useautumn.com",
+			url: `${SITE_URL}/contact`,
+			availableLanguage: "English",
+		},
+		address: {
+			"@type": "PostalAddress",
+			addressRegion: "Delaware",
+			addressCountry: "US",
+		},
 	};
 }
 
@@ -42,7 +56,7 @@ export function websiteSchema() {
 		"@type": "WebSite",
 		"@id": `${SITE_URL}/#website`,
 		name: ORG_NAME,
-		alternateName: "useautumn.com",
+		alternateName: ["Autumn Billing", "useautumn.com"],
 		url: SITE_URL,
 		publisher: { "@id": `${SITE_URL}/#organization` },
 	};

--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -53,6 +53,21 @@ const nextConfig = {
   async rewrites() {
     return [
       {
+        source: "/.well-known/oauth-authorization-server",
+        destination:
+          "https://api.useautumn.com/.well-known/oauth-authorization-server",
+      },
+      {
+        source: "/openapi.yml",
+        destination:
+          "https://raw.githubusercontent.com/useautumn/autumn/dev/packages/openapi/openapi.yml",
+      },
+      {
+        source: "/openapi.yaml",
+        destination:
+          "https://raw.githubusercontent.com/useautumn/autumn/dev/packages/openapi/openapi.yml",
+      },
+      {
         source: "/alog/:slug.md",
         destination: "/api/alog-md/:slug",
       },

--- a/apps/website/proxy.ts
+++ b/apps/website/proxy.ts
@@ -1,5 +1,5 @@
 import { Tracker } from "@bydefault/vercel";
-import { after, NextResponse, type NextRequest } from "next/server";
+import { after, type NextRequest, NextResponse } from "next/server";
 import { negotiate } from "@/lib/contentNegotiation";
 import { markdownTargetFor } from "@/lib/markdownRoutes";
 
@@ -7,6 +7,16 @@ import { markdownTargetFor } from "@/lib/markdownRoutes";
 // proxy is a no-op instead of throwing at module load.
 const token = process.env.BYDEFAULT_TOKEN;
 const tracker = token ? new Tracker({ token, exclude: ["/api"] }) : null;
+const NOT_FOUND_MARKDOWN = `# Page not found
+
+The requested page does not exist or has moved.
+
+- [Home](https://useautumn.com/)
+- [Developer resources](https://useautumn.com/developers)
+- [Sitemap](https://useautumn.com/sitemap.xml)
+- [llms.txt](https://useautumn.com/llms.txt)
+- [Documentation](https://docs.useautumn.com/welcome)
+`;
 
 function track(request: NextRequest) {
 	if (tracker) {
@@ -20,7 +30,21 @@ async function negotiateMarkdown(
 	request: NextRequest,
 ): Promise<NextResponse | null> {
 	const markdownTarget = markdownTargetFor(request.nextUrl.pathname);
-	if (!markdownTarget) return null;
+	if (!markdownTarget) {
+		if (
+			request.nextUrl.pathname !== "/docs" &&
+			negotiate(request.headers.get("accept")) === "markdown"
+		) {
+			return new NextResponse(NOT_FOUND_MARKDOWN, {
+				status: 404,
+				headers: {
+					"Content-Type": "text/markdown; charset=utf-8",
+					Vary: "Accept",
+				},
+			});
+		}
+		return null;
+	}
 
 	const decision = negotiate(request.headers.get("accept"));
 
@@ -89,6 +113,10 @@ export const config = {
 		// AI/agent text routes are dotted paths excluded above; track them explicitly.
 		{ source: "/llms.txt" },
 		{ source: "/llms-full.txt" },
+		{ source: "/pricing.md" },
+		{ source: "/about.md" },
+		{ source: "/contact.md" },
+		{ source: "/developers.md" },
 		{ source: "/alog.md" },
 		{ source: "/alog/:path*.md" },
 		{ source: "/blog.md" },

--- a/packages/mcp/src/constants.ts
+++ b/packages/mcp/src/constants.ts
@@ -4,6 +4,7 @@ import { Scopes } from "@autumn/shared/scopeDefinitions";
 /** Shared defaults for talking to the Autumn API from the MCP server. */
 export const DEFAULT_AUTUMN_API_URL = "https://api.useautumn.com";
 export const DEFAULT_API_VERSION = "2.3.0";
+export const AUTUMN_MCP_VERSION = "0.0.1";
 
 /** Scopes requested when exchanging an OAuth token for an Autumn API key. */
 export const MCP_OAUTH_SCOPES = [

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,6 +14,7 @@ export {
 	createConsoleLogger,
 } from "./console-logger.js";
 export {
+	AUTUMN_MCP_VERSION,
 	DEFAULT_API_VERSION,
 	DEFAULT_AUTUMN_API_URL,
 	MCP_OAUTH_SCOPES,
@@ -26,3 +27,4 @@ export {
 } from "./server/auth/auth.js";
 export type { MCPServerFlags } from "./server/flags.js";
 export { createAutumnOperationsMCPServer } from "./server/server.js";
+export { createAutumnMcpServerCard } from "./server/serverCard.js";

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1,6 +1,7 @@
 import { autumnMcpInstructions } from "@autumn/agent-docs/agent";
 import { withAgentDocResources } from "@autumn/agent-docs/mcp";
 import { MCPServer } from "@mastra/mcp";
+import { AUTUMN_MCP_VERSION } from "../constants.js";
 import { autumnMcpResources } from "../resources/index.js";
 import { createRawAutumnOperationTools } from "../tools/index.js";
 
@@ -12,7 +13,7 @@ export const createAutumnOperationsMCPServer = ({
 	new MCPServer({
 		id: "autumn-mcp",
 		name: "Autumn MCP",
-		version: "0.0.1",
+		version: AUTUMN_MCP_VERSION,
 		description: "Operate on Autumn customers, plans, and billing.",
 		instructions: autumnMcpInstructions,
 		tools: createRawAutumnOperationTools({ requireIntent }),

--- a/packages/mcp/src/server/serverCard.ts
+++ b/packages/mcp/src/server/serverCard.ts
@@ -1,0 +1,19 @@
+import { AUTUMN_MCP_VERSION } from "../constants.js";
+import { createRawAutumnOperationTools } from "../tools/index.js";
+
+const tools = Object.entries(
+	createRawAutumnOperationTools({ requireIntent: false }),
+).map(([name, tool]) => ({ name, description: tool.description }));
+
+export const createAutumnMcpServerCard = ({
+	serverUrl,
+}: {
+	serverUrl: string;
+}) => ({
+	name: "Autumn",
+	description:
+		"Inspect and manage Autumn billing catalogs, customers, subscriptions, balances, usage, and billing actions through typed tools.",
+	version: AUTUMN_MCP_VERSION,
+	serverUrl,
+	tools,
+});

--- a/packages/mcp/tests/unit/mcp-server/serverCard.test.ts
+++ b/packages/mcp/tests/unit/mcp-server/serverCard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { createAutumnMcpServerCard } from "../../../src/server/serverCard.js";
+
+describe("Autumn MCP server card", () => {
+	test("publishes a public tool index without credentials", () => {
+		const card = createAutumnMcpServerCard({
+			serverUrl: "https://mcp.useautumn.com/mcp",
+		});
+
+		expect(card).toMatchObject({
+			name: "Autumn",
+			version: "0.0.1",
+			serverUrl: "https://mcp.useautumn.com/mcp",
+		});
+		expect(card.tools.length).toBeGreaterThan(0);
+		expect(card.tools.every((tool) => tool.name && tool.description)).toBe(
+			true,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- add crawlable no-JS product guidance, agent-friendly markdown 404s, and indexed About, Contact, Developer, and pricing resources
- publish discoverable OAuth metadata and the typed OpenAPI schema; strengthen Autumn brand and organization metadata; link the official `atmn` CLI and explicit when-to-use guidance
- expose an MCP server card plus unauthenticated `initialize` / `tools/list` discovery while keeping every `tools/call` behind the existing OAuth or secret-key check

Covers all 13 findings in the [Is Agentic scan](https://is-agentic.com/scan/useautumn.com). Search-result findings will update after deployment and reindexing.

## Verification

- `bun run build` in `apps/website`
- changed website files pass ESLint 9 and Biome (the repository ESLint 10 command currently aborts inside `eslint-plugin-react` before linting)
- `bun run ts` in `apps/leaf` and `packages/mcp`
- 7 focused MCP tests pass
- React Doctor: 90/100, no findings
- local production probe: homepage 4,595 readable characters / 5.95% text-to-HTML; HTML and markdown 404s return 404; OAuth and OpenAPI routes return 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves agent readiness for useautumn.com and the hosted MCP server. Previously all MCP calls required credentials and much site content depended on JS; now agents can discover the server and tools unauthenticated, while tool execution remains authenticated, and the site serves crawlable, markdown-backed pages and 404s.

- MCP discovery: allow unauthenticated POSTs for initialize, notifications/initialized, ping, and tools/list; keep tools/call behind OAuth or secret key. Adds a server card at /.well-known/mcp/server-card.json and versioned exports in `@autumn/mcp`; includes unit tests.
- Website discoverability: adds About, Contact, and Developers pages with static and markdown routes; noscript markdown on the homepage; Accept-based markdown negotiation and a markdown 404. Updates sitemap, footer links, and structured data with legalName and contactPoint. Adds llms.txt content and a pricing.md endpoint. Injects <link rel="alternate" href="/home.md"> and <link rel="service-desc" href="/openapi.yml">; rewrites expose /.well-known/oauth-authorization-server and /openapi.yml.
- Security/caching: public discovery is strictly limited to the allowlist above; OAuth error handling unchanged. MCP server card responses are cacheable (public, max-age=3600).

<sup>Written for commit 27385d334fb44a013ea553672574d9011c9419bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves Autumn’s machine-readable website and MCP discovery surfaces, but the new OpenAPI endpoint publishes the unsanitized repository schema.
- **[Improvements]** Adds crawlable product guidance, markdown company and pricing pages, richer metadata, recovery links, and sitemap entries.
- **[API changes]** Adds an MCP server card and permits unauthenticated protocol initialization and tool discovery while retaining authentication for tool execution.
- **[API changes]** Publishes OAuth metadata and OpenAPI URLs; the OpenAPI rewrite currently exposes internal-only schema fields.
</details>


<h3>Confidence Score: 4/5</h3>

The OpenAPI rewrite should be fixed before merging because it publishes internal-only schema fields to developers and agents.

The newly advertised OpenAPI URLs serve the raw repository specification, bypassing the existing transformation that removes internal fields from public documentation.

**Files Needing Attention:** apps/website/next.config.mjs

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/mcp/auth/isPublicMcpDiscoveryRequest.ts | Adds a narrow allowlist for unauthenticated MCP discovery methods and rejects protected or mixed batches. |
| apps/leaf/src/mcp/handlers/handleMcp.ts | Selects synthetic discovery identity for public protocol requests while retaining existing authentication for other requests. |
| apps/website/proxy.ts | Adds markdown 404 responses for markdown-preferring clients without masking any current valid extensionless route. |
| apps/website/next.config.mjs | Adds OAuth and OpenAPI rewrites, but the OpenAPI paths expose the raw schema containing internal-only fields. |
| apps/website/lib/agentContent.ts | Expands machine-readable product, workflow, CLI, pricing, and agent guidance. |
| packages/mcp/src/server/serverCard.ts | Generates a discoverable MCP server card from the same registered public tool definitions. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/website/next.config.mjs:61-63
**Raw OpenAPI schema is published**

When a developer or agent downloads `/openapi.yml`, this rewrite serves the raw repository specification instead of the sanitized documentation copy, exposing internal-only fields such as `entitlement_id` and `price_id` to generated clients.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: improve agent readiness"](https://github.com/useautumn/autumn/commit/27385d334fb44a013ea553672574d9011c9419bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55667109)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Marketing and Docs Sites](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/marketing-and-docs-sites.md)
- Knowledge Base — [MCP Server Package (`packages/mcp`)](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/mcp-server.md)
- Knowledge Base — [Leaf: Autumn's AI Agent Service](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/leaf-agent-app.md)
</details>


<!-- /greptile_comment -->