### PR TITLE
fix: internal admin approval cards get dashboard deep links (org-aware)

### DIFF
--- a/apps/leaf/src/internal/approvals/domain/approvalRecord.ts
+++ b/apps/leaf/src/internal/approvals/domain/approvalRecord.ts
@@ -138,8 +138,8 @@ const sheetSeedableCustomize = (customize: unknown) => {
 	);
 };
 
-/** Excludes internal admin threads (they hop orgs — the link would 403) and
- * requests the sheet cannot faithfully represent. */
+/** Excludes requests the sheet cannot faithfully represent; internal admin
+ * threads link too — the URL carries org_id and the dashboard switches org. */
 export const dashboardLinkableApproval = ({
 	approval,
 	groupedStepCount,
@@ -159,8 +159,6 @@ export const dashboardLinkableApproval = ({
 	return (
 		groupedStepCount === 0 &&
 		sheetSeedableCustomize(customize) &&
-		SHEET_LINKABLE_TOOLS.has(normalizeToolName(approval.tool_name)) &&
-		// The column is notNull, but test fixtures construct partial rows.
-		!isInternalAutumnSlackProvider({ provider: approval.provider ?? "" })
+		SHEET_LINKABLE_TOOLS.has(normalizeToolName(approval.tool_name))
 	);
 };

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -81,6 +81,7 @@ const approvalDashboardUrl = ({
 		approvalId: approval.id,
 		env: approval.env,
 		groupedStepCount: groupedWrites?.length ?? 0,
+		orgId: approval.org_id,
 		provider: approval.provider,
 		toolArgs: approval.tool_args as Record<string, unknown>,
 		toolName: approval.tool_name,

--- a/apps/leaf/src/internal/approvals/surfaces/slack/present.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/present.ts
@@ -22,6 +22,7 @@ export const dashboardUrlFor = ({
 	approvalId,
 	env,
 	groupedStepCount,
+	orgId,
 	provider,
 	toolArgs,
 	toolName,
@@ -29,6 +30,7 @@ export const dashboardUrlFor = ({
 	approvalId: string;
 	env: ChatApproval["env"];
 	groupedStepCount: number;
+	orgId: string;
 	provider: string;
 	toolArgs?: Record<string, unknown>;
 	toolName: string;
@@ -45,6 +47,7 @@ export const dashboardUrlFor = ({
 				approvalId,
 				customerId: requestStringField(toolArgs, "customer_id"),
 				env,
+				orgId,
 				planId: requestStringField(toolArgs, "plan_id"),
 				toolName,
 			})
@@ -74,6 +77,7 @@ export const postApprovalCardForRow = async ({
 				approvalId: approval.id,
 				env: approval.env,
 				groupedStepCount: grouped.length,
+				orgId: approval.org_id,
 				provider: approval.provider,
 				toolArgs,
 				toolName: approval.tool_name,
@@ -203,6 +207,7 @@ export const presentApproval = async ({
 		approvalId: created.approvalId,
 		env,
 		groupedStepCount: created.withheld.length,
+		orgId,
 		provider: installation.provider,
 		toolArgs: created.toolArgs,
 		toolName: created.toolName,

--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -1372,12 +1372,14 @@ export const approvalSheetUrl = ({
 	approvalId,
 	customerId,
 	env,
+	orgId,
 	planId,
 	toolName,
 }: {
 	approvalId: string;
 	customerId?: string;
 	env?: AppEnv;
+	orgId?: string;
 	planId?: string;
 	toolName: string;
 }) => {
@@ -1390,7 +1392,8 @@ export const approvalSheetUrl = ({
 			: normalizedToolName === "createSchedule"
 				? "sheet=create-schedule"
 				: "sheet=attach-product";
-	return `${base}/customers/${encodeURIComponent(customerId)}?${sheet}&approval_id=${encodeURIComponent(approvalId)}`;
+	const orgParam = orgId ? `&org_id=${encodeURIComponent(orgId)}` : "";
+	return `${base}/customers/${encodeURIComponent(customerId)}?${sheet}&approval_id=${encodeURIComponent(approvalId)}${orgParam}`;
 };
 
 const viewInDashboardButton = (url: string | null | undefined) =>

--- a/apps/leaf/tests/unit/approvals/dashboardLinkableApproval.test.ts
+++ b/apps/leaf/tests/unit/approvals/dashboardLinkableApproval.test.ts
@@ -90,7 +90,7 @@ describe("dashboardLinkableApproval", () => {
 		).toBe(false);
 	});
 
-	test("excludes grouped, unresolvable customize, internal, and non-sheet tools", () => {
+	test("excludes grouped, unresolvable customize, and non-sheet tools (internal admin links too)", () => {
 		expect(
 			dashboardLinkableApproval({
 				approval: { ...base, tool_name: "attach" },
@@ -121,7 +121,7 @@ describe("dashboardLinkableApproval", () => {
 				},
 				groupedStepCount: 0,
 			}),
-		).toBe(false);
+		).toBe(true);
 		expect(
 			dashboardLinkableApproval({
 				approval: { ...base, tool_name: "updateCatalog" },

--- a/vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx
+++ b/vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx
@@ -5,6 +5,8 @@ import { attachFormOverridesFromRequestBody } from "@/components/forms/attach-v2
 import { scheduleFormFromRequestBody } from "@/components/forms/create-schedule/utils/scheduleFormFromRequestBody";
 import { updateSubscriptionFormOverridesFromRequestBody } from "@/components/forms/update-subscription-v2/utils/updateSubscriptionFormOverridesFromRequestBody";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useListOrganizations, useSession } from "@/lib/auth-client";
+import { setActiveOrg } from "@/lib/orgSync";
 import { useApprovalSeedStore } from "../stores/useApprovalSeedStore";
 import { useApprovalDetailQuery } from "./useApprovalDetailQuery";
 import { useResolvedApprovalRequest } from "./useResolvedApprovalRequest";
@@ -28,6 +30,7 @@ export const useApprovalSheetFromUrl = ({
 }) => {
 	const [params, setParams] = useQueryStates({
 		approval_id: parseAsString,
+		org_id: parseAsString,
 		plan_id: parseAsString,
 		sheet: parseAsString,
 	});
@@ -36,14 +39,53 @@ export const useApprovalSheetFromUrl = ({
 	const openedRef = useRef(false);
 
 	const sheetType = isApprovalSheet(params.sheet) ? params.sheet : null;
+	const { data: session } = useSession();
+	const { data: organizations, isPending: organizationsPending } =
+		useListOrganizations();
+	const activeOrgId = session?.session.activeOrganizationId;
+	// Internal admin cards carry org_id: the link targets another org, so the
+	// session must switch before any org-scoped fetch can resolve.
+	const orgMismatch = Boolean(
+		params.org_id && activeOrgId && params.org_id !== activeOrgId,
+	);
 	const { approval, approvalError } = useApprovalDetailQuery({
-		approvalId: sheetType ? params.approval_id : null,
+		approvalId: sheetType && !orgMismatch ? params.approval_id : null,
 	});
 	const { resolved, resolutionFailed, resolutionPending } =
 		useResolvedApprovalRequest({ approval });
 
 	useEffect(() => {
 		if (!sheetType || openedRef.current) return;
+		if (orgMismatch) {
+			if (organizationsPending) return;
+			openedRef.current = true;
+			const target = organizations?.find(
+				(organization) => organization.id === params.org_id,
+			);
+			if (!target) {
+				toast.error(
+					"This approval belongs to an organization you don't have access to.",
+				);
+				void setParams({
+					approval_id: null,
+					org_id: null,
+					plan_id: null,
+					sheet: null,
+				});
+				return;
+			}
+			void setActiveOrg(target.id).then((result) => {
+				if (result.error) {
+					toast.error("Couldn't switch organization for this approval.");
+					return;
+				}
+				toast.info(`Switched to ${target.name} for this approval.`);
+				// Reload with the deep-link params intact — the flow resumes
+				// under the right org.
+				window.location.reload();
+			});
+			return;
+		}
 		if (params.approval_id && !approval && !approvalError) return;
 		if (resolutionPending) return;
 
@@ -88,10 +130,20 @@ export const useApprovalSheetFromUrl = ({
 					: "subscription-update";
 			setSheet({ type, itemId, data });
 		}
-		void setParams({ approval_id: null, plan_id: null, sheet: null });
+		void setParams({
+			approval_id: null,
+			org_id: null,
+			plan_id: null,
+			sheet: null,
+		});
 	}, [
+		activeOrgId,
 		approval,
 		approvalError,
+		organizations,
+		organizationsPending,
+		orgMismatch,
+		params.org_id,
 		params.approval_id,
 		params.plan_id,
 		resolutionFailed,


### PR DESCRIPTION
Internal admin threads (`slack_admin:*` provider — the org-switching Autumn bot) were fail-closed excluded from "View in dashboard" in v1, because the dashboard URL carries no org: the sheet would open against the operator's ACTIVE org, risking a same-id customer in the wrong org.

**Fix:**
- `approvalSheetUrl` now carries `org_id` (from the approval row) on every card.
- The dashboard's deep-link bridge checks it before any org-scoped fetch: active org matches → flow unchanged; mismatch + operator is a member → `setActiveOrg` (the canonical switcher) + toast + reload with the deep-link params intact, so the flow resumes under the right org; not a member → error toast, params stripped, nothing fetched.
- The linkability gate drops the internal-provider exclusion (the org check makes it safe); `surfaceRendersGroup` semantics untouched.

**Verified:** leaf approvals + card suites 149/149 (gate test updated: internal provider now linkable), leaf + vite typechecks clean. Backend enforcement unchanged — `getWebApproval` still 403s on org mismatch, so the client check is UX, not the security boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable “View in dashboard” links for internal admin approval cards by deep-linking with an org_id and switching orgs in the dashboard when needed. Previously these cards were excluded; now the dashboard validates org, switches when allowed, or blocks with a clear error.

- Add org_id to `approvalSheetUrl` and pass it through Slack link construction; deep links now include `org_id`.
- Update dashboard hook to read `org_id`, defer org-scoped fetches until org matches, switch via `setActiveOrg` with toast + full reload preserving params; if the operator isn’t a member, show an error and clear params.
- Remove the internal-provider exclusion in `dashboardLinkableApproval`; other linkability checks remain unchanged.
- Backend behavior unchanged (`getWebApproval` still 403s on org mismatch). Tests updated to reflect linkability; typechecks remain clean.

<sup>Written for commit f7e478d02db677db9c4b6951cc4dd42e55f18c9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds organization-aware dashboard links to approval cards and switches the dashboard organization before opening an approval. The core path is non-blocking, but two organization-switch error paths can leave an authorized operator unable to open the link.
- **[Bug fixes, Improvements]** Adds `org_id` to approval dashboard URLs and allows internal-admin approval cards to expose dashboard links.
- **[Bug fixes]** Checks organization membership, switches to the target organization, reloads, and resumes the approval flow before making the intended org-scoped request.
- **[Improvements]** Updates approval-card linkability coverage for internal Slack-admin providers.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, although organization-switch and membership-list failures should be handled so authorized operators are not left with dead or incorrectly rejected links.

The normal organization-aware flow is coherent, but two newly added failure branches either permanently latch the hook after a failed switch or misclassify an organization-list error as lack of access.

**Files Needing Attention:** vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx | Adds the organization membership and switch bridge; failed switching or organization-list loading can leave valid deep links unusable. |
| apps/leaf/src/ui/blocks.ts | Adds the URL-encoded organization identifier to generated approval-sheet links. |
| apps/leaf/src/internal/approvals/surfaces/slack/present.ts | Propagates each approval's organization identifier into dashboard links for new and persisted cards. |
| apps/leaf/src/internal/approvals/surfaces/slack/decide.ts | Preserves the approval row's organization identifier when rebuilding dashboard links after Slack decisions. |
| apps/leaf/src/internal/approvals/domain/approvalRecord.ts | Makes internal-admin approvals dashboard-linkable now that links identify their organization. |
| apps/leaf/tests/unit/approvals/dashboardLinkableApproval.test.ts | Updates linkability coverage to expect internal-admin approvals to receive dashboard links. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open approval dashboard link] --> B{Target org matches active org?}
  B -- Yes --> C[Fetch approval and seed sheet]
  B -- No --> D[Load operator organizations]
  D --> E{Target organization found?}
  E -- No --> F[Show error and remove deep-link parameters]
  E -- Yes --> G[Set active organization]
  G --> H{Switch succeeds?}
  H -- Yes --> I[Reload with parameters intact]
  I --> C
  H -- No --> J[Show switch error]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx:61
**Failed switch leaves dead link**

When `setActiveOrg` returns an error, `openedRef.current` has already been set and is never reset, so later effect runs cannot retry or clear the request. The operator remains in the wrong organization with an approval link that does nothing until the page or component reloads.

### Issue 2
vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx:62-65
**List errors look like denial**

When the organization-list request finishes with an error and no data, `organizations?.find` treats that result as proof that the operator lacks access. This displays an incorrect denial and removes the approval parameters, forcing an authorized operator to revisit the original link.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 internal admin approval cards de..."](https://github.com/useautumn/autumn/commit/f7e478d02db677db9c4b6951cc4dd42e55f18c9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55668091)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->