### PR TITLE
Research: event stream as source of truth for customer balances

### DIFF
--- a/.plans/event-stream-balance-sot.md
+++ b/.plans/event-stream-balance-sot.md
@@ -2,6 +2,8 @@
 
 Research note. Not an implementation plan. The goal is to decide *what* would have to be true for an event stream to replace Redis as the durability source of truth, without pretending deduction is a simple decrement.
 
+Design target that landed later in the discussion: **up to ~1M events/s ingest**, plus **real-time remaining reads** (check ~50ms) on our infra. That split is worked in §15.
+
 Related existing work in this repo:
 
 - [check-reserve/01_mutation_logs.md](./check-reserve/01_mutation_logs.md) — mutation receipts + Redis Streams as the durability path for Postgres sync
@@ -552,73 +554,109 @@ If we had instead loaded Postgres remaining and replayed the original 40 *tracks
 
 ---
 
-## 15. Better fit for this stack: wallet WAL, not worker-served remaining
+## 15. 1M events/s changes the ingest path, not the read path
 
-If the requirements are **high track QPS** and **real-time remaining on our infra** (check, check+track, `customers.get` balances), I would not put a balance worker on the read/write path.
+A million events a second cannot land on request-path Lua. It also cannot land on today's async track: `runAsyncTrack` → SQS → `runQueuedTrack` → `runTrackV3` still runs **one full deduction per event**. SQS will not take 1M/s, and one Lua waterfall per event will not either.
 
-I would keep Redis as the serving layer and make a **fact WAL** the durability SoT. Recovery is still `snapshot(S) + tail`. The "worker" is Redis Lua, which we already run. Postgres and Tinybird stay projectors.
+At that number the user is right: **the ingest SoT is an event stream** (Kafka / Redpanda / WarpStream class). Redis is the remaining serving layer. Workers come back — as **batch appliers**, not as the thing check calls.
 
 ```text
-check / track / lock
+1M/s track (async, default cap)
         │
         ▼
-Redis Lua          apply + XADD facts in one script
+event log          durable ingest (intents)
         │
-        ├── hashes ──► real-time reads (existing replica pool)
+        ├──► Tinybird / Neon          analytics at ingest rate
         │
-        └── fact WAL (Redis Streams, relayed to Kafka/Redpanda if we want)
-                ├──► Postgres projector   dashboard, billing, snapshot(S)
-                └──► Tinybird / Neon      analytics
+        └──► apply workers            coalesce 50–200ms by customer + credit graph
+                    │
+                    ▼
+              Redis remaining         real-time check / customers.get
+                    │
+                    └──► Postgres     watermarked snapshot(S)
+
+check / reject / lock  (<< 1M/s)
+        └──► Redis wallet (sync). Do not put this on the firehose.
 ```
 
-That is how a database is built: pages for reads, WAL for durability, replicas for QPS. We already have the pages and the replica reads. We are missing the WAL.
+This is the split we already started (`overage_behavior` defaults to `cap`; `runAsyncTrack` returns 202 and shards a customer across 8 groups). The upgrade is: real log instead of SQS, and **sum-then-apply** instead of Lua-per-message.
 
-### 15.1 Why this matches the two constraints
+### 15.1 Why 1M Lua applies/s is not a thing
 
-**Real-time reads.** `getCachedFullSubject`, partial subjects, and `getCachedFeatureBalances` already go through `useReadPool: true`. Check's SLO is ~50ms and it fail-opens when Redis is down. A worker that *owns* remaining forces every check onto sticky routing, a warm snapshot, and a process hop. Kafka Streams interactive queries and "ask the customer partition owner" are the slow way to serve a point read we already serve from a Redis replica.
+A full `deductFromSubjectBalances` is not an `INCR`. It reads several hashes, runs two passes + rollovers + windows + epoch + JSON. Call it ~1ms of Redis CPU as a generous floor.
 
-**High throughput.** Lua on a cluster slot is a good apply engine for this shape: no extra network mid-apply, pipelined hash reads, different credit graphs can proceed on different key sets. A customer-partitioned worker serializes *all* of that customer's features, including ones that do not share a credit graph, and adds enqueue + ownership + cold-start. Streams are excellent at *fan-out* of facts after apply (Tinybird, PG, webhooks). They are a bad place to *serve* remaining.
+1M × 1ms = 1000 Redis-seconds per wall second. That is a thousand hot shards doing nothing else, before credit-graph coupling and hot customers. Request-path "apply + XADD in Lua" was the right design for today's QPS. It is the wrong ingest design at 1M/s.
 
-**Replay.** Identical to the worker-death story. Redis evicted or a node died: load watermarked Postgres remaining at `S`, fold WAL `(S, tip]`, write hashes, resume. We do not need a new actor to get that.
+A log *is* the thing that takes 1M/s: sequential append, partitioned, batched produce from the API (202). Tinybird/ClickHouse can ingest that with enough partitions. Redis hashes cannot be the place 1M events *arrive*.
 
-### 15.2 What I would not use this constraint set to justify
+### 15.2 Batch apply is the only way the allocator survives
 
-| Approach | Why it loses here |
-| --- | --- |
-| Balance workers serve check/track | Extra hop, coarser serialization, cold-start replay on the SLO path |
-| Tinybird / CH as remaining | OLAP, no reject isolation, ingest lag |
-| Postgres as apply | Already the fallback. Kills the 50ms path. |
-| Intent stream as SoT | Replay is the allocator, not addition |
-| TigerBeetle / new ledger DB | Simple transfers, not a waterfall allocator. New infra, same apply problem in front of it |
+Workers consume the log, keyed by `org + env + customer` (credit graph, not feature). Every 50–200ms they fold the window:
 
-Workers are still the right *projector* (the thing that folds facts into Postgres). They should not be the thing the API calls for remaining.
+```text
+50 tracks of messages, values 1,1,3,...  →  one deduct(47) on that snapshot
+```
 
-### 15.3 When I *would* move apply off Redis
+Then one Lua (or one TS apply) writes Redis remaining and emits **one fact** (or one fact per bucket) for that window.
 
-Only if Redis itself is the problem: Lua/SQL/TS drift, multi-region lock owners, 10k-entity subject blobs, cost. That is a serving-layer rewrite. It is not required for "we need a log we can replay" or for Tinybird to stop being a second write path.
+That is how 1M intents become far fewer remaining mutations — **if** traffic is Pareto (a few customers produce most events). LLM/API metering usually is.
 
-If we do it later, I would still keep a Redis (or similar) **read cache** in front of the worker. High QPS real-time reads and single-writer apply want different hardware. We already split that (write on primary, read on replica pool). A worker that is both is a regression.
+If the 1M is 1M distinct customers × 1 event, batching does not reduce apply count. Then the current waterfall cannot be the apply engine at all. Remaining has to become a cheaper counter (or apply is allowed to lag and check is stale by seconds). That is a product constraint, not just an infra one.
 
-### 15.4 What this changes vs today's mental model
+Property-filtered usage windows and per-event credit costs (AI tokens) also break naive summing. The worker has to bucket by the dimensions the allocator actually keys on, not only `feature_id`.
 
-Say "the WAL is the SoT, Redis remaining is a serving projection we apply into synchronously." Do not say "the event stream is the SoT, and we read remaining from it."
+### 15.3 Two SoTs, on purpose
 
-We never serve remaining from the stream, same way Postgres does not answer `SELECT` by scanning `pg_wal`. The stream exists so Redis can die.
+At 1M/s you do not get one log that is both "every intent" and "every bucket delta" unless you like 1M fat facts/s.
 
-The existing mutation-log plan is this architecture. The missing pieces are: `XADD` in Lua, stop snapshot-flushing Postgres, watermark PG remaining, relay the same WAL to Tinybird, emit grant/reset facts onto it.
+| Log | Rate | Role |
+| --- | --- | --- |
+| Intent stream | 1M/s | SoT for "this usage happened." Tinybird, replay of *usage*, billing meter |
+| Fact / apply log | apply rate after coalesce | SoT for remaining deltas. Replay of *wallet*. Watermarks Postgres + Redis |
+
+Worker dies: `snapshot(S)` from Postgres/Redis checkpoint + fold **apply facts** after `S`. Do not replay 86B intents/day through the allocator.
+
+Redis dies: same. Rebuild hashes from snapshot + apply-fact tail. The intent stream is how we prove usage; it is not how we rebuild remaining.
+
+### 15.4 Real-time reads stay on Redis
+
+Check still hits the replica pool. Workers **write** Redis; they do not **serve** check. That keeps the 50ms path.
+
+Remaining is only as fresh as the coalesce window (50–200ms) plus worker lag. That is the price of 1M/s. For `cap` / async track that is the contract we already have (202, apply later). For `reject` / lock / `send_event` check, keep the sync Redis path and **do not promise 1M/s of those**.
+
+Putting reject on the firehose means either overspend (apply later) or a 1M/s sync wallet (no).
+
+### 15.5 What this is not
+
+- Not "SQS but bigger." FIFO + one `runTrackV3` per message is the current async path. It will not grow 3–4 orders of magnitude.
+- Not Redis Streams as the 1M/s bus. Fine as a per-customer apply WAL. Wrong as the global ingest log (memory, fan-out, Tinybird).
+- Not Tinybird as remaining. Still OLAP.
+- Not genesis replay of intents. Checkpoints are mandatory at this rate.
+
+### 15.6 Revised recommendation
+
+1. **Ingest:** event stream at 1M/s. API acks from the log (async track). Tinybird consumes this.
+2. **Apply:** partitioned workers, coalesce, one deduct per window, write Redis remaining, append compact facts.
+3. **Read:** Redis replica pool for check / balances. Never serve remaining from the stream.
+4. **Recover:** watermarked Postgres (or hash dump) + apply-fact tail.
+5. **Sync wallet:** reject/lock stay on Redis, small QPS, separate from the firehose.
+
+The mutation-log plan is still the apply/recovery side. It is no longer the ingest side.
 
 ---
 
 ## 16. Bottom line
 
-The instinct is right: **remaining should be a fold of a durable log; Redis/Postgres/Tinybird should be projections; apply should be a single writer that holds a snapshot.** Worker death (or Redis death) is `snapshot(S) + fold(facts after S)`, and Postgres is a good place to keep `snapshot(S)` once it has a watermark.
+At **1M events/s** the ingest SoT is an event stream. Request-path Redis Lua cannot be where those events arrive. Today's async track (SQS → one `runTrackV3` each) cannot either.
 
-For *this* stack — high track QPS plus 50ms remaining reads — I would not introduce balance workers on the request path. I would add a **fact WAL behind the Redis we already serve from**. Redis Lua stays the apply engine and the real-time read layer. The WAL is what we replay. Postgres and Tinybird consume it.
+The serving split that fits both 1M/s and 50ms remaining reads:
 
-The first-idea version is wrong in three places:
+- Stream: durable intents, Tinybird, 202 ingest.
+- Workers: coalesce a window, one apply, write Redis, emit compact facts.
+- Redis: real-time check/balances (replica pool). Workers write it; check does not call workers.
+- Postgres: watermarked `snapshot(S)` for Redis/worker death.
+- Reject/lock: stay on a sync Redis wallet at much smaller QPS.
 
-1. It treats today's track events as that log. They are intents. Remaining needs facts, and also grant/reset/shape facts we do not emit. Replay is addition of deltas, not re-running deduction.
-2. It puts Tinybird on the SoT path. Tinybird is a projector. Worker recovery does not read it.
-3. It under-specifies apply. Check/reject/lock cannot wait on an eventually consistent worker unless that worker *is* the synchronous owner of the customer — and even then, that is the wrong serving layer for our read SLO.
+Recovery is still `snapshot(S) + fold(apply facts after S)`. Do not rebuild remaining by replaying a day of intents through the allocator.
 
-We already have the allocator, the mutation receipt shape, the subject epoch fence, the replica read pool, and a written plan to stream those receipts. The missing piece is the WAL, not a new fleet of snapshot owners.
+The first-idea version is still wrong if it (1) replays track intents as if they were remaining deltas, (2) serves check from Tinybird, or (3) puts reject on the firehose. It is right that the firehose is a stream, not Redis.

--- a/.plans/event-stream-balance-sot.md
+++ b/.plans/event-stream-balance-sot.md
@@ -633,30 +633,46 @@ Putting reject on the firehose means either overspend (apply later) or a 1M/s sy
 - Not Tinybird as remaining. Still OLAP.
 - Not genesis replay of intents. Checkpoints are mandatory at this rate.
 
-### 15.6 Revised recommendation
+### 15.6 Redis is not the source of truth
 
-1. **Ingest:** event stream at 1M/s. API acks from the log (async track). Tinybird consumes this.
-2. **Apply:** partitioned workers, coalesce, one deduct per window, write Redis remaining, append compact facts.
-3. **Read:** Redis replica pool for check / balances. Never serve remaining from the stream.
-4. **Recover:** watermarked Postgres (or hash dump) + apply-fact tail.
-5. **Sync wallet:** reject/lock stay on Redis, small QPS, separate from the firehose.
+This needs to be unambiguous, because "check still reads Redis" is easy to hear as "Redis is still SoT."
 
-The mutation-log plan is still the apply/recovery side. It is no longer the ingest side.
+| Role | Where | If it disappears |
+| --- | --- | --- |
+| Source of truth | Event stream (intents at ingest; apply facts at coalesce rate) | We are down. Nothing else can reconstruct. |
+| Serving projection | Redis remaining hashes (or worker memory) | Rebuild: `snapshot(S) + fold(facts after S)`. Check is stale or fail-opens until rebuilt. |
+| Checkpoint | Postgres remaining + `subject_seq` | Rebuild from an older snapshot + a longer tail. Slower failover, not data loss. |
+| Analytics | Tinybird | Re-consume the intent stream. |
+
+Redis must not be in the durability path for 1M/s. Events do not land there. A successful track is "appended to the log," not "Lua returned OK." Remaining in Redis is a cache of the fold, same as a Kafka Streams state store: discardable, rebuildable, never the copy you are afraid to lose.
+
+That is the opposite of today, where Redis hashes *are* the copy we are afraid to lose and Postgres/Tinybird try to catch up.
+
+Reject/lock can still *read* the Redis projection for a 50ms decision. The decision becomes durable only when the resulting fact is on the stream. If Redis is empty, the owner rebuilds from the stream first — it does not treat empty hashes as "full balance" (today's cache-miss rebuild-from-Postgres bug).
+
+### 15.7 Revised recommendation
+
+1. **SoT:** event stream. 1M/s intents land here. API acks from the log.
+2. **Apply:** partitioned workers consume the log, coalesce, deduct once, append compact facts, *then* refresh the serving projection.
+3. **Serve:** Redis (or equivalent) for check / balances. Workers write it. Check does not call the stream. Losing Redis is a cache miss, not a ledger miss.
+4. **Checkpoint:** watermarked Postgres so rebuild tails stay short.
+5. **Sync reject/lock:** small QPS, may read the projection, must commit on the stream. Not 1M/s.
+
+The mutation-log plan is the apply-fact side of this ledger. It is not permission to keep Redis as SoT.
 
 ---
 
 ## 16. Bottom line
 
-At **1M events/s** the ingest SoT is an event stream. Request-path Redis Lua cannot be where those events arrive. Today's async track (SQS → one `runTrackV3` each) cannot either.
+**Redis is not the source of truth.** It cannot be, at 1M events/s. The stream is. Redis is a serving projection of remaining: fast to read, legal to drop, rebuilt with `snapshot(S) + fold(facts after S)`.
 
-The serving split that fits both 1M/s and 50ms remaining reads:
+Today we have that backwards. Hashes are the copy we cannot lose; Postgres and Tinybird chase them.
 
-- Stream: durable intents, Tinybird, 202 ingest.
-- Workers: coalesce a window, one apply, write Redis, emit compact facts.
-- Redis: real-time check/balances (replica pool). Workers write it; check does not call workers.
-- Postgres: watermarked `snapshot(S)` for Redis/worker death.
-- Reject/lock: stay on a sync Redis wallet at much smaller QPS.
+At 1M/s:
 
-Recovery is still `snapshot(S) + fold(apply facts after S)`. Do not rebuild remaining by replaying a day of intents through the allocator.
+- Events land on the log. API acks the log. Tinybird consumes the log.
+- Workers fold the log into remaining and refresh Redis.
+- Check reads Redis because it is a cache, not because it is the ledger.
+- Reject/lock may read that cache; they commit on the stream.
 
-The first-idea version is still wrong if it (1) replays track intents as if they were remaining deltas, (2) serves check from Tinybird, or (3) puts reject on the firehose. It is right that the firehose is a stream, not Redis.
+Do not replay a day of intents through the allocator to rebuild remaining. Do not serve check from Tinybird. Do not put 1M/s reject on the firehose. Do not treat a Redis miss as "recompute from current Postgres balances" with no watermark.

--- a/.plans/event-stream-balance-sot.md
+++ b/.plans/event-stream-balance-sot.md
@@ -431,14 +431,135 @@ This is the user's sketch. It is phase 5, not phase 1.
 
 ---
 
-## 14. Bottom line
+## 14. Worker death and replay
 
-The instinct is right: **remaining should be a fold of a durable log; Redis/Postgres/Tinybird should be projections; apply should be a single writer that holds a snapshot.**
+Yes. If the stream is the durability SoT, a dead worker is not an incident. It is "load a snapshot, fold the tail, resume." The snapshot can live in Postgres. The trap is *what* you fold, and *from which starting remaining*.
+
+### 14.1 The only replay formula that works
+
+```text
+snapshot(S)  +  fold(facts where subject_seq > S)  =  remaining
+```
+
+`S` is a watermark: a stream offset, Redis Stream ID, or per-customer `subject_seq`. The snapshot and `S` must be captured together. A remaining vector without a watermark is not a snapshot. It is a rumor.
+
+You almost never replay from customer creation on the hot path. Genesis replay is for audit, backfill, and "we lost every snapshot." Live failover is checkpoint + tail. That is how Kafka Streams state stores, event-sourced aggregates, and TigerBeetle accounts work: the log is SoT, the in-memory map is a cache of the fold.
+
+### 14.2 What "fold" means
+
+Folding a **fact** is addition:
+
+```text
+ce_2.balance += -2
+ro_1.balance += -3
+uw_9.usage   +=  5
+```
+
+No sort order. No credit schema. No `now`. No Lua. Two workers folding the same fact tail from the same `snapshot(S)` get the same remaining. That is why the stream must be a fact ledger.
+
+Folding an **intent** ("used 5 messages") is re-running `prepareFeatureDeductionV2` + the allocator against whatever snapshot you just loaded. That is a different customer if:
+
+- a reset happened between intents
+- attach/cancel changed the grant graph
+- credit costs or AI markups changed
+- a lock was finalized
+- Postgres remaining already includes some of those tracks
+
+So: worker dies → replay **facts**. Do not replay today's `events` table through the deduction engine.
+
+### 14.3 What Postgres is allowed to be
+
+"Replay from the stream and maybe Postgres" is correct if Postgres is one of these, and only these:
+
+**A. Watermarked snapshot store (the practical one).**
+
+Postgres already has the grant graph (`customer_entitlements`, products, rollovers, usage windows). Give that row set a `subject_seq` (or `last_applied_stream_id`) meaning "this remaining already includes every fact `<= S`."
+
+Recovery:
+
+1. New worker takes ownership of the customer.
+2. Read Postgres structure + remaining where `subject_seq = S`.
+3. Read stream `(S, tip]`.
+4. Fold those facts into the snapshot in memory.
+5. Resume apply. New facts append at `tip+1`.
+
+This is the "maybe Postgres." It is not "Postgres is also SoT." It is "Postgres is the cheapest place we already store a checkpoint." The projector that keeps Postgres current (Phase 2) *is* the checkpoint writer. Worker failover and dashboard freshness become the same job.
+
+**B. Structure only, remaining only on the stream.**
+
+Postgres has which ents exist, allowances, intervals. Remaining starts at zero / grant facts. The stream has every usage, reset, and adjustment fact from genesis (or from the last stream-compacted snapshot). Recovery does not read Postgres remaining at all. Useful if we do not trust PG remaining. More stream retention.
+
+**C. Not this: current Postgres remaining + replay all events.**
+
+That double-applies every fact the snapshot flush already absorbed, and then applies intents the flush never saw, through an allocator that sees *today's* grant graph. This is the current `syncItemV5` bug rotated 90 degrees.
+
+Today's Postgres remaining cannot be `snapshot(S)` because it has no `S`. That is the whole point of the mutation-log watermark.
+
+### 14.4 What must already be on the stream before this works
+
+A worker that dies after a month of tracks cannot rebuild from Tinybird `events` + current `customer_entitlements`. Missing:
+
+- grant/shape facts (attach created `ce_9` last Tuesday)
+- reset facts (cron restored balance and minted rollovers)
+- admin / `set_usage` / `target_balance`
+- lock reserve/finalize
+- usage-window counter mutations
+- the watermark
+
+Until Phase 3, "replay the event stream" is not an operation we can run. Until Phase 1, the stream does not even have facts.
+
+### 14.5 Crash points (the worker is a state machine)
+
+Assume the apply path is: validate → append facts → ack API → fold into memory → (async) checkpoint Postgres.
+
+| Die after… | What is true | Recovery |
+| --- | --- | --- |
+| Validate, before append | Stream unchanged. Client will retry. | Nothing to replay. Idempotency on command id if the retry races a new owner. |
+| Append, before API ack | Fact is SoT. Client may retry. | New worker folds the fact. Retry is a no-op via `mutation_id` / command id. |
+| Ack, before memory fold | Same as above. | Fold from watermark. |
+| Memory fold, before PG checkpoint | Worker snapshot was ahead of Postgres. | New worker: `snapshot(S_pg)` + tail, which includes the fact. Postgres catches up as projector. |
+| PG checkpoint, stream truncated too early | Cannot rebuild. | Retention must outlive the oldest snapshot we are willing to recover from. |
+
+The ordering that makes death boring: **the fact hits the log before we tell the caller it happened.** Memory and Postgres are allowed to lag the log. The log is not allowed to lag memory. That is the opposite of today (Lua mutates hashes, then we hope a sync job copies them).
+
+If we keep Redis Lua as the apply engine, the equivalent is: Lua `XADD` facts in the same script as the hash writes (or XADD first, hashes as a projection). Worker death and Redis flush are the same recovery path: `snapshot(S) + tail`.
+
+### 14.6 You do not rebuild Tinybird to recover a worker
+
+Tinybird is a projector of intents + allocation for analytics. Worker recovery reads the **ledger topic** (or Redis Stream) and a watermarked snapshot. If those are gone, Tinybird cannot substitute: different schema, missing shape facts, eventual ingest, no `subject_seq`.
+
+### 14.7 How long is the tail
+
+Hot customer, 1k tracks/s, facts of a few hundred bytes: a 10-minute tail is cheap. A 90-day genesis replay is not a failover strategy. So:
+
+- Checkpoint remaining + structure every N seconds or every M facts (Postgres or a compacted snapshot topic).
+- Keep the fact log at least as long as `checkpoint_interval + projector_lag + ops_reaction`.
+- Offload older facts to object storage for audit, not for failover.
+
+This is why Phase 2 (Postgres as fact projector with a watermark) is the recovery mechanism, not a dashboard convenience.
+
+### 14.8 Worked example
+
+Customer has `ce_messages = 100`. Worker has applied facts 1..40. Postgres projector is at 37. Stream tip is 40.
+
+Worker dies.
+
+1. New owner reads Postgres: remaining 100 + deltas(1..37), `S = 37`.
+2. Reads facts 38, 39, 40. Folds. Memory now matches what the dead worker had.
+3. Track arrives. Allocator runs against that snapshot, appends fact 41, acks.
+
+If we had instead loaded Postgres remaining and replayed the original 40 *tracks* through Lua, we would re-allocate 38–40 against a graph that already included 1–37, and we would re-allocate 1–37 that Postgres already had. Remaining would be wrong in both directions.
+
+---
+
+## 15. Bottom line
+
+The instinct is right: **remaining should be a fold of a durable log; Redis/Postgres/Tinybird should be projections; apply should be a single writer that holds a snapshot.** Worker death is `snapshot(S) + fold(facts after S)`, and Postgres is a good place to keep `snapshot(S)` once it has a watermark.
 
 The first-idea version is wrong in three places:
 
-1. It treats today's track events as that log. They are intents. Remaining needs facts, and also grant/reset/shape facts we do not emit.
-2. It puts Tinybird on the SoT path. Tinybird is a projector.
+1. It treats today's track events as that log. They are intents. Remaining needs facts, and also grant/reset/shape facts we do not emit. Replay is addition of deltas, not re-running deduction.
+2. It puts Tinybird on the SoT path. Tinybird is a projector. Worker recovery does not read it.
 3. It under-specifies apply. Check/reject/lock cannot wait on an eventually consistent worker unless that worker *is* the synchronous owner of the customer.
 
 We already have the allocator, the mutation receipt shape, the subject epoch fence, and a written plan to stream those receipts. The missing piece is not a new conceptual architecture. It is making the **fact ledger** real, pointing Postgres and Tinybird at it, and only then deciding whether the process that folds the ledger is still Redis Lua or a worker we own.

--- a/.plans/event-stream-balance-sot.md
+++ b/.plans/event-stream-balance-sot.md
@@ -4,6 +4,8 @@ Research note. Not an implementation plan. The goal is to decide *what* would ha
 
 Design target that landed later in the discussion: **up to ~1M events/s ingest**, plus **real-time remaining reads** (check ~50ms) on our infra. That split is worked in §15.
 
+Base-substrate design (log vs queue, FIFO scope, how "insert/mutate" works without rewriting history): [event-stream-sot/01-durable-log.md](./event-stream-sot/01-durable-log.md).
+
 Related existing work in this repo:
 
 - [check-reserve/01_mutation_logs.md](./check-reserve/01_mutation_logs.md) — mutation receipts + Redis Streams as the durability path for Postgres sync

--- a/.plans/event-stream-balance-sot.md
+++ b/.plans/event-stream-balance-sot.md
@@ -552,14 +552,73 @@ If we had instead loaded Postgres remaining and replayed the original 40 *tracks
 
 ---
 
-## 15. Bottom line
+## 15. Better fit for this stack: wallet WAL, not worker-served remaining
 
-The instinct is right: **remaining should be a fold of a durable log; Redis/Postgres/Tinybird should be projections; apply should be a single writer that holds a snapshot.** Worker death is `snapshot(S) + fold(facts after S)`, and Postgres is a good place to keep `snapshot(S)` once it has a watermark.
+If the requirements are **high track QPS** and **real-time remaining on our infra** (check, check+track, `customers.get` balances), I would not put a balance worker on the read/write path.
+
+I would keep Redis as the serving layer and make a **fact WAL** the durability SoT. Recovery is still `snapshot(S) + tail`. The "worker" is Redis Lua, which we already run. Postgres and Tinybird stay projectors.
+
+```text
+check / track / lock
+        │
+        ▼
+Redis Lua          apply + XADD facts in one script
+        │
+        ├── hashes ──► real-time reads (existing replica pool)
+        │
+        └── fact WAL (Redis Streams, relayed to Kafka/Redpanda if we want)
+                ├──► Postgres projector   dashboard, billing, snapshot(S)
+                └──► Tinybird / Neon      analytics
+```
+
+That is how a database is built: pages for reads, WAL for durability, replicas for QPS. We already have the pages and the replica reads. We are missing the WAL.
+
+### 15.1 Why this matches the two constraints
+
+**Real-time reads.** `getCachedFullSubject`, partial subjects, and `getCachedFeatureBalances` already go through `useReadPool: true`. Check's SLO is ~50ms and it fail-opens when Redis is down. A worker that *owns* remaining forces every check onto sticky routing, a warm snapshot, and a process hop. Kafka Streams interactive queries and "ask the customer partition owner" are the slow way to serve a point read we already serve from a Redis replica.
+
+**High throughput.** Lua on a cluster slot is a good apply engine for this shape: no extra network mid-apply, pipelined hash reads, different credit graphs can proceed on different key sets. A customer-partitioned worker serializes *all* of that customer's features, including ones that do not share a credit graph, and adds enqueue + ownership + cold-start. Streams are excellent at *fan-out* of facts after apply (Tinybird, PG, webhooks). They are a bad place to *serve* remaining.
+
+**Replay.** Identical to the worker-death story. Redis evicted or a node died: load watermarked Postgres remaining at `S`, fold WAL `(S, tip]`, write hashes, resume. We do not need a new actor to get that.
+
+### 15.2 What I would not use this constraint set to justify
+
+| Approach | Why it loses here |
+| --- | --- |
+| Balance workers serve check/track | Extra hop, coarser serialization, cold-start replay on the SLO path |
+| Tinybird / CH as remaining | OLAP, no reject isolation, ingest lag |
+| Postgres as apply | Already the fallback. Kills the 50ms path. |
+| Intent stream as SoT | Replay is the allocator, not addition |
+| TigerBeetle / new ledger DB | Simple transfers, not a waterfall allocator. New infra, same apply problem in front of it |
+
+Workers are still the right *projector* (the thing that folds facts into Postgres). They should not be the thing the API calls for remaining.
+
+### 15.3 When I *would* move apply off Redis
+
+Only if Redis itself is the problem: Lua/SQL/TS drift, multi-region lock owners, 10k-entity subject blobs, cost. That is a serving-layer rewrite. It is not required for "we need a log we can replay" or for Tinybird to stop being a second write path.
+
+If we do it later, I would still keep a Redis (or similar) **read cache** in front of the worker. High QPS real-time reads and single-writer apply want different hardware. We already split that (write on primary, read on replica pool). A worker that is both is a regression.
+
+### 15.4 What this changes vs today's mental model
+
+Say "the WAL is the SoT, Redis remaining is a serving projection we apply into synchronously." Do not say "the event stream is the SoT, and we read remaining from it."
+
+We never serve remaining from the stream, same way Postgres does not answer `SELECT` by scanning `pg_wal`. The stream exists so Redis can die.
+
+The existing mutation-log plan is this architecture. The missing pieces are: `XADD` in Lua, stop snapshot-flushing Postgres, watermark PG remaining, relay the same WAL to Tinybird, emit grant/reset facts onto it.
+
+---
+
+## 16. Bottom line
+
+The instinct is right: **remaining should be a fold of a durable log; Redis/Postgres/Tinybird should be projections; apply should be a single writer that holds a snapshot.** Worker death (or Redis death) is `snapshot(S) + fold(facts after S)`, and Postgres is a good place to keep `snapshot(S)` once it has a watermark.
+
+For *this* stack — high track QPS plus 50ms remaining reads — I would not introduce balance workers on the request path. I would add a **fact WAL behind the Redis we already serve from**. Redis Lua stays the apply engine and the real-time read layer. The WAL is what we replay. Postgres and Tinybird consume it.
 
 The first-idea version is wrong in three places:
 
 1. It treats today's track events as that log. They are intents. Remaining needs facts, and also grant/reset/shape facts we do not emit. Replay is addition of deltas, not re-running deduction.
 2. It puts Tinybird on the SoT path. Tinybird is a projector. Worker recovery does not read it.
-3. It under-specifies apply. Check/reject/lock cannot wait on an eventually consistent worker unless that worker *is* the synchronous owner of the customer.
+3. It under-specifies apply. Check/reject/lock cannot wait on an eventually consistent worker unless that worker *is* the synchronous owner of the customer — and even then, that is the wrong serving layer for our read SLO.
 
-We already have the allocator, the mutation receipt shape, the subject epoch fence, and a written plan to stream those receipts. The missing piece is not a new conceptual architecture. It is making the **fact ledger** real, pointing Postgres and Tinybird at it, and only then deciding whether the process that folds the ledger is still Redis Lua or a worker we own.
+We already have the allocator, the mutation receipt shape, the subject epoch fence, the replica read pool, and a written plan to stream those receipts. The missing piece is the WAL, not a new fleet of snapshot owners.

--- a/.plans/event-stream-balance-sot.md
+++ b/.plans/event-stream-balance-sot.md
@@ -1,0 +1,444 @@
+# Event stream as source of truth for customer balances
+
+Research note. Not an implementation plan. The goal is to decide *what* would have to be true for an event stream to replace Redis as the durability source of truth, without pretending deduction is a simple decrement.
+
+Related existing work in this repo:
+
+- [check-reserve/01_mutation_logs.md](./check-reserve/01_mutation_logs.md) — mutation receipts + Redis Streams as the durability path for Postgres sync
+- [pooled-balances/balance-sync-correctness.md](./pooled-balances/balance-sync-correctness.md) — Redis remaining vs Postgres structural writes
+- [check-reserve.md](./check-reserve.md) — why snapshot sync loses deductions on cache eviction
+- Current apply path: `executeRedisDeductionV2` → Lua `deductFromSubjectBalances` → `SyncBatchingManagerV3` → `syncItemV5` → Postgres
+- Current analytics path: `EventBatchingManager` → Tinybird HTTP + SQS `InsertEventBatch` → Neon/Postgres events
+
+---
+
+## 1. What Redis is actually the source of truth *for*
+
+`getCachedFullSubject` does not store remaining balances on the subject blob. The cached subject is a **structural view**: products, entitlement definitions, flags, licenses, subscriptions, invoices, feature membership. Live remaining lives in **per-feature Redis hashes**. On read, the subject is hydrated from those hashes, then lazy-reset, usage-window reset, and pending migrations run.
+
+So today there are already four stores, and people say "Redis is SoT" as if it were one thing:
+
+| Store | What it owns | Freshness |
+| --- | --- | --- |
+| Redis balance hashes + Lua | Remaining, rollovers, usage-window counters, lock receipts, aggregated hashes | Authoritative for check/track |
+| Redis FullSubject blob + `subjectViewEpoch` | Grant graph / shape of the customer | Authoritative for "which buckets exist" on the hot path |
+| Postgres `customer_entitlements` / rollovers / usage_windows | Durable remaining *and* structure | Eventually consistent remaining (snapshot flush). Authoritative for billing/attach/reset |
+| Tinybird + Neon `events` | Track intents + post-hoc `deductions` JSON | Best-effort analytics. Not used to reconstruct remaining |
+
+The dangerous part is not "we cache a customer." It is that **remaining is only durable if the snapshot flush lands**, and the flush re-reads Redis. If the hashes are evicted first, the deduction vanishes from Postgres. That is already documented. Stripe webhooks, attach, pooled rebalance, and invalidation all delete or replace that cache.
+
+A second dangerous part: **structure is written in Postgres, remaining is mutated in Redis**. Pooled billing, resets, attach, and license changes race the usage path. `subjectViewEpoch` is the fence on the Redis side. There is no single ordered log that contains both.
+
+---
+
+## 2. What happens on one track
+
+`runTrackV3` → `runRedisTrackV3` → `executeRedisDeductionV2` is not "subtract N from a counter."
+
+### 2.1 Before Lua (TypeScript, state-dependent)
+
+`prepareFeatureDeductionV2` builds the allocation inputs from the live `FullSubject` and org feature catalog:
+
+1. **Feature expansion.** A `feature_id` track can also hit credit-system parents. An `event_name` can expand to many features. AI credit systems convert tokens → dollars via Models.dev + markups (`computeCreditCosts`).
+2. **Entitlement selection.** Only in-status products. Optional `customerEntitlementFilters`. Entity vs customer context.
+3. **Sort order** (`sortCusEntsForDeduction`): entity-vs-customer, boolean, credit systems last, unlimited first (then hoisted to the front as an infinite sink), resetting before lifetime, interval length, expiry, entity id, main product before add-on, prepaid before pay-per-use, `created_at`.
+4. **Per-entitlement clamps.** `usage_allowed`, `overage_allowed` controls, `min_balance` / `max_balance` from max overage and starting balance, unlimited sink.
+5. **Spend limits** and usage-based entitlement ids (for overage headroom).
+6. **Usage windows.** Resolved against the full relevant feature set (so `set_usage` on a member cannot bypass a parent cap). Filtered by event properties. Calendar vs billing-cycle anchors. Unlimited ents skip windows entirely.
+7. **Rollovers** flattened and sorted oldest-`expires_at` first, each with its credit cost.
+8. **Lock receipt** params if this is a reserve/check-with-lock.
+
+None of this is in the incoming track payload. It is a function of **current snapshot + current catalog + now**.
+
+### 2.2 Inside Lua (atomic apply)
+
+`deductFromSubjectBalances` is a single-threaded state machine on the customer's hash-slot keys:
+
+1. Compare `expected_subject_view_epoch` — abort `SUBJECT_VIEW_CHANGED` and retry after refresh.
+2. Idempotency key — skip already-applied features; 409 only if *every* feature is a replay.
+3. Load hashes into an in-memory context. Missing ents → `SUBJECT_BALANCE_NOT_FOUND`.
+4. Optional **lock unwind** (finalize): replay stored provenance backwards, decrement usage windows, fold leftover into the forward amount.
+5. **Pass 0:** rollovers, oldest first.
+6. **Pass 1:** main balance, floor at 0.
+7. **Pass 2:** negative if `usage_allowed`, gated by spend limits and usage-window headroom.
+8. Credit-cost conversion on every bucket.
+9. Entity-scoped nested balances when tracking an entity.
+10. `overage_behaviour`: `cap` (keep partial), `reject` (return `INSUFFICIENT_BALANCE` and **do not apply writes**), `overflow`.
+11. Increment usage-window counters only for real positive consumption (not refunds, not `target_balance`, not granted-balance edits). Locks count at lock time.
+12. Write lock receipt **before** applying pending writes, or apply nothing.
+13. Flush entitlement hashes, aggregated hashes, usage-window counters.
+14. Emit `mutation_logs` and `usage_window_mutations` — identifier-based deltas, not Redis paths.
+
+Lua is the only place today where "did this track succeed?" and "what remaining is now?" are decided together.
+
+### 2.3 After Lua (side effects that are not remaining)
+
+In request order, after a successful apply:
+
+- Allocated invoices for usage-based allocated entitlements (sync, can trigger rollback of the Redis apply).
+- In-memory `FullSubject` patched so the response is consistent.
+- Track webhooks (threshold / feature alerts).
+- Auto top-up enqueue (SQS, burst-suppressed).
+- `SyncBatchingManagerV3`: mark dirty selectors, coalesce ~1s, `syncItemV5` claims dirty state and **snapshot-flushes current Redis remaining** to Postgres. Not the mutation logs.
+- `EventBatchingManager`: 350ms / 200 events → Tinybird HTTP (errors swallowed) + SQS insert into Neon events.
+
+`mutation_logs` are already computed. They are used for the public `deductions[]` on the track response and the Tinybird event. They are **not** the Postgres sync payload. Postgres still copies the later snapshot.
+
+### 2.4 Other writers of remaining
+
+A stream that only contains tracks cannot rebuild remaining. These also change balances and often change the *shape* of the snapshot:
+
+- Lazy reset on cache read + cron reset (`processReset`, rollovers created, `next_reset_at`).
+- Invoice-owned resets (`reset_by_invoice`).
+- Attach / update / cancel / checkout confirmation.
+- Pooled balance rebalance (Postgres-first, then cache cutover).
+- `balances.update` / `target_balance` / `set_usage` / `alterGrantedBalance`.
+- Loose-entitlement expiry, rollover expiry.
+- Entity create/delete.
+- License assignment.
+- Manual grants / adjustments.
+- Lock finalize / release / expiry.
+- Auto top-up completing (a grant, not a usage).
+- Pending migrations applied on read.
+
+Today most of these write Postgres, then bump `subjectViewEpoch` and invalidate Redis. Usage that landed in Redis between the PG write and the flush is the race in `balance-sync-correctness.md`.
+
+---
+
+## 3. The question is not "Redis vs a stream"
+
+It is three different questions that get collapsed into one sentence.
+
+**Q1. Durability SoT.** If this process dies and Redis is empty, what do we replay to get remaining back?
+
+**Q2. Apply SoT.** Who decides, synchronously, that this track is allowed, which buckets it hits, and what remaining the caller sees?
+
+**Q3. Analytics SoT.** What does Tinybird / `events.list` / `events.aggregate` query?
+
+Today: Q1 is "hope the snapshot flush happened" (broken). Q2 is Redis Lua. Q3 is a best-effort EventInsert written *after* Q2.
+
+"Event stream as source of truth" only answers Q1 if the stream contains the right kind of event. It does not automatically answer Q2. Check's hydration budget is 2s and the SLO is ~50ms. Check does not read Tinybird. Check cannot wait for a Kafka consumer to catch up and then read Postgres.
+
+So the sketch "stream → Tinybird, and also balance workers that hold a snapshot and write Postgres eventually" is directionally right for Q1 + Q3. It is incomplete for Q2 unless the worker *is* the apply engine the API talks to, or Redis remains the apply engine and the stream is only the durable log.
+
+---
+
+## 4. Intents are not facts
+
+This is the load-bearing distinction.
+
+**Intent** (today's `EventInsert` / track body):
+
+```text
+customer C used 5 of feature messages at T, properties {...}, idempotency K
+```
+
+**Fact / allocation** (today's `MutationLogItem`):
+
+```text
+rollover ro_1 −3, customer_entitlement ce_2 −2, usage_window uw_9 +5
+```
+
+Allocation is a function of:
+
+- current remaining per bucket
+- current grant graph (which ents exist, entity vs customer, pooled)
+- current catalog (credit schema, event_names, AI markups)
+- `now` (window bounds, expiry, lazy reset)
+- overage behaviour, spend limits, locks
+
+Two concurrent "used 5" intents against the same customer are **not commutative**. Replay of intents is not deterministic unless you also freeze the catalog, the clock, and the exact prior snapshot, and serialize them through one writer.
+
+That is why Orb can make raw usage events the SoT for *invoices* (query-time pricing over an immutable log) and still keep a **separate append-only credit ledger** for prepaid blocks. Metronome-style event billing is a meter. Autumn `overage_behavior: reject`, locks, prepaid, rollovers, and check+track are a **wallet**. We are both.
+
+Tinybird already stores intents *plus* a lossy projection of facts (`deductions` JSON). That is enough for analytics. It is not enough to rebuild remaining, because:
+
+- resets, grants, attach, pool rebalances, admin updates are not on that log
+- ingestion is best-effort
+- ClickHouse/Tinybird cannot do "reject this request if remaining < N" at 50ms with transactional isolation
+- `deductions` is computed *after* Lua; if Lua is gone and you only have intents, you must re-run the allocator
+
+**If the stream is SoT for remaining, the stream must be a fact ledger (or intents that have already been applied by a single writer into facts).** Raw tracks cannot be the ledger.
+
+---
+
+## 5. Constraints that kill naive designs
+
+### 5.1 Check/track with reject is a synchronous wallet operation
+
+`runCheckV2` is a read of remaining. `send_event` / `lock` is the same Redis deduction as track. `overage_behavior: reject` must not apply writes if the allocator still has leftover.
+
+Any design that is "API appends to Kafka, worker applies later, check reads Postgres" accepts overspend. That is fine for in-arrears usage billing. It is not fine for the product we already ship.
+
+So apply must happen before the HTTP response, in a single-writer context for the contended keys.
+
+### 5.2 Redis Lua is already a balance worker
+
+Redis is single-threaded per hash slot. The script takes a routing key + epoch key + feature hashes (hash-tagged onto the customer). That *is* the actor model:
+
+- one writer at a time for those keys
+- snapshot in memory for the duration of the script
+- compare-and-set via `subjectViewEpoch`
+- no network round-trips mid-apply
+
+"Balance workers hold a snapshot" is not a new invention. It is a proposal to move that actor out of Lua into a process we own. The reasons to do that are real (Lua + SQL + TS triples, allocated invoices after apply, multi-region lock finalize, 10k-entity customers). The reasons not to do it first are also real: we would be rebuilding placement, failover, snapshot checkpointing, and request/response over a queue, while the actual data-loss bug is "facts are not durable."
+
+### 5.3 Credit systems couple features
+
+A messages track can drain a credit-system parent. Partitioning workers by `customer_id + feature_id` is wrong. The lock scope is the **credit graph** (what `getRelevantFeatures` already computes). Customer-level serialization is correct and simple, and too coarse for hot customers. Feature-level serialization is fast and incorrect.
+
+Today different features *can* Lua-concurrently if they do not share keys. A naive customer-sharded worker is *more* serial than Redis.
+
+### 5.4 Structural mutations must share the log (or a fence)
+
+If usage facts live on a stream and attach/reset/pool live only in Postgres, we have recreated the current race with extra hops. Either:
+
+- every grant/reset/shape change is a fact on the same per-customer log, or
+- usage apply and structural apply take the same customer fence (`withCustomerBalanceSyncLock` as designed), and the fence is held across "read snapshot → write both sides."
+
+`subjectViewEpoch` is a Redis-only fence. A stream SoT would use the log offset (or a per-customer sequence) as the epoch.
+
+### 5.5 Side effects are not foldable
+
+Allocated invoices, auto top-up, webhooks, Tinybird, lock receipts. Replay of a fact log must not create a second Stripe invoice. Side effects need idempotency keys derived from `mutation_id` / event id, or they must themselves be facts ("invoice I created for ce X").
+
+### 5.6 Three deduction engines already exist
+
+Lua (`deductFromSubjectBalances`), SQL (`executePostgresDeductionV2` / `performDeduction.sql`), TypeScript (`deductFromCusEntsTypescript`). They already drift. Moving apply to workers without collapsing these is how we get a fourth engine.
+
+### 5.7 Tinybird is the right analytics sink and the wrong wallet
+
+Orb's own architecture (from their docs): Redis/MemoryDB counters for *alerts*; invoices always computed from the columnar event store; prepaid credits on a separate ledger with pending→committed because events arrive late. They do not reject an API call against Tinybird.
+
+We already use Tinybird the way Orb uses the columnar store for analytics. Hourly MVs, `aggregate_deductions`, property grouping from raw JSON. Keep that. Do not point check at it.
+
+### 5.8 Kafka is a fan-out log, not an event store
+
+`kafkajs` is in `server/package.json` and unused. Kafka gives partition order, consumer groups, and Connect-into-Tinybird. It does not give per-aggregate CAS, snapshots, or "append this fact in the same atomic step as the Redis apply" unless we dual-write.
+
+Atomic apply+append while Redis is the apply engine means **XADD inside the same Lua script** (Redis Streams), then a relay to Kafka/Tinybird. That is exactly the mutation-log plan. Worker-as-apply can append to Kafka first (or in a transaction with a local snapshot) and ack the API only after the log is durable.
+
+---
+
+## 6. Architectures that are actually in the running
+
+### A. Persist facts, keep Redis as apply (evolution of `01_mutation_logs.md`)
+
+```text
+API ──► Lua apply + XADD facts ──► Redis Streams
+                                      │
+                                      ├─► PG workers (delta replay, not snapshot)
+                                      ├─► relay ──► Tinybird / Kafka
+                                      └─► rebuild Redis hashes on miss
+```
+
+- Q2 unchanged (Lua).
+- Q1 becomes the fact stream.
+- Q3 can eventually consume the same stream instead of a second best-effort EventInsert.
+- Smallest change that fixes cache-eviction loss and snapshot-overwrite races.
+- Redis remaining is a **projection** that happens to also be the apply snapshot.
+- Does not remove Lua. Does not make "the event stream" the thing the API writes first.
+
+This is the honest first step. It is also most of what "stream as SoT, workers write PG" needs, if we admit Redis *is* the worker.
+
+### B. Customer-partitioned apply workers (the sketch, specified)
+
+```text
+API ──► command to owner(customer) ──► worker
+                                         │
+                                         ├─ load snapshot (memory / RocksDB / Redis)
+                                         ├─ run ONE deduction engine (TS)
+                                         ├─ append facts to log (fsync)
+                                         ├─ update snapshot
+                                         └─ ack remaining to API
+                                              │
+                                              ├─► Tinybird (intents + facts)
+                                              └─► PG projection (eventually)
+```
+
+This is Kafka Streams / Orleans / TigerBeetle-shaped: single writer per aggregate, snapshot is derived, log is durable SoT.
+
+Required to not fail:
+
+- Partition key = credit graph, not feature, not "whatever is convenient."
+- Commands (track, check+track, update, finalize lock) go to the owner. Reads (plain check) can hit a replica snapshot with explicit staleness.
+- Snapshot checkpoint + log offset so failover is "load checkpoint, replay tail," not "scan Tinybird."
+- Structural commands on the same owner (or a fence).
+- Deduction engine is TS, Lua/SQL deleted or test-only.
+- API waits on the worker. Not fire-and-forget.
+- Hot customers (already `shouldWarmCache` for 10k+ entities) need snapshot sharding *inside* the customer without breaking credit-graph atomicity.
+
+This is a platform. It is the right long-term shape if we want to stop being a Redis-Lua company. It is the wrong first project.
+
+### C. Pure computed remaining (meter, not wallet)
+
+```text
+remaining(feature, window) = grants − Σ allocated usage
+```
+
+This is Orb invoices / Metronome billable metrics. It works when remaining is a *report*. It does not work when remaining is a *lock*.
+
+We would still need a wallet for prepaid, reject, locks, spend limits, usage windows that are not the entitlement interval, and unlimited-as-counter. We would have two systems again.
+
+Do not pick C as the SoT for check. We can still compute *analytics* remaining from facts for "where did the credits go."
+
+### D. Intent log as SoT, deduction as a replayable projection
+
+API writes intents. Workers re-run `prepareFeatureDeductionV2` + allocator on replay.
+
+This only works if every intent carries:
+
+- catalog version (credit schema, event_names, markups)
+- subject-view sequence (exact grant graph)
+- `usageWindowNow`
+- overage behaviour, filters, lock id
+
+And if replay is strictly single-writer. Feature updates that change credit cost mid-stream become "which version did this intent see?" We already fall back to cost 1 when cached schemas trail a feature update. That is unacceptable as a ledger rule.
+
+Treat this as a non-goal. Intents are for analytics and support. Facts are for remaining.
+
+### E. Split the product
+
+- **Meter:** intent stream → Tinybird / Neon. No remaining. In-arrears only.
+- **Wallet:** fact ledger + sync apply (Redis or workers) for prepaid, included, reject, locks, windows.
+
+This is what Orb actually does (events vs credit ledger). It is also approximately what we do today, except the wallet's durability is Redis hashes.
+
+The useful version of E is: stop asking Tinybird to be the wallet, and stop asking the wallet to be the only place a track exists. Unify *ingest* (one API) but keep two projections.
+
+---
+
+## 7. What a real SoT stream has to contain
+
+If we want to rebuild a customer's remaining from the log, the log is a **customer ledger**, not `events.datasource`.
+
+Minimum fact families:
+
+| Family | Examples | Why |
+| --- | --- | --- |
+| Grant / shape | ent created, cancelled, allowance changed, entity attached, pool graph, `usage_allowed`, unlimited | Without this, usage facts have nowhere to land |
+| Reset | balance restored, rollovers minted, `next_reset_at`, invoice-owned reset | Lazy reset is a write, not a read |
+| Usage allocation | `MutationLogItem` + usage-window mutations | The actual remaining deltas |
+| Adjustment | `balances.update`, admin grant, `target_balance`, `set_usage` | Already a first-class API |
+| Expiry | loose ent, rollover | Changes deductible set |
+| Lock | reserved / finalized / released / expired + provenance items | Reserve cannot be Redis-only |
+| Idempotency | `mutation_id` / command id applied | Replay safety |
+
+Each fact needs `mutation_id` (or command id), `org_id`, `env`, `internal_customer_id`, `subject_seq` (or stream offset), and enough identifiers to apply with SQL `jsonb_set` / `balance = balance + delta` — not Redis JSON paths. That shape is already in `01_mutation_logs.md` and `MutationLogItem`.
+
+Intents can ride along (`event_id`, properties, `event_name`) so Tinybird does not need a second ingest. They must not be required to fold remaining.
+
+Postgres `applied_balance_mutations` (or equivalent) is still required if more than one projector applies deltas. Per-mutation dedupe in the same transaction as the apply. Batch-level dedupe is not enough.
+
+---
+
+## 8. Where deduction should run
+
+| Option | Sync reject | Engine count | Atomic log | Cost |
+| --- | --- | --- | --- | --- |
+| Lua apply, stream is facts | Yes, today | 3 (Lua/SQL/TS) | XADD in Lua | Lowest. Fixes durability. |
+| TS worker apply, stream is facts | Yes, if API waits | 1 (if we delete the others) | Worker fsyncs log before ack | Highest. Removes Lua. |
+| SQL apply as primary | Yes, slow | 1 | PG WAL is the log | Kills check SLO. Already the fallback. |
+| Tinybird / Flink apply | No | 1 | n/a | Wrong isolation. |
+
+Recommendation: **do not move apply until facts are durable and Postgres is a projector.** Then decide if Lua is still the bottleneck. The TypeScript allocator (`deductFromCusEntsTypescript` + `prepareFeatureDeductionV2`) is the seed of a single engine; it is not complete enough to replace Lua today (usage windows, spend limits, aggregated hashes, lock unwind live in Lua).
+
+---
+
+## 9. Postgres "eventually consistent" is not new
+
+`syncItemV5` already is an eventually consistent projector. The bugs are the *kind* of projection:
+
+- It copies a **later snapshot**, so a delayed job can overwrite a newer pooled grant.
+- It **requires the Redis hashes to still exist**.
+- It is not keyed by mutation id, so retry/replay is not a fold.
+
+A worker that "holds a snapshot and writes Postgres" repeats this if the write is "here is remaining now." The PG write must be **apply these facts if not yet applied**, or a snapshot that is explicitly watermarked with `subject_seq` / stream id (the rolling-deploy bridge in the mutation-log plan).
+
+Dashboard reads of remaining can stay on Postgres if we accept lag. Check cannot.
+
+---
+
+## 10. Tinybird's place in the end state
+
+Keep Tinybird as a **projector of intents + allocation**, not as SoT.
+
+Today we dual-write: in-process batch → HTTP ingest, and a separate SQS path to Neon. Both are after apply and can fail independently. The end state is one fact+intent stream, Tinybird and Neon as consumer groups.
+
+Do not compute remaining in pipes. `aggregate_deductions` is the right query: "how much was allocated to which `balance_id`," which already depends on facts we emit at apply time.
+
+If we ever want "rebuild remaining from Tinybird" as a disaster tool, we would still be missing grant/reset facts. That is a different datasource (or the ledger topic), not `events`.
+
+---
+
+## 11. Recommended sequence (not a rewrite)
+
+This is ordered by risk, not by how close it is to the slide.
+
+### Phase 1 — Fact log exists
+
+Lua already produces `mutation_logs`. Persist them in the same script as the apply (`XADD` to a per-customer Redis Stream, as designed). Stop treating the FullSubject blob as the durability path.
+
+Done when: delete Redis hashes, run the sync worker, Postgres still has the deduction.
+
+### Phase 2 — Postgres is a fact projector
+
+Replace snapshot flush with mutation replay + `applied_balance_mutations`. Keep the customer fence. Snapshot sync only as a watermarked bridge (`last_snapshot_stream_id`).
+
+Done when: a delayed sync job cannot overwrite a pooled rebalance, and cache eviction does not drop usage.
+
+### Phase 3 — Structural facts on the same customer log
+
+Resets, attach grants, pool rebalance, admin updates emit facts (or go through the same fence and write a shape fact). `subjectViewEpoch` becomes "last applied `subject_seq`."
+
+Done when: you can rebuild hashes from (checkpoint snapshot + fact tail) after a total Redis loss.
+
+### Phase 4 — Unify analytics ingest
+
+Relay the same log to Tinybird / Neon. `EventBatchingManager` becomes a consumer. Intents are fields on the usage fact (or a paired intent record with the same id).
+
+Done when: we do not have a third write path that can lose events the wallet committed.
+
+### Phase 5 — Optional: move apply out of Lua
+
+Only if Phase 3 works and Lua/SQL/TS drift is costing more than a worker platform. One TS engine. Worker owns the snapshot. Redis becomes a cache of the worker snapshot, or goes away for remaining. API is request/response to the owner.
+
+This is the user's sketch. It is phase 5, not phase 1.
+
+---
+
+## 12. What I would not do
+
+- Make Tinybird the SoT for remaining.
+- Make raw track events the SoT and re-run deduction on every consumer.
+- Fire-and-forget tracks into a stream and read remaining from Postgres on check.
+- Replace Lua before facts are durable.
+- Partition workers by feature without a credit-graph lock.
+- Snapshot-flush Postgres from worker memory (same bug, new process).
+- Forget that reset/attach/pool are writers.
+- Keep three allocators while adding a fourth.
+
+---
+
+## 13. Open questions that actually matter
+
+1. **How stale may plain check be?** If "a few hundred ms behind the apply worker" is OK, reads can be replica snapshots. If check must see the track that just landed on another node, check is a command to the owner.
+2. **Is Redis allowed to remain the apply engine indefinitely?** If yes, Phases 1–4 deliver "stream as durability SoT" without a worker rewrite. If the goal is "no Redis for remaining," Phase 5 is in scope and should be costed as a platform.
+3. **One log or two?** Wallet facts (this doc) vs meter intents (Tinybird). One stream with two record types is operationally simpler. Two streams need a join key (`event_id`) and will drift.
+4. **Hot customer shape.** Do we shard snapshot state by entity *inside* a customer while keeping credit-graph apply atomic? Today's stale-while-revalidate for high-cardinality customers is a hint this will dominate worker design.
+5. **Multi-region.** Lock finalize (us-east API) vs expire (us-west worker) already races. A stream does not remove that; it moves it to "which region owns the customer partition."
+6. **Paid allocated / invoices.** Those are not remaining math. They have to sit *after* a committed fact, with their own idempotency, or stay sync-in-request with rollback of the fact (today's rollback path).
+
+---
+
+## 14. Bottom line
+
+The instinct is right: **remaining should be a fold of a durable log; Redis/Postgres/Tinybird should be projections; apply should be a single writer that holds a snapshot.**
+
+The first-idea version is wrong in three places:
+
+1. It treats today's track events as that log. They are intents. Remaining needs facts, and also grant/reset/shape facts we do not emit.
+2. It puts Tinybird on the SoT path. Tinybird is a projector.
+3. It under-specifies apply. Check/reject/lock cannot wait on an eventually consistent worker unless that worker *is* the synchronous owner of the customer.
+
+We already have the allocator, the mutation receipt shape, the subject epoch fence, and a written plan to stream those receipts. The missing piece is not a new conceptual architecture. It is making the **fact ledger** real, pointing Postgres and Tinybird at it, and only then deciding whether the process that folds the ledger is still Redis Lua or a worker we own.

--- a/.plans/event-stream-sot/01-durable-log.md
+++ b/.plans/event-stream-sot/01-durable-log.md
@@ -1,0 +1,208 @@
+# Base architecture: the durable log
+
+First-principles design for the substrate. Not Autumn-specific. Goal: pick the thing that can be the source of truth for ~1M events/s, then be honest about what that thing cannot do.
+
+## What we need
+
+| | Requirement | Notes |
+| --- | --- | --- |
+| A | Extreme throughput | Target ~1M appends/s, bursty, many producers |
+| B | FIFO | Order must be defined *somewhere*. Global FIFO at 1M/s is not real. |
+| C | Durable replay | If every worker and cache dies, we can rebuild from the log |
+| D | Insert / mutate "in between" | Late events, corrections, backfills, effective-dated grants |
+
+A, B, C are one product category. D is a different problem and fights naive FIFO. The architecture has to hold both without lying about either.
+
+## Log, not queue
+
+A **queue** (SQS, Rabbit, NATS-core) delivers a message to one consumer and then forgets it. That fails C. You cannot replay a queue. You cannot have Tinybird *and* a balance worker *and* a billing projector read the same history.
+
+A **log** (Kafka, Redpanda, WarpStream, Pulsar, Kinesis) appends, retains, and lets any number of consumers replay from an offset. The message stays. That is the SoT shape.
+
+So: durable **log**, not durable **queue**. FIFO is per partition, not "a single global queue." People say Kafka when they mean this category.
+
+```text
+producers  ──append──►  log (replicated, retained)
+                          │
+                          ├── consumer: analytics     (own offset)
+                          ├── consumer: apply/wallet  (own offset)
+                          └── consumer: audit/rebuild (own offset)
+```
+
+A consumer crashing does not delete events. It just stops moving its offset. That is C.
+
+## A — throughput
+
+Sequential append to partitioned disks (or object storage) is how you get 1M/s. Random writes to a serving store (Redis hashes, Postgres rows, worker memory) are not.
+
+Rules that make A true:
+
+- **Partition.** Parallel appends. Throughput ≈ partitions × per-partition append rate.
+- **Batch produce.** API never does one network write per event at 1M/s. Batch 1–10ms or N records.
+- **Small records.** Intent: id, customer, feature, value, event_time, properties ref. Fat payloads kill 1M/s.
+- **No read-on-write in the log.** The log does not compute remaining. It accepts bytes.
+
+If a write has to "read remaining, decide, then write," that write is not on the 1M/s path. It is on an apply path with a much lower rate.
+
+## B — FIFO, but of what?
+
+Total order of all events on earth does not exist at this scale. What you can have:
+
+| Scope | Guaranteed? | Use |
+| --- | --- | --- |
+| One partition | Yes. Append order = offset order | The only FIFO the log actually gives you |
+| One customer | Yes, **if** all of that customer's events share a partition key | Wallet apply, per-customer replay |
+| One feature of one customer | Yes, finer key | Breaks if two features share a credit pool |
+| Whole org / global | No | Do not design remaining around this |
+
+**Partition key for a wallet:** the unit that must be applied serially. Usually `customer` (or `org+customer`). Not `feature`, if features can drain each other. Not `event_id`.
+
+**Two clocks, always:**
+
+- `ingest_time` / offset — when the log accepted it. Immutable. This is B.
+- `event_time` — when the business says it happened. This is how D is expressed. May be in the past.
+
+FIFO of *ingest* is what the log guarantees. FIFO of *event_time* is something you reconstruct on read or in the apply engine. They diverge the moment an event is late.
+
+If you force "apply in event_time order" on the hot path, a late event means you rewind remaining and replay everything after it. That is incompatible with 1M/s real-time remaining unless you restrict it to a short grace window.
+
+## C — durable replay
+
+Minimum bar for "this log is SoT":
+
+1. **Replication** before ack (quorum). Producer `acks=all` (or equivalent). A 202 to the client means "on the log," not "in a producer buffer."
+2. **Retention longer than the oldest snapshot you will recover from.** Seven days of log + hourly snapshots is a system. Seven days of log and no snapshots is a hope.
+3. **No compaction on the intent log.** Compaction keeps the latest value per key. That deletes history. Compaction is for a *snapshot/changelog* topic, not for the SoT.
+4. **Idempotent produce** (`event_id` as producer key / idempotency). Retry must not create a second SoT event.
+5. **Snapshots of derived state** (`snapshot(S)` watermarked with offset `S`). Replay is tail, not genesis, except for audit.
+
+Replay formula (unchanged):
+
+```text
+snapshot(S) + fold(log offsets > S) = state
+```
+
+The fold function depends on event type. Usage intents and remaining facts are different folds. The log just has to still be there.
+
+## D — you do not insert into a log
+
+This is the important constraint.
+
+A durable high-throughput log is **append-only**. You cannot splice a record between offset 40 and 41. You cannot edit offset 40. Kafka, Redpanda, Pulsar, Kinesis, Redis Streams: all the same here. That immutability is why C works. If you can rewrite history, every consumer's offset is a lie.
+
+"Insert / mutate events in between times" is a real product need. It is **not** a log-mutate need. There are three legitimate ways to get it.
+
+### D1. Compensating events (ledger style)
+
+Wrong value was 5; should have been 3:
+
+```text
+offset 40  UsageRecorded   { id: evt_1, value: 5, event_time: T }
+offset 90  UsageCorrected  { id: evt_1, value: 3, event_time: T }   // or Retracted + new
+```
+
+The log stays append-only. Replay at the tip sees the correction. Audit still sees the mistake. This is how money systems work.
+
+Use for: admin edits, duplicate retraction, "customer says that track was wrong."
+
+### D2. Event-time, not offset-time (meter style)
+
+Late event: happened at 14:00, arrived at 16:00.
+
+```text
+offset 9000  UsageRecorded { id: evt_9, value: 2, event_time: 14:00, ingest_time: 16:00 }
+```
+
+Analytics / invoices **sort or query by `event_time`**. The event is "inserted" into Tuesday's usage without rewriting Monday's log. This is how Orb-style meters work: the SoT is the set of events, the bill is a query over `event_time`.
+
+Use for: late SDK flushes, backfills, "this hour was missing, here is the file."
+
+Backfill is the same: append a million records with old `event_time`. Do not splice them into last week's offsets.
+
+### D3. Pending window, then commit (wallet + late data)
+
+If remaining must move *as of event_time* (not as of ingest), you cannot finalize remaining at ingest.
+
+```text
+ingest  →  pending for grace (e.g. 15m–24h)
+        →  late events still enter that window
+        →  commit remaining / ledger lines for the window
+```
+
+Inside the window, "insert in between" is just another pending row. After commit, only D1 (compensation) is allowed.
+
+Use for: prepaid remaining that must match billed usage, grace for mobile / batch exporters.
+
+### What we will not do
+
+- Update-in-place on the log.
+- "Delete event 40 and rewrite the topic."
+- Treat Tinybird / ClickHouse `ALTER` as the SoT write path.
+- Recompute all remaining from genesis on every late event.
+
+If a late event must change *already-served* remaining (check already said `allowed: true` at 15:00), that is a business choice: apply the late event as of *now* (remaining moves now, history of decisions stays), or rewind a window (expensive, rare). The log does not make that choice for you. It only records both the late intent and the apply fact.
+
+## Recommended substrate
+
+**Category: Kafka-protocol durable log.**
+
+| System | Why consider | Why not |
+| --- | --- | --- |
+| Apache Kafka | Default, huge ecosystem, tiered storage | Ops weight |
+| Redpanda | Same API, lower latency, simpler ops | Smaller ecosystem |
+| WarpStream / S3-backed | Cheap long retention (C), 1M/s ingest (A) | Higher produce latency; bad if 202 must be <10ms everywhere |
+| Pulsar | Cursors, geo, queue+log | More moving parts |
+| Kinesis | If we want AWS-native | Shard math, cost, weaker multi-consumer story |
+| Redis Streams | Nice per-customer WAL, `XADD` local | Wrong global 1M/s bus; memory; not the SoT |
+| SQS / Rabbit | — | Queue. Fails C |
+
+**Pick: one Kafka-API log as the ingest SoT.** Implementation (Kafka vs Redpanda vs WarpStream) is an ops/latency/cost choice, not an architecture choice. Do not pick Redis Streams or SQS for this layer.
+
+Topics (minimum):
+
+```text
+usage.intents.v1        key=customer_id     retention long, no compaction     1M/s
+wallet.facts.v1         key=customer_id     retention long, no compaction     apply rate
+wallet.snapshots.v1     key=customer_id     compacted                         remaining checkpoints
+```
+
+- **intents:** what the world said happened (`event_time`, `value`, `properties`, `event_id`).
+- **facts:** what the apply engine did to remaining (bucket deltas, `applied_offset` / `subject_seq`).
+- **snapshots:** `remaining @ offset S` so replay is a tail.
+
+Analytics reads `usage.intents`. Wallet rebuild reads `wallet.snapshots` + `wallet.facts`. You can emit facts onto a compact changelog and still keep intents forever.
+
+## How A–D sit together
+
+```text
+                    event_time may be in the past
+                              │
+producers ──► usage.intents   │   append only, FIFO per customer
+                    │         ▼
+                    ├──► analytics (query / sort by event_time)      ← D2
+                    │
+                    └──► apply worker (per customer partition)
+                              │
+                              ├── coalesce window
+                              ├── deduct once
+                              ├── append wallet.facts                  ← D1 lives here too
+                              └── write serving projection (cache)
+                                        │
+                                        ▼
+                                   real-time remaining reads
+```
+
+- **A:** append to `usage.intents` is the 1M/s path. No remaining math.
+- **B:** per-customer partition key. Apply sees a FIFO of that customer's intents.
+- **C:** retain intents + facts; compact only snapshots; ack after quorum; recover from snapshot + tail.
+- **D:** never splice the log. Late/backfill = new append with old `event_time`. Wrong value = compensating append. Wallet grace = pending until commit.
+
+## Decisions to lock before the next layer
+
+1. **Partition key** = customer (or org+customer). Confirm nothing must be serial across customers.
+2. **Ack contract.** Is 202 = "on the log" (required for SoT) or "in our memory and we'll produce later"?
+3. **Late-event policy for remaining.** Apply-as-now vs pending-window vs rewind. Analytics can always use D2; remaining cannot do all three at 1M/s.
+4. **Idempotency key** = `event_id` (client or server). Unique per `(org, env, customer, event_id)`.
+5. **Retention vs snapshot interval.** Example: 7–30d hot log, snapshots every 1–5 min per active customer, cold intents on object storage.
+
+Next design layer (not this doc): the apply engine and the serving projection. Those sit *on* this log. They are not the log.

--- a/.plans/event-stream-sot/01-durable-log.md
+++ b/.plans/event-stream-sot/01-durable-log.md
@@ -205,4 +205,6 @@ producers ──► usage.intents   │   append only, FIFO per customer
 4. **Idempotency key** = `event_id` (client or server). Unique per `(org, env, customer, event_id)`.
 5. **Retention vs snapshot interval.** Example: 7–30d hot log, snapshots every 1–5 min per active customer, cold intents on object storage.
 
+S2 as a candidate substrate (not a default): [02-s2-vs-kafka.md](./02-s2-vs-kafka.md). Same log category as Kafka; different resource model (unlimited streams, fencing). Not a drop-in for the analytics firehose.
+
 Next design layer (not this doc): the apply engine and the serving projection. Those sit *on* this log. They are not the log.

--- a/.plans/event-stream-sot/02-s2-vs-kafka.md
+++ b/.plans/event-stream-sot/02-s2-vs-kafka.md
@@ -1,0 +1,135 @@
+# S2 vs Kafka for this substrate
+
+Research note. Sources: S2 docs (limits, architecture, appends, concurrency, snapshots, pricing, llms.txt), S2 intro blog, YC launch, founder notes on consumer groups. Not a vendor recommendation.
+
+S2 ([s2.dev](https://s2.dev)) is a serverless **stream store**: unlimited durable ordered streams, HTTP API, object-storage backed. Their line is "if Kafka and S3 had a baby." That is marketing. The useful question is whether the *actual* product shape fits a 1M/s usage ledger + per-customer remaining, or whether we just found a prettier log.
+
+## They are the same kind of thing
+
+Both are **append-only durable logs**. Neither is a queue.
+
+| Property | Kafka-class | S2 |
+| --- | --- | --- |
+| Append only | Yes | Yes. Tail only. |
+| Durable before ack | Replica ISR / fsync (typical) | Record acknowledged only after durable in S3 (Standard) or a 3-zone S3 Express quorum (Express) |
+| Replay from position | Offset | Sequence number, timestamp, or tail-relative |
+| Many independent readers | Yes | Yes. Each reader tracks its own cursor |
+| Splice / edit the middle | No | No |
+| Compensating events + `event_time` | App-level | App-level |
+
+If the question is "is S2 durable like Kafka?" — yes, in the SoT sense. A 202 that waits for S2's append ack is "on disk in object storage," which is a *stronger* durability story than a Kafka produce that only hit the leader's page cache (depends how you configure Kafka). It is also usually *slower*.
+
+S2 Standard: they publish p99 append **< 500ms**. Express: **< 50ms**. Kafka on local disks is often **5–20ms**. WarpStream-class S3 logs are in the same "object storage ack" latency band as S2 Standard.
+
+So: durability is not why you would pick S2 over Kafka. Latency vs ops vs **cardinality** is.
+
+## Where they actually differ
+
+### 1. Resource model (the real difference)
+
+Kafka's unit of scale is the **partition**. You provision a small number of fat topics (tens to thousands of partitions). A customer is a *key* hashed onto a partition. Many customers share a partition. Creating a million partitions is an operational disaster.
+
+S2's unit of scale is the **stream**. They explicitly allow unlimited streams. A stream has a URL. Dormant streams live as metadata + object segments and take no hot memory. This is the product: per agent session, per user, per customer.
+
+That is not a minor API difference. It changes the architecture:
+
+```text
+Kafka:   one topic  ×  N partitions     customer is a key inside a shared pipe
+S2:      one stream ×  1 customer       customer is the pipe
+```
+
+Per-customer FIFO in Kafka: yes, same key → same partition. You still **multiplex** unrelated customers on that partition. A poison / hot customer / rebalance hits neighbors.
+
+Per-customer FIFO in S2: the stream *is* the customer. Isolation is natural. `check-tail` is "where is this customer." Fencing is "who may write this customer."
+
+S2's own docs and launch post say they thought Kafka users would be the buyers; they found more traction where people were about to abuse Postgres/Redis, and where **stream count** is the problem Kafka will not let you have.
+
+### 2. Writer coordination (S2 is closer to a WAL primitive)
+
+S2 has first-class **conditional appends**:
+
+- `match_seq_num` — optimistic CAS. Append only if the next seq is what you think. 412 otherwise. Documented as a path to exactly-once with retries.
+- `fencing_token` — pessimistic exclusive writer. New owner sets a fence command; stale writers 412. Cooperative: appends *without* a token still succeed, so every real writer must send the token.
+
+Kafka does not give you per-key fencing in the protocol. You get partition leadership, transactions, consumer-group assignment. Single-writer-per-customer is an application lock on top.
+
+If the apply engine is "one owner per customer, failover must not dual-write," S2's primitive is closer to MemoryDB's internal log (they cite that paper) than to Kafka produce.
+
+### 3. Consumers
+
+Kafka: consumer groups, committed offsets, rebalance, Connect, Flink sources that speak the protocol.
+
+S2: **no consumer group** (as of their own founder comment and current docs). You know which stream to read. You store the cursor (seq). Flink integration exists and Flink assigns streams as splits. Kubernetes StatefulSet static assignment is the other pattern.
+
+This is fine for "worker W owns customer C, tails `customers/C`." It is awkward for "50 workers chew one org-wide firehose" unless you invent assignment.
+
+Kafka protocol compatibility was **planned** as an OSS layer in the intro blog. It is not the product today. S2 is unconstrained by the Kafka protocol on purpose.
+
+### 4. Throughput shape
+
+S2 documented limits (can be raised):
+
+- **100 MiBps write per stream** (blog earlier said 125; limits page says 100)
+- **200 append batches/s per stream per connection** (429 / session throttle)
+- Batch: **1000 records or 1 MiB**, atomic
+- Reads of recent data: blog said 500 MiBps/stream; historical reads from object storage "without a cap"
+
+1M events/s **aggregate** is not a per-stream problem. If events are ~500B, 1M/s ≈ 500 MiB/s. That is many streams in parallel, which is how S2 wants to be used.
+
+1M events/s on **one** customer is the test. 200 batches/s × 1000 records = 200k records/s **if every batch is full**. A hot customer works only with aggressive batching (same as Kafka). Tiny one-record HTTP appends will die at 200/s per connection.
+
+Kafka routinely does 1M/s on one topic with enough partitions. That is a solved, boring number. S2's published story is "hundreds of MB/s **per stream**" and unlimited streams. Aggregate 1M/s is plausible. It is less proven in public than Kafka.
+
+### 5. Snapshots and trim
+
+S2 documents **snapshot-and-follow** as a first-class pattern: materialize state at cursor `S`, store snapshot externally or in-stream, optionally **trim** the prefix. In-stream snapshot + trim can be one atomic batch with `match_seq_num`.
+
+Kafka has compacted changelog topics and you roll your own snapshot. Same idea, less opinionated.
+
+This matches `snapshot(S) + fold(tail)` exactly.
+
+### 6. Ops, maturity, ecosystem
+
+| | Kafka | S2 |
+| --- | --- | --- |
+| Age | ~13 years, default protocol | YC, hosted + `s2-lite` single binary |
+| Correctness work | Huge production corpus | DST (Turmoil), Antithesis, Porcupine linearizability — serious, still young |
+| Tinybird / Connect / Flink | Native, boring | Flink yes; no Kafka Connect universe; Tinybird is another HTTP produce unless we fan-in |
+| Compliance | Whatever you run | SOC 2, GDPR DPA, HIPAA BAA listed |
+| SLO | You operate it, or vendor | 99.99% availability SLO |
+| Price shape | Brokers / MSK / CUs | $0.05/GiB-month retain, $0.05/GiB Standard write, $0.075 Express, cheap per-stream ($0.01 / 1000 stream-months) |
+
+S2's pricing is built for **lots of tiny streams**. Kafka's pricing is built for **few fat clusters**. That again is the cardinality bet.
+
+### 7. Insert / mutate
+
+Same answer as the Kafka doc. S2 cannot splice. Trim deletes a *prefix*, not a hole. Corrections are new records. `event_time` is a field you put in the body (reads can start by timestamp, which is handy for D2 analytics).
+
+## Is this the right use case?
+
+S2's documented sweet spots: agent session WALs, per-user journeys, multiplayer rooms, live views, high-cardinality event sourcing. **Not** "replace our Kafka clickstream + Connect + 12 consumer groups."
+
+Our design wants **both**:
+
+1. **Per-customer wallet log** — serial apply, fencing, snapshot+follow, replay one customer. High stream count. Moderate per-stream rate except whales.
+2. **1M/s usage firehose** — analytics, Tinybird, org-wide consumers. Low stream count. High aggregate rate. Consumer groups / fan-in.
+
+S2 is a better *shape* for (1) than Kafka. Kafka is a better *shape* for (2) than S2.
+
+One stream per customer on S2 and "Tinybird tails everything" does **not** work. Tinybird cannot subscribe to a million streams. You would need a fan-in (workers or a second aggregated stream) or keep Tinybird ingest as a separate produce (HTTP, as today).
+
+Putting the **entire** SoT on S2 because the website is interesting is the wrong reason. Putting the **customer ledger** on a high-cardinality log (S2, or a Kafka topic used carefully) is the right reason. Those are different decisions.
+
+## Verdict
+
+**Do not treat S2 as "Kafka but durable."** Kafka is already durable. S2 is "unlimited streams + S3 ack + HTTP + fencing," with no consumer groups and a young ecosystem.
+
+**Do not pick S2 as the only bus** for 1M/s + Tinybird + remaining. Analytics wants a fat firehose. Wallet wants a stream per customer. One product rarely wins both without a fan-in.
+
+**S2 is worth keeping on the shortlist for the wallet log** if we commit to one stream per customer (or per credit-graph). `match_seq_num` / fencing / snapshot-and-follow / trim are the primitives we would otherwise build on Kafka. Unlimited streams is the thing Kafka will not give us cheaply.
+
+**Kafka (or Redpanda / WarpStream) stays the default for ingest + analytics** until S2 has a proven 1M/s aggregate path *and* a boring way to fan-in to Tinybird.
+
+**Risk if we made S2 the SoT tomorrow:** vendor/maturity, Express vs Standard latency for 202, 200 batches/s/connection footgun, no consumer groups, we invent Tinybird fan-in, fencing is cooperative (forgotten token = unfenced writer).
+
+Next layer can stay substrate-agnostic: `usage.intents` and `wallet.facts` keyed by customer. Whether that key is a Kafka partition key or an S2 stream name is a binding, not the architecture.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Research + substrate design. No runtime code changes.

`.plans/event-stream-sot/01-durable-log.md` — durable log (not a queue): throughput, per-customer FIFO, replay, no splicing.

`.plans/event-stream-sot/02-s2-vs-kafka.md` — S2 research. Same log category as Kafka. Difference is unlimited streams + fencing, not durability. Strong for a per-customer wallet log; not a drop-in for a 1M/s Tinybird firehose.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02660-e5a4-7bbf-b484-bd6e9d985d0b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02660-e5a4-7bbf-b484-bd6e9d985d0b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Establishes the event stream as the durable source of truth for balances and defines the log substrate, while keeping ~50ms check/lock reads by treating Redis remaining as a rebuildable serving projection. Research docs only; no runtime code changes.

- Adds `.plans/event-stream-balance-sot.md` outlining intents vs facts, current apply/analytics paths, recovery via snapshot(S)+fact tail, and a phased path: Lua XADD facts → Postgres as fact projector with watermark → structural facts on the same per-customer log → unified analytics ingest → optional worker-apply later.
- Adds `.plans/event-stream-sot/01-durable-log.md` specifying a Kafka-API append-only log: per-customer FIFO partitions, idempotent/quorum acks, long retention, watermarked snapshots; handle late/correct data via `event_time` and compensating appends; never splice the SoT. Now links to the S2 comparison.
- Adds `.plans/event-stream-sot/02-s2-vs-kafka.md` comparing substrates: S2’s unlimited streams + fencing fit a per-customer wallet ledger; Kafka/Redpanda/WarpStream fit the 1M/s analytics firehose and consumer groups. Recommendation: Kafka-class for ingest SoT, consider S2 for the per-customer wallet log with fan-in for Tinybird.
- Clarifies 1M/s plan: API acks from the log; workers coalesce by customer/credit graph, append compact apply facts, then refresh Redis; check/lock remain sync on Redis; recovery is `snapshot(S) + fact tail`, not replaying intents.

<sup>Written for commit 72a4b799ef88d1c5194442c472f4e03e6db660be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

