### PR TITLE
fix(capy): wait for fresh Neon branch operations

### DIFF
--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -40,6 +40,7 @@ import {
 	ensureChatDatabase,
 	ensureTemplateBranch,
 	findBranchByName,
+	waitForNeonBranchOperations,
 } from "../dw/helpers/neon.ts";
 
 // ---------------------------------------------------------------------------
@@ -626,6 +627,7 @@ function ensureNeonBranch(
 	);
 	ensureTemplateBranch();
 	const branch = createBranch(branchName, NEON_TEMPLATE_BRANCH);
+	waitForNeonBranchOperations(branch);
 	const pooledUrl = connectionString(branchName, { pooled: true });
 	return {
 		state: {

--- a/scripts/dw/helpers/neon.test.ts
+++ b/scripts/dw/helpers/neon.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, expect, test } from "bun:test";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const projectRoot = join(import.meta.dir, "..", "..", "..");
+const neonHelperUrl = pathToFileURL(join(import.meta.dir, "neon.ts")).href;
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of tempDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function runWaiter(neonScript: string) {
+	const directory = mkdtempSync(join(tmpdir(), "autumn-neon-operations-"));
+	tempDirectories.push(directory);
+	const binDir = join(directory, "bin");
+	const callsPath = join(directory, "calls");
+	const neonPath = join(binDir, "neon");
+	mkdirSync(binDir);
+	writeFileSync(neonPath, neonScript);
+	chmodSync(neonPath, 0o755);
+
+	const result = Bun.spawnSync(
+		[
+			"bun",
+			"-e",
+			`import { waitForNeonBranchOperations } from ${JSON.stringify(neonHelperUrl)}; waitForNeonBranchOperations({ id: "branch-1", name: "capy-1234567" });`,
+		],
+		{
+			cwd: projectRoot,
+			env: {
+				...process.env,
+				PATH: `${binDir}:${process.env.PATH}`,
+				NEON_OPERATION_TEST_CALLS: callsPath,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		},
+	);
+
+	return {
+		calls: readFileSync(callsPath, "utf8"),
+		code: result.exitCode,
+		stderr: new TextDecoder().decode(result.stderr),
+		stdout: new TextDecoder().decode(result.stdout),
+	};
+}
+
+test("waitForNeonBranchOperations waits for every matching operation", () => {
+	const result = runWaiter(`#!/bin/sh
+calls=$(cat "$NEON_OPERATION_TEST_CALLS" 2>/dev/null || echo 0)
+calls=$((calls + 1))
+printf '%s' "$calls" > "$NEON_OPERATION_TEST_CALLS"
+if [ "$calls" -eq 1 ]; then
+	cat <<'JSON'
+[{"branch_id":"branch-1","action":"create_branch","status":"finished"},{"branch_id":"branch-1","action":"start_compute","status":"finished"},{"branch_id":"branch-1","action":"timeline_update_protected_config","status":"running"},{"branch_id":"other-branch","action":"delete_branch","status":"failed"}]
+JSON
+else
+	cat <<'JSON'
+[{"branch_id":"branch-1","action":"create_branch","status":"finished"},{"branch_id":"branch-1","action":"start_compute","status":"finished"},{"branch_id":"branch-1","action":"timeline_update_protected_config","status":"finished"}]
+JSON
+fi
+`);
+
+	expect(result.code).toBe(0);
+	expect(result.calls).toBe("2");
+	expect(result.stdout).toContain(
+		"[dw] neon branch capy-1234567 operations ready",
+	);
+});
+
+test("waitForNeonBranchOperations fails on a matching terminal failure", () => {
+	const result = runWaiter(`#!/bin/sh
+printf '1' > "$NEON_OPERATION_TEST_CALLS"
+echo '[{"branch_id":"branch-1","action":"start_compute","status":"failed"}]'
+`);
+
+	expect(result.code).toBe(1);
+	expect(result.stderr).toContain(
+		"[dw] neon branch capy-1234567 operation start_compute entered terminal failure status failed",
+	);
+});

--- a/scripts/dw/helpers/neon.ts
+++ b/scripts/dw/helpers/neon.ts
@@ -13,6 +13,24 @@ import { fatal, log, sh } from "./shell.ts";
 
 let neonCmd: string | undefined;
 
+type NeonOperation = {
+	branch_id: string;
+	action: string;
+	status: string;
+};
+
+const REQUIRED_BRANCH_OPERATION_ACTIONS = [
+	"create_branch",
+	"start_compute",
+] as const;
+const TERMINAL_FAILURE_OPERATION_STATUSES = new Set([
+	"failed",
+	"cancelled",
+	"canceled",
+]);
+const NEON_OPERATION_TIMEOUT_MS = 120_000;
+const NEON_OPERATION_POLL_INTERVAL_MS = 1_000;
+
 function resolveNeonCmd(): string {
 	if (neonCmd) return neonCmd;
 	for (const candidate of ["neon", "neonctl"]) {
@@ -102,6 +120,82 @@ export function createBranch(name: string, parent: string): NeonBranch {
 	} catch {
 		fatal(`could not parse neon create output:\n${res.stdout}`);
 	}
+}
+
+function listOperations(branchName: string): NeonOperation[] {
+	const res = neon([
+		"operations",
+		"list",
+		"--project-id",
+		neonProjectId(),
+		"--output",
+		"json",
+	]);
+	if (res.code !== 0) {
+		fatal(
+			`neon operations list for ${branchName} failed: ${res.stderr || res.stdout}`,
+		);
+	}
+	try {
+		const operations = JSON.parse(res.stdout);
+		if (!Array.isArray(operations)) {
+			fatal(
+				`unexpected neon operations list output for ${branchName}:\n${res.stdout}`,
+			);
+		}
+		return operations as NeonOperation[];
+	} catch {
+		fatal(
+			`could not parse neon operations list for ${branchName} output:\n${res.stdout}`,
+		);
+	}
+}
+
+function pendingOperationsMessage(operations: NeonOperation[]): string {
+	const missing = REQUIRED_BRANCH_OPERATION_ACTIONS.filter(
+		(action) => !operations.some((operation) => operation.action === action),
+	).map((action) => `missing ${action}`);
+	const pending = operations
+		.filter((operation) => operation.status !== "finished")
+		.map((operation) => `${operation.action} (${operation.status})`);
+	return [...missing, ...pending].join(", ");
+}
+
+export function waitForNeonBranchOperations(branch: NeonBranch): void {
+	const deadline = Date.now() + NEON_OPERATION_TIMEOUT_MS;
+	let branchOperations: NeonOperation[] = [];
+
+	while (Date.now() < deadline) {
+		branchOperations = listOperations(branch.name).filter(
+			(operation) => operation.branch_id === branch.id,
+		);
+		const failedOperation = branchOperations.find((operation) =>
+			TERMINAL_FAILURE_OPERATION_STATUSES.has(operation.status.toLowerCase()),
+		);
+		if (failedOperation) {
+			fatal(
+				`neon branch ${branch.name} operation ${failedOperation.action} entered terminal failure status ${failedOperation.status}`,
+			);
+		}
+
+		const requiredOperationsAppeared = REQUIRED_BRANCH_OPERATION_ACTIONS.every(
+			(action) =>
+				branchOperations.some((operation) => operation.action === action),
+		);
+		if (
+			requiredOperationsAppeared &&
+			branchOperations.every((operation) => operation.status === "finished")
+		) {
+			log(`neon branch ${branch.name} operations ready`);
+			return;
+		}
+
+		Bun.sleepSync(NEON_OPERATION_POLL_INTERVAL_MS);
+	}
+
+	fatal(
+		`neon branch ${branch.name} did not become ready within ${NEON_OPERATION_TIMEOUT_MS / 1_000}s: ${pendingOperationsMessage(branchOperations)}`,
+	);
 }
 
 export function deleteBranch(


### PR DESCRIPTION
## Summary
- gate freshly created Capy branches on Neon control-plane operations before requesting connection strings
- require both `create_branch` and `start_compute`, plus every related branch-scoped operation, to reach `finished`
- fail immediately on terminal operation failures and after 120 seconds with the missing or pending action/status
- keep reused and adopted branch paths unchanged and free of readiness polling

neonctl 3.6.0 does not provide `branches create --wait`, so this uses `neonctl operations list` with a bounded one-second poll.

## Live verification
Started from an absent scratch branch and ran the real provisioning path once. The log order was:

1. create `capy-e4d5e2c`
2. report Neon operations ready
3. invoke committed migrations exactly once

The first attempt completed without `28P01` or password-authentication output. The resulting branch had 67 public tables, 68 Drizzle migration journal entries, and its own `unit-test-org`. The scratch branch was deleted afterward and confirmed absent.

## Checks
- `bunx biome check scripts/dw/helpers/neon.ts scripts/capy/provision.ts scripts/dw/helpers/neon.test.ts`
- `bun -F @autumn/scripts ts`
- focused `neon.test.ts`: 2 passed
- `git diff --check`
- commit-hook Knip check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for Neon control-plane operations before using new Capy branch connections. Previously we requested connection strings immediately after branch creation; now we wait until required operations finish to avoid race-induced auth failures.

- Add `waitForNeonBranchOperations` that polls `neon operations list` every 1s, requires `create_branch` and `start_compute` (and any branch-scoped ops) to reach finished, fails fast on terminal statuses, and times out after 120s.
- Invoke the wait during Capy branch provisioning right after `createBranch` and before requesting connection strings. Reused/adopted branches remain unchanged.
- Add tests that stub `neon` output to verify both the ready path and fail-fast behavior.

<sup>Written for commit 6f1fd0c48e649446f6594541166805ca94f6bc58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR waits for Neon control-plane work before newly created Capy branches request connection strings, while leaving reused and adopted branches unchanged.
- **Bug fixes:** Polls fresh branch operations until branch creation, compute startup, and visible related operations finish.
- **Improvements:** Adds bounded timeout and terminal-failure diagnostics.
- **Improvements:** Adds focused success and failure tests for the new readiness waiter.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking gap in coverage for operations that appear only in a later poll.

The fresh-branch path now waits before requesting connection strings, and no concrete blocking failure was established; the focused test does not exercise delayed operation discovery.

**Files Needing Attention:** scripts/dw/helpers/neon.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/provision.ts | Adds the readiness wait only to the newly created Capy branch path before requesting its connection string. |
| scripts/dw/helpers/neon.ts | Implements bounded polling, required-operation checks, terminal-failure handling, and timeout diagnostics. |
| scripts/dw/helpers/neon.test.ts | Covers visible pending and failed operations, but not a related operation that first appears in a later poll. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Capy as Capy provisioner
  participant Neon as Neon CLI
  participant DB as New branch database
  Capy->>Neon: create branch
  loop Every second, up to 120 seconds
    Capy->>Neon: list project operations
    Neon-->>Capy: branch-scoped operations
  end
  Capy->>Neon: request connection strings
  Capy->>DB: apply committed migrations
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/dw/helpers/neon.test.ts:66-73
**Delayed operation discovery is untested**

The mock includes `timeline_update_protected_config` in the first response, so it does not exercise a related operation that first appears after the required operations finish. This leaves the waiter's early-return boundary untested and allows a future timing regression to start migrations before a later operation completes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 wait for neon branch operations"](https://github.com/useautumn/autumn/commit/6f1fd0c48e649446f6594541166805ca94f6bc58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55752456)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->