### PR TITLE
fix(capy): recover reused branches and persist logs

### DIFF
--- a/scripts/capy/command.ts
+++ b/scripts/capy/command.ts
@@ -1,4 +1,11 @@
-import { join } from "node:path";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	ensureEmulateRunning,
@@ -14,6 +21,91 @@ import { spawnDevInTmux, tmuxSessionExists } from "../dw/helpers/tmux.ts";
 const SCRIPT_DIR = fileURLToPath(new URL(".", import.meta.url));
 const REPO_ROOT = join(SCRIPT_DIR, "..", "..");
 const CAPY_SESSION = "capy";
+const CAPY_PREFIX =
+	process.env.CAPY_PREFIX ??
+	join(process.env.HOME ?? "/home/user", ".autumn-capy");
+
+type CapyLogPaths = {
+	startup: string;
+	app: string;
+};
+
+function capyLogPaths({
+	prefix = CAPY_PREFIX,
+}: {
+	prefix?: string;
+} = {}): CapyLogPaths {
+	return {
+		startup: join(prefix, "startup.log"),
+		app: join(prefix, "app.log"),
+	};
+}
+
+function readLog(path: string): string | undefined {
+	if (!existsSync(path)) return undefined;
+	return readFileSync(path, "utf-8");
+}
+
+function logSection({
+	title,
+	path,
+	contents,
+}: {
+	title: string;
+	path: string;
+	contents: string;
+}): string {
+	return `=== ${title}: ${path} ===\n${contents.trimEnd() || "(empty)"}`;
+}
+
+function capyLogsText({
+	paths,
+	captureTmuxLogs,
+}: {
+	paths: CapyLogPaths;
+	captureTmuxLogs?: () => string | undefined;
+}): string {
+	const sections: string[] = [];
+	const startupLog = readLog(paths.startup);
+	if (startupLog !== undefined) {
+		sections.push(
+			logSection({
+				title: "Startup log",
+				path: paths.startup,
+				contents: startupLog,
+			}),
+		);
+	}
+
+	const appLog = readLog(paths.app);
+	if (appLog !== undefined) {
+		sections.push(
+			logSection({
+				title: "App log",
+				path: paths.app,
+				contents: appLog,
+			}),
+		);
+	} else {
+		const tmuxLogs = captureTmuxLogs?.();
+		if (tmuxLogs !== undefined) {
+			sections.push(
+				logSection({
+					title: "App log (tmux fallback)",
+					path: CAPY_SESSION,
+					contents: tmuxLogs,
+				}),
+			);
+		}
+	}
+
+	if (sections.length > 0) return sections.join("\n\n");
+	return [
+		"No Capy logs found.",
+		`Startup log: ${paths.startup}`,
+		`App log: ${paths.app}`,
+	].join("\n");
+}
 
 function ensureBunGlobalBin(): void {
 	const bin =
@@ -84,10 +176,18 @@ function ensureAppProcess(): void {
 		CAPY_DEV: "1",
 		VITE_BACKEND_URL: "/__autumn_api",
 	} as Record<string, string>;
+	const { app: appLog } = capyLogPaths();
+	mkdirSync(dirname(appLog), { recursive: true, mode: 0o700 });
+	writeFileSync(appLog, "", { mode: 0o600 });
+	chmodSync(appLog, 0o600);
 	spawnDevInTmux(
 		CAPY_SESSION,
 		env,
-		["bun", "scripts/dev.ts", "--worktree", "1"],
+		[
+			"bash",
+			"-lc",
+			`set -o pipefail; bun scripts/dev.ts --worktree 1 2>&1 | tee -a '${appLog.replace(/'/g, "'\\''")}'`,
+		],
 		REPO_ROOT,
 	);
 }
@@ -105,11 +205,15 @@ export function cmdCapyStatus(): void {
 }
 
 export function cmdCapyLogs(): void {
-	const res = sh("tmux", ["capture-pane", "-pt", CAPY_SESSION]);
-	if (res.code !== 0) {
-		fatal(`capy logs unavailable: ${res.stderr || res.stdout}`);
-	}
-	console.log(res.stdout);
+	console.log(
+		capyLogsText({
+			paths: capyLogPaths(),
+			captureTmuxLogs: () => {
+				const res = sh("tmux", ["capture-pane", "-pt", CAPY_SESSION]);
+				return res.code === 0 ? res.stdout : undefined;
+			},
+		}),
+	);
 }
 
 export function cmdCapyStop(): void {

--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -703,9 +703,7 @@ async function main(): Promise<void> {
 		trigger.accessToken,
 	);
 
-	if (created) {
-		runSetupTest(["--yes"], directUrl);
-	}
+	runSetupTest(["--ensure"], directUrl);
 	runSetupTest(["--ensure-key"], directUrl);
 
 	log(

--- a/scripts/setup/CAPY_README.md
+++ b/scripts/setup/CAPY_README.md
@@ -96,6 +96,18 @@ The script writes managed values into:
 The Bun preload in `scripts/preload-env.ts` loads those files for direct commands,
 so Capy does not need Infisical for the local stack.
 
+## Logs
+
+Startup appends all output to `~/.autumn-capy/startup.log` (or
+`$CAPY_PREFIX/startup.log` when `CAPY_PREFIX` is set). Each run has a UTC
+delimiter, including failures before tmux or the application starts. The app
+process writes to `~/.autumn-capy/app.log` (or `$CAPY_PREFIX/app.log`), which is
+truncated only when a new app session launches. Both files are mode `0600`.
+
+Use `bun capy logs` to print the Startup log followed by the app log. It works
+after a Startup failure before the tmux session exists; when `app.log` is absent,
+it uses tmux's capture pane only as a fallback.
+
 ## Troubleshooting
 
 Inspect local infrastructure with:

--- a/scripts/setup/capy-startup.sh
+++ b/scripts/setup/capy-startup.sh
@@ -13,6 +13,16 @@
 #     attached to a long-running process.
 set -euo pipefail
 
+CAPY_PREFIX="${CAPY_PREFIX:-$HOME/.autumn-capy}"
+export CAPY_PREFIX
+STARTUP_LOG="$CAPY_PREFIX/startup.log"
+umask 077
+mkdir -p "$CAPY_PREFIX"
+touch "$STARTUP_LOG"
+chmod 600 "$STARTUP_LOG"
+printf '\n===== Capy Startup %s UTC =====\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$STARTUP_LOG"
+exec > >(tee -a "$STARTUP_LOG") 2> >(tee -a "$STARTUP_LOG" >&2)
+
 log() { echo "[capy-startup] $*"; }
 die() { echo "[capy-startup] ERROR: $*" >&2; exit 1; }
 
@@ -46,9 +56,7 @@ fi
 
 cd "$REPO_ROOT"
 
-CAPY_PREFIX="${CAPY_PREFIX:-$HOME/.autumn-capy}"
 TRIGGER_ENV="$CAPY_PREFIX/trigger.env"
-mkdir -p "$CAPY_PREFIX"
 
 if [ ! -f "$TRIGGER_ENV" ]; then
   log "minting per-machine Trigger.dev secrets"


### PR DESCRIPTION
## Summary
- ensure `unit-test-org` exists before repairing its secret key on every fresh or reused Neon branch
- persist complete Startup/provision output to a private append-only per-machine log, including failures before tmux starts
- persist app output separately and make `bun capy logs` show both durable logs without requiring a live tmux session
- document the diagnostic paths and fallback behavior

## Verification
- `bunx biome check scripts/capy/provision.ts scripts/capy/command.ts`
- `bunx --package=@typescript/native-preview@7.0.0-dev.20260511.1 tsgo --build --noEmit scripts/tsconfig.json`
- `bash -n scripts/setup/capy-startup.sh`
- `git diff --check`
- manual temporary-prefix `bun capy logs` verification for ordered Startup and app sections

No Docker, Neon, full lifecycle, or test-suite runs were performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persistes Capy Startup and app logs and makes bun capy logs work without a live tmux session. Also always ensures the `unit-test-org` and its secret key when provisioning reused Neon branches to avoid drift.

- Startup now appends all output (including pre-tmux failures) to ~/.autumn-capy/startup.log; each run adds a UTC delimiter; file mode is 0600 and location can be changed via CAPY_PREFIX.
- The app process tees stdout/stderr to ~/.autumn-capy/app.log (0600) and truncates it only on a new app session.
- bun capy logs prints the Startup log then the app log; if app.log is missing, it falls back to tmux capture.
- Provisioning runs --ensure unconditionally, then --ensure-key, so reused branches repair org existence and key consistently.
- Docs updated with log paths and fallback behavior.

<sup>Written for commit a60f49b84d1dd8fccca2a51dabdf5d6fcbf68341. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR repairs the test organization on both fresh and reused Capy branches and adds durable startup and application logs.
- **Bug fixes:** Ensure the test organization exists before repairing its secret key on every provision run.
- **Improvements:** Persist startup and app output under the Capy prefix and allow `bun capy logs` to work without a live tmux session.
- **Improvements:** Document durable log locations, permissions, truncation, and tmux fallback behavior.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking logging issue where final or concurrent startup messages may be delayed or reordered.

The branch-recovery and app-log changes follow their surrounding contracts, while startup output is copied by two asynchronous writers that are not joined before the launcher continues.

**Files Needing Attention:** scripts/setup/capy-startup.sh

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/command.ts | Adds private durable app logging and combines startup/app output with a tmux fallback. |
| scripts/capy/provision.ts | Ensures the test organization exists before applying its configured secret key on every branch. |
| scripts/setup/capy-startup.sh | Adds private append-only startup logging, but separate asynchronous writers can delay or reorder the durable output. |
| scripts/setup/CAPY_README.md | Documents the new log paths, permissions, lifecycle, and fallback behavior. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Start[Capy command] --> Startup[Run capy-startup.sh]
  Startup --> StartupLog[(startup.log)]
  Startup --> Provision[Provision branch and test organization]
  Provision --> App[Launch app in tmux]
  App --> AppLog[(app.log)]
  Logs[bun capy logs] --> StartupLog
  Logs --> AppLog
  AppMissing{app.log absent?} -->|Yes| Tmux[Capture tmux pane]
  Tmux --> Logs
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/setup/capy-startup.sh:24
**Asynchronous startup log writers**

Stdout and stderr are appended by two independent `tee` processes that are not joined before the synchronous startup process exits. Concurrent messages can therefore be reordered, and an immediate provisioning failure can leave the final diagnostic temporarily absent when `bun capy logs` runs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve capy boot diagnostics"](https://github.com/useautumn/autumn/commit/a60f49b84d1dd8fccca2a51dabdf5d6fcbf68341) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55692077)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->