### PR TITLE
fix(capy): derive Neon branches from runtime hostname

### DIFF
--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -94,20 +94,8 @@ function shortHash(input: string): string {
 }
 
 function getMachineId(): string {
-	const configPath = process.env.CAPY_MACHINE_CONFIG?.trim();
-	if (configPath && existsSync(configPath)) {
-		try {
-			const config = JSON.parse(readFileSync(configPath, "utf-8")) as {
-				bindingId?: string;
-			};
-			if (config.bindingId?.trim()) return config.bindingId.trim();
-		} catch {
-			log(`machine config at ${configPath} is unreadable, using hostname`);
-		}
-	}
-	// Local repros do not have Capy's machine config. The hostname keeps the
-	// branch stable for the lifetime of that host.
-	return (process.env.HOSTNAME ?? hostname() ?? "unknown").trim();
+	// The hostname is assigned at runtime and remains stable when a VM wakes.
+	return process.env.HOSTNAME?.trim() || hostname();
 }
 
 function deriveBranchName(machineId: string): string {

--- a/scripts/setup/CAPY_README.md
+++ b/scripts/setup/CAPY_README.md
@@ -81,11 +81,11 @@ without repository preview configuration.
 
 ## Provisioning model
 
-`scripts/capy/provision.ts` reads the VM's `bindingId` from the file referenced
-by `CAPY_MACHINE_CONFIG`, hashes it into a `capy-<hash>` Neon branch name, and
-stores non-secret branch metadata plus generated local auth secrets in the
-mode-`0600` file `~/.autumn-capy/state.json`. A resumed VM reuses that
-branch and refreshes its connection string. A new VM gets a new branch.
+`scripts/capy/provision.ts` hashes the VM's runtime hostname into a
+`capy-<hash>` Neon branch name, and stores non-secret branch metadata plus
+generated local auth secrets in the mode-`0600` file `~/.autumn-capy/state.json`.
+A resumed VM keeps its hostname and reuses that branch; a new VM derives a new
+branch even if it inherits a stale state file.
 
 The script writes managed values into:
 


### PR DESCRIPTION
## Summary
- derive each Capy machine's Neon branch from its runtime hostname instead of the snapshot-baked `CAPY_MACHINE_CONFIG.bindingId`
- preserve the existing state-file reuse, stale-state recovery, and adopt-by-name behavior for wakes of the same VM
- update the provisioning documentation to describe hostname identity and cloned stale-state recovery

## Live verification
Provisioned two simulated machines using different `HOSTNAME` values, separate `CAPY_PREFIX` directories, and the same intentionally shared `CAPY_MACHINE_CONFIG` fixture. The first machine's completed `state.json` was copied into the second prefix before its first run to reproduce a snapshot-cloned stale state.

- machine A created `capy-d5e474c`
- machine B ignored A's cloned state identity and created `capy-b0d82ed`
- both branches coexisted under `dw-template`
- each first run applied the complete schema: 67 public tables and 68 Drizzle migration journal entries
- each branch independently created `unit-test-org`
- both temporary verification branches were deleted afterward

The one-time cleanup removed the existing poisoned `capy-*` branches, including branches created concurrently during the cleanup window. A final `neonctl branches list` confirmed zero `capy-template` or `capy-*` branches remain.

## Checks
- `bunx biome check scripts/capy/provision.ts scripts/setup/CAPY_README.md`
- `bun -F @autumn/scripts ts`
- `git diff --check`
- commit-hook Knip check

## Cleanup gap
There is no existing Neon lifecycle reaper for Capy branches. `triggerDevBranchReaper.ts` only archives Trigger.dev branches, while the DW registry cleanup owns registered `dw-wt-*` branches. Dead-machine `capy-*` cleanup therefore remains manual or periodic; this PR deliberately does not add new cleanup infrastructure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives Capy Neon branch names from the VM’s runtime hostname instead of a snapshot-baked `CAPY_MACHINE_CONFIG.bindingId`. This isolates branches across cloned machines while keeping branch reuse stable for the same VM.

- Behavior change: was bindingId → now hash of `HOSTNAME` (or OS hostname); clones no longer share a branch even if they inherit a stale `state.json`; a waking VM reuses its branch.
- Preserves state-file reuse and adopt-by-name behavior for the same VM; stale-state recovery no longer binds a new host to an old branch.
- Updates `scripts/setup/CAPY_README.md` to document hostname-derived identity and cloned stale-state handling.
- No new reaper: cleanup of dead `capy-*` branches remains manual or periodic.

<sup>Written for commit d1ae8ba5ea2fb49d045ccaf5b277ece3b5afed7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes Capy provisioning so each machine derives its Neon branch identity from its runtime hostname rather than snapshot-baked configuration.

- **Bug fixes:** Derives `capy-<hash>` branch names from the runtime hostname so cloned machines do not inherit the same configured identity.
- **Improvements:** Preserves branch reuse and adopt-by-name behavior while documenting hostname-based identity and stale-state recovery.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The hostname-derived identity integrates with the existing state reuse, branch lookup, and branch creation paths, and no reachable failure was established for the supported Capy lifecycle.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/provision.ts | Replaces snapshot-baked binding identity with runtime hostname identity while retaining the existing Neon branch reuse, adoption, and creation flow. |
| scripts/setup/CAPY_README.md | Updates provisioning documentation to explain hostname-derived branch identity and cloned stale-state recovery. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Capy startup] --> B[Read runtime hostname]
    B --> C[Hash hostname into capy branch name]
    C --> D{Matching branch in saved state exists?}
    D -->|Yes| E[Reuse branch and refresh connection]
    D -->|No| F{Branch with derived name exists?}
    F -->|Yes| G[Adopt existing branch]
    F -->|No| H[Create branch from dw-template]
    E --> I[Save state and write environment files]
    G --> I
    H --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 isolate capy machine identities"](https://github.com/useautumn/autumn/commit/d1ae8ba5ea2fb49d045ccaf5b277ece3b5afed7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55741857)</sub>

<!-- /greptile_comment -->