### PR TITLE
release

### DIFF
--- a/apps/leaf/src/internal/approvals/domain/approvalRecord.ts
+++ b/apps/leaf/src/internal/approvals/domain/approvalRecord.ts
@@ -138,8 +138,8 @@ const sheetSeedableCustomize = (customize: unknown) => {
 	);
 };
 
-/** Excludes internal admin threads (they hop orgs — the link would 403) and
- * requests the sheet cannot faithfully represent. */
+/** Excludes requests the sheet cannot faithfully represent; internal admin
+ * threads link too — the URL carries org_id and the dashboard switches org. */
 export const dashboardLinkableApproval = ({
 	approval,
 	groupedStepCount,
@@ -159,8 +159,6 @@ export const dashboardLinkableApproval = ({
 	return (
 		groupedStepCount === 0 &&
 		sheetSeedableCustomize(customize) &&
-		SHEET_LINKABLE_TOOLS.has(normalizeToolName(approval.tool_name)) &&
-		// The column is notNull, but test fixtures construct partial rows.
-		!isInternalAutumnSlackProvider({ provider: approval.provider ?? "" })
+		SHEET_LINKABLE_TOOLS.has(normalizeToolName(approval.tool_name))
 	);
 };

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -81,6 +81,7 @@ const approvalDashboardUrl = ({
 		approvalId: approval.id,
 		env: approval.env,
 		groupedStepCount: groupedWrites?.length ?? 0,
+		orgId: approval.org_id,
 		provider: approval.provider,
 		toolArgs: approval.tool_args as Record<string, unknown>,
 		toolName: approval.tool_name,

--- a/apps/leaf/src/internal/approvals/surfaces/slack/present.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/present.ts
@@ -22,6 +22,7 @@ export const dashboardUrlFor = ({
 	approvalId,
 	env,
 	groupedStepCount,
+	orgId,
 	provider,
 	toolArgs,
 	toolName,
@@ -29,6 +30,7 @@ export const dashboardUrlFor = ({
 	approvalId: string;
 	env: ChatApproval["env"];
 	groupedStepCount: number;
+	orgId: string;
 	provider: string;
 	toolArgs?: Record<string, unknown>;
 	toolName: string;
@@ -45,6 +47,7 @@ export const dashboardUrlFor = ({
 				approvalId,
 				customerId: requestStringField(toolArgs, "customer_id"),
 				env,
+				orgId,
 				planId: requestStringField(toolArgs, "plan_id"),
 				toolName,
 			})
@@ -74,6 +77,7 @@ export const postApprovalCardForRow = async ({
 				approvalId: approval.id,
 				env: approval.env,
 				groupedStepCount: grouped.length,
+				orgId: approval.org_id,
 				provider: approval.provider,
 				toolArgs,
 				toolName: approval.tool_name,
@@ -203,6 +207,7 @@ export const presentApproval = async ({
 		approvalId: created.approvalId,
 		env,
 		groupedStepCount: created.withheld.length,
+		orgId,
 		provider: installation.provider,
 		toolArgs: created.toolArgs,
 		toolName: created.toolName,

--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -1372,12 +1372,14 @@ export const approvalSheetUrl = ({
 	approvalId,
 	customerId,
 	env,
+	orgId,
 	planId,
 	toolName,
 }: {
 	approvalId: string;
 	customerId?: string;
 	env?: AppEnv;
+	orgId?: string;
 	planId?: string;
 	toolName: string;
 }) => {
@@ -1390,7 +1392,8 @@ export const approvalSheetUrl = ({
 			: normalizedToolName === "createSchedule"
 				? "sheet=create-schedule"
 				: "sheet=attach-product";
-	return `${base}/customers/${encodeURIComponent(customerId)}?${sheet}&approval_id=${encodeURIComponent(approvalId)}`;
+	const orgParam = orgId ? `&org_id=${encodeURIComponent(orgId)}` : "";
+	return `${base}/customers/${encodeURIComponent(customerId)}?${sheet}&approval_id=${encodeURIComponent(approvalId)}${orgParam}`;
 };
 
 const viewInDashboardButton = (url: string | null | undefined) =>

--- a/apps/leaf/tests/unit/approvals/dashboardLinkableApproval.test.ts
+++ b/apps/leaf/tests/unit/approvals/dashboardLinkableApproval.test.ts
@@ -90,7 +90,7 @@ describe("dashboardLinkableApproval", () => {
 		).toBe(false);
 	});
 
-	test("excludes grouped, unresolvable customize, internal, and non-sheet tools", () => {
+	test("excludes grouped, unresolvable customize, and non-sheet tools (internal admin links too)", () => {
 		expect(
 			dashboardLinkableApproval({
 				approval: { ...base, tool_name: "attach" },
@@ -121,7 +121,7 @@ describe("dashboardLinkableApproval", () => {
 				},
 				groupedStepCount: 0,
 			}),
-		).toBe(false);
+		).toBe(true);
 		expect(
 			dashboardLinkableApproval({
 				approval: { ...base, tool_name: "updateCatalog" },

--- a/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
+++ b/server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts
@@ -25,6 +25,7 @@ import { setupAttachProductContext } from "@/internal/billing/v2/actions/attach/
 import { setupAttachTransitionContext } from "@/internal/billing/v2/actions/attach/setup/setupAttachTransitionContext";
 import { setupStripeBillingContext } from "@/internal/billing/v2/providers/stripe/setup/setupStripeBillingContext";
 import { fetchStoredLineItemsForSubscriptionBilling } from "@/internal/billing/v2/setup/fetchStoredLineItemsForSubscriptionBilling";
+import { setupAnchorResetRefund } from "@/internal/billing/v2/setup/setupAnchorResetRefund";
 import { setupBillingCycleAnchor } from "@/internal/billing/v2/setup/setupBillingCycleAnchor";
 import { setupFeatureQuantitiesContext } from "@/internal/billing/v2/setup/setupFeatureQuantitiesContext";
 import { setupFullCustomerContext } from "@/internal/billing/v2/setup/setupFullCustomerContext";
@@ -309,6 +310,7 @@ export const setupImmediateMultiProductBillingContext = async ({
 		newFullProduct: firstProduct,
 		trialContext,
 		currentEpochMs,
+		requestedBillingCycleAnchor: params.billing_cycle_anchor,
 		billingStartsAt,
 		billingStartsAtToleranceMs,
 	});
@@ -376,6 +378,13 @@ export const setupImmediateMultiProductBillingContext = async ({
 		billingStartsAt,
 		subscriptionBackdateStartMs,
 		requestedProrationBehavior: params.billing_behavior,
+		requestedBillingCycleAnchor: params.billing_cycle_anchor,
+		// Multi-attach has no carry_over_balances param, so there is no reset
+		// cycle to round the refund to — only the no-partial-refund flag applies.
+		anchorResetRefund: setupAnchorResetRefund({
+			billingCycleAnchor: params.billing_cycle_anchor,
+			prorationBehavior: params.billing_behavior,
+		}),
 		stripeCustomer,
 		stripeSubscription,
 		stripeSubscriptionSchedule,

--- a/server/src/internal/billing/v2/actions/multiAttach/compute/computeMultiAttachPlan.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/compute/computeMultiAttachPlan.ts
@@ -4,6 +4,7 @@ import {
 	type MultiAttachBillingContext,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { applyBillingCycleAnchorToSharedSubscription } from "@/internal/billing/v2/compute/computeAutumnUtils/applyBillingCycleAnchorToSharedSubscription";
 import { computeImmediateMultiProductPlan } from "../../common/immediateMultiProduct/computeImmediateMultiProductPlan";
 
 /** Computes the atomic Autumn plan for every requested product. */
@@ -14,9 +15,18 @@ export const computeMultiAttachPlan = ({
 	ctx: AutumnContext;
 	multiAttachBillingContext: MultiAttachBillingContext;
 }): AutumnBillingPlan => {
-	const plan = computeImmediateMultiProductPlan({
-		ctx,
+	const plan = applyBillingCycleAnchorToSharedSubscription({
+		plan: computeImmediateMultiProductPlan({
+			ctx,
+			billingContext: multiAttachBillingContext,
+		}),
 		billingContext: multiAttachBillingContext,
+		stripeSubscriptionId:
+			multiAttachBillingContext.stripeSubscription?.id ??
+			multiAttachBillingContext.productContexts.find(
+				(productContext) =>
+					productContext.currentCustomerProduct?.subscription_ids?.[0],
+			)?.currentCustomerProduct?.subscription_ids?.[0],
 	});
 
 	// Lock the customer's currency on the first paid multi-attach (only when they

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachBillingCycleAnchorErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachBillingCycleAnchorErrors.ts
@@ -1,0 +1,50 @@
+import {
+	ErrCode,
+	isFutureStartDate,
+	isOneOffProduct,
+	type MultiAttachBillingContext,
+	RecaseError,
+} from "@autumn/shared";
+import { StatusCodes } from "http-status-codes";
+
+export const handleMultiAttachBillingCycleAnchorErrors = ({
+	billingContext,
+}: {
+	billingContext: MultiAttachBillingContext;
+}) => {
+	if (billingContext.requestedBillingCycleAnchor === undefined) return;
+
+	if (billingContext.trialContext?.trialEndsAt) {
+		throw new RecaseError({
+			message:
+				"billing_cycle_anchor cannot be used together with a free trial. The trial already controls the billing cycle start.",
+			code: ErrCode.InvalidRequest,
+			statusCode: StatusCodes.BAD_REQUEST,
+		});
+	}
+
+	if (
+		billingContext.fullProducts.every((product) => isOneOffProduct({ product }))
+	) {
+		throw new RecaseError({
+			message:
+				"billing_cycle_anchor is not supported when every plan is one-off. One-off plans do not have a recurring billing cycle.",
+			code: ErrCode.InvalidRequest,
+			statusCode: StatusCodes.BAD_REQUEST,
+		});
+	}
+
+	if (
+		isFutureStartDate(
+			billingContext.billingStartsAt,
+			billingContext.currentEpochMs,
+		)
+	) {
+		throw new RecaseError({
+			message:
+				"billing_cycle_anchor: 'now' cannot be used before the plans start",
+			code: ErrCode.InvalidRequest,
+			statusCode: StatusCodes.BAD_REQUEST,
+		});
+	}
+};

--- a/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
+++ b/server/src/internal/billing/v2/actions/multiAttach/errors/handleMultiAttachErrors.ts
@@ -9,6 +9,7 @@ import { handleRevertTrialErrors } from "@/internal/billing/v2/actions/attach/er
 import { handleProrationBehaviorErrors } from "@/internal/billing/v2/common/errors/handleBillingBehaviorErrors";
 import { handleSubscriptionIdErrors } from "@/internal/billing/v2/common/errors/handleSubscriptionIdErrors";
 import { handleStripeBillingPlanErrors } from "@/internal/billing/v2/providers/stripe/errors/handleStripeBillingPlanErrors";
+import { handleMultiAttachBillingCycleAnchorErrors } from "./handleMultiAttachBillingCycleAnchorErrors";
 import { handleMultiAttachCurrentProductErrors } from "./handleMultiAttachCurrentProductErrors";
 import { handleMultiAttachRedirectErrors } from "./handleMultiAttachRedirectErrors";
 import { handleMultiAttachStartDateErrors } from "./handleMultiAttachStartDateErrors";
@@ -37,6 +38,8 @@ export const handleMultiAttachErrors = async ({
 	});
 
 	handleRevertTrialErrors({ billingContext });
+
+	handleMultiAttachBillingCycleAnchorErrors({ billingContext });
 
 	// Subscription ID uniqueness
 	await handleSubscriptionIdErrors({

--- a/server/tests/integration/billing/multi-attach/multi-attach-billing-cycle-anchor.test.ts
+++ b/server/tests/integration/billing/multi-attach/multi-attach-billing-cycle-anchor.test.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "bun:test";
+import type { ApiCustomerV5, MultiAttachParamsV0Input } from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { expectBalanceCorrect } from "@tests/integration/utils/expectBalanceCorrect";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { addMonths } from "date-fns";
+
+test(`${chalk.yellowBright("multi-attach billing-cycle-anchor: 'now' resets the cycle for every plan on the subscription")}`, async () => {
+	const customerId = "ma-billing-cycle-anchor-now";
+
+	const pro = products.pro({
+		id: "pro",
+		group: "main",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+	const addOn = products.pro({
+		id: "add-on",
+		group: "addon",
+		items: [items.monthlyWords({ includedUsage: 200 })],
+	});
+
+	const { autumnV2_3, ctx, advancedTo } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro, addOn] }),
+		],
+		actions: [
+			s.billing.attach({ productId: pro.id }),
+			s.advanceTestClock({ days: 10 }),
+		],
+	});
+
+	const multiAttachParams: MultiAttachParamsV0Input = {
+		customer_id: customerId,
+		plans: [{ plan_id: addOn.id }],
+		billing_cycle_anchor: "now",
+	};
+
+	await autumnV2_3.billing.multiAttach(multiAttachParams);
+
+	const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+
+	await expectCustomerProducts({
+		customer,
+		active: [pro.id, addOn.id],
+	});
+
+	// The anchor reset moves the pre-existing plan's cycle too, not just the new one.
+	const resetAt = addMonths(advancedTo, 1).getTime();
+
+	await expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Messages,
+		remaining: 100,
+		usage: 0,
+		planId: pro.id,
+		nextResetAt: resetAt,
+	});
+	await expectBalanceCorrect({
+		customer,
+		featureId: TestFeature.Words,
+		remaining: 200,
+		usage: 0,
+		planId: addOn.id,
+		nextResetAt: resetAt,
+	});
+
+	await expectStripeSubscriptionCorrect({ ctx, customerId });
+});
+
+test(`${chalk.yellowBright("multi-attach billing-cycle-anchor: rejected alongside a free trial")}`, async () => {
+	const customerId = "ma-billing-cycle-anchor-trial";
+
+	const pro = products.pro({
+		id: "pro",
+		items: [items.monthlyMessages({ includedUsage: 100 })],
+	});
+
+	const { autumnV2_3 } = await initScenario({
+		customerId,
+		setup: [
+			s.customer({ paymentMethod: "success" }),
+			s.products({ list: [pro] }),
+		],
+		actions: [],
+	});
+
+	const trialParams: MultiAttachParamsV0Input = {
+		customer_id: customerId,
+		plans: [{ plan_id: pro.id }],
+		free_trial: { duration_length: 7 },
+		billing_cycle_anchor: "now",
+	};
+
+	const attachWithTrial = autumnV2_3.billing.multiAttach(trialParams);
+
+	expect(attachWithTrial).rejects.toThrow(/free trial/);
+});

--- a/shared/api/billing/attachV2/multiAttachParamsV0.ts
+++ b/shared/api/billing/attachV2/multiAttachParamsV0.ts
@@ -7,6 +7,7 @@ import { z } from "zod/v4";
 import { CustomerDataSchema } from "../../common/customerData";
 import { EntityDataSchema } from "../../common/entityData";
 import { BillingBehaviorSchema } from "../common/billingBehavior";
+import { ImmediateBillingCycleAnchorSchema } from "../common/billingCycleAnchor";
 import { InvoiceModeParamsSchema } from "../common/invoiceModeParams";
 import { RedirectModeSchema } from "../common/redirectMode";
 import { UnixMsTimestampSchema } from "../common/unixMsTimestamp";
@@ -91,6 +92,11 @@ export const MultiAttachParamsV0Schema = z.object({
 			"List of discounts to apply. Each discount can be an Autumn reward ID, Stripe coupon ID, or Stripe promotion code.",
 	}),
 	billing_behavior: BillingBehaviorSchema.optional(),
+
+	billing_cycle_anchor: ImmediateBillingCycleAnchorSchema.optional().meta({
+		description:
+			"Pass 'now' to reset the billing cycle of every plan on the subscription to the time of this request.",
+	}),
 
 	success_url: z.string().optional().meta({
 		description: "URL to redirect to after successful checkout.",

--- a/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
+++ b/vite/src/components/forms/attach-v2/components/AttachAdvancedSection.tsx
@@ -469,6 +469,7 @@ export function AttachAdvancedSection() {
 					customAnchor={billingCycleAnchorDate}
 					minUnixDate={endDateMin}
 					maxUnixDate={endDate ? endDate - 1_000 : undefined}
+					allowCustomAnchor={!isMultiPlan}
 					onEnabledChange={(enabled) => {
 						form.setFieldValue("resetBillingCycle", enabled);
 						if (enabled && billingCycleAnchorMode === "now") {

--- a/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
+++ b/vite/src/components/forms/attach-v2/context/AttachFormProvider.tsx
@@ -497,6 +497,7 @@ export function AttachFormProvider({
 		discounts,
 		currency: attachCurrency.requestCurrency,
 		startDate,
+		resetBillingCycle,
 		hasInvalidPlanScopes: additionalPlans.hasInvalidPlanScopes,
 	});
 	const billingOperation = isMultiPlan

--- a/vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts
+++ b/vite/src/components/forms/attach-v2/hooks/useAttachMultiRequestBody.ts
@@ -29,6 +29,7 @@ export type BuildAttachMultiRequestBodyParams = Pick<
 	| "discounts"
 	| "currency"
 	| "startDate"
+	| "resetBillingCycle"
 > & {
 	products: ProductV2[];
 	features: Feature[];
@@ -96,6 +97,7 @@ export function buildAttachMultiRequestBody({
 	discounts,
 	currency,
 	startDate,
+	resetBillingCycle,
 	hasInvalidPlanScopes = false,
 }: BuildAttachMultiRequestBodyParams): MultiAttachParamsV0 | null {
 	if (hasInvalidPlanScopes || !customerId || !product) return null;
@@ -159,6 +161,7 @@ export function buildAttachMultiRequestBody({
 		...(currency ? { currency: currency.toLowerCase() } : {}),
 		...(validDiscounts.length > 0 ? { discounts: validDiscounts } : {}),
 		...(startDate ? { starts_at: startDate } : {}),
+		...(resetBillingCycle ? { billing_cycle_anchor: "now" as const } : {}),
 	};
 }
 
@@ -186,6 +189,7 @@ export function useAttachMultiRequestBody(
 		discounts,
 		currency,
 		startDate,
+		resetBillingCycle,
 		hasInvalidPlanScopes,
 	} = params;
 	const requestBody = useMemo(
@@ -211,6 +215,7 @@ export function useAttachMultiRequestBody(
 				discounts,
 				currency,
 				startDate,
+				resetBillingCycle,
 				hasInvalidPlanScopes,
 			}),
 		[
@@ -234,6 +239,7 @@ export function useAttachMultiRequestBody(
 			discounts,
 			currency,
 			startDate,
+			resetBillingCycle,
 			hasInvalidPlanScopes,
 		],
 	);

--- a/vite/src/components/forms/shared/BillingCycleAnchorConfigRow.tsx
+++ b/vite/src/components/forms/shared/BillingCycleAnchorConfigRow.tsx
@@ -9,6 +9,7 @@ export function BillingCycleAnchorConfigRow({
 	customAnchor,
 	minUnixDate = Date.now(),
 	maxUnixDate,
+	allowCustomAnchor = true,
 	onEnabledChange,
 	onModeChange,
 	onCustomAnchorChange,
@@ -18,6 +19,7 @@ export function BillingCycleAnchorConfigRow({
 	customAnchor: number | null;
 	minUnixDate?: number;
 	maxUnixDate?: number;
+	allowCustomAnchor?: boolean;
 	onEnabledChange: (enabled: boolean) => void;
 	onModeChange: (mode: BillingCycleAnchorMode) => void;
 	onCustomAnchorChange: (anchor: number | null) => void;
@@ -36,7 +38,11 @@ export function BillingCycleAnchorConfigRow({
 	return (
 		<ConfigRow
 			title="Set Billing Cycle Anchor"
-			description="Restart the billing cycle now or on a future date"
+			description={
+				allowCustomAnchor
+					? "Restart the billing cycle now or on a future date"
+					: "Restart the billing cycle now"
+			}
 			expanded={enabled}
 			action={
 				<Switch
@@ -46,16 +52,18 @@ export function BillingCycleAnchorConfigRow({
 			}
 		>
 			<div className="space-y-2">
-				<GroupedTabButton
-					value={mode}
-					className="w-full"
-					onValueChange={handleModeChange}
-					options={[
-						{ value: "now", label: "Now" },
-						{ value: "custom", label: "Custom" },
-					]}
-				/>
-				{mode === "custom" && (
+				{allowCustomAnchor && (
+					<GroupedTabButton
+						value={mode}
+						className="w-full"
+						onValueChange={handleModeChange}
+						options={[
+							{ value: "now", label: "Now" },
+							{ value: "custom", label: "Custom" },
+						]}
+					/>
+				)}
+				{allowCustomAnchor && mode === "custom" && (
 					<DateInputUnix
 						unixDate={customAnchor}
 						setUnixDate={onCustomAnchorChange}

--- a/vite/src/components/forms/shared/utils/billingOptionRules.ts
+++ b/vite/src/components/forms/shared/utils/billingOptionRules.ts
@@ -80,7 +80,7 @@ function attachRules(state: BillingOptionState): BillingOptionRules {
 		carryOverUsages: show(!!state.hasCustomerEntitlements),
 		overrideLineItems: show(true),
 		newBillingSubscription: show(!!state.canChooseBillingCycle),
-		resetBillingCycle: show(singlePlanOnly && !!state.hasActiveSubscription),
+		resetBillingCycle: show(!!state.hasActiveSubscription),
 		skipBilling: show(singlePlanOnly),
 		resetUsage: HIDDEN,
 	};

--- a/vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx
+++ b/vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx
@@ -5,6 +5,8 @@ import { attachFormOverridesFromRequestBody } from "@/components/forms/attach-v2
 import { scheduleFormFromRequestBody } from "@/components/forms/create-schedule/utils/scheduleFormFromRequestBody";
 import { updateSubscriptionFormOverridesFromRequestBody } from "@/components/forms/update-subscription-v2/utils/updateSubscriptionFormOverridesFromRequestBody";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
+import { useListOrganizations, useSession } from "@/lib/auth-client";
+import { setActiveOrg } from "@/lib/orgSync";
 import { useApprovalSeedStore } from "../stores/useApprovalSeedStore";
 import { useApprovalDetailQuery } from "./useApprovalDetailQuery";
 import { useResolvedApprovalRequest } from "./useResolvedApprovalRequest";
@@ -28,6 +30,7 @@ export const useApprovalSheetFromUrl = ({
 }) => {
 	const [params, setParams] = useQueryStates({
 		approval_id: parseAsString,
+		org_id: parseAsString,
 		plan_id: parseAsString,
 		sheet: parseAsString,
 	});
@@ -36,14 +39,53 @@ export const useApprovalSheetFromUrl = ({
 	const openedRef = useRef(false);
 
 	const sheetType = isApprovalSheet(params.sheet) ? params.sheet : null;
+	const { data: session } = useSession();
+	const { data: organizations, isPending: organizationsPending } =
+		useListOrganizations();
+	const activeOrgId = session?.session.activeOrganizationId;
+	// Internal admin cards carry org_id: the link targets another org, so the
+	// session must switch before any org-scoped fetch can resolve.
+	const orgMismatch = Boolean(
+		params.org_id && activeOrgId && params.org_id !== activeOrgId,
+	);
 	const { approval, approvalError } = useApprovalDetailQuery({
-		approvalId: sheetType ? params.approval_id : null,
+		approvalId: sheetType && !orgMismatch ? params.approval_id : null,
 	});
 	const { resolved, resolutionFailed, resolutionPending } =
 		useResolvedApprovalRequest({ approval });
 
 	useEffect(() => {
 		if (!sheetType || openedRef.current) return;
+		if (orgMismatch) {
+			if (organizationsPending) return;
+			openedRef.current = true;
+			const target = organizations?.find(
+				(organization) => organization.id === params.org_id,
+			);
+			if (!target) {
+				toast.error(
+					"This approval belongs to an organization you don't have access to.",
+				);
+				void setParams({
+					approval_id: null,
+					org_id: null,
+					plan_id: null,
+					sheet: null,
+				});
+				return;
+			}
+			void setActiveOrg(target.id).then((result) => {
+				if (result.error) {
+					toast.error("Couldn't switch organization for this approval.");
+					return;
+				}
+				toast.info(`Switched to ${target.name} for this approval.`);
+				// Reload with the deep-link params intact — the flow resumes
+				// under the right org.
+				window.location.reload();
+			});
+			return;
+		}
 		if (params.approval_id && !approval && !approvalError) return;
 		if (resolutionPending) return;
 
@@ -88,10 +130,20 @@ export const useApprovalSheetFromUrl = ({
 					: "subscription-update";
 			setSheet({ type, itemId, data });
 		}
-		void setParams({ approval_id: null, plan_id: null, sheet: null });
+		void setParams({
+			approval_id: null,
+			org_id: null,
+			plan_id: null,
+			sheet: null,
+		});
 	}, [
+		activeOrgId,
 		approval,
 		approvalError,
+		organizations,
+		organizationsPending,
+		orgMismatch,
+		params.org_id,
 		params.approval_id,
 		params.plan_id,
 		resolutionFailed,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds org-aware approval deep links and supports resetting the billing cycle on multi-attach. Previously, internal admin cards had no dashboard link and multi-attach could not reset the cycle; now links switch to the approval’s org before loading, and multi-attach can anchor cycles to “now”.

- Internal admin approval cards: include optional org_id in dashboard URLs; switch the active org before any fetch, toast on success/failure, reload to resume, and clear deep-link params after opening. Internal-admin approvals are now linkable; non-internal links are unchanged.
- Multi-attach billing cycle anchor: accept billing_cycle_anchor: "now" to reset the subscription cycle for every attached plan and update entitlement reset dates; reject when combined with a free trial or when all plans are one-off. Dashboard shows “Reset billing cycle” for multi-plan attach (only “Now”); request bodies include billing_cycle_anchor when enabled.

<sup>Written for commit 757c7db3002dd131220e9d28588c19d1f1f669e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The release adds cross-organization dashboard links for internal Slack approvals and introduces billing-cycle-anchor support for multi-plan attachments.

- **[Improvements, Bug fixes]** Internal approval links now include the organization and switch the dashboard session before opening the approval.
- **[API changes, Improvements]** Multi-plan attach requests can reset the shared subscription billing cycle with `billing_cycle_anchor: "now"`.
- **[Improvements]** Dashboard attach forms expose the new billing-cycle-anchor option and serialize it into multi-attach requests.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because approval links can be consumed before the target organization is active, and a failed organization switch permanently prevents retry.

The organization mismatch check still becomes false while the session organization is undefined, allowing the approval request to run too early, while the switch path still marks the link as opened before the asynchronous switch succeeds and never resets that guard after failure.

**Files Needing Attention:** vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/approvals/hooks/useApprovalSheetFromUrl.tsx | Adds organization switching before opening approval links, but two previously reported state-handling failures remain. |
| apps/leaf/src/internal/approvals/surfaces/slack/present.ts | Propagates the approval organization into generated dashboard links. |
| apps/leaf/src/ui/blocks.ts | Adds an optional encoded organization identifier to approval-sheet URLs. |
| shared/api/billing/attachV2/multiAttachParamsV0.ts | Extends the multi-attach API with the immediate billing-cycle-anchor option. |
| server/src/internal/billing/v2/actions/common/immediateMultiProduct/setupImmediateMultiProductBillingContext.ts | Threads the requested anchor and anchor-reset refund configuration into multi-product billing context. |
| server/src/internal/billing/v2/actions/multiAttach/compute/computeMultiAttachPlan.ts | Applies a requested billing-cycle reset across plans sharing the target subscription. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Slack
  participant Dashboard
  participant Session
  participant ApprovalAPI
  Slack->>Dashboard: Open approval URL with org_id
  Dashboard->>Session: Read active organization
  alt Target organization differs
    Dashboard->>Session: Switch active organization
    Session-->>Dashboard: Switch result
    Dashboard->>Dashboard: Reload with link parameters
  end
  Dashboard->>ApprovalAPI: Fetch organization-scoped approval
  ApprovalAPI-->>Dashboard: Approval details
  Dashboard->>Dashboard: Seed and open billing sheet
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge pull request #2986 from useautumn/..."](https://github.com/useautumn/autumn/commit/757c7db3002dd131220e9d28588c19d1f1f669e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55674017)</sub>

**Context used:**

- Knowledge Base — [Leaf: Autumn's AI Agent Service](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/leaf-agent-app.md)
- Knowledge Base — [Billing Domain: Customers, Products, Features, Entitlements](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/server-billing-domain.md)

<!-- /greptile_comment -->