### PR TITLE
fix: reset drizzle schema on Neon template

### DIFF
--- a/scripts/dw/helpers/neon.ts
+++ b/scripts/dw/helpers/neon.ts
@@ -227,7 +227,7 @@ export function ensureTemplateBranch(): void {
 	// Wipe the inherited schema so children start truly empty.
 	const url = connectionString(NEON_TEMPLATE_BRANCH);
 	const reset = sh("psql", [url, "-v", "ON_ERROR_STOP=1"], {
-		stdin: `DROP SCHEMA IF EXISTS public CASCADE;\nCREATE SCHEMA public;\nCREATE EXTENSION IF NOT EXISTS pg_trgm;\n`,
+		stdin: `DROP SCHEMA IF EXISTS drizzle CASCADE;\nDROP SCHEMA IF EXISTS public CASCADE;\nCREATE SCHEMA public;\nCREATE EXTENSION IF NOT EXISTS pg_trgm;\n`,
 	});
 	if (reset.code !== 0) {
 		fatal(`failed to reset ${NEON_TEMPLATE_BRANCH}:\n${reset.stderr}`);


### PR DESCRIPTION
Reset the `drizzle` schema alongside `public` when recreating the shared Neon template branch. This removes the inherited `__drizzle_migrations` journal so forked machine branches apply migrations against the newly empty database.

Verification:
- `bunx biome check scripts/dw/helpers/neon.ts`
- `git diff --check`
- commit hook Knip check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets the Neon template by dropping the `drizzle` schema in addition to `public`, preventing inherited `__drizzle_migrations` from leaking into forks. Previously we only dropped `public`; now we drop `drizzle` and `public`, then recreate `public` and `pg_trgm`, so forked branches apply migrations to an empty database.

- Affects only `scripts/dw/helpers/neon.ts`; idempotent via `DROP SCHEMA IF EXISTS ... CASCADE`.
- Verify: `bunx biome check scripts/dw/helpers/neon.ts`, `git diff --check`, commit hook Knip check.

<sup>Written for commit e1447d6c48577d2878318afdff0ce72f64faa903. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes Neon template recreation by clearing Drizzle's inherited migration journal along with the application schema.

- **[Bug fixes]** Drops the `drizzle` schema before resetting `public`, ensuring newly forked machine branches apply all migrations to the empty database.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The reset removes only Drizzle's migration journal, and every reachable child-branch flow immediately recreates that journal and applies migrations in bootstrap mode against an empty database.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/dw/helpers/neon.ts | Safely extends template cleanup to remove the stale Drizzle migration journal; downstream migration flows recreate it using bootstrap mode. |

<sub>Reviews (1): Last reviewed commit: ["fix: drop drizzle schema from template r..."](https://github.com/useautumn/autumn/commit/e1447d6c48577d2878318afdff0ce72f64faa903) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55705668)</sub>

<!-- /greptile_comment -->