### PR TITLE
feat: keep old plan ids as aliases after rename

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeCheckoutSessionCompleted/setupCheckoutSessionCompletedContext.ts
@@ -11,6 +11,7 @@ import {
 	getExpandedStripeSubscription,
 } from "@/external/stripe/subscriptions/operations/getExpandedStripeSubscription";
 import { getMetadataFromCheckoutSession } from "@/internal/metadata/metadataUtils.js";
+import { rewritePlanIdAliasValues } from "@/internal/catalogV2/productAliases/rewritePlanIdAliasValues.js";
 import type { StripeWebhookContext } from "../../webhookMiddlewares/stripeWebhookContext.js";
 
 type CheckoutSessionExpansions = ["line_items"];
@@ -43,6 +44,12 @@ export const setupCheckoutSessionCompletedContext = async ({
 		stripeCheckoutSession,
 		db,
 	);
+	if (metadata?.data) {
+		rewritePlanIdAliasValues({
+			value: metadata.data,
+			aliases: ctx.org.planAliases ?? {},
+		});
+	}
 
 	// Extract subscription and invoice IDs
 	const subscriptionId =

--- a/server/src/external/vercel/handlers/resources/handleCreateResource.ts
+++ b/server/src/external/vercel/handlers/resources/handleCreateResource.ts
@@ -104,7 +104,8 @@ export const handleCreateResource = createRoute({
 		const { orgId, env, integrationConfigurationId } = c.req.param();
 		const ctx = c.get("ctx");
 		const { db, org, logger, fullCustomer: customer } = ctx;
-		const { productId, name, metadata, billingPlanId } = c.req.valid("json");
+		const { productId, name, metadata, billingPlanId } =
+			c.req.valid("json");
 		const appEnv = env as AppEnv;
 
 		if (!customer) {
@@ -199,7 +200,7 @@ export const handleCreateResource = createRoute({
 
 			if (existing) {
 				const product = installationCusProduct
-					? await loadProduct(installationCusProduct.product_id)
+					? await loadProduct(installationCusProduct.product.id)
 					: requestedProduct;
 				return c.json(
 					buildResourceResponse({ resourceId: existing.id, product }),
@@ -234,7 +235,7 @@ export const handleCreateResource = createRoute({
 					});
 				if (!winner) throw error;
 				const product = installationCusProduct
-					? await loadProduct(installationCusProduct.product_id)
+					? await loadProduct(installationCusProduct.product.id)
 					: requestedProduct;
 				return c.json(
 					buildResourceResponse({ resourceId: winner.id, product }),
@@ -242,9 +243,9 @@ export const handleCreateResource = createRoute({
 			}
 
 			const product = installationCusProduct
-				? installationCusProduct.product_id === billingPlanId
+				? installationCusProduct.product.id === billingPlanId
 					? requestedProduct
-					: await loadProduct(installationCusProduct.product_id)
+					: await loadProduct(installationCusProduct.product.id)
 				: (
 						await provisionVercelCusProduct({
 							ctx,
@@ -266,7 +267,7 @@ export const handleCreateResource = createRoute({
 							resourceId,
 							installationCusProductId: installationCusProduct.id,
 							requestedBillingPlanId: billingPlanId,
-							actualProductId: installationCusProduct.product_id,
+							actualProductId: installationCusProduct.product.id,
 							installationId: integrationConfigurationId,
 						},
 					},

--- a/server/src/external/vercel/misc/vercelMiddleware.ts
+++ b/server/src/external/vercel/misc/vercelMiddleware.ts
@@ -1,5 +1,6 @@
-import { AppEnv, AuthType, type Organization } from "@autumn/shared";
+import { AppEnv, AuthType, type Organization, productAliases } from "@autumn/shared";
 import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
 import type { Context, Next } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { getCtxWithCustomerRedis } from "@/external/redis/customerRedisRouting.js";
@@ -7,6 +8,7 @@ import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import { computeRolloutSnapshot } from "@/internal/misc/rollouts/rolloutUtils.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
+import { toPlanAliasMap } from "@/internal/catalogV2/productAliases/toPlanAliasMap.js";
 import { logCaughtError } from "@/utils/logging/logCaughtError.js";
 import {
 	addVercelCustomerToContext,
@@ -39,9 +41,20 @@ export const vercelSeederMiddleware = async (
 				})
 			: ctx.features;
 
+	const aliasRows = org
+		? await ctx.db.query.productAliases.findMany({
+				where: and(
+					eq(productAliases.org_id, org.id),
+					eq(productAliases.env, env),
+				),
+			})
+		: [];
+
 	const nextCtx = {
 		...ctx,
-		org,
+		org: org
+			? { ...org, planAliases: toPlanAliasMap({ rows: aliasRows }) }
+			: org,
 		env,
 		features,
 		authType: AuthType.Vercel,

--- a/server/src/external/vercel/vercelWebhookRouter.ts
+++ b/server/src/external/vercel/vercelWebhookRouter.ts
@@ -2,6 +2,7 @@ import { AppEnv } from "@autumn/shared";
 import { Hono } from "hono";
 import { handleRotateResourceSecret } from "@/external/vercel/handlers/resources/handleRotateResourceSecret.js";
 import { analyticsMiddleware } from "@/honoMiddlewares/analyticsMiddleware.js";
+import { planAliasMiddleware } from "@/honoMiddlewares/planAliasMiddleware.js";
 import { traceEnrichMiddleware } from "@/honoMiddlewares/traceMiddleware.js";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { logCaughtError } from "@/utils/logging/logCaughtError.js";
@@ -42,6 +43,7 @@ export const vercelWebhookRouter = new Hono<HonoEnv>();
 vercelWebhookRouter.use(
 	"/:orgId/:env/*",
 	vercelSeederMiddleware,
+	planAliasMiddleware,
 	analyticsMiddleware,
 	traceEnrichMiddleware,
 );

--- a/server/src/honoMiddlewares/authMiddlewares/handleOAuthMiddleware.ts
+++ b/server/src/honoMiddlewares/authMiddlewares/handleOAuthMiddleware.ts
@@ -16,6 +16,7 @@ import {
 	oauthAccessToken,
 	oauthConsent,
 	organizations,
+	productAliases,
 	RecaseError,
 	sortFeatures,
 } from "@autumn/shared";
@@ -25,6 +26,7 @@ import { alias } from "drizzle-orm/pg-core";
 import type { Context, Next } from "hono";
 import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
 import { isServedOAuthAudience } from "@/internal/auth/oauth/oauthResourceAudiences.js";
+import { toPlanAliasMap } from "@/internal/catalogV2/productAliases/toPlanAliasMap.js";
 
 const masterOrg = alias(organizations, "master_org");
 
@@ -112,6 +114,7 @@ const getOAuthRequestContext = async ({
 			org: organizations,
 			masterOrg,
 			feature: features,
+			productAlias: productAliases,
 		})
 		.from(oauthAccessToken)
 		.innerJoin(
@@ -128,6 +131,13 @@ const getOAuthRequestContext = async ({
 			and(
 				eq(features.org_id, organizations.id),
 				eq(features.env, oauthConsent.env),
+			),
+		)
+		.leftJoin(
+			productAliases,
+			and(
+				eq(productAliases.org_id, organizations.id),
+				eq(productAliases.env, oauthConsent.env),
 			),
 		)
 		.where(
@@ -169,14 +179,27 @@ const getOAuthRequestContext = async ({
 				config: OrgConfigSchema.parse(first.masterOrg.config || {}),
 			}
 		: null;
+	// Features × aliases is a cartesian product; keep one of each.
+	const orgFeatures: Feature[] = [];
+	const seenFeatureIds = new Set<string>();
+	const aliasRows: { alias_id: string; canonical_plan_id: string }[] = [];
+	const seenAliasIds = new Set<string>();
+	for (const row of rows) {
+		if (row.feature && !seenFeatureIds.has(row.feature.id)) {
+			seenFeatureIds.add(row.feature.id);
+			orgFeatures.push(row.feature as unknown as Feature);
+		}
+		if (row.productAlias && !seenAliasIds.has(row.productAlias.alias_id)) {
+			seenAliasIds.add(row.productAlias.alias_id);
+			aliasRows.push(row.productAlias);
+		}
+	}
 	const org: Organization = {
 		...first.org,
 		master,
 		config: OrgConfigSchema.parse(first.org.config || {}),
+		planAliases: toPlanAliasMap({ rows: aliasRows }),
 	};
-	const orgFeatures = rows.flatMap((row) =>
-		row.feature ? [row.feature] : [],
-	) as unknown as Feature[];
 
 	return {
 		env,

--- a/server/src/honoMiddlewares/planAliasMiddleware.ts
+++ b/server/src/honoMiddlewares/planAliasMiddleware.ts
@@ -1,0 +1,75 @@
+import type { Context, Next } from "hono";
+import { replaceJsonBody } from "@/honoUtils/forceJsonBody.js";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { rewritePlanIdAliasParams } from "@/internal/catalogV2/productAliases/rewritePlanIdAliasParams.js";
+import { rewritePlanIdAliasValues } from "@/internal/catalogV2/productAliases/rewritePlanIdAliasValues.js";
+
+const CREATE_PLAN_ID_SKIP_KEYS = new Set(["plan_id", "id", "product_id"]);
+
+const isCreatePlanRoute = ({
+	method,
+	path,
+}: {
+	method: string;
+	path: string;
+}): boolean => {
+	if (method !== "POST") return false;
+	const pathname = (path.split("?")[0] ?? path).replace(/^\/v1/, "");
+	return (
+		pathname === "/products" ||
+		pathname === "/plans" ||
+		pathname.endsWith("/plans.create")
+	);
+};
+
+/**
+ * Rewrites public plan ids in the JSON body and in `:product_id` path params.
+ * Dashboard is skipped (it always sends canonical ids). Empty alias maps are a no-op.
+ */
+export const planAliasMiddleware = async (c: Context<HonoEnv>, next: Next) => {
+	if (c.req.header("x-client-type") === "dashboard") {
+		await next();
+		return;
+	}
+
+	const ctx = c.get("ctx");
+	const aliases = ctx.org?.planAliases;
+	if (!aliases || Object.keys(aliases).length === 0) {
+		await next();
+		return;
+	}
+
+	// Own-property shadows param(); same trick as queryMiddleware.
+	// @ts-expect-error HonoRequest.param is a prototype method
+	c.req.param = rewritePlanIdAliasParams({
+		param: c.req.param.bind(c.req),
+		aliases,
+	});
+
+	if (c.req.method === "GET" || c.req.method === "HEAD") {
+		await next();
+		return;
+	}
+
+	const body = ctx.requestBody;
+	if (!body || typeof body !== "object") {
+		await next();
+		return;
+	}
+
+	const before = JSON.stringify(body);
+	rewritePlanIdAliasValues({
+		value: body,
+		aliases,
+		skipKeys: isCreatePlanRoute({ method: c.req.method, path: c.req.path })
+			? CREATE_PLAN_ID_SKIP_KEYS
+			: undefined,
+	});
+	// Skip replaceJsonBody on a no-op rewrite so bodyCache.text stays the
+	// original bytes (Vercel HMAC runs captureRawBody after this middleware).
+	if (before !== JSON.stringify(body)) {
+		ctx.requestBody = body;
+		await replaceJsonBody(c, body);
+	}
+	await next();
+};

--- a/server/src/honoUtils/forceJsonBody.ts
+++ b/server/src/honoUtils/forceJsonBody.ts
@@ -22,3 +22,10 @@ export const forceJsonBodyField = async (
 		text: Promise.resolve(forced),
 	};
 };
+
+export const replaceJsonBody = async (c: Context, body: unknown) => {
+	const forced = JSON.stringify(body);
+	(c.req as { bodyCache: Record<string, unknown> }).bodyCache = {
+		text: Promise.resolve(forced),
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
@@ -1,6 +1,31 @@
 import type { UpdateCatalogParams } from "@autumn/shared";
+import { resolveAliasReplacement } from "@/internal/catalogV2/productAliases/resolveAliasReplacement";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/renameProductPlan";
+
+const renameIfExisting = ({
+	planId,
+	toId,
+	productStatesContext,
+	aliases,
+}: {
+	planId: string;
+	toId: string;
+	productStatesContext: ProductStatesContext;
+	aliases?: Record<string, string>;
+}): RenameProductPlan[] => {
+	if (toId === planId) return [];
+	const versions = productStatesContext.versionsByPlanId[planId] ?? [];
+	if (versions.length === 0) return [];
+
+	return [
+		{
+			planId,
+			toId,
+			aliasReplacement: resolveAliasReplacement({ claimedId: toId, aliases }),
+		},
+	];
+};
 
 /**
  * One rename per existing plan with a differing new_plan_id. Creates carry
@@ -9,17 +34,29 @@ import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatal
 export const computeRenameProductIdsPlan = ({
 	params,
 	productStatesContext,
+	aliases,
 }: {
 	params: UpdateCatalogParams;
 	productStatesContext: ProductStatesContext;
+	aliases?: Record<string, string>;
 }): RenameProductPlan[] =>
-	params.plans.flatMap((planParams) => {
-		if (!planParams.new_plan_id) return [];
-		if (planParams.new_plan_id === planParams.plan_id) return [];
-
-		const versions =
-			productStatesContext.versionsByPlanId[planParams.plan_id] ?? [];
-		if (versions.length === 0) return [];
-
-		return [{ planId: planParams.plan_id, toId: planParams.new_plan_id }];
-	});
+	params.plans.flatMap((planParams) => [
+		...(planParams.new_plan_id
+			? renameIfExisting({
+					planId: planParams.plan_id,
+					toId: planParams.new_plan_id,
+					productStatesContext,
+					aliases,
+				})
+			: []),
+		...(planParams.variants ?? []).flatMap((variant) =>
+			variant.new_plan_id
+				? renameIfExisting({
+						planId: variant.variant_plan_id,
+						toId: variant.new_plan_id,
+						productStatesContext,
+						aliases,
+					})
+				: [],
+		),
+	]);

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateCatalogPlan.ts
@@ -91,6 +91,7 @@ export const computeUpdateCatalogPlan = ({
 		renamePlans: computeRenameProductIdsPlan({
 			params,
 			productStatesContext: catalogContext.productStatesContext,
+			aliases: ctx.org.planAliases,
 		}),
 		migrationDrafts: computeMigrationDraftPlans({
 			upsertProductPlans: plan.upsertProducts,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan.ts
@@ -19,6 +19,7 @@ import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatal
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
+import { resolveAliasReplacement } from "@/internal/catalogV2/productAliases/resolveAliasReplacement";
 
 const planHasVersionableCustomers = ({
 	planId,
@@ -135,6 +136,10 @@ export const computeUpsertProductPlan = ({
 		features: ctx.features,
 		currentFullProduct: baseFullProduct,
 	});
+	const aliasReplacement = resolveAliasReplacement({
+		claimedId: nextFullProduct.id,
+		aliases: ctx.org.planAliases,
+	});
 
 	const op = resolveUpsertOp({
 		currentFullProduct,
@@ -184,6 +189,7 @@ export const computeUpsertProductPlan = ({
 		...(planParams.create_in_stripe !== undefined
 			? { createInStripe: planParams.create_in_stripe }
 			: {}),
+		...(aliasReplacement ? { aliasReplacement } : {}),
 		state: {
 			hasCustomers:
 				versioning === "new_version"

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors.ts
@@ -8,49 +8,80 @@ import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCa
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 import { hasVercelCustomerOnProduct } from "@/internal/customers/cusProducts/repos/hasVercelCustomerOnProduct";
 
+type RenameTarget = {
+	fromId: string;
+	toId: string;
+};
+
+const renameTargetsFromParams = ({
+	params,
+}: {
+	params: UpdateCatalogParams;
+}): RenameTarget[] =>
+	params.plans.flatMap((planParams) => [
+		...(planParams.new_plan_id && planParams.new_plan_id !== planParams.plan_id
+			? [{ fromId: planParams.plan_id, toId: planParams.new_plan_id }]
+			: []),
+		...(planParams.variants ?? []).flatMap((variant) =>
+			variant.new_plan_id && variant.new_plan_id !== variant.variant_plan_id
+				? [{ fromId: variant.variant_plan_id, toId: variant.new_plan_id }]
+				: [],
+		),
+	]);
+
 /**
  * Ids a rename may not take: every id in the projected catalog and every
  * persisted id, minus this plan's own rows. Persisted ids stay taken even
  * when this batch renames them away, so execute never depends on op order.
+ * Reserved aliases are not taken — catalog execute claims them.
  */
 const takenPlanIdsForRename = ({
-	planParams,
+	fromId,
+	renameTargets,
 	params,
 	productStatesContext,
 	updateCatalogPlan,
 }: {
-	planParams: UpdateCatalogParams["plans"][number];
+	fromId: string;
+	renameTargets: RenameTarget[];
 	params: UpdateCatalogParams;
 	productStatesContext: ProductStatesContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 }): Set<string> => {
-	const renamingInternalIds = new Set(
-		(productStatesContext.versionsByPlanId[planParams.plan_id] ?? []).map(
+	const renamingInternalIds = new Set([
+		...(productStatesContext.versionsByPlanId[fromId] ?? []).map(
 			(product) => product.internal_id,
 		),
-	);
+		// new_version mints a new internal_id already stamped with toId
+		...updateCatalogPlan.upsertProducts
+			.filter((upsert) => upsert.row.planId === fromId)
+			.map((upsert) => upsert.row.nextFullProduct.internal_id),
+	]);
 	const persistedProducts = Object.values(
 		productStatesContext.versionsByPlanId,
 	).flat();
-	const siblingParamIds = params.plans.flatMap((entry) =>
-		entry.plan_id === planParams.plan_id
-			? []
-			: [entry.plan_id, entry.new_plan_id].filter(
-					(id): id is string => id != null,
-				),
-	);
+	const siblingPlanIds = params.plans.flatMap((entry) => [
+		...(entry.plan_id === fromId ? [] : [entry.plan_id]),
+		...(entry.variants ?? [])
+			.map((variant) => variant.variant_plan_id)
+			.filter((id) => id !== fromId),
+	]);
+	const siblingRenameToIds = renameTargets
+		.filter((target) => target.fromId !== fromId)
+		.map((target) => target.toId);
 
 	return new Set([
 		...[...updateCatalogPlan.projected.products, ...persistedProducts]
 			.filter((product) => !renamingInternalIds.has(product.internal_id))
 			.map((product) => product.id),
-		...siblingParamIds,
+		...siblingPlanIds,
+		...siblingRenameToIds,
 	]);
 };
 
 /**
- * Block new_plan_id when the target id is occupied, or when a Vercel-installed
- * customer is live on the plan (its id is their Vercel billing plan id).
+ * Block new_plan_id when the target id is a live plan id, or when a
+ * Vercel-installed customer is live on the plan (its id is their billing id).
  */
 export const handleUpsertProductRenameErrors = async ({
 	ctx,
@@ -63,20 +94,19 @@ export const handleUpsertProductRenameErrors = async ({
 	productStatesContext: ProductStatesContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 }): Promise<void> => {
-	for (const planParams of params.plans) {
-		if (!planParams.new_plan_id) continue;
-		if (planParams.new_plan_id === planParams.plan_id) continue;
-
+	const renameTargets = renameTargetsFromParams({ params });
+	for (const { fromId, toId } of renameTargets) {
 		if (
 			takenPlanIdsForRename({
-				planParams,
+				fromId,
+				renameTargets,
 				params,
 				productStatesContext,
 				updateCatalogPlan,
-			}).has(planParams.new_plan_id)
+			}).has(toId)
 		) {
 			throw new RecaseError({
-				message: `Cannot change product ID to ${planParams.new_plan_id}: a plan with that ID already exists (plan_id=${planParams.plan_id})`,
+				message: `Cannot change product ID to ${toId}: a plan with that ID already exists (plan_id=${fromId})`,
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});
@@ -89,12 +119,12 @@ export const handleUpsertProductRenameErrors = async ({
 			orgId: ctx.org.id,
 			env: ctx.env,
 			internalProductIds: (
-				productStatesContext.versionsByPlanId[planParams.plan_id] ?? []
+				productStatesContext.versionsByPlanId[fromId] ?? []
 			).map((product) => product.internal_id),
 		});
 		if (hasVercelCustomer) {
 			throw new RecaseError({
-				message: `Cannot change product ID while Vercel customers are subscribed to this plan (plan_id=${planParams.plan_id})`,
+				message: `Cannot change product ID while Vercel customers are subscribed to this plan (plan_id=${fromId})`,
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/aliasReplacementForPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/aliasReplacementForPlan.ts
@@ -1,0 +1,15 @@
+import type { PlanAliasReplacement } from "@autumn/shared";
+import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/renameProductPlan";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+
+export const aliasReplacementForPlan = ({
+	planId,
+	upsert,
+	renamePlans,
+}: {
+	planId: string;
+	upsert?: UpsertProductPlan;
+	renamePlans: RenameProductPlan[];
+}): PlanAliasReplacement | undefined =>
+	upsert?.aliasReplacement ??
+	renamePlans.find((rename) => rename.planId === planId)?.aliasReplacement;

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildPlansPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildPlansPreview.ts
@@ -3,6 +3,7 @@ import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/bu
 import { buildLicenseParentsPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview";
 import { buildLicensesPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicensesPreview";
 import { buildRemovePlansPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildRemovePlansPreview";
+import { aliasReplacementForPlan } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/aliasReplacementForPlan";
 import { buildVariantsPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildVariantsPreview";
 import { buildPlanVersioning } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildPlanVersioning";
 import { buildSiblingVersionsPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview";
@@ -62,6 +63,12 @@ export const buildPlansPreview = ({
 			upsertProducts,
 			productStatesContext,
 			previewContext: catalogContext.previewContext,
+			renamePlans: updateCatalogPlan.renamePlans,
+		});
+		const aliasReplacement = aliasReplacementForPlan({
+			planId: upsert.row.planId,
+			upsert,
+			renamePlans: updateCatalogPlan.renamePlans,
 		});
 
 		return [
@@ -104,6 +111,7 @@ export const buildPlansPreview = ({
 					: {}),
 				...(variants.length > 0 ? { variants } : {}),
 				...(licenses.length > 0 ? { licenses } : {}),
+				...(aliasReplacement ? { alias_replacement: aliasReplacement } : {}),
 			},
 		];
 	});

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildVariantsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildVariantsPreview.ts
@@ -15,7 +15,9 @@ import type {
 	PreviewCatalogContext,
 	ProductStatesContext,
 } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/renameProductPlan";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { aliasReplacementForPlan } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/aliasReplacementForPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
 
 const byPlanThenVersion = (
@@ -236,11 +238,13 @@ export const buildVariantsPreview = ({
 	upsertProducts,
 	productStatesContext,
 	previewContext,
+	renamePlans,
 }: {
 	directUpsert: UpsertProductPlan;
 	upsertProducts: UpsertProductPlan[];
 	productStatesContext: ProductStatesContext;
 	previewContext: PreviewCatalogContext | undefined;
+	renamePlans: RenameProductPlan[];
 }): CatalogVariantPreview[] => {
 	const variants = latestVariantsOfBase({
 		upsert: directUpsert,
@@ -273,6 +277,11 @@ export const buildVariantsPreview = ({
 				base: directUpsert,
 			});
 			const planChange = variantPlanChange({ variantUpsert });
+			const aliasReplacement = aliasReplacementForPlan({
+				planId: variant.id,
+				upsert: variantUpsert,
+				renamePlans,
+			});
 			const siblingVersions = siblingVersionsForVariant({
 				variant,
 				upsertProducts,
@@ -303,6 +312,7 @@ export const buildVariantsPreview = ({
 				...(siblingVersions.length > 0
 					? { sibling_versions: siblingVersions }
 					: {}),
+				...(aliasReplacement ? { alias_replacement: aliasReplacement } : {}),
 			};
 			if (variantAction === "explicit") return preview;
 			return withVariantConflicts({

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/renameProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/renameProductPlan.ts
@@ -1,3 +1,5 @@
+import type { PlanAliasReplacement } from "@autumn/shared";
+
 /**
  * Plan-scoped id change — every version row moves, plus plan-id references
  * (reward programs, rewards, RevenueCat mappings). customer_products.product_id
@@ -6,4 +8,6 @@
 export type RenameProductPlan = {
 	planId: string;
 	toId: string;
+	/** Set when toId is currently an alias — execute deletes that alias row. */
+	aliasReplacement?: PlanAliasReplacement;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
@@ -4,6 +4,7 @@ import type {
 	CatalogVariantParams,
 	CustomizePlanLicense,
 	FullProduct,
+	PlanAliasReplacement,
 	PlanLicenseParams,
 	RemovePlanLicense,
 } from "@autumn/shared";
@@ -68,6 +69,8 @@ export type UpsertProductPlan = {
 	planLicenses?: PlanLicensePlan[];
 	/** false = execute may reuse Stripe ids but never create objects. */
 	createInStripe?: boolean;
+	/** Set when this row's id claims a reserved alias — execute deletes that row. */
+	aliasReplacement?: PlanAliasReplacement;
 
 	state: { hasCustomers: boolean };
 };

--- a/server/src/internal/catalogV2/execute/deleteClaimedPlanAliases.ts
+++ b/server/src/internal/catalogV2/execute/deleteClaimedPlanAliases.ts
@@ -1,0 +1,24 @@
+import { productAliases } from "@autumn/shared";
+import { and, eq, inArray } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+/** Drop alias rows whose public id this catalog write is claiming. */
+export const deleteClaimedPlanAliases = async ({
+	ctx,
+	aliasIds,
+}: {
+	ctx: AutumnContext;
+	aliasIds: string[];
+}): Promise<void> => {
+	if (aliasIds.length === 0) return;
+
+	await ctx.db
+		.delete(productAliases)
+		.where(
+			and(
+				eq(productAliases.org_id, ctx.org.id),
+				eq(productAliases.env, ctx.env),
+				inArray(productAliases.alias_id, aliasIds),
+			),
+		);
+};

--- a/server/src/internal/catalogV2/execute/executeRenamePlans.ts
+++ b/server/src/internal/catalogV2/execute/executeRenamePlans.ts
@@ -68,6 +68,25 @@ const buildPlanRenameSql = ({
 			WHERE org_id = ${orgId} AND env = ${env}
 				AND autumn_product_id = ${planId}
 			RETURNING 1
+		),
+		del_aliases AS (
+			DELETE FROM product_aliases
+			WHERE org_id = ${orgId} AND env = ${env}
+				AND (canonical_plan_id = ${planId} OR alias_id = ${toId})
+			RETURNING 1
+		),
+		ins_aliases AS (
+			INSERT INTO product_aliases (
+				org_id, env, alias_id, canonical_plan_id, created_at
+			)
+			VALUES (
+				${orgId},
+				${env},
+				${planId},
+				${toId},
+				ROUND(date_part('epoch', NOW()) * 1000)::BIGINT
+			)
+			RETURNING 1
 		)
 		SELECT 1
 	`;

--- a/server/src/internal/catalogV2/execute/executeRenamePlans.ts
+++ b/server/src/internal/catalogV2/execute/executeRenamePlans.ts
@@ -19,6 +19,10 @@ const buildPlanRenameSql = ({
 	renamePlan: RenameProductPlan;
 }): SQL => {
 	const { planId, toId } = renamePlan;
+	const vercelAllowlistKey =
+		env === "live"
+			? "allowed_product_ids_live"
+			: "allowed_product_ids_sandbox";
 
 	return sql`
 		WITH upd_products AS (
@@ -67,6 +71,24 @@ const buildPlanRenameSql = ({
 			SET autumn_product_id = ${toId}
 			WHERE org_id = ${orgId} AND env = ${env}
 				AND autumn_product_id = ${planId}
+			RETURNING 1
+		),
+		upd_vercel_allowlists AS (
+			UPDATE organizations
+			SET processor_configs = jsonb_set(
+				processor_configs,
+				ARRAY['vercel', ${vercelAllowlistKey}]::text[],
+				(
+					SELECT to_jsonb(array_agg(
+						CASE WHEN elem = ${planId} THEN ${toId} ELSE elem END
+					))
+					FROM jsonb_array_elements_text(
+						processor_configs -> 'vercel' -> ${vercelAllowlistKey}
+					) AS elem
+				)
+			)
+			WHERE id = ${orgId}
+				AND processor_configs -> 'vercel' -> ${vercelAllowlistKey} ? ${planId}
 			RETURNING 1
 		),
 		del_aliases AS (

--- a/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
@@ -16,6 +16,7 @@ import { executeRemovePlans } from "@/internal/catalogV2/execute/executeRemovePl
 import { executeRenamePlans } from "@/internal/catalogV2/execute/executeRenamePlans";
 import { executeUpsertProducts } from "@/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts";
 import { queueRewardMigrations } from "@/internal/catalogV2/execute/queueRewardMigrations";
+import { rewritePublicPlanIdsAfterRename } from "@/internal/catalogV2/execute/rewritePublicPlanIdsAfterRename";
 import { FeatureService } from "@/internal/features/FeatureService.js";
 import type { ClearCreditSystemCachePayload } from "@/internal/features/featureActions/runClearCreditSystemCacheTask.js";
 import { clearOrgCache } from "@/internal/orgs/orgUtils/clearOrgCache";
@@ -167,6 +168,7 @@ export const executeUpdateCatalogPlan = async ({
 		phase: "execute.rename_plans",
 		run: () => executeRenamePlans({ ctx, updateCatalogPlan }),
 	});
+	rewritePublicPlanIdsAfterRename({ updateCatalogPlan });
 	await timeCatalogPhase({
 		ctx,
 		phases,

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
@@ -3,6 +3,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import type { CatalogAppliedResult } from "@/internal/catalogV2/execute/executeUpdateCatalogPlan";
+import { deleteClaimedPlanAliases } from "@/internal/catalogV2/execute/deleteClaimedPlanAliases";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { applyEntitlementPricesPlan } from "./applyEntitlementPricesPlan";
 import { applyFreeTrialPlan } from "./applyFreeTrialPlan";
@@ -22,6 +23,12 @@ const executeUpsertProduct = async ({
 		const product = upsert.details?.product ?? upsert.row.nextFullProduct;
 		await ProductService.insert({ db: ctx.db, product });
 		await clearDefaultFlagFromOtherVersions({ ctx, product });
+		if (upsert.aliasReplacement) {
+			await deleteClaimedPlanAliases({
+				ctx,
+				aliasIds: [upsert.aliasReplacement.alias_id],
+			});
+		}
 	}
 
 	await applyEntitlementPricesPlan({ ctx, upsert });

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
@@ -1,9 +1,10 @@
 import type { CatalogAction } from "@autumn/shared";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import type { CatalogAppliedResult } from "@/internal/catalogV2/execute/executeUpdateCatalogPlan";
-import { deleteClaimedPlanAliases } from "@/internal/catalogV2/execute/deleteClaimedPlanAliases";
+import { deleteClaimedPlanAliases } from "@/internal/catalogV2/execute/deleteClaimedPlanAliases.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { applyEntitlementPricesPlan } from "./applyEntitlementPricesPlan";
 import { applyFreeTrialPlan } from "./applyFreeTrialPlan";
@@ -21,14 +22,17 @@ const executeUpsertProduct = async ({
 }) => {
 	if (upsert.row.op === "create") {
 		const product = upsert.details?.product ?? upsert.row.nextFullProduct;
-		await ProductService.insert({ db: ctx.db, product });
-		await clearDefaultFlagFromOtherVersions({ ctx, product });
-		if (upsert.aliasReplacement) {
+		await ctx.db.transaction(async (tx) => {
+			const db = tx as unknown as DrizzleCli;
 			await deleteClaimedPlanAliases({
-				ctx,
-				aliasIds: [upsert.aliasReplacement.alias_id],
+				ctx: { ...ctx, db },
+				aliasIds: upsert.aliasReplacement
+					? [upsert.aliasReplacement.alias_id]
+					: [],
 			});
-		}
+			await ProductService.insert({ db, product });
+		});
+		await clearDefaultFlagFromOtherVersions({ ctx, product });
 	}
 
 	await applyEntitlementPricesPlan({ ctx, upsert });

--- a/server/src/internal/catalogV2/execute/rewritePublicPlanIdsAfterRename.ts
+++ b/server/src/internal/catalogV2/execute/rewritePublicPlanIdsAfterRename.ts
@@ -1,0 +1,24 @@
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+import { rewritePlanIdAliasValues } from "@/internal/catalogV2/productAliases/rewritePlanIdAliasValues";
+
+/** After identity moves, remaining execute consumers must see toId. */
+export const rewritePublicPlanIdsAfterRename = ({
+	updateCatalogPlan,
+}: {
+	updateCatalogPlan: UpdateCatalogPlan;
+}): void => {
+	if (updateCatalogPlan.renamePlans.length === 0) return;
+
+	const fromTo = Object.fromEntries(
+		updateCatalogPlan.renamePlans.map(({ planId, toId }) => [planId, toId]),
+	);
+
+	for (const upsert of updateCatalogPlan.upsertProducts) {
+		upsert.row.planId = fromTo[upsert.row.planId] ?? upsert.row.planId;
+	}
+
+	rewritePlanIdAliasValues({
+		value: updateCatalogPlan.migrationDrafts,
+		aliases: fromTo,
+	});
+};

--- a/server/src/internal/catalogV2/productAliases/planIdAliasRewriteKeys.ts
+++ b/server/src/internal/catalogV2/productAliases/planIdAliasRewriteKeys.ts
@@ -1,0 +1,18 @@
+/** Body keys whose string (or string[]) values are public plan ids. */
+export const PLAN_ID_ALIAS_REWRITE_KEYS = new Set([
+	"product_id",
+	"product_ids",
+	"plan_id",
+	"plan_ids",
+	"remove_plan_ids",
+	"base_plan_id",
+	"base_variant_id",
+	"variant_plan_id",
+	"license_plan_id",
+	"auto_enable_plan_id",
+	"free_product_id",
+	"autumn_product_id",
+	"skip_plan_ids",
+	"update_variant_ids",
+	"billingPlanId",
+]);

--- a/server/src/internal/catalogV2/productAliases/resolveAliasReplacement.ts
+++ b/server/src/internal/catalogV2/productAliases/resolveAliasReplacement.ts
@@ -1,0 +1,14 @@
+import type { PlanAliasReplacement } from "@autumn/shared";
+
+/** `claimedId` is someone else's (or this plan's own) alias — undefined if free. */
+export const resolveAliasReplacement = ({
+	claimedId,
+	aliases,
+}: {
+	claimedId: string;
+	aliases?: Record<string, string>;
+}): PlanAliasReplacement | undefined => {
+	const owner = aliases?.[claimedId];
+	if (!owner) return undefined;
+	return { alias_id: claimedId, plan_id: owner };
+};

--- a/server/src/internal/catalogV2/productAliases/rewritePlanIdAliasParams.ts
+++ b/server/src/internal/catalogV2/productAliases/rewritePlanIdAliasParams.ts
@@ -1,0 +1,41 @@
+const PLAN_ID_PATH_PARAMS = new Set(["product_id", "productId"]);
+
+type ParamFn = {
+	(key: string): string | undefined;
+	(): Record<string, string>;
+};
+
+const rewriteValue = ({
+	key,
+	value,
+	aliases,
+}: {
+	key: string;
+	value: string | undefined;
+	aliases: Record<string, string>;
+}): string | undefined => {
+	if (!value || !PLAN_ID_PATH_PARAMS.has(key)) return value;
+	return aliases[value] ?? value;
+};
+
+/** Wraps `c.req.param` so `product_id` / `productId` resolve through the alias map. */
+export const rewritePlanIdAliasParams = ({
+	param,
+	aliases,
+}: {
+	param: ParamFn;
+	aliases: Record<string, string>;
+}): ParamFn => {
+	return ((key?: string) => {
+		if (key) {
+			return rewriteValue({ key, value: param(key), aliases });
+		}
+
+		const all = param();
+		for (const pathKey of PLAN_ID_PATH_PARAMS) {
+			const value = all[pathKey];
+			if (value) all[pathKey] = aliases[value] ?? value;
+		}
+		return all;
+	}) as ParamFn;
+};

--- a/server/src/internal/catalogV2/productAliases/rewritePlanIdAliasValues.ts
+++ b/server/src/internal/catalogV2/productAliases/rewritePlanIdAliasValues.ts
@@ -1,0 +1,59 @@
+import { PLAN_ID_ALIAS_REWRITE_KEYS } from "./planIdAliasRewriteKeys.js";
+
+const canonicalValue = ({
+	value,
+	aliases,
+}: {
+	value: string;
+	aliases: Record<string, string>;
+}): string => aliases[value] ?? value;
+
+/**
+ * Mutates `value` in place: every known plan-id key becomes its canonical id.
+ * `new_plan_id` is intentionally not a rewrite key (rename target).
+ */
+export const rewritePlanIdAliasValues = ({
+	value,
+	aliases,
+	skipKeys,
+}: {
+	value: unknown;
+	aliases: Record<string, string>;
+	skipKeys?: Set<string>;
+}): unknown => {
+	if (value == null || typeof value !== "object") return value;
+
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			rewritePlanIdAliasValues({ value: item, aliases, skipKeys });
+		}
+		return value;
+	}
+
+	const record = value as Record<string, unknown>;
+	for (const [key, nested] of Object.entries(record)) {
+		if (skipKeys?.has(key)) continue;
+
+		if (PLAN_ID_ALIAS_REWRITE_KEYS.has(key)) {
+			if (typeof nested === "string") {
+				record[key] = canonicalValue({ value: nested, aliases });
+				continue;
+			}
+			if (Array.isArray(nested)) {
+				record[key] = nested.map((item) =>
+					typeof item === "string"
+						? canonicalValue({ value: item, aliases })
+						: item,
+				);
+				for (const item of record[key] as unknown[]) {
+					rewritePlanIdAliasValues({ value: item, aliases, skipKeys });
+				}
+				continue;
+			}
+		}
+
+		rewritePlanIdAliasValues({ value: nested, aliases, skipKeys });
+	}
+
+	return value;
+};

--- a/server/src/internal/catalogV2/productAliases/throwIfPlanIdReservedAsAlias.ts
+++ b/server/src/internal/catalogV2/productAliases/throwIfPlanIdReservedAsAlias.ts
@@ -1,0 +1,44 @@
+import {
+	type AppEnv,
+	ErrCode,
+	productAliases,
+	RecaseError,
+} from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export const throwIfPlanIdReservedAsAlias = async ({
+	ctx,
+	planId,
+	orgId,
+	env,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	orgId?: string;
+	env?: AppEnv;
+}): Promise<void> => {
+	const targetOrgId = orgId ?? ctx.org.id;
+	const targetEnv = env ?? ctx.env;
+
+	const owner =
+		targetOrgId === ctx.org.id && targetEnv === ctx.env
+			? ctx.org.planAliases?.[planId]
+			: (
+					await ctx.db.query.productAliases.findFirst({
+						where: and(
+							eq(productAliases.org_id, targetOrgId),
+							eq(productAliases.env, targetEnv),
+							eq(productAliases.alias_id, planId),
+						),
+					})
+				)?.canonical_plan_id;
+
+	if (!owner) return;
+
+	throw new RecaseError({
+		message: `Plan ID '${planId}' is reserved as an alias of '${owner}'`,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/catalogV2/productAliases/toPlanAliasMap.ts
+++ b/server/src/internal/catalogV2/productAliases/toPlanAliasMap.ts
@@ -1,0 +1,8 @@
+export const toPlanAliasMap = ({
+	rows,
+}: {
+	rows: { alias_id: string; canonical_plan_id: string }[] | null | undefined;
+}): Record<string, string> =>
+	Object.fromEntries(
+		(rows ?? []).map((row) => [row.alias_id, row.canonical_plan_id]),
+	);

--- a/server/src/internal/dev/apiKeys/publicKeyUtils.ts
+++ b/server/src/internal/dev/apiKeys/publicKeyUtils.ts
@@ -1,6 +1,7 @@
 import type { AppEnv } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { OrgService } from "@/internal/orgs/OrgService.js";
+import { toPlanAliasMap } from "@/internal/catalogV2/productAliases/toPlanAliasMap.js";
 
 export const verifyPublicKey = async ({
 	db,
@@ -21,9 +22,13 @@ export const verifyPublicKey = async ({
 
 	const org = structuredClone(data);
 	delete (org as any).features;
+	delete (org as any).product_aliases;
 
 	return {
-		org,
+		org: {
+			...org,
+			planAliases: toPlanAliasMap({ rows: data.product_aliases }),
+		},
 		features: data.features,
 	};
 };

--- a/server/src/internal/invoices/InvoiceService.ts
+++ b/server/src/internal/invoices/InvoiceService.ts
@@ -166,6 +166,7 @@ export class InvoiceService {
 				invoice: invoices,
 				resolved_product_ids: resolvedProductIdsForColumn({
 					internalProductIds: invoices.internal_product_ids,
+					productIds: invoices.product_ids,
 				}),
 				customer_id: customers.id,
 				entity_id: entities.id,
@@ -263,6 +264,7 @@ export class InvoiceService {
 				invoice: invoices,
 				resolved_product_ids: resolvedProductIdsForColumn({
 					internalProductIds: invoices.internal_product_ids,
+					productIds: invoices.product_ids,
 				}),
 			})
 			.from(invoices)

--- a/server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts
+++ b/server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts
@@ -1,27 +1,40 @@
-import { type AnyColumn, sql } from "drizzle-orm";
+import { type AnyColumn, type SQL, sql } from "drizzle-orm";
 
 /**
- * Current public plan ids for an invoice row, resolved from
- * `internal_product_ids` via the products table. NULL when nothing
- * resolves (legacy rows / deleted products) — consumers fall back to
- * the `product_ids` snapshot.
+ * Live public id when the product row exists; snapshot id when that
+ * internal id is gone. Partial resolve is not treated as complete.
  */
+const resolvedProductIdsMergeSql = ({
+	internalProductIds,
+	productIds,
+}: {
+	internalProductIds: SQL | AnyColumn;
+	productIds: SQL | AnyColumn;
+}) => sql<string[] | null>`(
+	SELECT array_agg(COALESCE(rp.id, snap.product_id) ORDER BY snap.ord)
+	FROM unnest(${internalProductIds}, ${productIds})
+		WITH ORDINALITY AS snap(internal_id, product_id, ord)
+	LEFT JOIN products rp ON rp.internal_id = snap.internal_id
+)`;
+
 export const resolvedProductIdsSql = ({
 	invoiceAlias,
 }: {
 	invoiceAlias: string;
-}) => sql<string[] | null>`(
-	SELECT array_agg(DISTINCT rp.id)
-	FROM products rp
-	WHERE rp.internal_id = ANY(${sql.raw(`${invoiceAlias}.internal_product_ids`)})
-)`;
+}) =>
+	resolvedProductIdsMergeSql({
+		internalProductIds: sql.raw(`${invoiceAlias}.internal_product_ids`),
+		productIds: sql.raw(`${invoiceAlias}.product_ids`),
+	});
 
 export const resolvedProductIdsForColumn = ({
 	internalProductIds,
+	productIds,
 }: {
 	internalProductIds: AnyColumn;
-}) => sql<string[] | null>`(
-	SELECT array_agg(DISTINCT rp.id)
-	FROM products rp
-	WHERE rp.internal_id = ANY(${internalProductIds})
-)`;
+	productIds: AnyColumn;
+}) =>
+	resolvedProductIdsMergeSql({
+		internalProductIds,
+		productIds,
+	});

--- a/server/src/internal/orgs/OrgService.ts
+++ b/server/src/internal/orgs/OrgService.ts
@@ -9,6 +9,7 @@ import {
 	type Organization,
 	OrgConfigSchema,
 	organizations,
+	productAliases,
 	user,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle.js";
@@ -26,6 +27,7 @@ import {
 	sql,
 } from "drizzle-orm";
 import { FeatureService } from "../features/FeatureService.js";
+import { toPlanAliasMap } from "../catalogV2/productAliases/toPlanAliasMap.js";
 import { clearOrgCache } from "./orgUtils/clearOrgCache.js";
 
 export class OrgService {
@@ -123,10 +125,14 @@ export class OrgService {
 				features: {
 					where: eq(features.env, env),
 				},
+				product_aliases: {
+					where: eq(productAliases.env, env),
+				},
 				master: true,
 			},
 		})) as Organization & {
 			features?: Feature[];
+			product_aliases?: { alias_id: string; canonical_plan_id: string }[];
 		};
 
 		if (!result) {
@@ -143,11 +149,13 @@ export class OrgService {
 
 		const org = structuredClone(result);
 		delete org.features;
+		delete org.product_aliases;
 
 		return {
 			org: {
 				...org,
 				config: OrgConfigSchema.parse(org.config || {}),
+				planAliases: toPlanAliasMap({ rows: result.product_aliases }),
 			},
 			features: result.features || [],
 		};
@@ -227,11 +235,15 @@ export class OrgService {
 				features: {
 					where: eq(features.env, env),
 				},
+				product_aliases: {
+					where: eq(productAliases.env, env),
+				},
 			},
 		});
 
-		return org as Organization & {
+		return org as unknown as Organization & {
 			features: Feature[];
+			product_aliases: { alias_id: string; canonical_plan_id: string }[];
 		};
 	}
 
@@ -373,12 +385,19 @@ export class OrgService {
 			orgId: result?.id || "",
 			env,
 		});
+		const aliasRows = await db.query.productAliases.findMany({
+			where: and(
+				eq(productAliases.org_id, result.id),
+				eq(productAliases.env, env),
+			),
+		});
 
 		return {
 			features,
 			org: {
 				...(result as Organization),
 				config: OrgConfigSchema.parse(result.config || {}),
+				planAliases: toPlanAliasMap({ rows: aliasRows }),
 			},
 			env,
 		};

--- a/server/src/internal/orgs/repos/findFullOrg.ts
+++ b/server/src/internal/orgs/repos/findFullOrg.ts
@@ -8,9 +8,11 @@ import {
 	OrgConfigSchema,
 	organizations,
 	type PendingMigration,
+	productAliases,
 } from "@autumn/shared";
 import { and, eq, inArray } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { toPlanAliasMap } from "@/internal/catalogV2/productAliases/toPlanAliasMap.js";
 
 export const findFullOrg = async ({
 	db,
@@ -30,6 +32,7 @@ export const findFullOrg = async ({
 		where: eq(organizations.id, orgId),
 		with: {
 			features: { where: eq(features.env, env) },
+			product_aliases: { where: eq(productAliases.env, env) },
 			master: true,
 			migration_runs: {
 				where: and(
@@ -48,6 +51,7 @@ export const findFullOrg = async ({
 	const cloned = structuredClone(row);
 	const {
 		features: rawFeatures,
+		product_aliases: rawProductAliases,
 		migration_runs: rawMigrationRuns,
 		master: rawMaster,
 		...orgCore
@@ -58,6 +62,7 @@ export const findFullOrg = async ({
 	// Same trade-off as `OrgService.getWithFeatures` — bridged with one cast.
 	const orgFeatures = (rawFeatures ?? []) as unknown as Feature[];
 	const pendingMigrations: PendingMigration[] = rawMigrationRuns ?? [];
+	const planAliases = toPlanAliasMap({ rows: rawProductAliases });
 
 	const master: Organization | null = rawMaster
 		? {
@@ -72,6 +77,7 @@ export const findFullOrg = async ({
 		master,
 		config: OrgConfigSchema.parse(orgCore.config || {}),
 		pendingMigrations,
+		planAliases,
 	};
 
 	const fullOrg: FullOrg = {

--- a/server/src/internal/product/actions/createProduct.ts
+++ b/server/src/internal/product/actions/createProduct.ts
@@ -10,6 +10,7 @@ import {
 	ProductAlreadyExistsError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { throwIfPlanIdReservedAsAlias } from "@/internal/catalogV2/productAliases/throwIfPlanIdReservedAsAlias.js";
 import {
 	applyPreparedPlanLicenseSync,
 	preparePlanLicenseSync,
@@ -39,6 +40,8 @@ export const createProduct = async ({
 	data: CreateProductV2Params;
 }) => {
 	const { logger, org, features, env, db } = ctx;
+
+	await throwIfPlanIdReservedAsAlias({ ctx, planId: data.id });
 
 	const existing = await ProductService.get({
 		db,

--- a/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
+++ b/server/src/internal/products/handlers/handleCopyProduct/copyProductForOrgs.ts
@@ -14,6 +14,7 @@ import {
 	initProductInStripe,
 } from "@/internal/products/productUtils.js";
 import RecaseError from "@/utils/errorUtils.js";
+import { throwIfPlanIdReservedAsAlias } from "@/internal/catalogV2/productAliases/throwIfPlanIdReservedAsAlias.js";
 import { copyBaseVariants } from "./copyBaseVariants.js";
 import { copyLicenseLinksForPlanCopy } from "./copyLicenseLinksForPlanCopy.js";
 import { copyMissingFeatures } from "./copyMissingFeatures.js";
@@ -69,6 +70,13 @@ export const copyProductForOrgs = async ({
 			message: `Product ${toId} already exists in ${toEnv}`,
 		});
 	}
+
+	await throwIfPlanIdReservedAsAlias({
+		ctx,
+		planId: toId,
+		orgId: toOrg.id,
+		env: toEnv,
+	});
 
 	// 1. Load the source plan and both sides' features
 	const [fromFullProduct, fromFeatures, toFeatures] = await Promise.all([

--- a/server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts
+++ b/server/src/internal/products/handlers/handleCreateProduct/handleCreatePlan.ts
@@ -17,6 +17,7 @@ import {
 } from "@autumn/shared";
 
 import { createRoute } from "@/honoMiddlewares/routeHandler.js";
+import { throwIfPlanIdReservedAsAlias } from "@/internal/catalogV2/productAliases/throwIfPlanIdReservedAsAlias.js";
 import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { captureOrgEvent } from "@/utils/posthog.js";
@@ -53,6 +54,8 @@ export const handleCreatePlan = createRoute({
 		) as CreateProductV2Params;
 
 		const { logger, org, features, env, db } = ctx;
+
+		await throwIfPlanIdReservedAsAlias({ ctx, planId: v1_2Body.id });
 
 		const existing = await ProductService.get({
 			db,

--- a/server/src/routers/apiRouter.ts
+++ b/server/src/routers/apiRouter.ts
@@ -11,6 +11,7 @@ import { customerJwtVersionMiddleware } from "../honoMiddlewares/customerJwtVers
 import { idempotencyMiddleware } from "../honoMiddlewares/idempotencyMiddleware.js";
 import { orgConfigMiddleware } from "../honoMiddlewares/orgConfigMiddleware.js";
 import { orgRedisMiddleware } from "../honoMiddlewares/orgRedisMiddleware.js";
+import { planAliasMiddleware } from "../honoMiddlewares/planAliasMiddleware.js";
 import { queryMiddleware } from "../honoMiddlewares/queryMiddleware.js";
 import { rateLimitMiddleware } from "../honoMiddlewares/rateLimitMiddleware.js";
 import { refreshCacheMiddleware } from "../honoMiddlewares/refreshCacheMiddleware.js";
@@ -47,6 +48,7 @@ export const apiRouter = new Hono<HonoEnv>();
 apiRouter.use("*", criticalDbMiddleware);
 apiRouter.use("*", responseFilterMiddleware);
 apiRouter.use("*", secretKeyMiddleware);
+apiRouter.use("*", planAliasMiddleware);
 apiRouter.use("*", requestBlockMiddleware);
 apiRouter.use("*", orgConfigMiddleware);
 apiRouter.use("*", rolloutMiddleware);

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -29,9 +29,15 @@ plans/
     create-plan-items-free.test.ts
     create-plan-items-priced.test.ts
     utils/createAndAssert.ts
+  aliases/
+    alias-billing-endpoints.test.ts
+    alias-catalog-endpoints.test.ts
+    alias-customer-license-endpoints.test.ts
+    alias-vercel-endpoints.test.ts
   update/
     idempotent-plans.test.ts
     update-plan-details.test.ts
+    rename-plan-aliases.test.ts
     update-plan-items.test.ts
     update-plan-rows.test.ts
     update-plan-free-trial.test.ts
@@ -155,6 +161,98 @@ free vs priced so the billing-model matrix stays navigable.
 | Rename with customers: every version row renamed (incl. siblings outside the batch); `customer_products.product_id` snapshot untouched, `internal_product_id` link intact | ✓ |
 | Rename rewrites `reward_programs.product_ids`, and `rewards.free_product_id` + `discount_config.product_ids` on ONE row (merged single UPDATE) | ✓ |
 | Rename rewrites `revenuecat_mappings.autumn_product_id` key | ✓ |
+
+### Plan id aliases — `update/rename-plan-aliases.test.ts`
+
+Ingress mapping (every route/field): `server/tests/unit/catalogV2/plan-id-alias-ingress.md`.
+Unit tests: `server/tests/unit/catalogV2/plan-id-alias-rewrite.test.ts`.
+
+Ingress only: after `pro → proNew`, requests with `pro` rewrite to `proNew`
+before handlers. Responses stay canonical. One alias per plan; re-rename
+replaces (old alias dies). Catalog create / `new_plan_id` onto another plan's
+alias succeeds and deletes that alias row (`alias_replacement` on preview).
+REST `POST /products` of a reserved id stays 400. Reclaiming this plan's own
+alias is allowed.
+
+| Case | Status |
+|---|---|
+| Rename writes `product_aliases` (`alias_id` = old id, `canonical_plan_id` = new) | ✓ t1 |
+| Re-rename replaces the alias row; the original alias no longer resolves | ✓ t1 |
+| Attach / `plans.get` with the old id succeeds; GET plan id is canonical (no `alias_id` field) | ✓ t2 |
+| REST create a plan whose id is another plan's alias → 400 | ✓ t3 |
+| Catalog `new_plan_id` onto another plan's alias → succeeds; alias row deleted; `alias_replacement` on preview | ✓ t3 |
+| `new_plan_id` reclaiming this plan's own alias → allowed | ✓ `rename-plan-alias-reclaim.test.ts` |
+
+### Own-alias reclaim roundtrip — `update/rename-plan-alias-reclaim.test.ts`
+
+| Case | Status |
+|---|---|
+| Rename `pro → proNew` then reclaim `proNew → pro`: live id returns to `pro`; `proNew` is the alias; old `pro → proNew` gone; attach/GET both ids; REST create of `proNew` is 400; `customer_products.product_id` snapshot untouched | ✓ t1 |
+
+Ingress field mapping (unit): `server/tests/unit/catalogV2/plan-id-alias-ingress.md`.
+Endpoint behavior below: send the OLD id, assert canonical side effects.
+
+### Plan id aliases — endpoint × field — `aliases/*.test.ts`
+
+Status: ✓ written (run when server is up). Invoice `plan_ids` SQL is layer 1 — not re-tested.
+
+| Endpoint | Field | Test | Status |
+|---|---|---|---|
+| `POST /billing.attach` | `plan_id` | `alias-billing-endpoints` attach | ✓ |
+| `POST /billing.preview_attach` | `plan_id` | `alias-billing-endpoints` attach | ✓ |
+| `POST /billing.attach` | `remove_plan_ids` | `alias-billing-endpoints` attach | ✓ |
+| `POST /attach` (legacy) | `product_id` | `alias-billing-endpoints` attach | ✓ |
+| `POST /cancel` | `product_id` | `alias-billing-endpoints` attach | ✓ |
+| `POST /billing.update` | `plan_id` | `alias-billing-endpoints` update | ✓ |
+| `POST /billing.preview_update` | `plan_id` | `alias-billing-endpoints` update | ✓ |
+| `POST /billing.multi_update` | `updates[].plan_id` | `alias-billing-endpoints` update | ✓ |
+| `POST /billing.preview_multi_update` | `updates[].plan_id` | `alias-billing-endpoints` update | ✓ |
+| `POST /billing.multi_attach` | `plans[].plan_id` | `alias-billing-endpoints` multi | ✓ |
+| `POST /billing.preview_multi_attach` | `plans[].plan_id` | `alias-billing-endpoints` multi | ✓ |
+| `POST /billing.create_schedule` | `phases[].plans[].plan_id` | `alias-billing-endpoints` multi | ✓ |
+| `POST /billing.preview_create_schedule` | `phases[].plans[].plan_id` | `alias-billing-endpoints` multi | ✓ |
+| `GET /products/:product_id` | path `product_id` | `alias-catalog-endpoints` GET + t2 | ✓ |
+| `POST /plans.get` | `plan_id` | `alias-catalog-endpoints` GET | ✓ |
+| `POST /plans.has_customers` | `plan_id` | `alias-catalog-endpoints` GET | ✓ |
+| `POST /products/:product_id/has_customers` | path `product_id` | `alias-catalog-endpoints` GET | ✓ |
+| dashboard `GET /products/:id` | skip rewrite | unit `planAliasMiddleware skips dashboard` | ✓ unit (secret-key client cannot send `x-client-type: dashboard`) |
+| `POST /catalogV2.update` | `plans[].plan_id` | `alias-catalog-endpoints` update | ✓ |
+| `POST /catalogV2.preview_update` | `plans[].plan_id` | `alias-catalog-endpoints` update | ✓ |
+| `PATCH /products/:product_id` | path `product_id` | `alias-catalog-endpoints` update | ✓ |
+| `POST /catalogV2.update` | `licenses[].license_plan_id` | `alias-catalog-endpoints` update | ✓ |
+| `DELETE /products/:product_id` | path `product_id` | `alias-catalog-endpoints` delete | ✓ |
+| `POST /catalogV2.update` | `remove_plans[].plan_id` | `alias-catalog-endpoints` delete | ✓ |
+| `POST /plans.delete` | `plan_id` | `alias-catalog-endpoints` delete | ✓ |
+| `POST /plans.create_variant` | `base_plan_id` | `alias-catalog-endpoints` delete | ✓ |
+| `POST /catalogV2.update` | `new_plan_id` not rewritten | `alias-catalog-endpoints` delete + t3 | ✓ |
+| `POST /products` create | `id` reserved (not rewritten) | t3 | ✓ |
+| `POST /customers` | `auto_enable_plan_id` | `alias-customer-license-endpoints` customer | ✓ |
+| `POST /customers/:id/transfer` | `product_id` | `alias-customer-license-endpoints` customer | ✓ |
+| `POST /check` | `product_id` | `alias-customer-license-endpoints` customer | ✓ |
+| `POST /licenses.attach` | `plan_id` | `alias-customer-license-endpoints` licenses | ✓ |
+| `POST /licenses.release` | `license_plan_id` | `alias-customer-license-endpoints` licenses | ✓ |
+| `POST /billing.attach` | `license_quantities[].license_plan_id` | `alias-customer-license-endpoints` licenses | ✓ |
+| `POST /billing.update` | `customize.upsert_licenses[].license_plan_id` | `alias-customer-license-endpoints` licenses | ✓ |
+| Vercel `POST .../resources` | `billingPlanId` | `alias-vercel-endpoints` | ✓ |
+| Vercel `PATCH .../installations/:id` | `billingPlanId` | `alias-vercel-endpoints` | ✓ |
+
+Gaps (rewrite key exists, no endpoint test here):
+
+| Endpoint | Field | Why |
+|---|---|---|
+| `POST /billing.sync` / `sync_v2` | `plan_id` | admin/import, not CORE attach |
+| `POST /billing.setup_payment` | `plan_id` | checkout-adjacent; attach covers the same key |
+| `POST /billing.resolve_request` | nested bodies | same rewrite as attach/update/schedule |
+| `POST /billing.dfu.flash` | `plan_id` | internal |
+| `POST /catalog.update` (v1) | `plan_id` / `skip_plan_ids` | v1 catalog; v2 covered |
+| `POST /plans.update` RPC | `plan_id` | catalogV2.update covers the same key |
+| `POST /attach/preview` | `product_id` | legacy; v2 preview_attach covered |
+| `POST /rewards` / reward_programs | `plan_ids` / `free_product_id` | admin catalog, not CORE billing |
+| `migrations.*` | `plan_id` | admin |
+| `customers.list` `plans[].id` | `id` | **not a rewrite key** — list filter uses `id` |
+| Vercel body `productId` | marketplace resource id | intentional skip (ingress.md) |
+| Invoice `plan_ids` | snapshot SQL | layer 1, do not re-test |
+| Stripe checkout metadata | manual rewrite | webhook, not public request |
 
 ## 5. Item/price update lanes — `update/update-plan-items.test.ts`
 
@@ -1179,4 +1277,27 @@ sends `all_versions`).
 |---|---|
 | `archived: false` + `all_versions` → every version unarchived | ✓ |
 | `archived: false` alone → latest unarchived, older versions stay archived | ✓ |
+
+## 23. Alias replacement preview — `update/rename-plan-alias-replacement.test.ts`
+
+After `pro → proNew`, `pro` is an alias of `proNew`. Catalog preview/update
+claiming `pro` (create `plan_id` or `new_plan_id`, including
+`variants[].new_plan_id`) surfaces `alias_replacement` on that plan/variant
+and proceeds — the alias row is deleted so `pro` is a real id again.
+REST `POST /products` / `POST /plans` / `plans.create` stay 400.
+
+Own-reclaim (`proNew → pro`) still allowed; preview includes
+`alias_replacement` because that alias row dies.
+
+| Case | Status |
+|---|---|
+| Preview create `pro` while alias of `proNew` → field on plan, not a blocking error | ✓ t1 |
+| Preview rename other `starter → pro` → same field on that plan op | ✓ t1 |
+| Preview `variants[n].new_plan_id: "pro"` → field on THAT variant, not only the parent | ✓ t1 |
+| Preview own-reclaim `proNew → pro` → allowed; `alias_replacement` present (alias dies) | ✓ t1 |
+| Preview no collision → field absent/`undefined` | ✓ t1 |
+| Execute create-`pro` → alias row gone; GET/attach `pro` hits the NEW plan | ✓ t2 |
+| Execute rename `starter → pro` → starter is `pro`; alias `pro→proNew` gone | ✓ t2 |
+| Execute variant `new_plan_id` → `products.id` + alias CTE; `customer_products.product_id` untouched | ✓ t2 |
+| REST create of reserved id still 400 | ✓ t3 |
 

--- a/server/tests/integration/catalog-v2/plans/aliases/alias-billing-endpoints.test.ts
+++ b/server/tests/integration/catalog-v2/plans/aliases/alias-billing-endpoints.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Ingress plan-id aliases on CORE billing endpoints.
+ *
+ * Sending the old id after `pro → proNew` must succeed and land on proNew.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type AttachParamsV1Input,
+	type CreateScheduleParamsV0Input,
+	type MultiUpdateParamsV0Input,
+	type UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect/expectStripeSubscriptionCorrect.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import {
+	collectResponsePlanIds,
+	deleteAliases,
+	renamePlan,
+} from "../utils/planAliasTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases billing: attach / preview_attach / remove_plan_ids / legacy attach")}`,
+	async () => {
+		const customerId = uniqueTestId("alias_att");
+		const otherId = uniqueTestId("alias_att_b");
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const addon = products.recurringAddOn({
+			id: "addon",
+			items: [items.dashboard()],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro, addon] }),
+				s.otherCustomers([{ id: otherId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const proOld = pro.id;
+		const proNew = `${proOld}_n`;
+		const addonOld = addon.id;
+		const addonNew = `${addonOld}_n`;
+		const planIds = [proOld, proNew, addonOld, addonNew];
+
+		await deleteAliases({ ctx, planIds });
+		try {
+			await renamePlan({ autumn: autumnV2_3, fromId: proOld, toId: proNew });
+			await renamePlan({ autumn: autumnV2_3, fromId: addonOld, toId: addonNew });
+
+			const preview = await autumnV2_3.billing.previewAttach<AttachParamsV1Input>(
+				{
+					customer_id: customerId,
+					plan_id: proOld,
+				},
+			);
+			const previewPlanIds = collectResponsePlanIds(preview);
+			expect(previewPlanIds.length).toBeGreaterThan(0);
+			expect(previewPlanIds.every((id) => id !== proOld)).toBe(true);
+			expect(previewPlanIds).toContain(proNew);
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: proOld,
+			});
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				active: [proNew],
+			});
+			await expectStripeSubscriptionCorrect({ ctx, customerId });
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: addonOld,
+				remove_plan_ids: [proOld],
+			});
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				active: [addonNew],
+				notPresent: [proNew],
+			});
+
+			await autumnV2_3.post("/attach", {
+				customer_id: otherId,
+				product_id: proOld,
+				redirect_mode: "if_required",
+			});
+			await expectCustomerProducts({
+				customerId: otherId,
+				autumn: autumnV2_3,
+				active: [proNew],
+			});
+
+			await autumnV2_3.cancel({
+				customer_id: otherId,
+				product_id: proOld,
+				cancel_immediately: false,
+			});
+			await expectCustomerProducts({
+				customerId: otherId,
+				autumn: autumnV2_3,
+				canceling: [proNew],
+			});
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await autumnV2_3.customers.delete(otherId).catch(() => {});
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases billing: update / preview_update / cancel / multi_update")}`,
+	async () => {
+		const customerId = uniqueTestId("alias_upd");
+		const otherId = uniqueTestId("alias_upd_b");
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: otherId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const oldId = pro.id;
+		const newId = `${oldId}_n`;
+		const planIds = [oldId, newId];
+
+		await deleteAliases({ ctx, planIds });
+		try {
+			await renamePlan({ autumn: autumnV2_3, fromId: oldId, toId: newId });
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: oldId,
+			});
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: otherId,
+				plan_id: oldId,
+			});
+
+			const preview = await autumnV2_3.billing.previewUpdate<UpdateSubscriptionV1ParamsInput>(
+				{
+					customer_id: customerId,
+					plan_id: oldId,
+					cancel_action: "cancel_end_of_cycle",
+				},
+			);
+			expect(collectResponsePlanIds(preview)).toContain(newId);
+
+			await autumnV2_3.billing.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: oldId,
+				cancel_action: "cancel_end_of_cycle",
+			});
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				canceling: [newId],
+			});
+
+			await autumnV2_3.billing.previewMultiUpdate<MultiUpdateParamsV0Input>({
+				customer_id: otherId,
+				updates: [{ plan_id: oldId, cancel_action: "cancel_end_of_cycle" }],
+			});
+			await autumnV2_3.billing.multiUpdate<MultiUpdateParamsV0Input>({
+				customer_id: otherId,
+				updates: [{ plan_id: oldId, cancel_action: "cancel_end_of_cycle" }],
+			});
+			await expectCustomerProducts({
+				customerId: otherId,
+				autumn: autumnV2_3,
+				canceling: [newId],
+			});
+			await expectStripeSubscriptionCorrect({ ctx, customerId });
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await autumnV2_3.customers.delete(otherId).catch(() => {});
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases billing: multi_attach / preview_multi_attach / create_schedule")}`,
+	async () => {
+		const customerId = uniqueTestId("alias_ma");
+		const scheduleId = uniqueTestId("alias_sch");
+		const planA = products.pro({
+			id: "plana",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const planB = products.pro({
+			id: "planb",
+			items: [items.monthlyWords({ includedUsage: 50 })],
+			group: "group-b",
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [planA, planB] }),
+				s.otherCustomers([{ id: scheduleId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const aOld = planA.id;
+		const aNew = `${aOld}_n`;
+		const bOld = planB.id;
+		const bNew = `${bOld}_n`;
+		const planIds = [aOld, aNew, bOld, bNew];
+
+		await deleteAliases({ ctx, planIds });
+		try {
+			await renamePlan({ autumn: autumnV2_3, fromId: aOld, toId: aNew });
+			await renamePlan({ autumn: autumnV2_3, fromId: bOld, toId: bNew });
+
+			const multiParams = {
+				customer_id: customerId,
+				plans: [{ plan_id: aOld }, { plan_id: bOld }],
+			};
+			const multiPreview = await autumnV2_3.billing.previewMultiAttach(
+				multiParams,
+			);
+			expect(collectResponsePlanIds(multiPreview)).toContain(aNew);
+			expect(collectResponsePlanIds(multiPreview)).toContain(bNew);
+
+			await autumnV2_3.billing.multiAttach(multiParams);
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				active: [aNew, bNew],
+			});
+			await expectStripeSubscriptionCorrect({ ctx, customerId });
+
+			const scheduleParams: CreateScheduleParamsV0Input = {
+				customer_id: scheduleId,
+				phases: [{ starts_at: "now", plans: [{ plan_id: aOld }] }],
+			};
+			const schedulePreview = await autumnV2_3.post(
+				"/billing.preview_create_schedule",
+				scheduleParams,
+			);
+			expect(collectResponsePlanIds(schedulePreview)).toContain(aNew);
+
+			await autumnV2_3.billing.createSchedule<CreateScheduleParamsV0Input>(
+				scheduleParams,
+			);
+			await expectCustomerProducts({
+				customerId: scheduleId,
+				autumn: autumnV2_3,
+				active: [aNew],
+			});
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await autumnV2_3.customers.delete(scheduleId).catch(() => {});
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/aliases/alias-catalog-endpoints.test.ts
+++ b/server/tests/integration/catalog-v2/plans/aliases/alias-catalog-endpoints.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Ingress plan-id aliases on CORE catalog read/write endpoints.
+ *
+ * Path `:product_id` and body `plan_id` rewrite to the canonical id.
+ * `new_plan_id` and create-plan identity fields are not rewritten.
+ */
+
+import { expect, test } from "bun:test";
+import { type ApiPlanV1, ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { expectLicenseLinkCorrect } from "../licenses/utils/expectLicenseLinkCorrect.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+import {
+	deleteAliases,
+	renamePlan,
+} from "../utils/planAliasTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases catalog: GET path / plans.get / has_customers")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const oldId = uniqueTestId("alias_get");
+		const newId = uniqueTestId("alias_get_n");
+		const planIds = [oldId, newId];
+
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: oldId, name: "Alias Get" }],
+			});
+			await renamePlan({ autumn: autumnV2_3, fromId: oldId, toId: newId });
+
+			const viaPath = await autumnV2_3.products.get<ApiPlanV1>(oldId);
+			expect(viaPath.id).toBe(newId);
+
+			const viaRpc = (await autumnV2_3.post("/plans.get", {
+				plan_id: oldId,
+			})) as ApiPlanV1;
+			expect(viaRpc.id).toBe(newId);
+
+			const hasCustomers = (await autumnV2_3.post("/plans.has_customers", {
+				plan_id: oldId,
+			})) as { current_version: number };
+			expect(hasCustomers.current_version).toBe(1);
+
+			const hasCustomersPath = (await autumnV2_3.post(
+				`/products/${oldId}/has_customers`,
+				{},
+			)) as { current_version: number };
+			expect(hasCustomersPath.current_version).toBe(1);
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases catalog: catalogV2.update / preview / PATCH path / licenses[]")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const oldId = uniqueTestId("alias_upd");
+		const newId = uniqueTestId("alias_upd_n");
+		const childOld = uniqueTestId("alias_lic");
+		const childNew = uniqueTestId("alias_lic_n");
+		const planIds = [oldId, newId, childOld, childNew];
+
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: oldId, name: "Parent" },
+					{ plan_id: childOld, name: "Seat" },
+				],
+			});
+			await renamePlan({ autumn: autumnV2_3, fromId: oldId, toId: newId });
+			await renamePlan({ autumn: autumnV2_3, fromId: childOld, toId: childNew });
+
+			const preview = await autumnV2_3.catalogV2.previewUpdate({
+				plans: [{ plan_id: oldId, name: "Parent Renamed" }],
+			});
+			const previewIds = JSON.stringify(preview);
+			expect(previewIds).toContain(newId);
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: oldId, name: "Parent Renamed" }],
+			});
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [{ id: newId, name: "Parent Renamed" }],
+			});
+
+			await autumnV2_3.products.update(oldId, { name: "Parent Patched" });
+			const patched = await autumnV2_3.products.get<ApiPlanV1>(newId);
+			expect(patched.name).toBe("Parent Patched");
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: newId,
+						licenses: [{ license_plan_id: childOld, included: 2 }],
+					},
+				],
+			});
+			await expectLicenseLinkCorrect({
+				ctx,
+				parentPlanId: newId,
+				licensePlanId: childNew,
+				included: 2,
+			});
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases catalog: delete path / remove_plans / create_variant / new_plan_id skip")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const deleteOld = uniqueTestId("alias_del");
+		const deleteNew = uniqueTestId("alias_del_n");
+		const removeOld = uniqueTestId("alias_rm");
+		const removeNew = uniqueTestId("alias_rm_n");
+		const rpcOld = uniqueTestId("alias_rpc");
+		const rpcNew = uniqueTestId("alias_rpc_n");
+		const baseOld = uniqueTestId("alias_var");
+		const baseNew = uniqueTestId("alias_var_n");
+		const variantId = uniqueTestId("alias_var_eu");
+		const planIds = [
+			deleteOld,
+			deleteNew,
+			removeOld,
+			removeNew,
+			rpcOld,
+			rpcNew,
+			baseOld,
+			baseNew,
+			variantId,
+		];
+
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: deleteOld, name: "Delete Me" },
+					{ plan_id: removeOld, name: "Remove Me" },
+					{ plan_id: rpcOld, name: "Rpc Delete" },
+					{ plan_id: baseOld, name: "Base" },
+				],
+			});
+			await renamePlan({
+				autumn: autumnV2_3,
+				fromId: deleteOld,
+				toId: deleteNew,
+			});
+			await renamePlan({
+				autumn: autumnV2_3,
+				fromId: removeOld,
+				toId: removeNew,
+			});
+			await renamePlan({ autumn: autumnV2_3, fromId: rpcOld, toId: rpcNew });
+			await renamePlan({ autumn: autumnV2_3, fromId: baseOld, toId: baseNew });
+
+			await autumnV2_3.products.delete(deleteOld);
+			await expectAutumnError({
+				func: () => autumnV2_3.products.get(deleteNew),
+			});
+
+			await autumnV2_3.catalogV2.update({
+				remove_plans: [{ plan_id: removeOld }],
+			});
+			await expectAutumnError({
+				func: () => autumnV2_3.products.get(removeNew),
+			});
+
+			await autumnV2_3.post("/plans.delete", { plan_id: rpcOld });
+			await expectAutumnError({
+				func: () => autumnV2_3.products.get(rpcNew),
+			});
+
+			await autumnV2_3.plans.createVariant({
+				base_plan_id: baseOld,
+				variant_plan_id: variantId,
+				name: "EU",
+			});
+			const variant = await autumnV2_3.products.get<ApiPlanV1>(variantId);
+			expect(variant.id).toBe(variantId);
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "reserved as an alias",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: variantId, new_plan_id: baseOld }],
+					}),
+			});
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/aliases/alias-customer-license-endpoints.test.ts
+++ b/server/tests/integration/catalog-v2/plans/aliases/alias-customer-license-endpoints.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Ingress plan-id aliases on customer create, transfer, and license attach.
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	AttachParamsV1Input,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import {
+	listLicenseAssignments,
+	listLicensePools,
+} from "@tests/integration/licenses/licenseTestUtils.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { deleteAliases, renamePlan } from "../utils/planAliasTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases customer: auto_enable_plan_id / transfer product_id")}`,
+	async () => {
+		const customerId = uniqueTestId("alias_cus");
+		const free = products.base({
+			id: "free",
+			items: [items.monthlyMessages({ includedUsage: 50 })],
+			isDefault: true,
+		});
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { autumnV2_3, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [free, pro] }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+			],
+			actions: [],
+		});
+
+		const freeOld = free.id;
+		const freeNew = `${freeOld}_n`;
+		const proOld = pro.id;
+		const proNew = `${proOld}_n`;
+		const planIds = [freeOld, freeNew, proOld, proNew];
+		const createdId = uniqueTestId("alias_ae");
+
+		await deleteAliases({ ctx, planIds });
+		try {
+			await renamePlan({ autumn: autumnV2_3, fromId: freeOld, toId: freeNew });
+			await renamePlan({ autumn: autumnV2_3, fromId: proOld, toId: proNew });
+
+			await autumnV2_3.customers.create({
+				id: createdId,
+				auto_enable_plan_id: freeOld,
+			});
+			await expectCustomerProducts({
+				customerId: createdId,
+				autumn: autumnV2_3,
+				active: [freeNew],
+			});
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: proOld,
+			});
+			const check = await autumnV2_3.check({
+				customer_id: customerId,
+				product_id: proOld,
+			});
+			expect(check.allowed).toBe(true);
+
+			await autumnV2_3.transfer(customerId, {
+				to_entity_id: entities[0].id,
+				product_id: proOld,
+			});
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				active: [proNew],
+			});
+		} finally {
+			await autumnV2_3.customers.delete(createdId).catch(() => {});
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases licenses: attach plan_id / license_quantities / upsert_licenses")}`,
+	async () => {
+		const customerId = uniqueTestId("alias_lic");
+		const parent = products.base({
+			id: "parent",
+			items: [items.dashboard()],
+		});
+		const license = products.base({
+			id: "seat",
+			items: [items.monthlyMessages({ includedUsage: 25 })],
+		});
+
+		const { autumnV2_3, ctx, entities } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.entities({ count: 1, featureId: TestFeature.Users }),
+				s.products({ list: [parent, license] }),
+			],
+			actions: [
+				s.licenses.link({
+					parentProductId: parent.id,
+					licenseProductId: license.id,
+					included: 1,
+				}),
+			],
+		});
+
+		const parentOld = parent.id;
+		const parentNew = `${parentOld}_n`;
+		const licenseOld = license.id;
+		const licenseNew = `${licenseOld}_n`;
+		const planIds = [parentOld, parentNew, licenseOld, licenseNew];
+
+		await deleteAliases({ ctx, planIds });
+		try {
+			await renamePlan({
+				autumn: autumnV2_3,
+				fromId: parentOld,
+				toId: parentNew,
+			});
+			await renamePlan({
+				autumn: autumnV2_3,
+				fromId: licenseOld,
+				toId: licenseNew,
+			});
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: parentOld,
+				license_quantities: [{ license_plan_id: licenseOld, quantity: 2 }],
+			});
+
+			const pools = await listLicensePools({
+				autumn: autumnV2_3,
+				customerId,
+			});
+			expect(pools[0]).toMatchObject({
+				license_plan_id: licenseNew,
+				granted: 2,
+			});
+
+			await autumnV2_3.licenses.attach({
+				customer_id: customerId,
+				plan_id: licenseOld,
+				entities: [{ entity_id: entities[0].id }],
+			});
+			const assignments = await listLicenseAssignments({
+				autumn: autumnV2_3,
+				customerId,
+				licensePlanId: licenseOld,
+				active: true,
+			});
+			expect(assignments).toHaveLength(1);
+			expect(assignments[0].license_plan_id).toBe(licenseNew);
+
+			await autumnV2_3.licenses.release({
+				customer_id: customerId,
+				license_plan_id: licenseOld,
+				entity_ids: [entities[0].id],
+			});
+
+			await autumnV2_3.billing.update<UpdateSubscriptionV1ParamsInput>({
+				customer_id: customerId,
+				plan_id: parentOld,
+				customize: {
+					upsert_licenses: [{ license_plan_id: licenseOld, included: 3 }],
+				},
+			});
+			const poolsAfter = await listLicensePools({
+				autumn: autumnV2_3,
+				customerId,
+			});
+			expect(
+				poolsAfter.some((pool) => pool.license_plan_id === licenseNew),
+			).toBe(true);
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/aliases/alias-vercel-endpoints.test.ts
+++ b/server/tests/integration/catalog-v2/plans/aliases/alias-vercel-endpoints.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Ingress plan-id aliases on Vercel marketplace `billingPlanId`.
+ */
+
+import { expect, test } from "bun:test";
+import { ApiVersion, CusProductStatus } from "@autumn/shared";
+import {
+	buildTestOidcHeaders,
+	seedVercelCustomer,
+	setupVercelOrg,
+} from "@tests/integration/external-psps/vercel/utils/vercel-test-helpers.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import ctx from "@tests/utils/testInitUtils/createTestContext.js";
+import chalk from "chalk";
+import { AutumnInt } from "@/external/autumn/autumnCli.js";
+import { CusProductService } from "@/internal/customers/cusProducts/CusProductService.js";
+import { initProductsV0 } from "@/utils/scriptUtils/testUtils/initProductsV0.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { deleteAliases, renamePlan } from "../utils/planAliasTestUtils.js";
+
+const baseUrl = () =>
+	(process.env.AUTUMN_TEST_BASE_URL ?? "http://localhost:8080").replace(
+		/\/$/,
+		"",
+	);
+
+const vercelPath = ({
+	installationId,
+	suffix,
+}: {
+	installationId: string;
+	suffix: string;
+}) =>
+	`${baseUrl()}/webhooks/vercel/${ctx.org.id}/${ctx.env}/v1/installations/${installationId}${suffix}`;
+
+test.concurrent(
+	`${chalk.yellowBright("plan aliases vercel: create-resource / update-billing-plan billingPlanId")}`,
+	async () => {
+		const suffix = uniqueTestId("valias");
+		const customerId = `${suffix}-cus`;
+		const installationId = `icfg_${suffix}`;
+		const otherInstallationId = `icfg_${suffix}_b`;
+		const otherCustomerId = `${suffix}-cus-b`;
+		const proRaw = products.pro({
+			id: `${suffix}-pro`,
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		await setupVercelOrg(ctx);
+		await initProductsV0({
+			ctx,
+			products: [proRaw],
+			prefix: suffix,
+		});
+		const oldId = proRaw.id;
+		const newId = `${oldId}_n`;
+		const planIds = [oldId, newId];
+		const autumn = new AutumnInt({ version: ApiVersion.V2_3 });
+
+		await deleteAliases({ ctx, planIds });
+		try {
+			await renamePlan({ autumn, fromId: oldId, toId: newId });
+
+			const { internalCustomerId } = await seedVercelCustomer({
+				ctx,
+				customerId,
+				installationId,
+			});
+
+			const createRes = await fetch(
+				vercelPath({ installationId, suffix: "/resources" }),
+				{
+					method: "POST",
+					headers: buildTestOidcHeaders(installationId, "user"),
+					body: JSON.stringify({
+						productId: oldId,
+						billingPlanId: oldId,
+						name: `${suffix} resource`,
+					}),
+				},
+			);
+			expect(createRes.status).toBe(200);
+			const created = (await createRes.json()) as { billingPlan?: { id?: string } };
+			expect(created.billingPlan?.id).toBe(newId);
+
+			const cusProducts = await CusProductService.list({
+				db: ctx.db,
+				internalCustomerId,
+				inStatuses: [CusProductStatus.Active, CusProductStatus.Trialing],
+			});
+			expect(cusProducts.some((row) => row.product_id === newId)).toBe(true);
+
+			await seedVercelCustomer({
+				ctx,
+				customerId: otherCustomerId,
+				installationId: otherInstallationId,
+			});
+			const updateRes = await fetch(
+				vercelPath({ installationId: otherInstallationId, suffix: "" }),
+				{
+					method: "PATCH",
+					headers: buildTestOidcHeaders(otherInstallationId, "user"),
+					body: JSON.stringify({ billingPlanId: oldId }),
+				},
+			);
+			expect(updateRes.status).toBe(200);
+			const updated = (await updateRes.json()) as {
+				billingPlan?: { id?: string };
+			};
+			expect(updated.billingPlan?.id).toBe(newId);
+		} finally {
+			await autumn.customers.delete(customerId).catch(() => {});
+			await autumn.customers.delete(otherCustomerId).catch(() => {});
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
@@ -88,6 +88,8 @@ type ExpectedPlanPreviewRow = {
 	licenseParents?: ExpectedLicenseParent[] | null;
 	/** Containment over variants; pass `null` to assert the lane is omitted. */
 	variants?: ExpectedVariant[] | null;
+	/** Exact match; pass `null` to assert absent. */
+	aliasReplacement?: PlanPreviewRow["alias_replacement"] | null;
 };
 
 type ExpectedVariant = {
@@ -104,6 +106,8 @@ type ExpectedVariant = {
 	licenseChanges?: ExpectedLicenseChange[] | null;
 	nestedItemChanges?: Array<Record<string, unknown>>;
 	siblingVersions?: ExpectedSiblingVersion[] | null;
+	/** Exact match; pass `null` to assert absent. */
+	aliasReplacement?: CatalogVariantPreview["alias_replacement"] | null;
 };
 
 const expectAbsent = (value: unknown) => {
@@ -274,6 +278,13 @@ export const expectPlanPreviewRowCorrect = ({
 	}
 	if (expected.name !== undefined) {
 		expect(row.name).toBe(expected.name);
+	}
+	if (expected.aliasReplacement !== undefined) {
+		if (expected.aliasReplacement === null) {
+			expect(row.alias_replacement).toBeUndefined();
+		} else {
+			expect(row.alias_replacement).toEqual(expected.aliasReplacement);
+		}
 	}
 	if (expected.hasCustomers !== undefined) {
 		expect(row.state.has_customers).toBe(expected.hasCustomers);
@@ -459,6 +470,15 @@ export const expectPlanPreviewRowCorrect = ({
 				).toBeDefined();
 				if (expectedVariant.variantAction !== undefined) {
 					expect(variant?.variant_action).toBe(expectedVariant.variantAction);
+				}
+				if (expectedVariant.aliasReplacement !== undefined) {
+					if (expectedVariant.aliasReplacement === null) {
+						expect(variant?.alias_replacement).toBeUndefined();
+					} else {
+						expect(variant?.alias_replacement).toEqual(
+							expectedVariant.aliasReplacement,
+						);
+					}
 				}
 				if (expectedVariant.versioning !== undefined) {
 					expect(

--- a/server/tests/integration/catalog-v2/plans/update/rename-plan-alias-reclaim.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/rename-plan-alias-reclaim.test.ts
@@ -1,0 +1,136 @@
+/**
+ * catalogV2.update — own-alias reclaim roundtrip.
+ *
+ * After pro → proNew, pro aliases proNew. Renaming back (proNew → pro)
+ * reclaims the original id: proNew becomes the alias, the old alias dies.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiPlanV1,
+	type AttachParamsV1Input,
+	customerProducts,
+	ErrCode,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { eq } from "drizzle-orm";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import {
+	deleteAliases,
+	listAliases,
+	renamePlan,
+} from "../utils/planAliasTestUtils.js";
+import { cleanupRefs, seedCustomerProductRef } from "../utils/seedPlanRefs.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan aliases: rename then reclaim original id (own-alias roundtrip)")}`,
+	async () => {
+		const pro = products.pro({ items: [] });
+		const customerId = uniqueTestId("cv2_reclaim");
+		const otherId = uniqueTestId("cv2_reclaim_b");
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: otherId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+		const originalId = pro.id;
+		const newPlanId = uniqueTestId("cv2_reclaim_new");
+		const planIds = [originalId, newPlanId];
+		await deleteAliases({ ctx, planIds });
+		await deleteDbPlans({ ctx, planIds: [newPlanId] });
+		let cusProductId: string | undefined;
+		try {
+			({ cusProductId } = await seedCustomerProductRef({
+				ctx,
+				planId: originalId,
+			}));
+
+			await renamePlan({
+				autumn: autumnV2_3,
+				fromId: originalId,
+				toId: newPlanId,
+			});
+
+			const afterFirstRename = await listAliases({ ctx, planIds });
+			expect(afterFirstRename).toHaveLength(1);
+			expect(afterFirstRename[0]?.alias_id).toBe(originalId);
+			expect(afterFirstRename[0]?.canonical_plan_id).toBe(newPlanId);
+
+			const liveAfterFirst =
+				await autumnV2_3.products.get<ApiPlanV1>(originalId);
+			expect(liveAfterFirst.id).toBe(newPlanId);
+			expect(liveAfterFirst).not.toHaveProperty("alias_id");
+
+			const [cusProductAfterFirst] = await ctx.db
+				.select()
+				.from(customerProducts)
+				.where(eq(customerProducts.id, cusProductId));
+			expect(cusProductAfterFirst.product_id).toBe(originalId);
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: originalId,
+			});
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				active: [newPlanId],
+			});
+
+			await renamePlan({
+				autumn: autumnV2_3,
+				fromId: newPlanId,
+				toId: originalId,
+			});
+
+			const afterReclaim = await listAliases({ ctx, planIds });
+			expect(afterReclaim).toHaveLength(1);
+			expect(afterReclaim[0]?.alias_id).toBe(newPlanId);
+			expect(afterReclaim[0]?.canonical_plan_id).toBe(originalId);
+
+			const liveByOriginal =
+				await autumnV2_3.products.get<ApiPlanV1>(originalId);
+			const liveByPrevious =
+				await autumnV2_3.products.get<ApiPlanV1>(newPlanId);
+			expect(liveByOriginal.id).toBe(originalId);
+			expect(liveByPrevious.id).toBe(originalId);
+			expect(liveByOriginal).not.toHaveProperty("alias_id");
+			expect(liveByPrevious).not.toHaveProperty("alias_id");
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: otherId,
+				plan_id: newPlanId,
+			});
+			await expectCustomerProducts({
+				customerId: otherId,
+				autumn: autumnV2_3,
+				active: [originalId],
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "reserved as an alias",
+				func: () =>
+					autumnV2_3.products.create({
+						id: newPlanId,
+						name: "Should Not Create",
+					}),
+			});
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await autumnV2_3.customers.delete(otherId).catch(() => {});
+			await cleanupRefs({ ctx, planIds });
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/rename-plan-alias-replacement.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/rename-plan-alias-replacement.test.ts
@@ -1,0 +1,522 @@
+/**
+ * catalogV2 preview/update — claiming a reserved plan-id alias.
+ *
+ * After pro → proNew, pro aliases proNew. Catalog preview surfaces
+ * alias_replacement and execute deletes that alias so pro is a real id
+ * again. REST create stays 400. Own-reclaim includes the field (alias dies).
+ *
+ * Create-claim calls the catalog action directly: public ingress rewrites
+ * plan_id to the owner; dashboard skips rewrite (secret-key tests cannot).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiPlanV1,
+	type AttachParamsV1Input,
+	customerProducts,
+	ErrCode,
+	products,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { catalogV2Actions } from "@/internal/catalogV2/actions/index.js";
+import { buildUpdateCatalogPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/buildUpdateCatalogPreview.js";
+import { toPlanAliasMap } from "@/internal/catalogV2/productAliases/toPlanAliasMap.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectDbPlansAbsent,
+} from "../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../preview/utils/expectPlanPreview.js";
+import {
+	cleanupRefs,
+	seedCustomerProductRef,
+} from "../utils/seedPlanRefs.js";
+import {
+	deleteAliases,
+	listAliases,
+	renamePlan,
+} from "../utils/planAliasTestUtils.js";
+
+const replacement = ({
+	aliasId,
+	ownerId,
+}: {
+	aliasId: string;
+	ownerId: string;
+}) => ({ alias_id: aliasId, plan_id: ownerId });
+
+const seedReservedAlias = async ({
+	autumn,
+	aliasId,
+	ownerId,
+	name,
+}: {
+	autumn: AutumnInt;
+	aliasId: string;
+	ownerId: string;
+	name: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: aliasId, name }],
+	});
+	await renamePlan({ autumn, fromId: aliasId, toId: ownerId });
+};
+
+/** Dashboard skips ingress rewrite; secret-key tests cannot send that header. */
+const syncPlanAliasesOnCtx = async ({
+	ctx,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+}) => {
+	const rows = await listAliases({ ctx, planIds });
+	ctx.org.planAliases = toPlanAliasMap({ rows });
+};
+
+const previewCreateClaim = async ({
+	ctx,
+	planId,
+	name,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	name: string;
+	planIds: string[];
+}) => {
+	await syncPlanAliasesOnCtx({ ctx, planIds });
+	const params = {
+		features: [],
+		remove_features: [],
+		plans: [{ plan_id: planId, name }],
+		remove_plans: [],
+	};
+	const { catalogContext, updateCatalogPlan } =
+		await catalogV2Actions.updateCatalog({
+			ctx,
+			params,
+			preview: true,
+		});
+	return parsePlanPreview(
+		buildUpdateCatalogPreview({ catalogContext, updateCatalogPlan }),
+	);
+};
+
+const executeCreateClaim = async ({
+	ctx,
+	planId,
+	name,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	name: string;
+	planIds: string[];
+}) => {
+	await syncPlanAliasesOnCtx({ ctx, planIds });
+	await catalogV2Actions.updateCatalog({
+		ctx,
+		params: {
+			features: [],
+			remove_features: [],
+			plans: [{ plan_id: planId, name }],
+			remove_plans: [],
+		},
+	});
+};
+
+const getPlanRows = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) =>
+	ctx.db
+		.select()
+		.from(products)
+		.where(
+			and(
+				eq(products.org_id, ctx.org.id),
+				eq(products.env, ctx.env),
+				eq(products.id, planId),
+			),
+		);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 alias replacement: preview field on create / rename / variant / reclaim; absent otherwise")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const aliasId = uniqueTestId("cv2_ar_prev");
+		const ownerId = uniqueTestId("cv2_ar_prev_own");
+		const starterId = uniqueTestId("cv2_ar_prev_st");
+		const baseId = uniqueTestId("cv2_ar_prev_base");
+		const variantId = uniqueTestId("cv2_ar_prev_eu");
+		const cleanId = uniqueTestId("cv2_ar_prev_ok");
+		const planIds = [aliasId, ownerId, starterId, baseId, variantId, cleanId];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await seedReservedAlias({
+				autumn: autumnV2_3,
+				aliasId,
+				ownerId,
+				name: "Occupied",
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: starterId, name: "Starter" },
+					{ plan_id: baseId, name: "Team" },
+					{ plan_id: cleanId, name: "Clean" },
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: baseId,
+						variants: [{ variant_plan_id: variantId, name: "Team EU" }],
+					},
+				],
+			});
+
+			// Create-claim bypasses HTTP ingress (dashboard does the same).
+			const createPreview = await previewCreateClaim({
+				ctx,
+				planId: aliasId,
+				name: "Claimed Create",
+				planIds,
+			});
+			expectPlanPreviewRowCorrect({
+				preview: createPreview,
+				expected: {
+					planId: aliasId,
+					action: "create",
+					aliasReplacement: replacement({ aliasId, ownerId }),
+				},
+			});
+			await expectDbPlansAbsent({ ctx, planIds: [aliasId] });
+
+			const renamePreview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: starterId, new_plan_id: aliasId }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: renamePreview,
+				expected: {
+					planId: starterId,
+					action: "update",
+					aliasReplacement: replacement({ aliasId, ownerId }),
+				},
+			});
+
+			const variantPreview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: baseId,
+							variants: [
+								{ variant_plan_id: variantId, new_plan_id: aliasId },
+							],
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: variantPreview,
+				expected: {
+					planId: baseId,
+					aliasReplacement: null,
+					variants: [
+						{
+							planId: variantId,
+							aliasReplacement: replacement({ aliasId, ownerId }),
+						},
+					],
+				},
+			});
+
+			const reclaimPreview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: ownerId, new_plan_id: aliasId }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: reclaimPreview,
+				expected: {
+					planId: ownerId,
+					action: "update",
+					aliasReplacement: replacement({ aliasId, ownerId }),
+				},
+			});
+
+			const cleanPreview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: cleanId, name: "Still Clean" }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: cleanPreview,
+				expected: {
+					planId: cleanId,
+					action: "update",
+					aliasReplacement: null,
+				},
+			});
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 alias replacement: execute create / rename / variant new_plan_id claims alias")}`,
+	async () => {
+		const { autumnV2_3, ctx, customerId } = await initScenario({
+			customerId: uniqueTestId("cv2_ar_ex"),
+			setup: [s.customer()],
+			actions: [],
+		});
+		const createAlias = uniqueTestId("cv2_ar_ex_c");
+		const createOwner = uniqueTestId("cv2_ar_ex_c_own");
+		const starterId = uniqueTestId("cv2_ar_ex_st");
+		const starterAlias = uniqueTestId("cv2_ar_ex_st_a");
+		const starterOwner = uniqueTestId("cv2_ar_ex_st_own");
+		const baseId = uniqueTestId("cv2_ar_ex_base");
+		const variantId = uniqueTestId("cv2_ar_ex_eu");
+		const variantAlias = uniqueTestId("cv2_ar_ex_eu_a");
+		const variantOwner = uniqueTestId("cv2_ar_ex_eu_own");
+		const planIds = [
+			createAlias,
+			createOwner,
+			starterId,
+			starterAlias,
+			starterOwner,
+			baseId,
+			variantId,
+			variantAlias,
+			variantOwner,
+		];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		let cusProductId: string | undefined;
+		try {
+			await seedReservedAlias({
+				autumn: autumnV2_3,
+				aliasId: createAlias,
+				ownerId: createOwner,
+				name: "Create Occupied",
+			});
+			await executeCreateClaim({
+				ctx,
+				planId: createAlias,
+				name: "Claimed Create",
+				planIds,
+			});
+
+			const afterCreate = await listAliases({
+				ctx,
+				planIds: [createAlias, createOwner],
+			});
+			expect(
+				afterCreate.some((row) => row.alias_id === createAlias),
+			).toBe(false);
+			const created = await autumnV2_3.products.get<ApiPlanV1>(createAlias);
+			expect(created.id).toBe(createAlias);
+			expect(created.name).toBe("Claimed Create");
+			const createOwnerPlan =
+				await autumnV2_3.products.get<ApiPlanV1>(createOwner);
+			expect(createOwnerPlan.id).toBe(createOwner);
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: createAlias,
+			});
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				active: [createAlias],
+			});
+
+			await seedReservedAlias({
+				autumn: autumnV2_3,
+				aliasId: starterAlias,
+				ownerId: starterOwner,
+				name: "Rename Occupied",
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: starterId, name: "Starter" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: starterId, new_plan_id: starterAlias }],
+			});
+
+			const afterRename = await listAliases({
+				ctx,
+				planIds: [starterId, starterAlias, starterOwner],
+			});
+			expect(
+				afterRename.some((row) => row.alias_id === starterAlias),
+			).toBe(false);
+			expect(
+				afterRename.some(
+					(row) =>
+						row.alias_id === starterId &&
+						row.canonical_plan_id === starterAlias,
+				),
+			).toBe(true);
+			const renamed = await autumnV2_3.products.get<ApiPlanV1>(starterAlias);
+			expect(renamed.id).toBe(starterAlias);
+			expect(renamed.name).toBe("Starter");
+			const starterOwnerPlan =
+				await autumnV2_3.products.get<ApiPlanV1>(starterOwner);
+			expect(starterOwnerPlan.id).toBe(starterOwner);
+
+			await seedReservedAlias({
+				autumn: autumnV2_3,
+				aliasId: variantAlias,
+				ownerId: variantOwner,
+				name: "Variant Occupied",
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: baseId, name: "Team" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: baseId,
+						variants: [{ variant_plan_id: variantId, name: "Team EU" }],
+					},
+				],
+			});
+			({ cusProductId } = await seedCustomerProductRef({
+				ctx,
+				planId: variantId,
+			}));
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: baseId,
+						variants: [
+							{ variant_plan_id: variantId, new_plan_id: variantAlias },
+						],
+					},
+				],
+			});
+
+			expect(await getPlanRows({ ctx, planId: variantId })).toHaveLength(0);
+			const variantRows = await getPlanRows({ ctx, planId: variantAlias });
+			expect(variantRows).toHaveLength(1);
+			const afterVariant = await listAliases({
+				ctx,
+				planIds: [variantId, variantAlias, variantOwner],
+			});
+			expect(
+				afterVariant.some((row) => row.alias_id === variantAlias),
+			).toBe(false);
+			expect(
+				afterVariant.some(
+					(row) =>
+						row.alias_id === variantId &&
+						row.canonical_plan_id === variantAlias,
+				),
+			).toBe(true);
+			const [cusProduct] = await ctx.db
+				.select()
+				.from(customerProducts)
+				.where(eq(customerProducts.id, cusProductId));
+			expect(cusProduct.product_id).toBe(variantId);
+			expect(cusProduct.internal_product_id).toBe(variantRows[0]?.internal_id);
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await cleanupRefs({ ctx, planIds });
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 alias replacement: new_version rename claims reserved alias")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const aliasId = uniqueTestId("cv2_ar_nv");
+		const ownerId = uniqueTestId("cv2_ar_nv_own");
+		const starterId = uniqueTestId("cv2_ar_nv_st");
+		const planIds = [aliasId, ownerId, starterId];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await seedReservedAlias({
+				autumn: autumnV2_3,
+				aliasId,
+				ownerId,
+				name: "Occupied",
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: starterId, name: "Starter" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: starterId,
+						new_plan_id: aliasId,
+						versioning: "new_version",
+					},
+				],
+			});
+			const afterClaim = await listAliases({ ctx, planIds });
+			expect(afterClaim.some((row) => row.alias_id === aliasId)).toBe(false);
+			const claimed = await autumnV2_3.products.get<ApiPlanV1>(aliasId);
+			expect(claimed.id).toBe(aliasId);
+			expect(claimed.name).toBe("Starter");
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 alias replacement: REST create of reserved id still 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const aliasId = uniqueTestId("cv2_ar_rest");
+		const ownerId = uniqueTestId("cv2_ar_rest_own");
+		const planIds = [aliasId, ownerId];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await seedReservedAlias({
+				autumn: autumnV2_3,
+				aliasId,
+				ownerId,
+				name: "Rest Occupied",
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "reserved as an alias",
+				func: () =>
+					autumnV2_3.products.create({
+						id: aliasId,
+						name: "Should Not Create",
+					}),
+			});
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/rename-plan-aliases.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/rename-plan-aliases.test.ts
@@ -1,0 +1,180 @@
+/**
+ * catalogV2.update — plan-id aliases. Rename writes one alias row (old → new);
+ * ingress rewrites the old id to the live id; responses stay canonical.
+ *
+ * Contract:
+ *   Rename writes product_aliases (alias_id=old, canonical_plan_id=new)
+ *   Re-rename replaces the row; the original alias no longer resolves
+ *   Attach / GET with the old id succeeds; response id is canonical (no alias_id)
+ *   REST POST /products reserved id → 400
+ *   Catalog new_plan_id onto another plan's alias → succeeds; alias deleted
+ *   Preview of that claim stamps alias_replacement
+ *
+ * Endpoint × field coverage: `../aliases/*.test.ts` and CASES.md §4.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiPlanV1,
+	type AttachParamsV1Input,
+	ErrCode,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../preview/utils/expectPlanPreview.js";
+import {
+	deleteAliases,
+	listAliases,
+} from "../utils/planAliasTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan aliases: rename writes alias; re-rename replaces; old alias dies")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_alias");
+		const newPlanId = uniqueTestId("cv2_alias_new");
+		const newerPlanId = uniqueTestId("cv2_alias_newer");
+		const planIds = [planId, newPlanId, newerPlanId];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Alias Source" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+			});
+
+			const afterRename = await listAliases({ ctx, planIds });
+			expect(afterRename).toHaveLength(1);
+			expect(afterRename[0]?.alias_id).toBe(planId);
+			expect(afterRename[0]?.canonical_plan_id).toBe(newPlanId);
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: newPlanId, new_plan_id: newerPlanId }],
+			});
+
+			const afterReRename = await listAliases({ ctx, planIds });
+			expect(afterReRename).toHaveLength(1);
+			expect(afterReRename[0]?.alias_id).toBe(newPlanId);
+			expect(afterReRename[0]?.canonical_plan_id).toBe(newerPlanId);
+
+			await expectAutumnError({
+				func: () => autumnV2_3.products.get(planId),
+			});
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan aliases: attach and GET with old id resolve to canonical id")}`,
+	async () => {
+		const { autumnV2_3, ctx, customerId } = await initScenario({
+			customerId: uniqueTestId("cv2_alias_cus"),
+			setup: [s.customer()],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_alias_get");
+		const newPlanId = uniqueTestId("cv2_alias_get_new");
+		const planIds = [planId, newPlanId];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "Alias Attach" }],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+			});
+
+			await autumnV2_3.billing.attach<AttachParamsV1Input>({
+				customer_id: customerId,
+				plan_id: planId,
+			});
+
+			const plan = await autumnV2_3.products.get<ApiPlanV1>(planId);
+			expect(plan.id).toBe(newPlanId);
+			expect(plan).not.toHaveProperty("alias_id");
+
+			await expectCustomerProducts({
+				customerId,
+				autumn: autumnV2_3,
+				active: [newPlanId],
+			});
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan aliases: REST create reserved id 400; catalog rename claims alias")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_alias_err");
+		const newPlanId = uniqueTestId("cv2_alias_err_new");
+		const otherPlanId = uniqueTestId("cv2_alias_err_other");
+		const planIds = [planId, newPlanId, otherPlanId];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planId, name: "Alias Occupied" },
+					{ plan_id: otherPlanId, name: "Other" },
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "reserved as an alias",
+				func: () =>
+					autumnV2_3.products.create({
+						id: planId,
+						name: "Should Not Create",
+					}),
+			});
+
+			const collidePreview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: otherPlanId, new_plan_id: planId }],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview: collidePreview,
+				expected: {
+					planId: otherPlanId,
+					action: "update",
+					aliasReplacement: { alias_id: planId, plan_id: newPlanId },
+				},
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: otherPlanId, new_plan_id: planId }],
+			});
+			const afterClaim = await listAliases({ ctx, planIds });
+			expect(afterClaim.some((row) => row.alias_id === planId)).toBe(false);
+			const claimed = await autumnV2_3.products.get<ApiPlanV1>(planId);
+			expect(claimed.id).toBe(planId);
+			expect(claimed.name).toBe("Other");
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/rename-plan-stale-ids.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/rename-plan-stale-ids.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Rename + price change must rewrite execute-plan public ids to the new id.
+ * Reward migration looks up via ProductService.getFull (no alias resolve).
+ *
+ * Red (current): results.plans[].id stays the old id after pro → proNew.
+ * Green (after): results.plans[].id is proNew; getFull(proNew) finds the row.
+ */
+
+import { expect, test } from "bun:test";
+import { isFixedPrice } from "@autumn/shared";
+import { expectCatalogResultsCorrect } from "@tests/integration/catalog-v2/utils/expectCatalogUpdate.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { deleteAliases } from "../utils/planAliasTestUtils.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rename: results.plans id and getFull use the new id after rename+price")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_stale");
+		const newPlanId = uniqueTestId("cv2_stale_new");
+		const planIds = [planId, newPlanId];
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Stale Source",
+						price: { amount: 20, interval: "month" },
+					},
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						new_plan_id: newPlanId,
+						price: { amount: 35, interval: "month" },
+					},
+				],
+			});
+
+			expectCatalogResultsCorrect({
+				response,
+				plans: [{ id: newPlanId, action: "update" }],
+			});
+
+			const after = await ProductService.getFull({
+				db: ctx.db,
+				idOrInternalId: newPlanId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+			expect(after.id).toBe(newPlanId);
+			expect(after.prices.find(isFixedPrice)?.config).toMatchObject({
+				amount: 35,
+			});
+		} finally {
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/update/rename-plan-vercel-allowlist.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/rename-plan-vercel-allowlist.test.ts
@@ -1,0 +1,150 @@
+/**
+ * catalogV2.update new_plan_id must rewrite the env Vercel allowlist
+ * so handleListBillingPlans still lists the renamed plan.
+ *
+ * Red (current):  allowlist keeps the old public id; listFull({ inIds })
+ *                 misses the renamed products.id and the plan vanishes.
+ * Green (after):  sandbox allowlist swaps old → new in the rename CTE;
+ *                 list billing plans returns the new id, not the old.
+ */
+
+import { expect, test } from "bun:test";
+import { BillingInterval, ResetInterval } from "@autumn/shared";
+import {
+	buildTestOidcHeaders,
+	seedVercelCustomer,
+	setupVercelOrg,
+} from "@tests/integration/external-psps/vercel/utils/vercel-test-helpers.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import {
+	expectVercelAllowlistRewritten,
+	expectVercelBillingPlansListed,
+} from "../utils/expectVercelAllowlistCorrect.js";
+import { deleteAliases, renamePlan } from "../utils/planAliasTestUtils.js";
+
+const baseUrl = () =>
+	(process.env.AUTUMN_TEST_BASE_URL ?? "http://localhost:8080").replace(
+		/\/$/,
+		"",
+	);
+
+const sandboxAllowlist = ({
+	ctx,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+}) => ctx.org.processor_configs?.vercel?.allowed_product_ids_sandbox;
+
+const setSandboxAllowlist = async ({
+	ctx,
+	planIds,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	planIds: string[] | undefined;
+}) => {
+	const existing = ctx.org.processor_configs?.vercel;
+	if (!existing) throw new Error("Vercel processor config missing");
+
+	const vercel = { ...existing };
+	if (planIds === undefined) {
+		delete vercel.allowed_product_ids_sandbox;
+	} else {
+		vercel.allowed_product_ids_sandbox = planIds;
+	}
+
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			processor_configs: {
+				...ctx.org.processor_configs,
+				vercel,
+			},
+		},
+	});
+	const refreshed = await OrgService.get({ db: ctx.db, orgId: ctx.org.id });
+	ctx.org = refreshed;
+};
+
+const listVercelBillingPlans = async ({
+	ctx,
+	installationId,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	installationId: string;
+}) => {
+	const res = await fetch(
+		`${baseUrl()}/webhooks/vercel/${ctx.org.id}/${ctx.env}/v1/installations/${installationId}/plans`,
+		{ headers: buildTestOidcHeaders(installationId, "user") },
+	);
+	expect(res.status).toBe(200);
+	return (await res.json()) as { plans: Array<{ id: string }> };
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rename refs: vercel allowlist old id rewritten; plan still listed")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ren_va");
+		const newPlanId = uniqueTestId("cv2_ren_va_new");
+		const planIds = [planId, newPlanId];
+		const customerId = `${planId}-cus`;
+		const installationId = `icfg_${planId}`;
+		const previousAllowlist = sandboxAllowlist({ ctx });
+
+		await deleteDbPlans({ ctx, planIds });
+		await deleteAliases({ ctx, planIds });
+		try {
+			await setupVercelOrg(ctx);
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Vercel Allowlist",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			await setSandboxAllowlist({
+				ctx,
+				planIds: [...(previousAllowlist ?? []), planId],
+			});
+
+			await renamePlan({ autumn: autumnV2_3, fromId: planId, toId: newPlanId });
+
+			const org = await OrgService.get({ db: ctx.db, orgId: ctx.org.id });
+			expectVercelAllowlistRewritten({
+				allowlist: org.processor_configs?.vercel?.allowed_product_ids_sandbox,
+				oldId: planId,
+				newId: newPlanId,
+			});
+
+			// Seed after rename so the Vercel subscriber gate does not block it.
+			await seedVercelCustomer({ ctx, customerId, installationId });
+			const listed = await listVercelBillingPlans({ ctx, installationId });
+			expectVercelBillingPlansListed({
+				listedIds: listed.plans.map((plan) => plan.id),
+				oldId: planId,
+				newId: newPlanId,
+			});
+		} finally {
+			await autumnV2_3.customers.delete(customerId).catch(() => {});
+			await setSandboxAllowlist({ ctx, planIds: previousAllowlist }).catch(
+				() => {},
+			);
+			await deleteAliases({ ctx, planIds });
+			await deleteDbPlans({ ctx, planIds });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/utils/expectVercelAllowlistCorrect.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/expectVercelAllowlistCorrect.ts
@@ -1,0 +1,27 @@
+import { expect } from "bun:test";
+
+export const expectVercelAllowlistRewritten = ({
+	allowlist,
+	oldId,
+	newId,
+}: {
+	allowlist: string[] | undefined;
+	oldId: string;
+	newId: string;
+}) => {
+	expect(allowlist).toContain(newId);
+	expect(allowlist).not.toContain(oldId);
+};
+
+export const expectVercelBillingPlansListed = ({
+	listedIds,
+	oldId,
+	newId,
+}: {
+	listedIds: string[];
+	oldId: string;
+	newId: string;
+}) => {
+	expect(listedIds).toContain(newId);
+	expect(listedIds).not.toContain(oldId);
+};

--- a/server/tests/integration/catalog-v2/plans/utils/planAliasTestUtils.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/planAliasTestUtils.ts
@@ -1,0 +1,79 @@
+import { productAliases } from "@autumn/shared";
+import { and, eq, inArray, or } from "drizzle-orm";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export const listAliases = async ({
+	ctx,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+}) =>
+	ctx.db
+		.select()
+		.from(productAliases)
+		.where(
+			and(
+				eq(productAliases.org_id, ctx.org.id),
+				eq(productAliases.env, ctx.env),
+				or(
+					inArray(productAliases.alias_id, planIds),
+					inArray(productAliases.canonical_plan_id, planIds),
+				),
+			),
+		);
+
+export const deleteAliases = async ({
+	ctx,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+}) => {
+	await ctx.db
+		.delete(productAliases)
+		.where(
+			and(
+				eq(productAliases.org_id, ctx.org.id),
+				eq(productAliases.env, ctx.env),
+				or(
+					inArray(productAliases.alias_id, planIds),
+					inArray(productAliases.canonical_plan_id, planIds),
+				),
+			),
+		);
+};
+
+export const renamePlan = async ({
+	autumn,
+	fromId,
+	toId,
+}: {
+	autumn: AutumnInt;
+	fromId: string;
+	toId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: fromId, new_plan_id: toId }],
+	});
+};
+
+/** Walk a preview/response and return every plan_id / plan_ids string. */
+export const collectResponsePlanIds = (value: unknown): string[] => {
+	if (value == null || typeof value !== "object") return [];
+	if (Array.isArray(value)) return value.flatMap(collectResponsePlanIds);
+
+	const record = value as Record<string, unknown>;
+	const ids: string[] = [];
+	for (const [key, nested] of Object.entries(record)) {
+		if (key === "plan_id" && typeof nested === "string") ids.push(nested);
+		if (key === "plan_ids" && Array.isArray(nested)) {
+			ids.push(
+				...nested.filter((item): item is string => typeof item === "string"),
+			);
+		}
+		ids.push(...collectResponsePlanIds(nested));
+	}
+	return ids;
+};

--- a/server/tests/integration/invoices/invoice-partial-resolve-deleted-plan.test.ts
+++ b/server/tests/integration/invoices/invoice-partial-resolve-deleted-plan.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Invoice plan_ids must keep a hard-deleted plan from the snapshot when
+ * its sibling still resolves live. Partial array_agg is not complete.
+ *
+ * Red (current):  resolved_product_ids is [A]; processInvoice treats a
+ *                 nonempty array as complete and drops snapshot B.
+ * Green (after):  resolver merges live A + snapshot B, so fetch returns both.
+ */
+
+import { test } from "bun:test";
+import { type ApiCustomerV5, CustomerExpand } from "@autumn/shared";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products as productFixtures } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { expectInvoicePlanIdsCorrect } from "./utils/expectInvoicePlanIdsCorrect.js";
+
+test.concurrent(
+	`${chalk.yellowBright("invoices resolve: hard-deleted plan stays on invoice via snapshot")}`,
+	async () => {
+		const customerId = "inv-partial-del";
+		const stripeId = `in_partial_del_${Date.now()}`;
+		const pro = productFixtures.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+		const premium = productFixtures.premium({
+			id: "premium",
+			items: [items.monthlyMessages({ includedUsage: 200 })],
+		});
+
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [pro, premium] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.post("/invoices.insert", {
+			invoices: [
+				{
+					customer_id: customerId,
+					plan_ids: [pro.id, premium.id],
+					stripe_id: stripeId,
+					processor_type: "stripe",
+					status: "paid",
+					total: 70,
+					created_at: Date.UTC(2016, 0, 1),
+				},
+			],
+		});
+
+		await autumnV2_3.catalogV2.update({
+			remove_plans: [{ plan_id: premium.id }],
+		});
+
+		const customer = await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			expand: [CustomerExpand.Invoices],
+			skip_cache: "true",
+		});
+
+		expectInvoicePlanIdsCorrect({
+			invoices: customer.invoices ?? [],
+			stripeId,
+			planIds: [pro.id, premium.id],
+		});
+	},
+);

--- a/server/tests/integration/invoices/utils/expectInvoicePlanIdsCorrect.ts
+++ b/server/tests/integration/invoices/utils/expectInvoicePlanIdsCorrect.ts
@@ -1,0 +1,18 @@
+import { expect } from "bun:test";
+
+export const expectInvoicePlanIdsCorrect = ({
+	invoices,
+	stripeId,
+	planIds,
+}: {
+	invoices: Array<{ stripe_id: string; plan_ids: string[] }>;
+	stripeId: string;
+	planIds: string[];
+}) => {
+	const invoice = invoices.find((row) => row.stripe_id === stripeId);
+	expect(invoice, `missing invoice ${stripeId}`).toBeDefined();
+	expect(
+		[...(invoice?.plan_ids ?? [])].sort(),
+		`plan_ids=${JSON.stringify(invoice?.plan_ids)}`,
+	).toEqual([...planIds].sort());
+};

--- a/server/tests/perf/catalog-v2/benchExecuteRenamePlans.ts
+++ b/server/tests/perf/catalog-v2/benchExecuteRenamePlans.ts
@@ -1,0 +1,375 @@
+/**
+ * Worst-case timing for executeRenamePlans (one multi-CTE statement) on a
+ * throwaway DEV org: 100 plan versions + reward/RC/alias refs.
+ *
+ *   bun tests/perf/catalog-v2/benchExecuteRenamePlans.ts
+ *
+ * Creates `bench-rename-txn-*`, times the CTE, then deletes the org.
+ * Does not call Stripe or the catalog HTTP path.
+ */
+
+import {
+	CouponDurationType,
+	CusProductStatus,
+	customerProducts,
+	customers,
+	productAliases,
+	products,
+	RewardTriggerEvent,
+	RewardType,
+	revenuecatMappings,
+	rewardPrograms,
+	rewards,
+} from "@autumn/shared";
+import { and, eq, sql } from "drizzle-orm";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan.js";
+import { executeRenamePlans } from "@/internal/catalogV2/execute/executeRenamePlans.js";
+import { generateId } from "@/utils/genUtils.js";
+import {
+	createPlanRenameBenchContext,
+	deleteLeftoverRenameBenchOrgs,
+	deletePlanRenameBenchOrg,
+	ensureProductAliasesTable,
+	openPlanRenameBenchDb,
+	PLAN_RENAME_BENCH_CUSTOMER_PRODUCTS,
+	PLAN_RENAME_BENCH_ENV,
+	PLAN_RENAME_BENCH_ORG_PREFIX,
+	PLAN_RENAME_BENCH_PLAN_ID,
+	PLAN_RENAME_BENCH_REWARD_PROGRAMS,
+	PLAN_RENAME_BENCH_REWARDS,
+	PLAN_RENAME_BENCH_TO_ID,
+	PLAN_RENAME_BENCH_VERSIONS,
+} from "./utils/planRenameBenchContext.js";
+
+const EXISTING_ALIAS_ID = "pro_legacy";
+const FREE_REWARD_COUNT = PLAN_RENAME_BENCH_REWARDS / 2;
+
+const time = async <T>(label: string, fn: () => Promise<T>): Promise<{
+	result: T;
+	ms: number;
+}> => {
+	const start = performance.now();
+	const result = await fn();
+	const ms = performance.now() - start;
+	console.log(`${label.padEnd(48)} ${ms.toFixed(1)}ms`);
+	return { result, ms };
+};
+
+const countWhere = async ({
+	db,
+	query,
+}: {
+	db: ReturnType<typeof openPlanRenameBenchDb>["db"];
+	query: ReturnType<typeof sql>;
+}): Promise<number> => {
+	const [row] = await db.execute<{ count: string }>(query);
+	return Number(row?.count ?? 0);
+};
+
+const seedRenameFixture = async ({
+	ctx,
+}: {
+	ctx: Awaited<ReturnType<typeof createPlanRenameBenchContext>>["ctx"];
+}) => {
+	const { db, org } = ctx;
+	const env = PLAN_RENAME_BENCH_ENV;
+	const now = Date.now();
+	const planId = PLAN_RENAME_BENCH_PLAN_ID;
+
+	const productRows = Array.from(
+		{ length: PLAN_RENAME_BENCH_VERSIONS },
+		(_, index) => ({
+			internal_id: generateId("prod"),
+			id: planId,
+			org_id: org.id,
+			env,
+			name: `Pro v${index + 1}`,
+			created_at: now,
+			version: index + 1,
+			active: index === PLAN_RENAME_BENCH_VERSIONS - 1,
+		}),
+	);
+	await db.insert(products).values(productRows);
+
+	const rewardRows = Array.from(
+		{ length: PLAN_RENAME_BENCH_REWARDS },
+		(_, index) => {
+			const isFree = index < FREE_REWARD_COUNT;
+			return {
+				internal_id: generateId("rew"),
+				id: `bench_rew_${index}`,
+				org_id: org.id,
+				env,
+				created_at: now,
+				name: `bench reward ${index}`,
+				type: isFree
+					? RewardType.FreeProduct
+					: RewardType.PercentageDiscount,
+				free_product_id: isFree ? planId : null,
+				discount_config: isFree
+					? null
+					: {
+							discount_value: 10,
+							duration_type: CouponDurationType.OneOff,
+							duration_value: 1,
+							apply_to_all: false,
+							product_ids: [planId],
+						},
+			};
+		},
+	);
+	await db.insert(rewards).values(rewardRows);
+
+	await db.insert(rewardPrograms).values(
+		rewardRows.slice(0, PLAN_RENAME_BENCH_REWARD_PROGRAMS).map((reward, index) => ({
+			internal_id: generateId("rp"),
+			id: `bench_rp_${index}`,
+			org_id: org.id,
+			env,
+			created_at: now,
+			internal_reward_id: reward.internal_id,
+			product_ids: [planId],
+			when: RewardTriggerEvent.Checkout,
+			max_redemptions: 1,
+			unlimited_redemptions: false,
+			exclude_trial: false,
+		})),
+	);
+
+	// PK is (org_id, env, autumn_product_id) — one row per plan is the max legal.
+	await db.insert(revenuecatMappings).values({
+		org_id: org.id,
+		env,
+		autumn_product_id: planId,
+		revenuecat_product_ids: [`rc_${planId}`],
+	});
+
+	await db.insert(productAliases).values({
+		org_id: org.id,
+		env,
+		alias_id: EXISTING_ALIAS_ID,
+		canonical_plan_id: planId,
+		created_at: now,
+	});
+
+	const cpTargets = productRows.slice(0, PLAN_RENAME_BENCH_CUSTOMER_PRODUCTS);
+	for (const [index, product] of cpTargets.entries()) {
+		const internalCustomerId = generateId("cus");
+		await db.insert(customers).values({
+			internal_id: internalCustomerId,
+			id: `bench_rename_cus_${index}`,
+			org_id: org.id,
+			env,
+			created_at: now,
+			name: `bench rename cus ${index}`,
+			email: `bench-rename-${index}@test.com`,
+		});
+		await db.insert(customerProducts).values({
+			id: generateId("cus_prod"),
+			internal_customer_id: internalCustomerId,
+			product_id: planId,
+			internal_product_id: product.internal_id,
+			status: CusProductStatus.Active,
+			created_at: now,
+			starts_at: now,
+			quantity: 1,
+			options: [],
+			is_custom: false,
+		});
+	}
+
+	const seeded = {
+		products: productRows.length,
+		rewards: rewardRows.length,
+		rewardPrograms: PLAN_RENAME_BENCH_REWARD_PROGRAMS,
+		revenuecatMappings: 1,
+		productAliases: 1,
+		customers: cpTargets.length,
+		customerProducts: cpTargets.length,
+	};
+	return { seeded, productInternalIds: productRows.map((row) => row.internal_id) };
+};
+
+const verifyRename = async ({
+	ctx,
+}: {
+	ctx: Awaited<ReturnType<typeof createPlanRenameBenchContext>>["ctx"];
+}) => {
+	const { db, org } = ctx;
+	const orgId = org.id;
+	const env = PLAN_RENAME_BENCH_ENV;
+	const fromId = PLAN_RENAME_BENCH_PLAN_ID;
+	const toId = PLAN_RENAME_BENCH_TO_ID;
+
+	const productCount = await countWhere({
+		db,
+		query: sql`
+			SELECT count(*)::text AS count FROM products
+			WHERE org_id = ${orgId} AND env = ${env} AND id = ${toId}
+		`,
+	});
+	const leftoverProducts = await countWhere({
+		db,
+		query: sql`
+			SELECT count(*)::text AS count FROM products
+			WHERE org_id = ${orgId} AND env = ${env} AND id = ${fromId}
+		`,
+	});
+	const rewardProgramsUpdated = await countWhere({
+		db,
+		query: sql`
+			SELECT count(*)::text AS count FROM reward_programs
+			WHERE org_id = ${orgId} AND env = ${env}
+				AND ${toId} = ANY(product_ids)
+		`,
+	});
+	const rewardsUpdated = await countWhere({
+		db,
+		query: sql`
+			SELECT count(*)::text AS count FROM rewards
+			WHERE org_id = ${orgId} AND env = ${env}
+				AND (
+					free_product_id = ${toId}
+					OR discount_config -> 'product_ids' ? ${toId}
+				)
+		`,
+	});
+	const rcUpdated = await countWhere({
+		db,
+		query: sql`
+			SELECT count(*)::text AS count FROM revenuecat_mappings
+			WHERE org_id = ${orgId} AND env = ${env}
+				AND autumn_product_id = ${toId}
+		`,
+	});
+	const aliasRows = await db
+		.select()
+		.from(productAliases)
+		.where(
+			and(eq(productAliases.org_id, orgId), eq(productAliases.env, env)),
+		);
+	const cpUnchanged = await countWhere({
+		db,
+		query: sql`
+			SELECT count(*)::text AS count FROM customer_products
+			WHERE product_id = ${fromId}
+				AND internal_customer_id IN (
+					SELECT internal_id FROM customers WHERE org_id = ${orgId}
+				)
+		`,
+	});
+
+	if (productCount !== PLAN_RENAME_BENCH_VERSIONS || leftoverProducts !== 0) {
+		throw new Error(
+			`products: expected ${PLAN_RENAME_BENCH_VERSIONS} at ${toId}, got ${productCount} (leftover ${fromId}=${leftoverProducts})`,
+		);
+	}
+	if (rewardProgramsUpdated !== PLAN_RENAME_BENCH_REWARD_PROGRAMS) {
+		throw new Error(
+			`reward_programs: expected ${PLAN_RENAME_BENCH_REWARD_PROGRAMS} updated, got ${rewardProgramsUpdated}`,
+		);
+	}
+	if (rewardsUpdated !== PLAN_RENAME_BENCH_REWARDS) {
+		throw new Error(
+			`rewards: expected ${PLAN_RENAME_BENCH_REWARDS} updated, got ${rewardsUpdated}`,
+		);
+	}
+	if (rcUpdated !== 1) {
+		throw new Error(`revenuecat_mappings: expected 1 updated, got ${rcUpdated}`);
+	}
+	if (
+		aliasRows.length !== 1 ||
+		aliasRows[0]?.alias_id !== fromId ||
+		aliasRows[0]?.canonical_plan_id !== toId
+	) {
+		throw new Error(
+			`product_aliases: expected ${fromId}→${toId}, got ${JSON.stringify(aliasRows)}`,
+		);
+	}
+	if (cpUnchanged !== PLAN_RENAME_BENCH_CUSTOMER_PRODUCTS) {
+		throw new Error(
+			`customer_products.product_id should stay ${fromId} (${PLAN_RENAME_BENCH_CUSTOMER_PRODUCTS} rows), got ${cpUnchanged}`,
+		);
+	}
+
+	return {
+		productsRenamed: productCount,
+		rewardProgramsUpdated,
+		rewardsUpdated,
+		revenuecatMappingsUpdated: rcUpdated,
+		aliasAfter: `${aliasRows[0].alias_id}→${aliasRows[0].canonical_plan_id}`,
+		customerProductsUnchanged: cpUnchanged,
+	};
+};
+
+const main = async () => {
+	const { db, client } = openPlanRenameBenchDb();
+	const orgSlug = `${PLAN_RENAME_BENCH_ORG_PREFIX}${Date.now()}`;
+	let orgId: string | undefined;
+
+	try {
+		await deleteLeftoverRenameBenchOrgs({ db });
+		await ensureProductAliasesTable({ db });
+
+		const { ctx, org } = await createPlanRenameBenchContext({ db, orgSlug });
+		orgId = org.id;
+		console.log(`bench: org ${org.slug} (${org.id}) env=${PLAN_RENAME_BENCH_ENV}`);
+
+		const { seeded } = await seedRenameFixture({ ctx });
+		console.log("seeded:", JSON.stringify(seeded, null, 2));
+		console.log(
+			"revenuecat_mappings: seeded 1 (PK is org_id+env+autumn_product_id — 10 rows per plan is illegal)",
+		);
+
+		await db.execute(sql`SELECT 1`);
+
+		const { ms: renameMs } = await time(
+			"executeRenamePlans (one CTE statement)",
+			() =>
+				executeRenamePlans({
+					ctx,
+					updateCatalogPlan: {
+						renamePlans: [
+							{
+								planId: PLAN_RENAME_BENCH_PLAN_ID,
+								toId: PLAN_RENAME_BENCH_TO_ID,
+							},
+						],
+					} as UpdateCatalogPlan,
+				}),
+		);
+
+		const verified = await verifyRename({ ctx });
+
+		console.log(
+			JSON.stringify(
+				{
+					renameMs: Number(renameMs.toFixed(1)),
+					oneStatement: true,
+					seeded,
+					verified,
+					planId: PLAN_RENAME_BENCH_PLAN_ID,
+					toId: PLAN_RENAME_BENCH_TO_ID,
+				},
+				null,
+				2,
+			),
+		);
+	} finally {
+		if (db && orgId) {
+			console.log("tearing down bench org…");
+			await deletePlanRenameBenchOrg({ db, orgId });
+		}
+		if (db) {
+			await deleteLeftoverRenameBenchOrgs({ db });
+		}
+		await client?.end();
+	}
+
+	process.exit(0);
+};
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/server/tests/perf/catalog-v2/utils/planRenameBenchContext.ts
+++ b/server/tests/perf/catalog-v2/utils/planRenameBenchContext.ts
@@ -1,0 +1,251 @@
+/**
+ * Dedicated DEV-DB org for the catalogV2 plan-rename execute CTE.
+ *
+ *   bun tests/perf/catalog-v2/benchExecuteRenamePlans.ts
+ *
+ * Loads server/.env.local (worktree / local DEV) — never staging/prod.
+ * Org slug is ephemeral (`bench-rename-txn-*`) and deleted after the run.
+ */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	ApiVersionClass,
+	AppEnv,
+	AuthType,
+	LATEST_VERSION,
+	type Organization,
+} from "@autumn/shared";
+import { config } from "dotenv";
+import { sql } from "drizzle-orm";
+import { initDrizzle } from "@/db/initDrizzle.js";
+import { logger } from "@/external/logtail/logtailUtils.js";
+import { resolveRedisV2 } from "@/external/redis/resolveRedisV2.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
+import { generateId } from "@/utils/genUtils.js";
+
+const SERVER_DIR = resolve(
+	fileURLToPath(new URL(".", import.meta.url)),
+	"../../../..",
+);
+
+const PROD_DB_REGION = "us-east-2";
+const DEV_DB_REGION = "eu-west-2";
+const LOCAL_DB_HOSTS = ["localhost", "127.0.0.1"];
+const FORBIDDEN_HOST_RE = /staging|prod|planetscale|amazonaws/i;
+
+export const PLAN_RENAME_BENCH_ENV = AppEnv.Sandbox;
+export const PLAN_RENAME_BENCH_PLAN_ID = "pro";
+export const PLAN_RENAME_BENCH_TO_ID = "proNew";
+export const PLAN_RENAME_BENCH_ORG_PREFIX = "bench-rename-txn-";
+
+export const PLAN_RENAME_BENCH_VERSIONS = 100;
+export const PLAN_RENAME_BENCH_REWARD_PROGRAMS = 20;
+export const PLAN_RENAME_BENCH_REWARDS = 20;
+export const PLAN_RENAME_BENCH_CUSTOMER_PRODUCTS = 3;
+
+const loadWorktreeDevEnv = () => {
+	const envFile = process.env.ENV_FILE ?? "";
+	if (/staging|prod/i.test(envFile)) {
+		throw new Error(
+			`bench: refusing ENV_FILE=${envFile} — this script is DEV/local only`,
+		);
+	}
+
+	const envLocalPath = resolve(SERVER_DIR, ".env.local");
+	if (!existsSync(envLocalPath)) {
+		throw new Error(
+			"bench: server/.env.local missing — need the worktree/local DEV DATABASE_URL",
+		);
+	}
+
+	const loaded = config({ path: envLocalPath, override: true });
+	if (!loaded.parsed?.DATABASE_URL && !process.env.DATABASE_URL) {
+		throw new Error("bench: DATABASE_URL missing in server/.env.local");
+	}
+};
+
+export type SafeDatabaseTarget = {
+	hostname: string;
+	database: string;
+};
+
+export const describeDatabaseUrl = (url: string): SafeDatabaseTarget => {
+	try {
+		const parsed = new URL(url);
+		return {
+			hostname: parsed.hostname,
+			database: parsed.pathname.replace(/^\//, "") || "<none>",
+		};
+	} catch {
+		throw new Error(
+			"bench: DATABASE_URL is unset or unparseable — expected server/.env.local",
+		);
+	}
+};
+
+/** Print host/db (no password) and abort unless this is the DEV/local Neon. */
+export const assertBenchDatabaseSafe = (): SafeDatabaseTarget => {
+	loadWorktreeDevEnv();
+	const target = describeDatabaseUrl(process.env.DATABASE_URL ?? "");
+	console.log(`bench: DB host=${target.hostname} db=${target.database}`);
+
+	if (target.hostname.includes(PROD_DB_REGION)) {
+		throw new Error(
+			`bench: refusing to run against a prod DATABASE_URL (${target.hostname})`,
+		);
+	}
+	if (
+		FORBIDDEN_HOST_RE.test(target.hostname) &&
+		!target.hostname.includes(DEV_DB_REGION)
+	) {
+		throw new Error(
+			`bench: refusing staging/prod-looking host ${target.hostname}`,
+		);
+	}
+	if (
+		/prod|staging/i.test(target.database) &&
+		target.database !== "neondb"
+	) {
+		throw new Error(
+			`bench: refusing database name ${target.database} (looks like staging/prod)`,
+		);
+	}
+	if (
+		!target.hostname.includes(DEV_DB_REGION) &&
+		!LOCAL_DB_HOSTS.includes(target.hostname)
+	) {
+		throw new Error(
+			`bench: expected the dev DB (${DEV_DB_REGION}) or a local DB, but DATABASE_URL points at ${target.hostname}`,
+		);
+	}
+
+	return target;
+};
+
+export type PlanRenameBenchDb = {
+	db: ReturnType<typeof initDrizzle>["db"];
+	client: ReturnType<typeof initDrizzle>["client"];
+};
+
+export type PlanRenameBenchContext = {
+	ctx: AutumnContext;
+	org: Organization;
+};
+
+export const openPlanRenameBenchDb = (): PlanRenameBenchDb => {
+	assertBenchDatabaseSafe();
+	return initDrizzle({ maxConnections: 2, name: "plan-rename-bench" });
+};
+
+export const createPlanRenameBenchContext = async ({
+	db,
+	orgSlug,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+	orgSlug: string;
+}): Promise<PlanRenameBenchContext> => {
+	const org = await OrgService.create({
+		db,
+		id: generateId("org"),
+		slug: orgSlug,
+		name: "Plan Rename Txn Bench",
+		createdBy: "plan-rename-txn-bench",
+	});
+
+	const ctx: AutumnContext = {
+		org,
+		env: PLAN_RENAME_BENCH_ENV,
+		features: [],
+		db,
+		dbGeneral: db,
+		logger,
+		redisV2: resolveRedisV2(),
+		id: generateId("bench"),
+		isPublic: false,
+		authType: AuthType.Unknown,
+		apiVersion: new ApiVersionClass(LATEST_VERSION),
+		timestamp: Date.now(),
+		scopes: [],
+		skipCache: false,
+		expand: [],
+		extraLogs: {},
+	};
+
+	return { ctx, org };
+};
+
+/** customer_products → products has no ON DELETE CASCADE. */
+export const deletePlanRenameBenchOrg = async ({
+	db,
+	orgId,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+	orgId: string;
+}) => {
+	await db.execute(sql`
+		DELETE FROM customer_products
+		WHERE internal_customer_id IN (
+			SELECT internal_id FROM customers WHERE org_id = ${orgId}
+		)
+	`);
+	await OrgService.delete({ db, orgId });
+};
+
+export const deleteLeftoverRenameBenchOrgs = async ({
+	db,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+}) => {
+	const leftovers = await db.execute<{ id: string; slug: string }>(sql`
+		SELECT id, slug
+		FROM organizations
+		WHERE slug LIKE ${`${PLAN_RENAME_BENCH_ORG_PREFIX}%`}
+	`);
+	for (const row of leftovers) {
+		console.log(`bench: deleting leftover org ${row.slug}`);
+		await deletePlanRenameBenchOrg({ db, orgId: row.id });
+	}
+};
+
+export const hasProductAliasesTable = async ({
+	db,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+}): Promise<boolean> => {
+	const [row] = await db.execute<{ exists: boolean }>(sql`
+		SELECT to_regclass('public.product_aliases') IS NOT NULL AS exists
+	`);
+	return Boolean(row?.exists);
+};
+
+/** Apply 0068 on this already-verified DEV connection only. */
+export const ensureProductAliasesTable = async ({
+	db,
+}: {
+	db: ReturnType<typeof initDrizzle>["db"];
+}) => {
+	if (await hasProductAliasesTable({ db })) return;
+
+	console.log(
+		"bench: product_aliases missing — applying 0068_petite_bug on this DEV connection",
+	);
+	await db.execute(`
+		CREATE TABLE "product_aliases" (
+			"org_id" text NOT NULL,
+			"env" text NOT NULL,
+			"alias_id" text NOT NULL,
+			"canonical_plan_id" text NOT NULL,
+			"created_at" numeric DEFAULT ROUND(date_part('epoch', NOW()) * 1000)::BIGINT NOT NULL,
+			CONSTRAINT "product_aliases_pkey" PRIMARY KEY("org_id","env","alias_id"),
+			CONSTRAINT "product_aliases_canonical_unique" UNIQUE("org_id","env","canonical_plan_id")
+		)
+	`);
+	await db.execute(`
+		ALTER TABLE "product_aliases" ADD CONSTRAINT "product_aliases_org_id_fkey"
+		FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id")
+		ON DELETE cascade ON UPDATE no action
+	`);
+};

--- a/server/tests/unit/catalogV2/claim-alias-insert-transaction.test.ts
+++ b/server/tests/unit/catalogV2/claim-alias-insert-transaction.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Create-claim must delete the reserved alias and insert the product
+ * in one transaction. Separate commits leave both products.id and
+ * product_aliases.alias_id equal to the claimed id.
+ *
+ * Red (current): insert's transaction commits, then delete throws —
+ * the insert stays committed.
+ * Green (after): delete-then-insert share one tx; a delete failure
+ * does not commit the insert.
+ */
+
+import { expect, test } from "bun:test";
+import { AppEnv, type Product } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan.js";
+import { executeUpsertProducts } from "@/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.js";
+
+const product = {
+	id: "pro",
+	name: "Claimed",
+	org_id: "org_1",
+	env: AppEnv.Sandbox,
+	internal_id: "prod_1",
+	version: 1,
+	active: true,
+} as Product;
+
+const queryChain = () => {
+	const chain: Record<string, unknown> = {};
+	chain.from = () => chain;
+	chain.where = () => chain;
+	chain.limit = async () => [];
+	chain.set = () => chain;
+	chain.values = () => chain;
+	chain.returning = async () => [{ ...product, active: true }];
+	return chain;
+};
+
+test("create-claim insert rolls back when alias delete fails", async () => {
+	const commits: string[] = [];
+	const tx = {
+		delete: () => ({
+			where: async () => {
+				throw new Error("delete failed");
+			},
+		}),
+		transaction: async (fn: (client: unknown) => Promise<unknown>) => {
+			const result = await fn(tx);
+			commits.push("nested");
+			return result;
+		},
+		select: queryChain,
+		update: queryChain,
+		insert: queryChain,
+	};
+	const db = {
+		delete: () => ({
+			where: async () => {
+				throw new Error("delete failed");
+			},
+		}),
+		transaction: async (fn: (client: unknown) => Promise<unknown>) => {
+			const result = await fn(tx);
+			commits.push("commit");
+			return result;
+		},
+		select: queryChain,
+		update: queryChain,
+		insert: queryChain,
+	};
+
+	await expect(
+		executeUpsertProducts({
+			ctx: {
+				db,
+				org: { id: "org_1" },
+				env: AppEnv.Sandbox,
+			} as unknown as AutumnContext,
+			updateCatalogPlan: {
+				upsertProducts: [
+					{
+						row: { op: "create", nextFullProduct: product },
+						aliasReplacement: { alias_id: "pro", plan_id: "pro_v2" },
+					},
+				],
+			} as unknown as UpdateCatalogPlan,
+		}),
+	).rejects.toThrow("delete failed");
+
+	expect(commits).toEqual([]);
+});

--- a/server/tests/unit/catalogV2/plan-id-alias-ingress.md
+++ b/server/tests/unit/catalogV2/plan-id-alias-ingress.md
@@ -1,0 +1,204 @@
+# Plan id alias — ingress mapping
+
+After rename `pro → proNew`, public callers may still send `pro`. Ingress rewrites
+to `proNew` before handlers; responses stay canonical (no `alias_id` in API).
+
+Mechanisms:
+
+| Mechanism | Where | Notes |
+|---|---|---|
+| `planAliasMiddleware` | `/v1/*` (`apiRouter`), `/webhooks/vercel/:orgId/:env/*` | Body via `rewritePlanIdAliasValues`; path via `rewritePlanIdAliasParams` |
+| Manual rewrite | Stripe `checkout.session.completed` metadata | `setupCheckoutSessionCompletedContext.ts` |
+| None | `internalRouter`, Stripe/RevenueCat webhooks (except above), `publicRouter`, `cliRouter` | See intentional skips |
+
+Rewrite keys: `planIdAliasRewriteKeys.ts` (`PLAN_ID_ALIAS_REWRITE_KEYS`).
+
+Path params rewritten: `product_id`, `productId` only — never `customer_id`.
+
+Create-plan skip keys (body only): `plan_id`, `id`, `product_id` on
+`POST /products`, `POST /plans`, `POST /plans.create`.
+
+---
+
+## Path params (`rewritePlanIdAliasParams`)
+
+| # | File / route | Param | Middleware | Notes |
+|---|---|---|---|---|
+| 1–8 | `productRouter.ts` → `/v1/products/:product_id` | `product_id` | ✓ | GET, POST, PATCH, DELETE, copy, has_customers×2, deletion_info |
+| 9–16 | same router → `/v1/plans/:product_id` | `product_id` | ✓ | alias mount of `honoProductRouter` |
+| 17 | `vercelWebhookRouter.ts` GET `.../v1/products/:productId/plans` | `productId` | ✓ | List billing plans |
+| 18–22 | `internalProductRouter.ts`, `internalCusRouter.ts` | `productId` / `product_id` | **intentionally skipped** | Dashboard session auth; no `planAliasMiddleware` |
+| — | `vercelWebhookRouter.ts` `:productId` on create-resource body | body `productId` | **intentionally skipped** | Vercel marketplace resource id, not an Autumn plan id |
+
+---
+
+## JSON body — `/v1` RPC & REST (via `planAliasMiddleware`)
+
+### Plans (`plansRpcRouter` + `honoProductRouter`)
+
+| # | Route / handler | Schema field(s) | Key(s) |
+|---|---|---|---|
+| 23 | `POST /plans.get` | `plan_id` | `plan_id` |
+| 24 | `POST /plans.create` | `plan_id` | **skip** (create route) |
+| 25 | `POST /plans.update` | `plan_id`, `new_plan_id`, `base_plan_id`, `update_variant_ids`, `variants[].variant_plan_id`, `variants[].base_variant_id`, `licenses[].license_plan_id`, `update_license_parents[].plan_id` | mixed — `new_plan_id` **not** rewritten |
+| 26 | `POST /plans.delete` | `plan_id` | `plan_id` |
+| 27 | `POST /plans.preview_update` | same as update | mixed |
+| 28 | `POST /plans.create_variant` | `base_plan_id`, `variant_plan_id` | both |
+| 29 | `POST /plans.has_customers` | body `plan_id` (RPC); REST uses path | `plan_id` + path |
+| 30 | `POST /products` (REST create) | `id` (v1), body keys | **skip** `plan_id`/`id`/`product_id` |
+| 31 | `POST/PATCH /products/:product_id` (v1 update) | plan shape fields | `base_plan_id`, etc. |
+| 32 | `POST /products/:product_id/copy` | `CopyProductParams.id` | **intentionally skipped** — new id in target env, not alias lookup |
+
+### Catalog V2 (`catalogV2RpcRouter`)
+
+| # | Route | Schema field(s) | Key(s) |
+|---|---|---|---|
+| 33 | `POST /catalogV2.update` | `plans[].plan_id`, `new_plan_id`, `base_plan_id`, `base_variant_id`, `variants[].*`, `licenses[].license_plan_id`, `propagate.*.plan_id`, `remove_plans[].plan_id` | mixed |
+| 34 | `POST /catalogV2.preview_update` | same tree | mixed |
+
+### Catalog V1 (`catalogRpcRouter`)
+
+| # | Route | Schema field(s) | Key(s) |
+|---|---|---|---|
+| 35 | `POST /catalog.update` | `plans[].plan_id`, `skip_plan_ids`, nested variants/licenses | `plan_id`, `skip_plan_ids`, … |
+| 36 | `POST /catalog.preview_update` | same | same |
+| 37 | `POST /catalog.update_mappings` | `plan_mappings[].plan_id` | `plan_id` |
+
+### Billing (`billingRpcRouter` + `billingRouter`)
+
+| # | Route | Schema field(s) | Key(s) |
+|---|---|---|---|
+| 38 | `POST /billing.attach` | `plan_id`, `remove_plan_ids`, `license_quantities[].license_plan_id`, `customize.upsert/remove_licenses[].license_plan_id` | all |
+| 39 | `POST /billing.preview_attach` | same | same |
+| 40 | `POST /billing.update` | `plan_id`, license customize | same |
+| 41 | `POST /billing.preview_update` | same | same |
+| 41 | `POST /attach` (legacy) | `product_id`, `product_ids`, `remove_plan_ids` | `product_id`, `product_ids` |
+| 42 | `POST /attach/preview` | legacy attach shape | `product_id` |
+| 43 | `POST /cancel` | `product_id` | `product_id` |
+| 44 | `POST /billing.multi_attach` | `plans[].plan_id` | `plan_id` |
+| 45 | `POST /billing.preview_multi_attach` | same | same |
+| 46 | `POST /billing.multi_update` | `updates[].plan_id` | `plan_id` |
+| 47 | `POST /billing.preview_multi_update` | same | same |
+| 48 | `POST /billing.create_schedule` | `phases[].plans[].plan_id`, `unscheduled_plans[].plan_id` | `plan_id` |
+| 49 | `POST /billing.preview_create_schedule` | same | same |
+| 50 | `POST /billing.sync` / `sync_v2` | `phases[].plans[].plan_id` | `plan_id` |
+| 51 | `POST /billing.setup_payment` | `plan_id` | `plan_id` |
+| 52 | `POST /billing.resolve_request` | nested attach/schedule/update bodies | recursive |
+| 53 | `POST /billing.dfu.flash` (internal) | `plans[].plan_id` | `plan_id` |
+
+### Balances
+
+| # | Route | Field | Key |
+|---|---|---|---|
+| 54 | `POST /check` | `product_id` (legacy) | `product_id` |
+
+### Licenses (`licenseRpcRouter`)
+
+| # | Route | Field | Key |
+|---|---|---|---|
+| 55 | `POST /licenses.attach` | `plan_id` | `plan_id` |
+| 56 | `POST /licenses.release` | `license_plan_id` | `license_plan_id` |
+
+### Rewards & referrals (`rewardRouter`, `rewardProgramRouter`)
+
+| # | Route | Field | Key |
+|---|---|---|---|
+| 57 | `POST /rewards` | `coupon.plan_ids` | `plan_ids` |
+| 58 | `PUT /rewards/:id` | `coupon.plan_ids` | `plan_ids` |
+| 59 | `POST /reward_programs` | `plan_ids` | `plan_ids` |
+| 60 | `PUT /reward_programs/:id` | `plan_ids` | `plan_ids` |
+
+### Migrations V2 (`migrationRpcRouter` on `/v1` and internal)
+
+| # | Route | Field | Key |
+|---|---|---|---|
+| 61–68 | `migrations.create/update/...` | `operations[].add_plan.plan_id`, `operations[].update_plan.plan_filter.plan_id`, nested `$or` | `plan_id` (recursive) |
+| 69 | `migrations.filter.preview` | filter may embed plan filters in stored migration | via loaded ops |
+
+### Platform / org (under `/v1/organization` or RPC)
+
+| # | Route | Field | Key |
+|---|---|---|---|
+| 70 | `POST /organization/revenuecat/sync` | `product_ids` | `product_ids` |
+| 71 | `POST /organization/revenuecat/mappings` | `mappings[].autumn_product_id` | `autumn_product_id` |
+| 72 | `POST /platform.sync_revenuecat` | `product_ids` | `product_ids` |
+
+### Customers (nested on billing attach / create)
+
+| # | Source | Field | Key |
+|---|---|---|---|
+| 73 | `customer_data` / `CustomerDataSchema` on attach | `auto_enable_plan_id` | `auto_enable_plan_id` |
+| 74 | `updateCustomerParams` (if used on public API) | `auto_enable_plan_id` | `auto_enable_plan_id` |
+
+### Invoices (RPC)
+
+| # | Route | Field | Key |
+|---|---|---|---|
+| 75 | invoice insert RPC | `plan_ids` | `plan_ids` |
+
+---
+
+## Vercel webhooks (`planAliasMiddleware` on `/:orgId/:env/*`)
+
+| # | Route / handler | Field | Key |
+|---|---|---|---|
+| 76 | PATCH installation `handleUpdateBillingPlan` | `billingPlanId` | `billingPlanId` |
+| 77 | POST resource `handleCreateResource` | `billingPlanId` | `billingPlanId` |
+| 78 | PATCH resource `handleUpdateResource` | `billingPlanId` | `billingPlanId` |
+| 79 | Marketplace invoice handlers | `billingPlanId` in provisioning | set server-side from Stripe metadata |
+
+Vercel `productId` path/body = marketplace resource id → **not** rewritten.
+
+---
+
+## Post-auth webhooks without middleware (manual or N/A)
+
+| # | Source | Field | Rewrite |
+|---|---|---|---|
+| 80 | Stripe checkout completed | metadata `data.plan_id` / attach payload | **manual** `rewritePlanIdAliasValues` in `setupCheckoutSessionCompletedContext` |
+| 81 | RevenueCat webhooks | `event.product_id` | **intentionally skipped** — RevenueCat store id, mapped via `revenuecat_mappings` |
+| 82 | Stripe setup-payment deferred attach | metadata `plan_id` | flows through checkout metadata rewrite |
+| 83 | Vercel marketplace POST `/:orgId/:env/*` | invoice payloads | no public plan id in request body |
+
+---
+
+## Intentional skips (not bugs)
+
+| Item | Why |
+|---|---|
+| `x-client-type: dashboard` on `/v1` | Dashboard sends canonical ids |
+| `internalRouter` (`/products`, RPC on internal) | Session auth; canonical ids |
+| GET/HEAD request bodies | No body rewrite; path params still rewrite on mutating routes |
+| Empty / missing `ctx.requestBody` | No-op; must not invent a body |
+| `new_plan_id` | Rename **target**, not alias lookup |
+| Create-plan identity: `plan_id`, `id`, `product_id` | Minting a plan may intentionally use an old alias string as the new id |
+| `customer_id` path/body | Never a plan id |
+| Stripe price ids, `internal_id`, `base_internal_product_id` | Not public plan ids |
+| Vercel `productId` (marketplace) | Foreign namespace |
+| RevenueCat `product_id` | Store sku, not Autumn plan id |
+| Copy-product body `id` | New id in target environment |
+| Query strings | No plan-id query params found in public API |
+
+---
+
+## Gaps fixed in this branch
+
+| Field | Where | Fix |
+|---|---|---|
+| `base_variant_id` | `catalogV2` plan + `variants[]` pointer writes | Added to `PLAN_ID_ALIAS_REWRITE_KEYS` |
+
+---
+
+## Count summary
+
+| Category | Count |
+|---|---|
+| Path-param ingress routes | **17** (middleware-covered) + **5** dashboard internal (skipped) |
+| Body ingress endpoint groups (table rows 23–75) | **53** |
+| Vercel body ingress | **3** |
+| Webhook / manual | **4** |
+| **Total mapped ingress sites** | **77** |
+
+Each row is one transport surface (route family + field tree). Nested arrays/objects
+dedupe to the schema field — one `plan_id` key covers `plans[]`, `phases[].plans[]`,
+migration `plan_filter.$or[]`, etc., via recursive `rewritePlanIdAliasValues`.

--- a/server/tests/unit/catalogV2/plan-id-alias-rewrite.test.ts
+++ b/server/tests/unit/catalogV2/plan-id-alias-rewrite.test.ts
@@ -1,0 +1,413 @@
+import { expect, test } from "bun:test";
+import { Hono } from "hono";
+import { planAliasMiddleware } from "@/honoMiddlewares/planAliasMiddleware.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import type { HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { PLAN_ID_ALIAS_REWRITE_KEYS } from "@/internal/catalogV2/productAliases/planIdAliasRewriteKeys.js";
+import { rewritePlanIdAliasParams } from "@/internal/catalogV2/productAliases/rewritePlanIdAliasParams.js";
+import { rewritePlanIdAliasValues } from "@/internal/catalogV2/productAliases/rewritePlanIdAliasValues.js";
+
+const ALIASES = { pro: "proNew", starter: "starterNew" };
+
+const rewriteBody = <T extends Record<string, unknown>>({
+	body,
+	skipKeys,
+}: {
+	body: T;
+	skipKeys?: Set<string>;
+}): T => {
+	rewritePlanIdAliasValues({ value: body, aliases: ALIASES, skipKeys });
+	return body;
+};
+
+test("PLAN_ID_ALIAS_REWRITE_KEYS covers every public plan-id body field", () => {
+	const expected = [
+		"product_id",
+		"product_ids",
+		"plan_id",
+		"plan_ids",
+		"remove_plan_ids",
+		"base_plan_id",
+		"base_variant_id",
+		"variant_plan_id",
+		"license_plan_id",
+		"auto_enable_plan_id",
+		"free_product_id",
+		"autumn_product_id",
+		"skip_plan_ids",
+		"update_variant_ids",
+		"billingPlanId",
+	];
+	expect([...PLAN_ID_ALIAS_REWRITE_KEYS].sort()).toEqual(expected.sort());
+});
+
+test.each([
+	["product_id", "pro", "proNew"],
+	["product_ids", ["pro", "starter"], ["proNew", "starterNew"]],
+	["plan_id", "pro", "proNew"],
+	["plan_ids", ["pro"], ["proNew"]],
+	["remove_plan_ids", ["pro"], ["proNew"]],
+	["base_plan_id", "pro", "proNew"],
+	["base_variant_id", "pro", "proNew"],
+	["variant_plan_id", "pro", "proNew"],
+	["license_plan_id", "pro", "proNew"],
+	["auto_enable_plan_id", "pro", "proNew"],
+	["free_product_id", "pro", "proNew"],
+	["autumn_product_id", "pro", "proNew"],
+	["skip_plan_ids", ["pro"], ["proNew"]],
+	["update_variant_ids", ["pro"], ["proNew"]],
+	["billingPlanId", "pro", "proNew"],
+] as const)(
+	"rewritePlanIdAliasValues rewrites top-level %s",
+	(key, input, expected) => {
+		const body = rewriteBody({
+			body: { [key]: input } as Record<string, unknown>,
+		});
+		expect(body[key]).toEqual(expected);
+	},
+);
+
+test("rewritePlanIdAliasValues rewrites nested objects and arrays", () => {
+	const body = rewriteBody({
+		body: {
+			plans: [{ plan_id: "pro", propagate: { license_parents: [{ plan_id: "starter" }] } }],
+			phases: [{ plans: [{ plan_id: "pro", license_quantities: [{ license_plan_id: "starter" }] }] }],
+			customize: {
+				upsert_licenses: [{ license_plan_id: "pro" }],
+				remove_licenses: [{ license_plan_id: "starter" }],
+			},
+			remove_plans: [{ plan_id: "pro" }],
+			mappings: [{ autumn_product_id: "pro", revenuecat_product_ids: ["rc_1"] }],
+		},
+	});
+
+	expect(body.plans[0].plan_id).toBe("proNew");
+	expect(body.plans[0].propagate.license_parents[0].plan_id).toBe("starterNew");
+	expect(body.phases[0].plans[0].plan_id).toBe("proNew");
+	expect(body.phases[0].plans[0].license_quantities[0].license_plan_id).toBe(
+		"starterNew",
+	);
+	expect(body.customize.upsert_licenses[0].license_plan_id).toBe("proNew");
+	expect(body.customize.remove_licenses[0].license_plan_id).toBe("starterNew");
+	expect(body.remove_plans[0].plan_id).toBe("proNew");
+	expect(body.mappings[0].autumn_product_id).toBe("proNew");
+	expect(body.mappings[0].revenuecat_product_ids).toEqual(["rc_1"]);
+});
+
+test("rewritePlanIdAliasValues does not rewrite new_plan_id", () => {
+	const body = rewriteBody({
+		body: { plan_id: "pro", new_plan_id: "pro" },
+	});
+	expect(body.plan_id).toBe("proNew");
+	expect(body.new_plan_id).toBe("pro");
+});
+
+test("rewritePlanIdAliasValues skipKeys leaves create identity fields untouched", () => {
+	const skipKeys = new Set(["plan_id", "id", "product_id"]);
+	const body = rewriteBody({
+		body: {
+			plan_id: "pro",
+			id: "pro",
+			product_id: "pro",
+			license_plan_id: "pro",
+		},
+		skipKeys,
+	});
+
+	expect(body.plan_id).toBe("pro");
+	expect(body.id).toBe("pro");
+	expect(body.product_id).toBe("pro");
+	expect(body.license_plan_id).toBe("proNew");
+});
+
+test("rewritePlanIdAliasValues is a no-op for empty alias map", () => {
+	const body = { plan_id: "pro", product_id: "pro" };
+	rewritePlanIdAliasValues({ value: body, aliases: {} });
+	expect(body).toEqual({ plan_id: "pro", product_id: "pro" });
+});
+
+test("rewritePlanIdAliasValues ignores null, primitives, and missing body", () => {
+	expect(rewritePlanIdAliasValues({ value: null, aliases: ALIASES })).toBe(null);
+	expect(rewritePlanIdAliasValues({ value: "pro", aliases: ALIASES })).toBe("pro");
+	expect(rewritePlanIdAliasValues({ value: undefined, aliases: ALIASES })).toBe(
+		undefined,
+	);
+});
+
+test("rewritePlanIdAliasParams rewrites product_id and productId, not customer_id", () => {
+	const param = ((key?: string) => {
+		const all = { product_id: "pro", productId: "pro", customer_id: "pro" };
+		return key ? all[key as keyof typeof all] : all;
+	}) as Parameters<typeof rewritePlanIdAliasParams>[0]["param"];
+
+	const rewritten = rewritePlanIdAliasParams({ param, aliases: ALIASES });
+
+	expect(rewritten("product_id")).toBe("proNew");
+	expect(rewritten("productId")).toBe("proNew");
+	expect(rewritten("customer_id")).toBe("pro");
+	expect(rewritten()).toEqual({
+		product_id: "proNew",
+		productId: "proNew",
+		customer_id: "pro",
+	});
+});
+
+test("wrapped c.req.param is what a later :product_id handler sees", async () => {
+	const app = new Hono();
+	app.use("*", async (c, next) => {
+		// @ts-expect-error prototype method
+		c.req.param = rewritePlanIdAliasParams({
+			param: c.req.param.bind(c.req),
+			aliases: ALIASES,
+		});
+		await next();
+	});
+	app.get("/products/:product_id", (c) =>
+		c.json({
+			byKey: c.req.param("product_id"),
+			all: c.req.param().product_id,
+		}),
+	);
+
+	const res = await app.request("/products/pro");
+	expect(await res.json()).toEqual({ byKey: "proNew", all: "proNew" });
+});
+
+const mountPlanAliasHarness = ({
+	clientType,
+	method,
+	path,
+	body,
+	route = "*",
+	org = { planAliases: ALIASES },
+	rawBody,
+	contentType = "application/json",
+}: {
+	clientType?: string;
+	method: string;
+	path: string;
+	body?: unknown;
+	route?: string;
+	org?: { planAliases?: Record<string, string> } | null;
+	rawBody?: string;
+	contentType?: string;
+}) => {
+	const seen: {
+		body?: unknown;
+		productId?: string;
+		json?: unknown;
+		text?: string;
+		bodyCacheKeys?: string[];
+	} = {};
+	const app = new Hono<HonoEnv>();
+	app.use("*", async (c, next) => {
+		c.set("ctx", {
+			org,
+			requestBody: body,
+		} as unknown as AutumnContext);
+		await next();
+	});
+	app.use("*", planAliasMiddleware);
+	app.all(route, async (c) => {
+		seen.body = c.get("ctx").requestBody;
+		seen.productId = c.req.param("product_id");
+		seen.bodyCacheKeys = Object.keys(
+			(c.req as { bodyCache: Record<string, unknown> }).bodyCache,
+		);
+		try {
+			seen.json = await c.req.json();
+		} catch {
+			seen.json = undefined;
+		}
+		try {
+			seen.text = await c.req.text();
+		} catch {
+			seen.text = undefined;
+		}
+		return c.json({ ok: true });
+	});
+
+	const headers: Record<string, string> = {};
+	if (clientType) headers["x-client-type"] = clientType;
+
+	const init: RequestInit = { method, headers };
+	const hasHttpBody =
+		rawBody !== undefined ||
+		(body !== undefined && method !== "GET" && method !== "HEAD");
+	if (hasHttpBody) {
+		init.body = rawBody ?? JSON.stringify(body);
+		init.headers = { ...headers, "Content-Type": contentType };
+	}
+
+	return {
+		request: () => app.request(path, init),
+		seen,
+	};
+};
+
+test("planAliasMiddleware skips dashboard clients", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		clientType: "dashboard",
+		method: "POST",
+		path: "/products/pro",
+		route: "/products/:product_id",
+		body: { plan_id: "pro" },
+	});
+	await request();
+	expect(seen.productId).toBe("pro");
+	expect(seen.body).toEqual({ plan_id: "pro" });
+});
+
+test("planAliasMiddleware skips GET bodies but still rewrites path params", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		method: "GET",
+		path: "/products/pro",
+		route: "/products/:product_id",
+		body: { plan_id: "pro" },
+	});
+	await request();
+	expect(seen.productId).toBe("proNew");
+	expect(seen.body).toEqual({ plan_id: "pro" });
+});
+
+test("planAliasMiddleware does not invent a body when requestBody is missing", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		method: "POST",
+		path: "/billing.attach",
+		body: undefined,
+	});
+	await request();
+	expect(seen.body).toBeUndefined();
+});
+
+test("planAliasMiddleware skips create-plan identity keys on POST /plans", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		method: "POST",
+		path: "/v1/plans",
+		body: {
+			plan_id: "pro",
+			id: "pro",
+			product_id: "pro",
+			license_plan_id: "pro",
+		},
+	});
+	await request();
+	expect(seen.body).toEqual({
+		plan_id: "pro",
+		id: "pro",
+		product_id: "pro",
+		license_plan_id: "proNew",
+	});
+});
+
+test("planAliasMiddleware skips create-plan identity keys on POST /plans.create", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		method: "POST",
+		path: "/plans.create",
+		body: { plan_id: "pro", name: "Pro" },
+	});
+	await request();
+	expect(seen.body).toEqual({ plan_id: "pro", name: "Pro" });
+});
+
+test("planAliasMiddleware rewrites billing bodies on non-create routes", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		method: "POST",
+		path: "/billing.attach",
+		body: {
+			customer_id: "cus_1",
+			plan_id: "pro",
+			remove_plan_ids: ["starter"],
+			new_plan_id: "pro",
+		},
+	});
+	await request();
+	expect(seen.body).toEqual({
+		customer_id: "cus_1",
+		plan_id: "proNew",
+		remove_plan_ids: ["starterNew"],
+		new_plan_id: "pro",
+	});
+	expect(seen.json).toEqual(seen.body);
+});
+
+test("planAliasMiddleware skips HEAD bodies but still rewrites path params", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		method: "HEAD",
+		path: "/products/pro",
+		route: "/products/:product_id",
+		body: { plan_id: "pro" },
+	});
+	await request();
+	expect(seen.productId).toBe("proNew");
+	expect(seen.body).toEqual({ plan_id: "pro" });
+});
+
+test("planAliasMiddleware does not invent a body for empty object or non-object", async () => {
+	const empty = mountPlanAliasHarness({
+		method: "POST",
+		path: "/billing.attach",
+		body: {},
+	});
+	await empty.request();
+	expect(empty.seen.body).toEqual({});
+
+	const primitive = mountPlanAliasHarness({
+		method: "POST",
+		path: "/billing.attach",
+		body: "pro",
+	});
+	await primitive.request();
+	expect(primitive.seen.body).toBe("pro");
+});
+
+test("planAliasMiddleware no-op rewrite keeps original bodyCache.text", async () => {
+	const pretty = '{\n  "keep": 1,\n  "type": "marketplace.invoice.created"\n}';
+	const { request, seen } = mountPlanAliasHarness({
+		method: "POST",
+		path: "/webhooks/vercel/org_1/sandbox/marketplace",
+		body: { keep: 1, type: "marketplace.invoice.created" },
+		rawBody: pretty,
+	});
+	await request();
+	expect(seen.body).toEqual({ keep: 1, type: "marketplace.invoice.created" });
+	expect(seen.text).toBe(pretty);
+	expect(seen.json).toEqual({ keep: 1, type: "marketplace.invoice.created" });
+});
+
+test("planAliasMiddleware is a no-op when org or alias map is missing", async () => {
+	const noOrg = mountPlanAliasHarness({
+		method: "POST",
+		path: "/products/pro",
+		route: "/products/:product_id",
+		body: { plan_id: "pro" },
+		org: null,
+	});
+	await noOrg.request();
+	expect(noOrg.seen.productId).toBe("pro");
+	expect(noOrg.seen.body).toEqual({ plan_id: "pro" });
+
+	const emptyMap = mountPlanAliasHarness({
+		method: "POST",
+		path: "/products/pro",
+		route: "/products/:product_id",
+		body: { plan_id: "pro" },
+		org: { planAliases: {} },
+	});
+	await emptyMap.request();
+	expect(emptyMap.seen.productId).toBe("pro");
+	expect(emptyMap.seen.body).toEqual({ plan_id: "pro" });
+});
+
+test("planAliasMiddleware does not replace a non-JSON content type", async () => {
+	const { request, seen } = mountPlanAliasHarness({
+		method: "POST",
+		path: "/billing.attach",
+		body: undefined,
+		rawBody: "plan_id=pro",
+		contentType: "application/x-www-form-urlencoded",
+	});
+	await request();
+	expect(seen.body).toBeUndefined();
+	expect(seen.text).toBe("plan_id=pro");
+});

--- a/server/tests/unit/forceJsonBody.test.ts
+++ b/server/tests/unit/forceJsonBody.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { Hono } from "hono";
-import { forceJsonBodyField } from "@/honoUtils/forceJsonBody.js";
+import { forceJsonBodyField, replaceJsonBody } from "@/honoUtils/forceJsonBody.js";
 
 /**
  * Guards the one Hono-internal coupling in forceJsonBodyField. If a Hono upgrade
@@ -24,4 +24,48 @@ test("forceJsonBodyField overrides a field seen by downstream c.req.json()", asy
 
 	expect(body.customer_id).toBe("forced");
 	expect(body.keep).toBe(1);
+});
+
+test("replaceJsonBody replaces the body seen by downstream c.req.json()", async () => {
+	const app = new Hono();
+	app.use("*", async (c, next) => {
+		await replaceJsonBody(c, { customer_id: "rewritten", keep: 1 });
+		await next();
+	});
+	app.post("/x", async (c) => c.json(await c.req.json()));
+
+	const res = await app.request("/x", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ customer_id: "original" }),
+	});
+	const body = (await res.json()) as { customer_id: string; keep: number };
+
+	expect(body.customer_id).toBe("rewritten");
+	expect(body.keep).toBe(1);
+});
+
+test("replaceJsonBody resets bodyCache to { text } so json() re-parses", async () => {
+	const seen: { keys?: string[]; text?: string } = {};
+	const app = new Hono();
+	app.use("*", async (c, next) => {
+		await c.req.json();
+		await replaceJsonBody(c, { plan_id: "proNew" });
+		const bodyCache = (c.req as { bodyCache: Record<string, unknown> })
+			.bodyCache;
+		seen.keys = Object.keys(bodyCache);
+		seen.text = await (bodyCache.text as Promise<string>);
+		await next();
+	});
+	app.post("/x", async (c) => c.json(await c.req.json()));
+
+	const res = await app.request("/x", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ plan_id: "pro" }),
+	});
+
+	expect(seen.keys).toEqual(["text"]);
+	expect(seen.text).toBe(JSON.stringify({ plan_id: "proNew" }));
+	expect(await res.json()).toEqual({ plan_id: "proNew" });
 });

--- a/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
@@ -22,6 +22,10 @@ export const CatalogVariantParamsSchema = z.object({
 	name: z.string().nonempty().optional().meta({
 		description: "Display name when creating the variant if it does not exist.",
 	}),
+	new_plan_id: z.string().nonempty().regex(idRegex).optional().meta({
+		description:
+			"Rename this variant to this id. Same execute path as a top-level new_plan_id.",
+	}),
 	archived: z.boolean().optional().meta({
 		description:
 			"Archive or unarchive this variant. Omit to leave archived state unchanged.",

--- a/shared/api/catalogV2/planUpdate/preview/catalogPlanPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogPlanPreview.ts
@@ -11,6 +11,7 @@ import {
 import { CatalogSiblingVersionPreviewSchema } from "./catalogSiblingVersionPreview.js";
 import { CatalogVariantPreviewSchema } from "./catalogVariantPreview.js";
 import { CatalogPlanVersioningSchema } from "./catalogVersioningPreview.js";
+import { PlanAliasReplacementSchema } from "./planAliasReplacement.js";
 
 /**
  * One direct `plans[]` entry from the request.
@@ -53,6 +54,10 @@ export const CatalogPlanUpdatePreviewSchema = CatalogCorePreviewSchema.extend({
 	licenses: z.array(ApiPlanLicenseV1Schema).optional().meta({
 		description:
 			"planLicenses on this plan after the update. Omitted when there are none.",
+	}),
+	alias_replacement: PlanAliasReplacementSchema.optional().meta({
+		description:
+			"This create/rename claims a reserved alias. Omitted when the id is free.",
 	}),
 });
 

--- a/shared/api/catalogV2/planUpdate/preview/catalogVariantPreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogVariantPreview.ts
@@ -3,6 +3,7 @@ import { CatalogConflictPreviewSchema } from "./catalogConflictPreview.js";
 import { CatalogCorePreviewSchema } from "./catalogCorePreview.js";
 import { CatalogSiblingVersionPreviewSchema } from "./catalogSiblingVersionPreview.js";
 import { CatalogPlanVersioningSchema } from "./catalogVersioningPreview.js";
+import { PlanAliasReplacementSchema } from "./planAliasReplacement.js";
 
 export const CatalogVariantActionSchema = z
 	.enum(["unchanged", "propagated", "explicit"])
@@ -48,6 +49,10 @@ export const CatalogVariantPreviewSchema = CatalogCorePreviewSchema.extend({
 			description:
 				"Other existing versions of this variant that could receive the base edit. Each version reports whether it is unchanged, propagated, or explicit.",
 		}),
+	alias_replacement: PlanAliasReplacementSchema.optional().meta({
+		description:
+			"This variant create/rename claims a reserved alias. Omitted when the id is free.",
+	}),
 });
 
 export type CatalogVariantAction = z.infer<typeof CatalogVariantActionSchema>;

--- a/shared/api/catalogV2/planUpdate/preview/planAliasReplacement.ts
+++ b/shared/api/catalogV2/planUpdate/preview/planAliasReplacement.ts
@@ -1,0 +1,13 @@
+import { z } from "zod/v4";
+
+/** Claiming this reserved alias deletes the row so the id is a live plan again. */
+export const PlanAliasReplacementSchema = z.object({
+	alias_id: z.string().meta({
+		description: "The reserved alias being claimed as a real plan id.",
+	}),
+	plan_id: z.string().meta({
+		description: "The live plan that currently owns that alias.",
+	}),
+});
+
+export type PlanAliasReplacement = z.infer<typeof PlanAliasReplacementSchema>;

--- a/shared/api/models.ts
+++ b/shared/api/models.ts
@@ -19,6 +19,7 @@ export * from "./catalogV2/planUpdate/preview/catalogCorePreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogLicenseParentPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogPlanPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogPlanUsage.js";
+export * from "./catalogV2/planUpdate/preview/planAliasReplacement.js";
 export * from "./catalogV2/planUpdate/preview/catalogVariantPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogSiblingVersionPreview.js";
 export * from "./catalogV2/planUpdate/preview/catalogVersioningPreview.js";

--- a/shared/db/schema.ts
+++ b/shared/db/schema.ts
@@ -95,6 +95,8 @@ import { freeTrialRelations } from "../models/productModels/freeTrialModels/free
 import { freeTrials } from "../models/productModels/freeTrialModels/freeTrialTable.js";
 import { priceRelations } from "../models/productModels/priceModels/priceRelations.js";
 import { prices } from "../models/productModels/priceModels/priceTable.js";
+import { productAliasRelations } from "../models/productModels/productAliasRelations.js";
+import { productAliases } from "../models/productModels/productAliasTable.js";
 import { productRelations } from "../models/productModels/productRelations.js";
 // Product Tables
 import { products } from "../models/productModels/productTable.js";
@@ -217,6 +219,8 @@ export {
 	organizationsRelations,
 	priceRelations,
 	prices,
+	productAliasRelations,
+	productAliases,
 	productRelations,
 	products,
 	rewardRelations,

--- a/shared/drizzle/0068_petite_bug.sql
+++ b/shared/drizzle/0068_petite_bug.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "product_aliases" (
+	"org_id" text NOT NULL,
+	"env" text NOT NULL,
+	"alias_id" text NOT NULL,
+	"canonical_plan_id" text NOT NULL,
+	"created_at" numeric DEFAULT ROUND(date_part('epoch', NOW()) * 1000)::BIGINT NOT NULL,
+	CONSTRAINT "product_aliases_pkey" PRIMARY KEY("org_id","env","alias_id"),
+	CONSTRAINT "product_aliases_canonical_unique" UNIQUE("org_id","env","canonical_plan_id")
+);
+--> statement-breakpoint
+ALTER TABLE "product_aliases" ADD CONSTRAINT "product_aliases_org_id_fkey" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;

--- a/shared/drizzle/meta/0068_snapshot.json
+++ b/shared/drizzle/meta/0068_snapshot.json
@@ -1,0 +1,11286 @@
+{
+  "id": "c302db27-d260-4768-a875-6be356c30d88",
+  "prevId": "581173ae-964a-47cb-bafa-308f516e4af6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_actions_on_internal_entity_id": {
+          "name": "idx_actions_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_org_id_fkey": {
+          "name": "actions_org_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_customer_id_fkey": {
+          "name": "actions_customer_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "actions_entity_id_fkey": {
+          "name": "actions_entity_id_fkey",
+          "tableFrom": "actions",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.agent_rules": {
+      "name": "agent_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_rules": {
+          "name": "entity_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit_rules": {
+          "name": "credit_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_rules_org_id_fkey": {
+          "name": "agent_rules_org_id_fkey",
+          "tableFrom": "agent_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_org_id_fkey": {
+          "name": "api_keys_org_id_fkey",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_key": {
+          "name": "api_keys_hashed_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_topup_limit_states": {
+      "name": "auto_topup_limit_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_window_ends_at": {
+          "name": "purchase_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_window_ends_at": {
+          "name": "attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_attempt_window_ends_at": {
+          "name": "failed_attempt_window_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempt_count": {
+          "name": "failed_attempt_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failed_attempt_at": {
+          "name": "last_failed_attempt_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failure_count": {
+          "name": "consecutive_failure_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_reason": {
+          "name": "suspended_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_payment_method_fingerprint": {
+          "name": "suspended_payment_method_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "auto_topup_limits_org_env_internal_customer_feature_unique": {
+          "name": "auto_topup_limits_org_env_internal_customer_feature_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auto_topup_limits_org_id_fkey": {
+          "name": "auto_topup_limits_org_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auto_topup_limits_internal_customer_id_fkey": {
+          "name": "auto_topup_limits_internal_customer_id_fkey",
+          "tableFrom": "auto_topup_limit_states",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approval_writes": {
+      "name": "chat_approval_writes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approval_id": {
+          "name": "approval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deny_option_id": {
+          "name": "deny_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approval_writes_approval_id_fkey": {
+          "name": "chat_approval_writes_approval_id_fkey",
+          "tableFrom": "chat_approval_writes",
+          "tableTo": "chat_approvals",
+          "columnsFrom": [
+            "approval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_approval_writes_approval_position_key": {
+          "name": "chat_approval_writes_approval_position_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "approval_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_approvals": {
+      "name": "chat_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_ts": {
+          "name": "message_ts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness": {
+          "name": "harness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_args": {
+          "name": "tool_args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_session_ids": {
+          "name": "child_session_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approve_option_id": {
+          "name": "approve_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deny_option_id": {
+          "name": "deny_option_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_provider_user_id": {
+          "name": "decided_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_approvals_org_id_fkey": {
+          "name": "chat_approvals_org_id_fkey",
+          "tableFrom": "chat_approvals",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_installations": {
+      "name": "chat_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_access_token": {
+          "name": "bot_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_env": {
+          "name": "default_env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_api_key_id": {
+          "name": "sandbox_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_api_key": {
+          "name": "sandbox_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key_id": {
+          "name": "live_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_api_key": {
+          "name": "live_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_by_provider_user_id": {
+          "name": "installed_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_installations_org_id_fkey": {
+          "name": "chat_installations_org_id_fkey",
+          "tableFrom": "chat_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_installations_org_provider_key": {
+          "name": "chat_installations_org_provider_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "provider"
+          ]
+        },
+        "chat_installations_provider_workspace_key": {
+          "name": "chat_installations_provider_workspace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_oauth_credentials": {
+      "name": "chat_oauth_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_oauth_credentials_installation_id_fkey": {
+          "name": "chat_oauth_credentials_installation_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "chat_installations",
+          "columnsFrom": [
+            "chat_installation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_oauth_credentials_org_id_fkey": {
+          "name": "chat_oauth_credentials_org_id_fkey",
+          "tableFrom": "chat_oauth_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_oauth_credentials_installation_org_env_user_key": {
+          "name": "chat_oauth_credentials_installation_org_env_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_results": {
+      "name": "chat_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.chat_thread_contexts": {
+      "name": "chat_thread_contexts",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chat_thread_contexts_thread_key": {
+          "name": "chat_thread_contexts_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkouts": {
+      "name": "checkouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params_version": {
+          "name": "params_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_checkouts_stripe_invoice_id": {
+          "name": "idx_checkouts_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_memory": {
+      "name": "cma_memory",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_store_id": {
+          "name": "memory_store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_memory_org_id_env_pk": {
+          "name": "cma_memory_org_id_env_pk",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_sessions": {
+      "name": "cma_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "cma_sessions_org_id_env_thread_key_pk": {
+          "name": "cma_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.cma_vaults": {
+      "name": "cma_vaults",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vault_id": {
+          "name": "vault_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cma_vaults_installation_org_env_user_key": {
+          "name": "cma_vaults_installation_org_env_user_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "chat_installation_id",
+            "org_id",
+            "env",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_entitlements": {
+      "name": "customer_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_reset_at": {
+          "name": "next_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_allowed": {
+          "name": "usage_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "separate_interval": {
+          "name": "separate_interval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_pooled_balance": {
+          "name": "is_pooled_balance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pooled_contribution_id": {
+          "name": "pooled_contribution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjustment": {
+          "name": "adjustment",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_balance": {
+          "name": "additional_balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_version": {
+          "name": "cache_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired": {
+          "name": "expired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_by_invoice": {
+          "name": "reset_by_invoice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_entitlements_product_id": {
+          "name": "idx_customer_entitlements_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_customer_id_btree": {
+          "name": "idx_customer_entitlements_internal_customer_id_btree",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_entitlement_id": {
+          "name": "idx_customer_entitlements_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_feature_id_c": {
+          "name": "idx_customer_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_internal_feature_id": {
+          "name": "idx_ce_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ce_customer_product_id_c": {
+          "name": "idx_ce_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_internal_entity_id": {
+          "name": "idx_customer_entitlements_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hash",
+          "with": {}
+        },
+        "idx_customer_entitlements_on_next_reset_at": {
+          "name": "idx_customer_entitlements_on_next_reset_at",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_loose_customer_expires": {
+          "name": "idx_customer_entitlements_loose_customer_expires",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"customer_product_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_next_reset_not_expired": {
+          "name": "idx_customer_entitlements_next_reset_not_expired",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_pooled_contribution": {
+          "name": "idx_customer_entitlements_pooled_contribution",
+          "columns": [
+            {
+              "expression": "pooled_contribution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"pooled_contribution_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_entitlements_reset_scan": {
+          "name": "idx_customer_entitlements_reset_scan",
+          "columns": [
+            {
+              "expression": "next_reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_entitlements\".\"expired\" IS NOT TRUE AND \"customer_entitlements\".\"reset_by_invoice\" IS NOT TRUE AND \"customer_entitlements\".\"pooled_contribution_id\" IS NULL AND \"customer_entitlements\".\"next_reset_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_internal_entity_id_fkey": {
+          "name": "customer_entitlements_internal_entity_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_entitlements_customer_product_id_fkey": {
+          "name": "customer_entitlements_customer_product_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_entitlements_entitlement_id_fkey": {
+          "name": "customer_entitlements_entitlement_id_fkey",
+          "tableFrom": "customer_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_exports": {
+      "name": "customer_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_count": {
+          "name": "byte_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_exports_org_env_created_at": {
+          "name": "idx_customer_exports_org_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "customer_exports_active_per_org_env_unique": {
+          "name": "customer_exports_active_per_org_env_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customer_exports\".\"status\" IN ('queued', 'running')",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_exports_org_id_fkey": {
+          "name": "customer_exports_org_id_fkey",
+          "tableFrom": "customer_exports",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_jwt_families": {
+      "name": "customer_jwt_families",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refresh_kid": {
+          "name": "refresh_kid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indefinite": {
+          "name": "indefinite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "customer_jwt_families_internal_customer_id_fkey": {
+          "name": "customer_jwt_families_internal_customer_id_fkey",
+          "tableFrom": "customer_jwt_families",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "customer_jwt_families_internal_customer_id_key": {
+          "name": "customer_jwt_families_internal_customer_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_licenses": {
+      "name": "customer_licenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_id": {
+          "name": "link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_customer_product_id": {
+          "name": "parent_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_customer_licenses_plan_license": {
+          "name": "idx_customer_licenses_plan_license",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_customer_license": {
+          "name": "unique_customer_license",
+          "columns": [
+            {
+              "expression": "parent_customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_customer": {
+          "name": "idx_customer_licenses_customer",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_licenses_link": {
+          "name": "idx_customer_licenses_link",
+          "columns": [
+            {
+              "expression": "link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_licenses_customer_fkey": {
+          "name": "customer_licenses_customer_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_parent_customer_product_fkey": {
+          "name": "customer_licenses_parent_customer_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "parent_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_license_product_fkey": {
+          "name": "customer_licenses_license_product_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_licenses_plan_license_fkey": {
+          "name": "customer_licenses_plan_license_fkey",
+          "tableFrom": "customer_licenses",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_lsns": {
+      "name": "customer_lsns",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "customer_lsns_pkey": {
+          "name": "customer_lsns_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.customer_prices": {
+      "name": "customer_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_id": {
+          "name": "customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_prices_product_id": {
+          "name": "idx_customer_prices_product_id",
+          "columns": [
+            {
+              "expression": "customer_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_price_id": {
+          "name": "idx_customer_prices_price_id",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_prices_internal_customer_id": {
+          "name": "idx_customer_prices_internal_customer_id",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_prices\".\"internal_customer_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cpr_customer_product_id_c": {
+          "name": "idx_cpr_customer_product_id_c",
+          "columns": [
+            {
+              "expression": "\"customer_product_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_prices_customer_product_id_fkey": {
+          "name": "customer_prices_customer_product_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_internal_customer_id_fkey": {
+          "name": "customer_prices_internal_customer_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "customer_prices_price_id_fkey": {
+          "name": "customer_prices_price_id_fkey",
+          "tableFrom": "customer_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_products": {
+      "name": "customer_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled": {
+          "name": "canceled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_starts_at": {
+          "name": "access_starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_trial_id": {
+          "name": "free_trial_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor": {
+          "name": "billing_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_resets_at": {
+          "name": "billing_cycle_anchor_resets_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_method": {
+          "name": "collection_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'charge_automatically'"
+        },
+        "subscription_ids": {
+          "name": "subscription_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_ids": {
+          "name": "scheduled_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_version": {
+          "name": "billing_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_version": {
+          "name": "api_version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_semver": {
+          "name": "api_semver",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_customer_product_id": {
+          "name": "previous_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_trial_end": {
+          "name": "on_trial_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_products_customer_status": {
+          "name": "idx_customer_products_customer_status",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_status_created_at": {
+          "name": "idx_customer_products_customer_status_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_status": {
+          "name": "idx_customer_products_product_status",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_entity_id": {
+          "name": "idx_customer_products_on_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_customer_c": {
+          "name": "idx_customer_products_product_customer_c",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_on_internal_product_id": {
+          "name": "idx_customer_products_on_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_subscription_ids": {
+          "name": "idx_customer_products_subscription_ids",
+          "columns": [
+            {
+              "expression": "subscription_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_scheduled_ids": {
+          "name": "idx_customer_products_scheduled_ids",
+          "columns": [
+            {
+              "expression": "scheduled_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customer_products_stripe_checkout_session_id": {
+          "name": "idx_customer_products_stripe_checkout_session_id",
+          "columns": [
+            {
+              "expression": "stripe_checkout_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_customer_license": {
+          "name": "idx_customer_products_customer_license",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_license_seat_order": {
+          "name": "idx_customer_products_license_seat_order",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_seat_sync": {
+          "name": "idx_customer_products_seat_sync",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_unused_seats": {
+          "name": "idx_customer_products_unused_seats",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "released_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_pool_assignment": {
+          "name": "unique_active_pool_assignment",
+          "columns": [
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customer_products\".\"customer_license_link_id\" IS NOT NULL AND \"customer_products\".\"internal_entity_id\" IS NOT NULL AND \"customer_products\".\"status\" IN ('active', 'past_due')",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_free_trial_id": {
+          "name": "idx_customer_products_free_trial_id",
+          "columns": [
+            {
+              "expression": "free_trial_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"free_trial_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_revenuecat_processor": {
+          "name": "idx_customer_products_revenuecat_processor",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"customer_products\".\"processor\" ->> 'type') = 'revenuecat'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_ended_at": {
+          "name": "idx_customer_products_ended_at",
+          "columns": [
+            {
+              "expression": "ended_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"ended_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_trial_ends_at": {
+          "name": "idx_customer_products_trial_ends_at",
+          "columns": [
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customer_products\".\"status\" IN ('active', 'past_due') AND \"customer_products\".\"trial_ends_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_products_product_id": {
+          "name": "idx_customer_products_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_products_free_trial_id_fkey": {
+          "name": "customer_products_free_trial_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "free_trials",
+          "columnsFrom": [
+            "free_trial_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_customer_id_fkey": {
+          "name": "customer_products_internal_customer_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_products_internal_product_id_fkey": {
+          "name": "customer_products_internal_product_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "customer_products_internal_entity_id_fkey": {
+          "name": "customer_products_internal_entity_id_fkey",
+          "tableFrom": "customer_products",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customers": {
+      "name": "customers",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processors": {
+          "name": "processors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "send_email_receipts": {
+          "name": "send_email_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "customers_email_null_id_unique": {
+          "name": "customers_email_null_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"customers\".\"id\" IS NULL AND \"customers\".\"email\" IS NOT NULL AND \"customers\".\"email\" != ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_fingerprint": {
+          "name": "idx_customers_org_env_fingerprint",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"fingerprint\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processor_id": {
+          "name": "idx_customers_processor_id",
+          "columns": [
+            {
+              "expression": "(\"processor\" ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_composite": {
+          "name": "idx_customers_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_org_env_internal_id": {
+          "name": "idx_customers_org_env_internal_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_email_trgm": {
+          "name": "idx_customers_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_name_trgm": {
+          "name": "idx_customers_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_id_trgm": {
+          "name": "idx_customers_id_trgm",
+          "columns": [
+            {
+              "expression": "\"id\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"customers\".\"id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_org_id_env_created_at": {
+          "name": "idx_customers_org_id_env_created_at",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_cursor": {
+          "name": "idx_customers_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat": {
+          "name": "idx_customers_processors_revenuecat",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'revenuecat')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_id": {
+          "name": "idx_customers_processors_revenuecat_id",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' ->> 'id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customers_processors_revenuecat_aliases": {
+          "name": "idx_customers_processors_revenuecat_aliases",
+          "columns": [
+            {
+              "expression": "(\"processors\" -> 'revenuecat' -> 'aliases')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_customers_processors_vercel": {
+          "name": "idx_customers_processors_vercel",
+          "columns": [
+            {
+              "expression": "(\"processors\" ->> 'vercel')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customers_org_id_fkey": {
+          "name": "customers_org_id_fkey",
+          "tableFrom": "customers",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cus_id_constraint": {
+          "name": "cus_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted": {
+          "name": "deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entities_internal_customer_id": {
+          "name": "idx_entities_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id_c": {
+          "name": "idx_entities_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_internal_feature_id": {
+          "name": "idx_entities_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entities\".\"internal_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_internal_desc": {
+          "name": "idx_entities_customer_internal_desc",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"internal_id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_org_env_id": {
+          "name": "idx_entities_org_env_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_cursor": {
+          "name": "idx_entities_cursor",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entities_customer_created_at": {
+          "name": "idx_entities_customer_created_at",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entities_internal_customer_id_fkey": {
+          "name": "entities_internal_customer_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_internal_feature_id_fkey": {
+          "name": "entities_internal_feature_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entities_org_id_fkey": {
+          "name": "entities_org_id_fkey",
+          "tableFrom": "entities",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_id_constraint": {
+          "name": "entity_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "internal_customer_id",
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entitlements": {
+      "name": "entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "allowance_type": {
+          "name": "allowance_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowance": {
+          "name": "allowance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "carry_from_previous": {
+          "name": "carry_from_previous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_feature_id": {
+          "name": "entity_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "pooled": {
+          "name": "pooled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limit": {
+          "name": "usage_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_duration": {
+          "name": "expiry_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_length": {
+          "name": "expiry_length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover": {
+          "name": "rollover",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_entitlements_internal_product_id": {
+          "name": "idx_entitlements_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id": {
+          "name": "idx_entitlements_internal_reward_id",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_reward_feature": {
+          "name": "idx_entitlements_reward_feature",
+          "columns": [
+            {
+              "expression": "internal_reward_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id_c": {
+          "name": "idx_entitlements_internal_feature_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_feature_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_feature_id": {
+          "name": "idx_entitlements_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_internal_reward_id_c_partial": {
+          "name": "idx_entitlements_internal_reward_id_c_partial",
+          "columns": [
+            {
+              "expression": "\"internal_reward_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"internal_reward_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_entitlements_entity_feature_id": {
+          "name": "idx_entitlements_entity_feature_id",
+          "columns": [
+            {
+              "expression": "entity_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"entitlements\".\"entity_feature_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entitlements_internal_feature_id_fkey": {
+          "name": "entitlements_internal_feature_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entitlements_internal_product_id_fkey": {
+          "name": "entitlements_internal_product_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "entitlements_internal_reward_id_fkey": {
+          "name": "entitlements_internal_reward_id_fkey",
+          "tableFrom": "entitlements",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entitlements_id_key": {
+          "name": "entitlements_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "set_usage": {
+          "name": "set_usage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductions": {
+          "name": "deductions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_events_internal_customer_id": {
+          "name": "idx_events_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_internal_entity_id": {
+          "name": "idx_events_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_customer_non_usage_ts": {
+          "name": "idx_events_customer_non_usage_ts",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"timestamp\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"set_usage\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_timestamp": {
+          "name": "idx_events_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_internal_customer_id_fkey": {
+          "name": "events_internal_customer_id_fkey",
+          "tableFrom": "events",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_constraint": {
+          "name": "unique_event_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "customer_id",
+            "event_name",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.features": {
+      "name": "features",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display": {
+          "name": "display",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "event_names": {
+          "name": "event_names",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "model_markups": {
+          "name": "model_markups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "stripe_meter": {
+          "name": "stripe_meter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_features_composite": {
+          "name": "idx_features_composite",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "features_org_id_fkey": {
+          "name": "features_org_id_fkey",
+          "tableFrom": "features",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_id_constraint": {
+          "name": "feature_id_constraint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.free_trials": {
+      "name": "free_trials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'day'"
+        },
+        "length": {
+          "name": "length",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_fingerprint": {
+          "name": "unique_fingerprint",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "card_required": {
+          "name": "card_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "on_end": {
+          "name": "on_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_free_trials_internal_product_id": {
+          "name": "idx_free_trials_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "free_trials_internal_product_id_fkey": {
+          "name": "free_trials_internal_product_id_fkey",
+          "tableFrom": "free_trials",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "leaf.harness_sessions": {
+      "name": "harness_sessions",
+      "schema": "leaf",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_key": {
+          "name": "thread_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resume_state": {
+          "name": "resume_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "braintrust_parent": {
+          "name": "braintrust_parent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_harness_sessions_session_id": {
+          "name": "idx_harness_sessions_session_id",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "harness_sessions_org_id_env_thread_key_pk": {
+          "name": "harness_sessions_org_id_env_thread_key_pk",
+          "columns": [
+            "org_id",
+            "env",
+            "thread_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organizations_id_fk": {
+          "name": "invitation_organization_id_organizations_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.invoice_line_items": {
+      "name": "invoice_line_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_item_id": {
+          "name": "stripe_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_discountable": {
+          "name": "stripe_discountable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_after_discounts": {
+          "name": "amount_after_discounts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_quantity": {
+          "name": "stripe_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_quantity": {
+          "name": "paid_quantity",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_source": {
+          "name": "description_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_timing": {
+          "name": "billing_timing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prorated": {
+          "name": "prorated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_price_ids": {
+          "name": "customer_price_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_entitlement_ids": {
+          "name": "customer_entitlement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_start": {
+          "name": "effective_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_period_end": {
+          "name": "effective_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoice_line_items_customer_product_ids": {
+          "name": "idx_invoice_line_items_customer_product_ids",
+          "columns": [
+            {
+              "expression": "customer_product_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_invoice_id": {
+          "name": "idx_invoice_line_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"invoice_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoice_line_items_stripe_invoice_item_id": {
+          "name": "idx_invoice_line_items_stripe_invoice_item_id",
+          "columns": [
+            {
+              "expression": "stripe_invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoice_line_items\".\"stripe_invoice_item_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_line_items_invoice_id_fkey": {
+          "name": "invoice_line_items_invoice_id_fkey",
+          "tableFrom": "invoice_line_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_line_items_stripe_id_unique": {
+          "name": "invoice_line_items_stripe_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_templates": {
+      "name": "invoice_templates",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "footer": {
+          "name": "footer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_terms_days": {
+          "name": "net_terms_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_invoice_templates_org_id": {
+          "name": "idx_invoice_templates_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_templates_org_id_fkey": {
+          "name": "invoice_templates_org_id_fkey",
+          "tableFrom": "invoice_templates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoice_templates_id_unique": {
+          "name": "invoice_templates_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_product_ids": {
+          "name": "internal_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processor_type": {
+          "name": "processor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "hosted_invoice_url": {
+          "name": "hosted_invoice_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "discounts": {
+          "name": "discounts",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "items": {
+          "name": "items",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_invoices_customer_created": {
+          "name": "idx_invoices_customer_created",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_internal_entity_id": {
+          "name": "idx_invoices_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoices\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_internal_customer_id_fkey": {
+          "name": "invoices_internal_customer_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_internal_entity_id_fkey": {
+          "name": "invoices_internal_entity_id_fkey",
+          "tableFrom": "invoices",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_stripe_id_key": {
+          "name": "invoices_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.license_entitlements": {
+      "name": "license_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_entitlement": {
+          "name": "unique_license_entitlement",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_entitlements_entitlement": {
+          "name": "idx_license_entitlements_entitlement",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_entitlements_plan_license_fkey": {
+          "name": "license_entitlements_plan_license_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_entitlements_entitlement_fkey": {
+          "name": "license_entitlements_entitlement_fkey",
+          "tableFrom": "license_entitlements",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.license_prices": {
+      "name": "license_prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "plan_license_id": {
+          "name": "plan_license_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_license_price": {
+          "name": "unique_license_price",
+          "columns": [
+            {
+              "expression": "plan_license_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_license_prices_price": {
+          "name": "idx_license_prices_price",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "license_prices_plan_license_fkey": {
+          "name": "license_prices_plan_license_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "plan_license",
+          "columnsFrom": [
+            "plan_license_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "license_prices_price_fkey": {
+          "name": "license_prices_price_fkey",
+          "tableFrom": "license_prices",
+          "tableTo": "prices",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organizations_id_fk": {
+          "name": "member_organization_id_organizations_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.metadata": {
+      "name": "metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_metadata_on_type_expires_at": {
+          "name": "idx_metadata_on_type_expires_at",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "metadata_expires_at_idx": {
+          "name": "metadata_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"metadata\".\"expires_at\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_errors": {
+      "name": "migration_errors",
+      "schema": "",
+      "columns": {
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_job_id": {
+          "name": "migration_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_customers_internal_customer_id_fkey": {
+          "name": "migration_customers_internal_customer_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_customers_migration_job_id_fkey": {
+          "name": "migration_customers_migration_job_id_fkey",
+          "tableFrom": "migration_errors",
+          "tableTo": "migration_jobs",
+          "columnsFrom": [
+            "migration_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "migration_errors_pkey": {
+          "name": "migration_errors_pkey",
+          "columns": [
+            "internal_customer_id",
+            "migration_job_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_item_runs": {
+      "name": "migration_item_runs",
+      "schema": "",
+      "columns": {
+        "migration_item_run_id": {
+          "name": "migration_item_run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "migration_run_id": {
+          "name": "migration_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_item_runs_live_unique": {
+          "name": "migration_item_runs_live_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_c_idx": {
+          "name": "migration_item_runs_live_c_idx",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_live_item_exclusive": {
+          "name": "migration_item_runs_live_item_exclusive",
+          "columns": [
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"item_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"status\" = 'running' AND \"migration_item_runs\".\"dry_run\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_dry_run_unique": {
+          "name": "migration_item_runs_dry_run_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "migration_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_item_runs\".\"dry_run\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_item_runs_customer_recent_idx": {
+          "name": "migration_item_runs_customer_recent_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_item_runs\".\"item_kind\" = 'customer'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_jobs": {
+      "name": "migration_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_internal_product_id": {
+          "name": "from_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_internal_product_id": {
+          "name": "to_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_details": {
+          "name": "step_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "migration_jobs_from_internal_product_id_fkey": {
+          "name": "migration_jobs_from_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "from_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_org_id_fkey": {
+          "name": "migration_jobs_org_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_jobs_to_internal_product_id_fkey": {
+          "name": "migration_jobs_to_internal_product_id_fkey",
+          "tableFrom": "migration_jobs",
+          "tableTo": "products",
+          "columnsFrom": [
+            "to_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "migration_internal_id": {
+          "name": "migration_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lazy_run": {
+          "name": "lazy_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_run_id": {
+          "name": "trigger_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "only_ids": {
+          "name": "only_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_limit": {
+          "name": "target_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_per_migration_unique": {
+          "name": "migration_runs_active_per_migration_unique",
+          "columns": [
+            {
+              "expression": "migration_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_migration_internal_id_fkey": {
+          "name": "migration_runs_migration_internal_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "migrations",
+          "columnsFrom": [
+            "migration_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_org_id_fkey": {
+          "name": "migration_runs_org_id_fkey",
+          "tableFrom": "migration_runs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migrations": {
+      "name": "migrations",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operations": {
+          "name": "operations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prepared_state": {
+          "name": "prepared_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_billing_changes": {
+          "name": "no_billing_changes",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_failed": {
+          "name": "retry_failed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migrations_org_env_id_unique": {
+          "name": "migrations_org_env_id_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migrations_org_id_fkey": {
+          "name": "migrations_org_id_fkey",
+          "tableFrom": "migrations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_access_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_api_key_id": {
+          "name": "oauth_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_consent_id": {
+          "name": "oauth_consent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk": {
+          "name": "oauth_refresh_token_oauth_consent_id_oauth_consent_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_consent",
+          "columnsFrom": [
+            "oauth_consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'usd'"
+        },
+        "stripe_connected": {
+          "name": "stripe_connected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "stripe_config": {
+          "name": "stripe_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_stripe_connect": {
+          "name": "test_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "live_stripe_connect": {
+          "name": "live_stripe_connect",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "processor_configs": {
+          "name": "processor_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_pkey": {
+          "name": "test_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_pkey": {
+          "name": "live_pkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "svix_config": {
+          "name": "svix_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "idempotency_config": {
+          "name": "idempotency_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_buttons": {
+          "name": "custom_buttons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded": {
+          "name": "onboarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deployed": {
+          "name": "deployed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_sandbox": {
+          "name": "is_sandbox",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sandbox_color": {
+          "name": "sandbox_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_icon": {
+          "name": "sandbox_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redis_config": {
+          "name": "redis_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_organizations_name_trgm": {
+          "name": "idx_organizations_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_slug_trgm": {
+          "name": "idx_organizations_slug_trgm",
+          "columns": [
+            {
+              "expression": "\"slug\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"organizations\".\"slug\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_organizations_created_at_id": {
+          "name": "idx_organizations_created_at_id",
+          "columns": [
+            {
+              "expression": "\"createdAt\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_default_account": {
+          "name": "idx_orgs_test_connect_default_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'default_account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_test_connect_account": {
+          "name": "idx_orgs_test_connect_account",
+          "columns": [
+            {
+              "expression": "(\"test_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_orgs_live_connect_account": {
+          "name": "idx_orgs_live_connect_account",
+          "columns": [
+            {
+              "expression": "(\"live_stripe_connect\"->>'account_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organizations_test_pkey_key": {
+          "name": "organizations_test_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_pkey"
+          ]
+        },
+        "organizations_live_pkey_key": {
+          "name": "organizations_live_pkey_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "live_pkey"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialId_idx": {
+          "name": "passkey_credentialId_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkey_credential_id_unique": {
+          "name": "passkey_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.plan_license": {
+      "name": "plan_license",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_internal_product_id": {
+          "name": "parent_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_internal_product_id": {
+          "name": "license_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "included": {
+          "name": "included",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prepaid_only": {
+          "name": "prepaid_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "customized": {
+          "name": "customized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "unique_plan_license": {
+          "name": "unique_plan_license",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"plan_license\".\"is_custom\" = false",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_parent_product": {
+          "name": "idx_plan_license_parent_product",
+          "columns": [
+            {
+              "expression": "parent_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_plan_license_license": {
+          "name": "idx_plan_license_license",
+          "columns": [
+            {
+              "expression": "license_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_license_parent_product_fkey": {
+          "name": "plan_license_parent_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "parent_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plan_license_license_product_fkey": {
+          "name": "plan_license_license_product_fkey",
+          "tableFrom": "plan_license",
+          "tableTo": "products",
+          "columnsFrom": [
+            "license_internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pooled_balance_contributions": {
+      "name": "pooled_balance_contributions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pooled_balance_id": {
+          "name": "pooled_balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_product_id": {
+          "name": "source_customer_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_customer_entitlement_id": {
+          "name": "source_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_contribution": {
+          "name": "current_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_cycle_contribution": {
+          "name": "next_cycle_contribution",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "effective_at": {
+          "name": "effective_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balance_contributions_pool": {
+          "name": "idx_pooled_balance_contributions_pool",
+          "columns": [
+            {
+              "expression": "pooled_balance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balance_contributions_source_customer_entitlement": {
+          "name": "idx_pooled_balance_contributions_source_customer_entitlement",
+          "columns": [
+            {
+              "expression": "source_customer_entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balance_contributions_pool_fkey": {
+          "name": "pooled_balance_contributions_pool_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "pooled_balances",
+          "columnsFrom": [
+            "pooled_balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_product_fkey": {
+          "name": "pooled_balance_contributions_customer_product_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_products",
+          "columnsFrom": [
+            "source_customer_product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balance_contributions_customer_entitlement_fkey": {
+          "name": "pooled_balance_contributions_customer_entitlement_fkey",
+          "tableFrom": "pooled_balance_contributions",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "source_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance_contribution": {
+          "name": "unique_pooled_balance_contribution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balance_contributions_current_non_negative": {
+          "name": "pooled_balance_contributions_current_non_negative",
+          "value": "\"pooled_balance_contributions\".\"current_contribution\" >= 0"
+        },
+        "pooled_balance_contributions_next_non_negative": {
+          "name": "pooled_balance_contributions_next_non_negative",
+          "value": "\"pooled_balance_contributions\".\"next_cycle_contribution\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pooled_balances": {
+      "name": "pooled_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unlimited": {
+          "name": "unlimited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "granted": {
+          "name": "granted",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_count": {
+          "name": "interval_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reset_cycle_anchor": {
+          "name": "reset_cycle_anchor",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_mode": {
+          "name": "reset_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_license_link_id": {
+          "name": "customer_license_link_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollover_signature": {
+          "name": "rollover_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "customer_entitlement_id": {
+          "name": "customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_applied_reset_at": {
+          "name": "last_applied_reset_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {
+        "idx_pooled_balances_org": {
+          "name": "idx_pooled_balances_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_reset_mode": {
+          "name": "idx_pooled_balances_reset_mode",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reset_mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_feature": {
+          "name": "idx_pooled_balances_feature",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_stripe_subscription": {
+          "name": "idx_pooled_balances_stripe_subscription",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pooled_balances_customer_license": {
+          "name": "idx_pooled_balances_customer_license",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "customer_license_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"pooled_balances\".\"customer_license_link_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pooled_balances_customer_fkey": {
+          "name": "pooled_balances_customer_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_feature_fkey": {
+          "name": "pooled_balances_feature_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "pooled_balances_customer_entitlement_fkey": {
+          "name": "pooled_balances_customer_entitlement_fkey",
+          "tableFrom": "pooled_balances",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_pooled_balance": {
+          "name": "unique_pooled_balance",
+          "nullsNotDistinct": true,
+          "columns": [
+            "internal_customer_id",
+            "internal_feature_id",
+            "unlimited",
+            "interval",
+            "interval_count",
+            "reset_cycle_anchor",
+            "reset_mode",
+            "stripe_subscription_id",
+            "customer_license_link_id",
+            "rollover_signature",
+            "expires_at"
+          ]
+        },
+        "unique_pooled_balance_customer_entitlement": {
+          "name": "unique_pooled_balance_customer_entitlement",
+          "nullsNotDistinct": false,
+          "columns": [
+            "customer_entitlement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "pooled_balances_interval_count_positive": {
+          "name": "pooled_balances_interval_count_positive",
+          "value": "\"pooled_balances\".\"interval_count\" > 0"
+        },
+        "pooled_balances_granted_non_negative": {
+          "name": "pooled_balances_granted_non_negative",
+          "value": "\"pooled_balances\".\"granted\" >= 0"
+        },
+        "pooled_balances_reset_mode_valid": {
+          "name": "pooled_balances_reset_mode_valid",
+          "value": "\"pooled_balances\".\"reset_mode\" IN ('lazy', 'subscription', 'lifetime')"
+        },
+        "pooled_balances_lifecycle_ids_valid": {
+          "name": "pooled_balances_lifecycle_ids_valid",
+          "value": "(\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'subscription'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NOT NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lazy'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t) OR (\n\t\t\t\t\"pooled_balances\".\"reset_mode\" = 'lifetime'\n\t\t\t\tAND \"pooled_balances\".\"stripe_subscription_id\" IS NULL\n\t\t\t\tAND \"pooled_balances\".\"customer_license_link_id\" IS NULL\n\t\t\t)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_product_id": {
+          "name": "internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier_behavior": {
+          "name": "tier_behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "proration_config": {
+          "name": "proration_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        }
+      },
+      "indexes": {
+        "idx_prices_internal_product_id": {
+          "name": "idx_prices_internal_product_id",
+          "columns": [
+            {
+              "expression": "internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_entitlement_id": {
+          "name": "idx_prices_entitlement_id",
+          "columns": [
+            {
+              "expression": "entitlement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_config_internal_feature_id": {
+          "name": "idx_prices_config_internal_feature_id",
+          "columns": [
+            {
+              "expression": "(\"config\" ->> 'internal_feature_id')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"prices\".\"config\" ->> 'internal_feature_id') IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prices_entitlement_id_fkey": {
+          "name": "prices_entitlement_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "entitlements",
+          "columnsFrom": [
+            "entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prices_internal_product_id_fkey": {
+          "name": "prices_internal_product_id_fkey",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": [
+            "internal_product_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "prices_id_key": {
+          "name": "prices_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_aliases": {
+      "name": "product_aliases",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias_id": {
+          "name": "alias_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_plan_id": {
+          "name": "canonical_plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_aliases_org_id_fkey": {
+          "name": "product_aliases_org_id_fkey",
+          "tableFrom": "product_aliases",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_aliases_pkey": {
+          "name": "product_aliases_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "alias_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "product_aliases_canonical_unique": {
+          "name": "product_aliases_canonical_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "env",
+            "canonical_plan_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_add_on": {
+          "name": "is_add_on",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "version": {
+          "name": "version",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "processor": {
+          "name": "processor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "null"
+        },
+        "base_variant_id": {
+          "name": "base_variant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_internal_product_id": {
+          "name": "base_internal_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "auto_topups": {
+          "name": "auto_topups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend_limits": {
+          "name": "spend_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_limits": {
+          "name": "usage_limits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_alerts": {
+          "name": "usage_alerts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overage_allowed": {
+          "name": "overage_allowed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_org_env_id_version": {
+          "name": "idx_products_org_env_id_version",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_org_env_base_internal_product_id": {
+          "name": "idx_products_org_env_base_internal_product_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "base_internal_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"products\".\"base_internal_product_id\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_product_version_slug": {
+          "name": "unique_product_version_slug",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"products\".\"version_slug\" IS NOT NULL",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_product": {
+          "name": "unique_active_product",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"products\".\"active\" = true",
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_org_id_fkey": {
+          "name": "products_org_id_fkey",
+          "tableFrom": "products",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_product": {
+          "name": "unique_product",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id",
+            "id",
+            "env",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.referral_codes": {
+      "name": "referral_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_referral_codes_internal_customer_id": {
+          "name": "idx_referral_codes_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "referral_codes_internal_customer_id_fkey": {
+          "name": "referral_codes_internal_customer_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_internal_reward_program_id_fkey": {
+          "name": "referral_codes_internal_reward_program_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "referral_codes_org_id_fkey": {
+          "name": "referral_codes_org_id_fkey",
+          "tableFrom": "referral_codes",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "referral_codes_pkey": {
+          "name": "referral_codes_pkey",
+          "columns": [
+            "code",
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "referral_codes_id_key": {
+          "name": "referral_codes_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.replaceables": {
+      "name": "replaceables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_entity_id": {
+          "name": "from_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delete_next_cycle": {
+          "name": "delete_next_cycle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_replaceables_cus_ent_id": {
+          "name": "idx_replaceables_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "replaceables_cus_ent_id_fkey": {
+          "name": "replaceables_cus_ent_id_fkey",
+          "tableFrom": "replaceables",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.revenuecat_mappings": {
+      "name": "revenuecat_mappings",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autumn_product_id": {
+          "name": "autumn_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revenuecat_product_ids": {
+          "name": "revenuecat_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "feature_quantities": {
+          "name": "feature_quantities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "revenuecat_mappings_org_id_fkey": {
+          "name": "revenuecat_mappings_org_id_fkey",
+          "tableFrom": "revenuecat_mappings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "revenuecat_mappings_pkey": {
+          "name": "revenuecat_mappings_pkey",
+          "columns": [
+            "org_id",
+            "env",
+            "autumn_product_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_programs": {
+      "name": "reward_programs",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_id": {
+          "name": "internal_reward_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unlimited_redemptions": {
+          "name": "unlimited_redemptions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "when": {
+          "name": "when",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'immediately'"
+        },
+        "product_ids": {
+          "name": "product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"\"}'"
+        },
+        "exclude_trial": {
+          "name": "exclude_trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reward_triggers_internal_reward_id_fkey": {
+          "name": "reward_triggers_internal_reward_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "rewards",
+          "columnsFrom": [
+            "internal_reward_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_triggers_org_id_fkey": {
+          "name": "reward_triggers_org_id_fkey",
+          "tableFrom": "reward_programs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_redemptions": {
+      "name": "reward_redemptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered": {
+          "name": "triggered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_reward_program_id": {
+          "name": "internal_reward_program_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied": {
+          "name": "applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "redeemer_applied": {
+          "name": "redeemer_applied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "referral_code_id": {
+          "name": "referral_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_internal_id": {
+          "name": "reward_internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code": {
+          "name": "promo_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_reward_redemptions_referral_code_id": {
+          "name": "idx_reward_redemptions_referral_code_id",
+          "columns": [
+            {
+              "expression": "referral_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_reward_internal_id": {
+          "name": "idx_reward_redemptions_reward_internal_id",
+          "columns": [
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reward_redemptions_customer_reward": {
+          "name": "idx_reward_redemptions_customer_reward",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reward_internal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reward_redemptions_internal_customer_id_fkey": {
+          "name": "reward_redemptions_internal_customer_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_internal_reward_program_id_fkey": {
+          "name": "reward_redemptions_internal_reward_program_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "reward_programs",
+          "columnsFrom": [
+            "internal_reward_program_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reward_redemptions_referral_code_id_fkey": {
+          "name": "reward_redemptions_referral_code_id_fkey",
+          "tableFrom": "reward_redemptions",
+          "tableTo": "referral_codes",
+          "columnsFrom": [
+            "referral_code_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_config": {
+          "name": "discount_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_config": {
+          "name": "free_product_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "free_product_id": {
+          "name": "free_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_codes": {
+          "name": "promo_codes",
+          "type": "jsonb[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_rewards_org_id_env": {
+          "name": "idx_rewards_org_id_env",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coupons_org_id_fkey": {
+          "name": "coupons_org_id_fkey",
+          "tableFrom": "rewards",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rollovers": {
+      "name": "rollovers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cus_ent_id": {
+          "name": "cus_ent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "entities": {
+          "name": "entities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_rollovers_cus_ent_id": {
+          "name": "idx_rollovers_cus_ent_id",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rollovers_cus_ent_expires": {
+          "name": "idx_rollovers_cus_ent_expires",
+          "columns": [
+            {
+              "expression": "cus_ent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rollover_cus_ent_id_fkey": {
+          "name": "rollover_cus_ent_id_fkey",
+          "tableFrom": "rollovers",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "cus_ent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.phases": {
+      "name": "phases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_product_ids": {
+          "name": "customer_product_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phases_schedule_id_fkey": {
+          "name": "phases_schedule_id_fkey",
+          "tableFrom": "phases",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "phases_schedule_id_starts_at_key": {
+          "name": "phases_schedule_id_starts_at_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "schedule_id",
+            "starts_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "schedules_customer_scope_unique": {
+          "name": "schedules_customer_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_entity_scope_unique": {
+          "name": "schedules_entity_scope_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedules\".\"internal_entity_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_customer_id": {
+          "name": "idx_schedules_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_internal_entity_id": {
+          "name": "idx_schedules_internal_entity_id",
+          "columns": [
+            {
+              "expression": "internal_entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_org_id_fkey": {
+          "name": "schedules_org_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_customer_id_fkey": {
+          "name": "schedules_internal_customer_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedules_internal_entity_id_fkey": {
+          "name": "schedules_internal_entity_id_fkey",
+          "tableFrom": "schedules",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "leaf.slack_admin_threads": {
+      "name": "slack_admin_threads",
+      "schema": "leaf",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_installation_id": {
+          "name": "chat_installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_identifier": {
+          "name": "target_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_provider_user_id": {
+          "name": "created_by_provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "slack_admin_threads_thread_key": {
+          "name": "slack_admin_threads_thread_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "channel_id",
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_connection": {
+      "name": "sso_connection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_domain_verification'"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sso_connection_organization_id_idx": {
+          "name": "sso_connection_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_connection_provider_id_sso_provider_provider_id_fk": {
+          "name": "sso_connection_provider_id_sso_provider_provider_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "sso_provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "provider_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_connection_organization_id_organizations_id_fk": {
+          "name": "sso_connection_organization_id_organizations_id_fk",
+          "tableFrom": "sso_connection",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_connection_provider_id_unique": {
+          "name": "sso_connection_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        },
+        "sso_connection_organization_id_unique": {
+          "name": "sso_connection_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_domain_idx": {
+          "name": "sso_provider_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organizations_id_fk": {
+          "name": "sso_provider_organization_id_organizations_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_domain_unique": {
+          "name": "sso_provider_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        },
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_id": {
+          "name": "stripe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_schedule_id": {
+          "name": "stripe_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "usage_features": {
+          "name": "usage_features",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cycle_anchor_seconds": {
+          "name": "billing_cycle_anchor_seconds",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_org_id_fkey": {
+          "name": "subscriptions_org_id_fkey",
+          "tableFrom": "subscriptions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripe_id_key": {
+          "name": "subscriptions_stripe_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transition_rules": {
+      "name": "transition_rules",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carry_over_usages": {
+          "name": "carry_over_usages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ROUND(date_part('epoch', NOW()) * 1000)::BIGINT"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transition_rules_org_id_fkey": {
+          "name": "transition_rules_org_id_fkey",
+          "tableFrom": "transition_rules",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transition_rules_pkey": {
+          "name": "transition_rules_pkey",
+          "columns": [
+            "org_id",
+            "env"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_windows": {
+      "name": "usage_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_customer_id": {
+          "name": "internal_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_entity_id": {
+          "name": "internal_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_feature_id": {
+          "name": "internal_feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_key": {
+          "name": "filter_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_customer_entitlement_id": {
+          "name": "anchor_customer_entitlement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_start_at": {
+          "name": "window_start_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end_at": {
+          "name": "window_end_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage": {
+          "name": "usage",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_usage_windows_internal_customer_id": {
+          "name": "idx_usage_windows_internal_customer_id",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_internal_customer_id_c": {
+          "name": "idx_usage_windows_internal_customer_id_c",
+          "columns": [
+            {
+              "expression": "\"internal_customer_id\" COLLATE \"C\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uw_internal_feature_id": {
+          "name": "idx_uw_internal_feature_id",
+          "columns": [
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_windows_customer_feature_scope": {
+          "name": "idx_usage_windows_customer_feature_scope",
+          "columns": [
+            {
+              "expression": "internal_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "internal_feature_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"internal_entity_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "COALESCE(\"filter_key\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": true,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_windows_internal_customer_id_fkey": {
+          "name": "usage_windows_internal_customer_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customers",
+          "columnsFrom": [
+            "internal_customer_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_entity_id_fkey": {
+          "name": "usage_windows_internal_entity_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "entities",
+          "columnsFrom": [
+            "internal_entity_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_internal_feature_id_fkey": {
+          "name": "usage_windows_internal_feature_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "features",
+          "columnsFrom": [
+            "internal_feature_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "usage_windows_anchor_customer_entitlement_id_fkey": {
+          "name": "usage_windows_anchor_customer_entitlement_id_fkey",
+          "tableFrom": "usage_windows",
+          "tableTo": "customer_entitlements",
+          "columnsFrom": [
+            "anchor_customer_entitlement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_name_trgm": {
+          "name": "idx_user_name_trgm",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"name\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_email_trgm": {
+          "name": "idx_user_email_trgm",
+          "columns": [
+            {
+              "expression": "\"email\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"user\".\"email\" IS NOT NULL",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_user_created_at_id": {
+          "name": "idx_user_created_at_id",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_created_by_fkey": {
+          "name": "user_created_by_fkey",
+          "tableFrom": "user",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vercel_resources": {
+      "name": "vercel_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "vercel_resources_installation_name_unique_idx": {
+          "name": "vercel_resources_installation_name_unique_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "env",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status <> 'uninstalled'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vercel_resources_org_id_fkey": {
+          "name": "vercel_resources_org_id_fkey",
+          "tableFrom": "vercel_resources",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "leaf": "leaf"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/shared/drizzle/meta/_journal.json
+++ b/shared/drizzle/meta/_journal.json
@@ -1,482 +1,489 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1779096275848,
-			"tag": "0000_bumpy_tinkerer",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1779971507895,
-			"tag": "0001_concerned_ravenous",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1780329256103,
-			"tag": "0002_aromatic_johnny_blaze",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1780423680857,
-			"tag": "0003_short_gargoyle",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1780493543535,
-			"tag": "0004_lucky_electro",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1780582242747,
-			"tag": "0005_fresh_runaways",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1780584591419,
-			"tag": "0006_sad_madrox",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1780655063264,
-			"tag": "0007_cute_ikaris",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1780679328640,
-			"tag": "0008_premium_pet_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1780687569277,
-			"tag": "0009_perpetual_wonder_man",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1780990532501,
-			"tag": "0010_magenta_misty_knight",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1781085888296,
-			"tag": "0011_easy_spot",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1781125150955,
-			"tag": "0012_low_moonstone",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1781165345168,
-			"tag": "0013_third_darkhawk",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1781186995896,
-			"tag": "0014_repair_migrations_archived",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1781188376470,
-			"tag": "0015_reflective_mystique",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1781342244254,
-			"tag": "0016_cynical_morg",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1781689355978,
-			"tag": "0017_colossal_meltdown",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1781696431377,
-			"tag": "0018_modern_jocasta",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1781877264759,
-			"tag": "0019_slack_admin_threads",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1781880506096,
-			"tag": "0020_loud_carnage",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1781886743530,
-			"tag": "0021_wonderful_firedrake",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1781886743531,
-			"tag": "0022_wild_union_jack",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1782294963052,
-			"tag": "0023_flaky_cannonball",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1782294963053,
-			"tag": "0024_rewards_org_env_idx",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1782317599973,
-			"tag": "0025_condemned_madelyne_pryor",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1782328105039,
-			"tag": "0026_panoramic_blob",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1782397854425,
-			"tag": "0027_magical_gargoyle",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1782459162420,
-			"tag": "0028_supreme_karen_page",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1782460700487,
-			"tag": "0029_reflective_miracleman",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1782462848407,
-			"tag": "0030_windy_wolfsbane",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1782573840271,
-			"tag": "0031_absent_adam_destine",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1782760749233,
-			"tag": "0032_white_stone_men",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1782770925277,
-			"tag": "0033_dusty_crystal",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1782836417268,
-			"tag": "0034_ambiguous_wolfsbane",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1782844933101,
-			"tag": "0035_boring_maggott",
-			"breakpoints": true
-		},
-		{
-			"idx": 36,
-			"version": "7",
-			"when": 1782907607380,
-			"tag": "0036_remarkable_spirit",
-			"breakpoints": true
-		},
-		{
-			"idx": 37,
-			"version": "7",
-			"when": 1782981605443,
-			"tag": "0037_match_slack_auth_mode",
-			"breakpoints": true
-		},
-		{
-			"idx": 38,
-			"version": "7",
-			"when": 1783090737295,
-			"tag": "0038_exotic_scarlet_spider",
-			"breakpoints": true
-		},
-		{
-			"idx": 39,
-			"version": "7",
-			"when": 1783200161669,
-			"tag": "0039_unique_molecule_man",
-			"breakpoints": true
-		},
-		{
-			"idx": 40,
-			"version": "7",
-			"when": 1783416274113,
-			"tag": "0040_abnormal_stranger",
-			"breakpoints": true
-		},
-		{
-			"idx": 41,
-			"version": "7",
-			"when": 1783529369844,
-			"tag": "0041_sweet_klaw",
-			"breakpoints": true
-		},
-		{
-			"idx": 42,
-			"version": "7",
-			"when": 1783533774922,
-			"tag": "0042_shocking_sharon_carter",
-			"breakpoints": true
-		},
-		{
-			"idx": 43,
-			"version": "7",
-			"when": 1783954630481,
-			"tag": "0043_motionless_agent_brand",
-			"breakpoints": true
-		},
-		{
-			"idx": 44,
-			"version": "7",
-			"when": 1784112581877,
-			"tag": "0044_large_moonstone",
-			"breakpoints": true
-		},
-		{
-			"idx": 45,
-			"version": "7",
-			"when": 1784124820600,
-			"tag": "0045_omniscient_human_torch",
-			"breakpoints": true
-		},
-		{
-			"idx": 46,
-			"version": "7",
-			"when": 1784127872787,
-			"tag": "0046_swift_warbird",
-			"breakpoints": true
-		},
-		{
-			"idx": 47,
-			"version": "7",
-			"when": 1784903183283,
-			"tag": "0047_dry_the_enforcers",
-			"breakpoints": true
-		},
-		{
-			"idx": 48,
-			"version": "7",
-			"when": 1784909275551,
-			"tag": "0048_lucky_loa",
-			"breakpoints": true
-		},
-		{
-			"idx": 49,
-			"version": "7",
-			"when": 1784987089139,
-			"tag": "0049_round_speed",
-			"breakpoints": true
-		},
-		{
-			"idx": 50,
-			"version": "7",
-			"when": 1784991222817,
-			"tag": "0050_dazzling_blacklash",
-			"breakpoints": true
-		},
-		{
-			"idx": 51,
-			"version": "7",
-			"when": 1785158350408,
-			"tag": "0051_empty_justin_hammer",
-			"breakpoints": true
-		},
-		{
-			"idx": 52,
-			"version": "7",
-			"when": 1785177455125,
-			"tag": "0052_keen_giant_girl",
-			"breakpoints": true
-		},
-		{
-			"idx": 53,
-			"version": "7",
-			"when": 1785236772276,
-			"tag": "0053_true_giant_girl",
-			"breakpoints": true
-		},
-		{
-			"idx": 54,
-			"version": "7",
-			"when": 1785238643793,
-			"tag": "0054_aspiring_squadron_supreme",
-			"breakpoints": true
-		},
-		{
-			"idx": 55,
-			"version": "7",
-			"when": 1785259823613,
-			"tag": "0055_cuddly_firedrake",
-			"breakpoints": true
-		},
-		{
-			"idx": 56,
-			"version": "7",
-			"when": 1785268449447,
-			"tag": "0056_lean_maginty",
-			"breakpoints": true
-		},
-		{
-			"idx": 57,
-			"version": "7",
-			"when": 1785337088338,
-			"tag": "0057_demonic_lionheart",
-			"breakpoints": true
-		},
-		{
-			"idx": 58,
-			"version": "7",
-			"when": 1785704393674,
-			"tag": "0058_black_thundra",
-			"breakpoints": true
-		},
-		{
-			"idx": 59,
-			"version": "7",
-			"when": 1785786538657,
-			"tag": "0059_square_captain_cross",
-			"breakpoints": true
-		},
-		{
-			"idx": 60,
-			"version": "7",
-			"when": 1785839076387,
-			"tag": "0060_blushing_leo",
-			"breakpoints": true
-		},
-		{
-			"idx": 61,
-			"version": "7",
-			"when": 1785859361018,
-			"tag": "0061_customer_lsns_fillfactor",
-			"breakpoints": true
-		},
-		{
-			"idx": 62,
-			"version": "7",
-			"when": 1785919170528,
-			"tag": "0062_pretty_hex",
-			"breakpoints": true
-		},
-		{
-			"idx": 63,
-			"version": "7",
-			"when": 1786477215400,
-			"tag": "0063_youthful_expediter",
-			"breakpoints": true
-		},
-		{
-			"idx": 64,
-			"version": "7",
-			"when": 1786543222434,
-			"tag": "0064_tidy_kang",
-			"breakpoints": true
-		},
-		{
-			"idx": 65,
-			"version": "7",
-			"when": 1787142211653,
-			"tag": "0065_normal_crusher_hogan",
-			"breakpoints": true
-		},
-		{
-			"idx": 66,
-			"version": "7",
-			"when": 1787219495927,
-			"tag": "0066_outstanding_princess_powerful",
-			"breakpoints": true
-		},
-		{
-			"idx": 67,
-			"version": "7",
-			"when": 1787324679367,
-			"tag": "0067_narrow_zzzax",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1779096275848,
+      "tag": "0000_bumpy_tinkerer",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1779971507895,
+      "tag": "0001_concerned_ravenous",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780329256103,
+      "tag": "0002_aromatic_johnny_blaze",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1780423680857,
+      "tag": "0003_short_gargoyle",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1780493543535,
+      "tag": "0004_lucky_electro",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780582242747,
+      "tag": "0005_fresh_runaways",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1780584591419,
+      "tag": "0006_sad_madrox",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1780655063264,
+      "tag": "0007_cute_ikaris",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1780679328640,
+      "tag": "0008_premium_pet_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1780687569277,
+      "tag": "0009_perpetual_wonder_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1780990532501,
+      "tag": "0010_magenta_misty_knight",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1781085888296,
+      "tag": "0011_easy_spot",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1781125150955,
+      "tag": "0012_low_moonstone",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1781165345168,
+      "tag": "0013_third_darkhawk",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1781186995896,
+      "tag": "0014_repair_migrations_archived",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1781188376470,
+      "tag": "0015_reflective_mystique",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1781342244254,
+      "tag": "0016_cynical_morg",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1781689355978,
+      "tag": "0017_colossal_meltdown",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1781696431377,
+      "tag": "0018_modern_jocasta",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1781877264759,
+      "tag": "0019_slack_admin_threads",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1781880506096,
+      "tag": "0020_loud_carnage",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1781886743530,
+      "tag": "0021_wonderful_firedrake",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1781886743531,
+      "tag": "0022_wild_union_jack",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1782294963052,
+      "tag": "0023_flaky_cannonball",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1782294963053,
+      "tag": "0024_rewards_org_env_idx",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1782317599973,
+      "tag": "0025_condemned_madelyne_pryor",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1782328105039,
+      "tag": "0026_panoramic_blob",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1782397854425,
+      "tag": "0027_magical_gargoyle",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1782459162420,
+      "tag": "0028_supreme_karen_page",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1782460700487,
+      "tag": "0029_reflective_miracleman",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1782462848407,
+      "tag": "0030_windy_wolfsbane",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1782573840271,
+      "tag": "0031_absent_adam_destine",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1782760749233,
+      "tag": "0032_white_stone_men",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1782770925277,
+      "tag": "0033_dusty_crystal",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1782836417268,
+      "tag": "0034_ambiguous_wolfsbane",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1782844933101,
+      "tag": "0035_boring_maggott",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1782907607380,
+      "tag": "0036_remarkable_spirit",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1782981605443,
+      "tag": "0037_match_slack_auth_mode",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1783090737295,
+      "tag": "0038_exotic_scarlet_spider",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1783200161669,
+      "tag": "0039_unique_molecule_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1783416274113,
+      "tag": "0040_abnormal_stranger",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1783529369844,
+      "tag": "0041_sweet_klaw",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1783533774922,
+      "tag": "0042_shocking_sharon_carter",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1783954630481,
+      "tag": "0043_motionless_agent_brand",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784112581877,
+      "tag": "0044_large_moonstone",
+      "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1784124820600,
+      "tag": "0045_omniscient_human_torch",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1784127872787,
+      "tag": "0046_swift_warbird",
+      "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1784903183283,
+      "tag": "0047_dry_the_enforcers",
+      "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1784909275551,
+      "tag": "0048_lucky_loa",
+      "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1784987089139,
+      "tag": "0049_round_speed",
+      "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1784991222817,
+      "tag": "0050_dazzling_blacklash",
+      "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1785158350408,
+      "tag": "0051_empty_justin_hammer",
+      "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1785177455125,
+      "tag": "0052_keen_giant_girl",
+      "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1785236772276,
+      "tag": "0053_true_giant_girl",
+      "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1785238643793,
+      "tag": "0054_aspiring_squadron_supreme",
+      "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1785259823613,
+      "tag": "0055_cuddly_firedrake",
+      "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1785268449447,
+      "tag": "0056_lean_maginty",
+      "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1785337088338,
+      "tag": "0057_demonic_lionheart",
+      "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1785704393674,
+      "tag": "0058_black_thundra",
+      "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1785786538657,
+      "tag": "0059_square_captain_cross",
+      "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1785839076387,
+      "tag": "0060_blushing_leo",
+      "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1785859361018,
+      "tag": "0061_customer_lsns_fillfactor",
+      "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1785919170528,
+      "tag": "0062_pretty_hex",
+      "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1786477215400,
+      "tag": "0063_youthful_expediter",
+      "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1786543222434,
+      "tag": "0064_tidy_kang",
+      "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1787142211653,
+      "tag": "0065_normal_crusher_hogan",
+      "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1787219495927,
+      "tag": "0066_outstanding_princess_powerful",
+      "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1787324679367,
+      "tag": "0067_narrow_zzzax",
+      "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1787335364987,
+      "tag": "0068_petite_bug",
+      "breakpoints": true
+    }
+  ]
 }

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -220,6 +220,8 @@ export * from "./models/productModels/productConfig/productConfig";
 export * from "./models/productModels/productEnums";
 export * from "./models/productModels/productMetadata";
 export * from "./models/productModels/productModels";
+export * from "./models/productModels/productAliasRelations";
+export * from "./models/productModels/productAliasTable";
 export * from "./models/productModels/productRelations";
 export * from "./models/productModels/productTable";
 export * from "./models/productV2Models/productItemModels/featureItem";

--- a/shared/models/orgModels/orgRelations.ts
+++ b/shared/models/orgModels/orgRelations.ts
@@ -3,6 +3,7 @@ import { member } from "../../db/auth-schema.js";
 import { apiKeys } from "../devModels/apiKeyTable.js";
 import { features } from "../featureModels/featureTable.js";
 import { migrationRuns } from "../migrationV2Models/migrationRunTable.js";
+import { productAliases } from "../productModels/productAliasTable.js";
 import { organizations } from "./orgTable.js";
 
 export const organizationsRelations = relations(
@@ -10,6 +11,7 @@ export const organizationsRelations = relations(
 	({ many, one }) => ({
 		api_keys: many(apiKeys),
 		features: many(features),
+		product_aliases: many(productAliases),
 		members: many(member),
 		migration_runs: many(migrationRuns),
 		master: one(organizations, {

--- a/shared/models/orgModels/orgTable.ts
+++ b/shared/models/orgModels/orgTable.ts
@@ -153,6 +153,8 @@ export const organizations = pgTable(
 export type Organization = typeof organizations.$inferSelect & {
 	master: Organization | null;
 	pendingMigrations?: PendingMigration[];
+	/** alias_id → live plan id. Empty (or omitted) for orgs with no renames. */
+	planAliases?: Record<string, string>;
 };
 
 // Multi tenancy flow <-> stripe connect...

--- a/shared/models/productModels/productAliasRelations.ts
+++ b/shared/models/productModels/productAliasRelations.ts
@@ -1,0 +1,10 @@
+import { relations } from "drizzle-orm";
+import { organizations } from "../orgModels/orgTable";
+import { productAliases } from "./productAliasTable";
+
+export const productAliasRelations = relations(productAliases, ({ one }) => ({
+	org: one(organizations, {
+		fields: [productAliases.org_id],
+		references: [organizations.id],
+	}),
+}));

--- a/shared/models/productModels/productAliasTable.ts
+++ b/shared/models/productModels/productAliasTable.ts
@@ -1,0 +1,40 @@
+import {
+	foreignKey,
+	numeric,
+	pgTable,
+	primaryKey,
+	text,
+	unique,
+} from "drizzle-orm/pg-core";
+import { sqlNow } from "../../db/utils";
+import { organizations } from "../orgModels/orgTable";
+
+export const productAliases = pgTable(
+	"product_aliases",
+	{
+		org_id: text("org_id").notNull(),
+		env: text().notNull(),
+		alias_id: text("alias_id").notNull(),
+		canonical_plan_id: text("canonical_plan_id").notNull(),
+		created_at: numeric({ mode: "number" }).notNull().default(sqlNow),
+	},
+	(table) => [
+		primaryKey({
+			columns: [table.org_id, table.env, table.alias_id],
+			name: "product_aliases_pkey",
+		}),
+		unique("product_aliases_canonical_unique").on(
+			table.org_id,
+			table.env,
+			table.canonical_plan_id,
+		),
+		foreignKey({
+			columns: [table.org_id],
+			foreignColumns: [organizations.id],
+			name: "product_aliases_org_id_fkey",
+		}).onDelete("cascade"),
+	],
+);
+
+export type DbProductAlias = typeof productAliases.$inferSelect;
+export type InsertDbProductAlias = typeof productAliases.$inferInsert;

--- a/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
+++ b/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
@@ -69,6 +69,10 @@ export const buildUpdateCatalogPlanParams = ({
 	includeContent?: boolean;
 }): UpdateCatalogPlanParamsInput => {
 	const source = baseProduct ?? editedProduct;
+	const newPlanId =
+		baseProduct && editedProduct.id !== baseProduct.id
+			? editedProduct.id
+			: undefined;
 	const plan = frontendProductToApiPlanV1(
 		{
 			...editedProduct,
@@ -81,6 +85,7 @@ export const buildUpdateCatalogPlanParams = ({
 
 	return {
 		plan_id: source.id,
+		...(newPlanId ? { new_plan_id: newPlanId } : {}),
 		...(pinsVersion(versioning) && baseProduct?.version
 			? { version: baseProduct.version }
 			: {}),

--- a/vite/src/views/products/plan/catalog/catalogPlanPreview.ts
+++ b/vite/src/views/products/plan/catalog/catalogPlanPreview.ts
@@ -7,6 +7,7 @@ import type {
 	CatalogPropagateParams,
 	CatalogVariantPreview,
 	CatalogVariantVersionPreview,
+	PlanAliasReplacement,
 	PlanChangeV0,
 	PlanItemChangeV0,
 	PlanLicenseChangeV0,
@@ -40,14 +41,25 @@ export const previewOpensStrategyStep = ({
 	preview: CatalogPlanUpdatePreview | undefined;
 }): boolean => (preview?.versioning?.options.length ?? 0) > 0;
 
-export const catalogPreviewOpensDialog = ({
+export const catalogPreviewAliasReplacements = ({
 	preview,
 }: {
 	preview: CatalogPlanUpdatePreview | undefined;
-}): boolean =>
-	previewOpensStrategyStep({ preview }) ||
-	(preview?.variants?.length ?? 0) > 0 ||
-	(preview?.license_parents?.length ?? 0) > 0;
+}): PlanAliasReplacement[] => {
+	if (!preview) return [];
+	const replacements: PlanAliasReplacement[] = [];
+	if (preview.alias_replacement) replacements.push(preview.alias_replacement);
+	for (const variant of preview.variants ?? []) {
+		if (variant.alias_replacement) replacements.push(variant.alias_replacement);
+	}
+	return replacements;
+};
+
+export const catalogPreviewHasAliasReplacement = ({
+	preview,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+}): boolean => catalogPreviewAliasReplacements({ preview }).length > 0;
 
 export const isCatalogMetadataOnly = ({
 	preview,
@@ -57,6 +69,75 @@ export const isCatalogMetadataOnly = ({
 	!!preview &&
 	!preview.plan_change?.customize &&
 	(preview.plan_change?.license_changes?.length ?? 0) === 0;
+
+export const catalogPreviewHasPlanIdChange = ({
+	preview,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+}): boolean => typeof preview?.plan_change?.previous_attributes?.id === "string";
+
+export const catalogPreviewPlanIdChange = ({
+	preview,
+	nextPlanId,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+	nextPlanId?: string;
+}): { from: string; to: string } | undefined => {
+	const from = preview?.plan_change?.previous_attributes?.id;
+	if (typeof from !== "string" || !nextPlanId || from === nextPlanId) {
+		return undefined;
+	}
+	return { from, to: nextPlanId };
+};
+
+export const catalogPreviewOpensDialog = ({
+	preview,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+}): boolean => {
+	if (catalogPreviewHasAliasReplacement({ preview })) return true;
+	if (isCatalogMetadataOnly({ preview })) {
+		return catalogPreviewHasPlanIdChange({ preview });
+	}
+	return (
+		previewOpensStrategyStep({ preview }) ||
+		(preview?.variants?.length ?? 0) > 0 ||
+		(preview?.license_parents?.length ?? 0) > 0
+	);
+};
+
+export const isConfirmOnlyPlanChangeDialog = ({
+	preview,
+	showVersionStrategy,
+	showVariantScope,
+	showLicenseParentScope,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+	showVersionStrategy: boolean;
+	showVariantScope: boolean;
+	showLicenseParentScope: boolean;
+}): boolean =>
+	(catalogPreviewHasAliasReplacement({ preview }) ||
+		catalogPreviewHasPlanIdChange({ preview })) &&
+	!showVersionStrategy &&
+	!showVariantScope &&
+	!showLicenseParentScope;
+
+export const isAliasOnlyPlanChangeDialog = ({
+	preview,
+	showVersionStrategy,
+	showVariantScope,
+	showLicenseParentScope,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+	showVersionStrategy: boolean;
+	showVariantScope: boolean;
+	showLicenseParentScope: boolean;
+}): boolean =>
+	catalogPreviewHasAliasReplacement({ preview }) &&
+	!showVersionStrategy &&
+	!showVariantScope &&
+	!showLicenseParentScope;
 
 export const strategyForCatalogPreview = ({
 	choice,

--- a/vite/src/views/products/plan/components/SaveChangesBar.tsx
+++ b/vite/src/views/products/plan/components/SaveChangesBar.tsx
@@ -1,6 +1,7 @@
 import { isFeaturePriceItem, type PlanLicenseParams } from "@autumn/shared";
 import { Button, ShortcutButton } from "@autumn/ui";
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import { toast } from "sonner";
 import { useFetchPreviewUpdateCatalog } from "@/hooks/queries/catalog/usePreviewUpdateCatalog";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
@@ -14,7 +15,7 @@ import {
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { CatalogV2Service } from "@/services/CatalogV2Service";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
-import { getBackendErr } from "@/utils/genUtils";
+import { getBackendErr, navigateTo } from "@/utils/genUtils";
 import { useProductQuery } from "../../product/hooks/useProductQuery";
 import { useProductContext } from "../../product/ProductContext";
 import { buildCatalogUpdatePlans } from "../catalog/buildUpdateCatalogPlanParams";
@@ -38,6 +39,7 @@ export const SaveChangesBar = ({
 	isOnboarding = false,
 }: SaveChangesBarProps) => {
 	const axiosInstance = useAxiosInstance();
+	const navigate = useNavigate();
 	const { setShowNewVersionDialog, catalogLicenses } = useProductContext();
 
 	const product = useProductStore((s) => s.product);
@@ -137,9 +139,11 @@ export const SaveChangesBar = ({
 			await CatalogV2Service.update(axiosInstance, { plans });
 			if (licenses) commitLicenseChanges();
 			setBaseProduct(product);
-			await queryRefetch();
+			const renamed = Boolean(baseProduct && product.id !== baseProduct.id);
+			if (!renamed) await queryRefetch();
 			await Promise.all([invalidateProduct(), invalidateProducts()]);
 			toast.success("Changes saved successfully");
+			if (renamed) navigateTo(`/products/${product.id}`, navigate);
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to save plan"));
 		}

--- a/vite/src/views/products/plan/components/edit-plan-details/MainDetailsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/MainDetailsSection.tsx
@@ -1,6 +1,7 @@
 import { FormLabel, Input } from "@autumn/ui";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { SheetSection } from "@/components/v2/sheets/InlineSheet";
+import { PlanIdField } from "./PlanIdField";
 
 export const MainDetailsSection = () => {
 	const { product, setProduct } = useProduct();
@@ -17,14 +18,7 @@ export const MainDetailsSection = () => {
 							onChange={(e) => setProduct({ ...product, name: e.target.value })}
 						/>
 					</div>
-					<div>
-						<FormLabel>ID</FormLabel>
-						<Input
-							placeholder="fills automatically"
-							disabled
-							value={product.id}
-						/>
-					</div>
+					<PlanIdField />
 				</div>
 				{/* <div>
 					<div className="text-form-label block mb-1">Description</div>

--- a/vite/src/views/products/plan/components/edit-plan-details/PlanIdField.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/PlanIdField.tsx
@@ -1,0 +1,43 @@
+import { FormLabel, IconButton, Input } from "@autumn/ui";
+import { PencilSimpleIcon } from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import { slugify } from "@/utils/formatUtils/formatTextUtils";
+
+export const PlanIdField = () => {
+	const { product, setProduct } = useProduct();
+	const [idUnlocked, setIdUnlocked] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const unlockId = () => {
+		setIdUnlocked(true);
+		queueMicrotask(() => inputRef.current?.focus());
+	};
+
+	return (
+		<div>
+			<div className="flex items-center justify-between gap-1">
+				<FormLabel>ID</FormLabel>
+				{!idUnlocked && (
+					<IconButton
+						aria-label="Edit plan ID"
+						icon={<PencilSimpleIcon />}
+						iconOrientation="center"
+						onClick={unlockId}
+						size="mini"
+						variant="muted"
+					/>
+				)}
+			</div>
+			<Input
+				disabled={!idUnlocked}
+				onChange={(event) =>
+					setProduct({ ...product, id: slugify(event.target.value) })
+				}
+				placeholder="fills automatically"
+				ref={inputRef}
+				value={product.id}
+			/>
+		</div>
+	);
+};

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -1,4 +1,9 @@
-import type { FrontendProduct } from "@autumn/shared";
+import type {
+	CatalogPlanUpdatePreview,
+	FrontendProduct,
+	UpdateCatalogPlanParamsInput,
+	UpdateCatalogResponse,
+} from "@autumn/shared";
 import {
 	AreaRadioGroupItem,
 	Dialog,
@@ -43,13 +48,19 @@ import {
 	useProductQuery,
 	useProductQueryState,
 } from "../../product/hooks/useProductQuery";
-import { useProductContext } from "../../product/ProductContext";
-import type { CatalogVersionChoice } from "../catalog/catalogPlanPreview";
+import { useOptionalProductContext } from "../../product/ProductContext";
+import {
+	type CatalogVersionChoice,
+	catalogPreviewAliasReplacements,
+	catalogPreviewPlanIdChange,
+	isConfirmOnlyPlanChangeDialog,
+} from "../catalog/catalogPlanPreview";
 import { usePlanChangeCatalogPreview } from "../catalog/usePlanChangeCatalogPreview";
 import {
 	commitLicenseChanges,
 	getLicenseUpdatePayload,
 } from "../components/plan-licenses/useLicenseSaveRegistry";
+import { PlanIdChangeNotice } from "./PlanIdChangeNotice";
 import { LicenseChangeList } from "./LicenseChangeList";
 import { LicenseParentTargetsStep } from "./LicenseParentTargetsStep";
 import { MigrateTargetsStep } from "./MigrateTargetsStep";
@@ -117,12 +128,22 @@ const planChangePrimaryText = ({
 };
 
 const planChangeDescription = ({
+	aliasOnly,
+	planIdChangeOnly,
 	step,
 	migrateNeeded,
 }: {
+	aliasOnly: boolean;
+	planIdChangeOnly: boolean;
 	step: StepKey;
 	migrateNeeded: boolean;
 }) => {
+	if (planIdChangeOnly) {
+		return "Confirm you want to change this plan's ID.";
+	}
+	if (aliasOnly) {
+		return "This plan ID is currently an alias of another plan.";
+	}
 	if (step === "review") return "Review what's changing before you save.";
 	if (step === "strategy") return "Choose how this applies across versions.";
 	if (step === "variant_scope") {
@@ -196,10 +217,18 @@ function ConfirmInput({
 	);
 }
 
+export type PlanChangeCreateConfirm = {
+	preview: CatalogPlanUpdatePreview;
+	plans: UpdateCatalogPlanParamsInput[];
+	onSaved?: (result: UpdateCatalogResponse) => void | Promise<void>;
+};
+
 export default function PlanChangeDialog({
+	createConfirm,
 	open,
 	setOpen,
 }: {
+	createConfirm?: PlanChangeCreateConfirm;
 	open: boolean;
 	setOpen: (open: boolean) => void;
 }) {
@@ -210,7 +239,8 @@ export default function PlanChangeDialog({
 	const setBaseProduct = useProductStore((s) => s.setBaseProduct);
 	const { basePlanId: persistedBasePlanId } = useVariantLinkVisibility(product);
 	const { features = [] } = useFeaturesQuery();
-	const { catalogLicenses } = useProductContext();
+	const catalogLicenses =
+		useOptionalProductContext()?.catalogLicenses ?? [];
 	const {
 		refetch,
 		invalidate: invalidateProduct,
@@ -218,7 +248,7 @@ export default function PlanChangeDialog({
 		numVersions,
 	} = useProductQuery();
 	const { setQueryStates } = useProductQueryState();
-	const { invalidate: invalidateProducts } = useProductsQuery();
+	const { products, invalidate: invalidateProducts } = useProductsQuery();
 	const { invalidate: invalidateLicenseProducts } = useLicenseProductsQuery();
 	const { invalidate: invalidateMigrations } = useMigrationsQuery();
 	const { org } = useOrg();
@@ -242,16 +272,18 @@ export default function PlanChangeDialog({
 	const currency = org?.default_currency ?? "USD";
 	const isLatest = product.version >= numVersions;
 	const priceChange = getPlanPriceChange({ baseProduct, product, currency });
-	const licenses = open
+	const editorOpen = open && !createConfirm;
+	const licenses = editorOpen
 		? getLicenseUpdatePayload({
 				persistedLinks: catalogLicenses.map(({ planLicense }) => planLicense),
 			})
 		: undefined;
 
-	const { data: variants = [] } = usePlanVariants(product.id, open);
-	const namesByPlanId = Object.fromEntries(
-		variants.map((variant) => [variant.id, variant.name]),
-	);
+	const { data: variants = [] } = usePlanVariants(product.id, editorOpen);
+	const namesByPlanId = {
+		...Object.fromEntries(products.map((entry) => [entry.id, entry.name])),
+		...Object.fromEntries(variants.map((variant) => [variant.id, variant.name])),
+	};
 
 	const {
 		preview,
@@ -275,7 +307,7 @@ export default function PlanChangeDialog({
 		migrateTargets,
 		buildSaveParams,
 	} = usePlanChangeCatalogPreview({
-		open,
+		open: editorOpen,
 		baseProduct,
 		product,
 		features,
@@ -294,11 +326,31 @@ export default function PlanChangeDialog({
 		0,
 	);
 
-	const steps = buildPlanChangeSteps({
-		showVersionStrategy,
-		showVariantScope,
-		showLicenseParentScope,
+	const planPreview = createConfirm?.preview ?? preview;
+	const aliasReplacements = catalogPreviewAliasReplacements({
+		preview: planPreview,
 	});
+	const planIdChange = createConfirm
+		? undefined
+		: catalogPreviewPlanIdChange({
+				preview: planPreview,
+				nextPlanId: product.id,
+			});
+	const confirmOnlyDialog =
+		!!createConfirm ||
+		isConfirmOnlyPlanChangeDialog({
+			preview: planPreview,
+			showVersionStrategy,
+			showVariantScope,
+			showLicenseParentScope,
+		});
+	const steps = confirmOnlyDialog
+		? [{ key: "review", label: "Review", icon: SealCheckIcon }]
+		: buildPlanChangeSteps({
+				showVersionStrategy,
+				showVariantScope,
+				showLicenseParentScope,
+			});
 	const stepKeys = steps.map((s) => s.key as StepKey);
 	const currentIndex = stepKeys.indexOf(step);
 	const isFinalStep = currentIndex === stepKeys.length - 1;
@@ -326,12 +378,22 @@ export default function PlanChangeDialog({
 	};
 
 	const applyChanges = async ({ migrate }: { migrate: boolean }) => {
-		if (step === "migrate" && !confirmed) {
+		if (!createConfirm && step === "migrate" && !confirmed) {
 			toast.error("Confirmation text is incorrect");
 			return;
 		}
 		setIsLoading(true);
 		try {
+			if (createConfirm) {
+				const result = await CatalogV2Service.update(axiosInstance, {
+					plans: createConfirm.plans,
+				});
+				toast.success("Plan created");
+				closeDialog();
+				await createConfirm.onSaved?.(result);
+				return;
+			}
+
 			const willMigrate =
 				migrateNeeded && migrate && strategy !== "new_version";
 			const result = await CatalogV2Service.update(axiosInstance, {
@@ -348,8 +410,14 @@ export default function PlanChangeDialog({
 			void invalidateProduct();
 			void invalidateProducts();
 			closeDialog();
-			if (effectiveVersionChoice === "new") void syncToLatestVersion();
-			else void refetch();
+			const renamed = Boolean(baseProduct && product.id !== baseProduct.id);
+			if (renamed) {
+				navigateTo(`/products/${product.id}`, navigate);
+			} else if (effectiveVersionChoice === "new") {
+				void syncToLatestVersion();
+			} else {
+				void refetch();
+			}
 
 			if (willMigrate) {
 				void invalidateMigrations();
@@ -362,7 +430,12 @@ export default function PlanChangeDialog({
 				);
 			}
 		} catch (error) {
-			toast.error(getBackendErr(error, "Failed to save plan"));
+			toast.error(
+				getBackendErr(
+					error,
+					createConfirm ? "Failed to create plan" : "Failed to save plan",
+				),
+			);
 		} finally {
 			setIsLoading(false);
 		}
@@ -396,8 +469,13 @@ export default function PlanChangeDialog({
 		isLatest,
 	});
 
-	const title = "Save plan changes";
-	const description = planChangeDescription({ step, migrateNeeded });
+	const title = createConfirm ? "Create plan" : "Save plan changes";
+	const description = planChangeDescription({
+		aliasOnly: confirmOnlyDialog && aliasReplacements.length > 0,
+		planIdChangeOnly: confirmOnlyDialog && !!planIdChange,
+		step,
+		migrateNeeded,
+	});
 	const migrateSubtitle = planChangeMigrateSubtitle({
 		isMetadataOnly,
 		migrateNeeded,
@@ -435,7 +513,16 @@ export default function PlanChangeDialog({
 								transition={{ duration: 0.15, ease: "easeOut" }}
 								className="text-sm flex flex-col gap-4"
 							>
-								{step === "review" && (
+								{step === "review" && confirmOnlyDialog && (
+									<PlanIdChangeNotice
+										from={planIdChange?.from}
+										to={planIdChange?.to}
+										namesByPlanId={namesByPlanId}
+										replacements={aliasReplacements}
+									/>
+								)}
+
+								{step === "review" && !confirmOnlyDialog && (
 									<div className="flex flex-col gap-2.5">
 										<FieldLabel>Preview changes</FieldLabel>
 										<div className="rounded-lg bg-secondary/40 px-3 py-2.5 flex flex-col gap-2">
@@ -565,6 +652,12 @@ export default function PlanChangeDialog({
 
 								{step === "migrate" && (
 									<>
+										<PlanIdChangeNotice
+											from={planIdChange?.from}
+											to={planIdChange?.to}
+											namesByPlanId={namesByPlanId}
+											replacements={aliasReplacements}
+										/>
 										<div className="flex flex-col gap-2.5">
 											<div className="flex flex-col gap-0.5">
 												<FieldLabel>Review &amp; confirm</FieldLabel>

--- a/vite/src/views/products/plan/versioning/PlanIdChangeNotice.tsx
+++ b/vite/src/views/products/plan/versioning/PlanIdChangeNotice.tsx
@@ -1,0 +1,70 @@
+import type { PlanAliasReplacement } from "@autumn/shared";
+
+const PlanId = ({ id }: { id: string }) => (
+	<span className="font-mono font-medium text-foreground">{id}</span>
+);
+
+const ownerLabel = ({
+	namesByPlanId,
+	planId,
+}: {
+	namesByPlanId: Record<string, string>;
+	planId: string;
+}) => namesByPlanId[planId] ?? planId;
+
+export const PlanIdChangeNotice = ({
+	from,
+	to,
+	namesByPlanId,
+	replacements,
+}: {
+	from?: string;
+	to?: string;
+	namesByPlanId: Record<string, string>;
+	replacements: PlanAliasReplacement[];
+}) => {
+	const claimed =
+		to === undefined
+			? undefined
+			: replacements.find((replacement) => replacement.alias_id === to);
+
+	if (from === undefined || to === undefined) {
+		if (replacements.length === 0) return null;
+		return (
+			<div className="rounded-lg bg-secondary/40 px-3 py-2.5 text-sm text-muted-foreground">
+				{replacements.map((replacement, index) => {
+					const owner = ownerLabel({
+						namesByPlanId,
+						planId: replacement.plan_id,
+					});
+					return (
+						<span key={`${replacement.alias_id}:${replacement.plan_id}`}>
+							{index > 0 ? " " : null}
+							<PlanId id={replacement.alias_id} /> is currently an alias of{" "}
+							<span className="font-medium text-foreground">{owner}</span> and
+							will stop working after saving.
+						</span>
+					);
+				})}
+			</div>
+		);
+	}
+
+	return (
+		<div className="rounded-lg bg-secondary/40 px-3 py-2.5 text-sm text-muted-foreground">
+			You're changing this plan's ID from <PlanId id={from} /> to{" "}
+			<PlanId id={to} />. Existing calls using <PlanId id={from} /> will
+			continue to work as an alias of <PlanId id={to} />.
+			{claimed ? (
+				<>
+					{" "}
+					<PlanId id={to} /> is currently an alias of{" "}
+					<span className="font-medium text-foreground">
+						{ownerLabel({ namesByPlanId, planId: claimed.plan_id })}
+					</span>{" "}
+					and will stop working after saving.
+				</>
+			) : null}
+		</div>
+	);
+};

--- a/vite/src/views/products/products/components/CreateProductSheet.tsx
+++ b/vite/src/views/products/products/components/CreateProductSheet.tsx
@@ -1,4 +1,7 @@
-import { productV2ToBasePrice } from "@autumn/shared";
+import {
+	productV2ToBasePrice,
+	type UpdateCatalogResponse,
+} from "@autumn/shared";
 import { Sheet, SheetContent, ShortcutButton } from "@autumn/ui";
 import type { AxiosError } from "axios";
 import { useState } from "react";
@@ -13,12 +16,17 @@ import {
 	SheetFooter,
 	SheetHeader,
 } from "@/components/v2/sheets/SharedSheetComponents";
+import { useFetchPreviewUpdateCatalog } from "@/hooks/queries/catalog/usePreviewUpdateCatalog";
 import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
 import { CatalogV2Service } from "@/services/CatalogV2Service";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr, navigateTo } from "@/utils/genUtils";
 import { buildUpdateCatalogPlanParams } from "../../plan/catalog/buildUpdateCatalogPlanParams";
+import { catalogPreviewOpensDialog } from "../../plan/catalog/catalogPlanPreview";
+import PlanChangeDialog, {
+	type PlanChangeCreateConfirm,
+} from "../../plan/versioning/PlanChangeDialog";
 import { AdditionalOptions } from "../../plan/components/edit-plan-details/AdditionalOptions";
 import { BasePriceSection } from "../../plan/components/edit-plan-details/BasePriceSection";
 import { MoreSettingsSection } from "../../plan/components/edit-plan-details/MoreSettingsSection";
@@ -142,6 +150,8 @@ function CreateProductFormContent({
 	setOpen: (open: boolean) => void;
 }) {
 	const [loading, setLoading] = useState(false);
+	const [createConfirm, setCreateConfirm] =
+		useState<PlanChangeCreateConfirm | null>(null);
 	const { product } = useProduct();
 	const basePrice = productV2ToBasePrice({ product });
 	const { features = [] } = useFeaturesQuery();
@@ -149,8 +159,25 @@ function CreateProductFormContent({
 	const axiosInstance = useAxiosInstance();
 	const navigate = useNavigate();
 	const { invalidate } = useProductsQuery();
+	const fetchPreviewUpdateCatalog = useFetchPreviewUpdateCatalog();
 
 	const { title, description, submit } = sheetCopy({ isAddOn, isLicense });
+
+	const finishCreate = async (response: UpdateCatalogResponse) => {
+		const created = response.plans[0];
+		if (!created) {
+			throw new Error("Plan was not created");
+		}
+
+		invalidate();
+
+		if (onSuccess) {
+			await onSuccess(created);
+		} else {
+			navigateTo(`/products/${created.id}`, navigate);
+		}
+		setOpen(false);
+	};
 
 	const handleCreateClicked = async () => {
 		const productName = product.name?.trim() || "";
@@ -160,33 +187,34 @@ function CreateProductFormContent({
 			return;
 		}
 
+		const plans = [
+			buildUpdateCatalogPlanParams({
+				editedProduct: product,
+				features,
+			}),
+		];
+
 		setLoading(true);
 		try {
-			const response = await CatalogV2Service.update(axiosInstance, {
-				plans: [
-					buildUpdateCatalogPlanParams({
-						editedProduct: product,
-						features,
-					}),
-				],
-			});
-			const created = response.plans[0];
-			if (!created) {
-				throw new Error("Plan was not created");
+			const preview = await fetchPreviewUpdateCatalog({ plans });
+			const planPreview = preview.plans[0];
+			if (planPreview && catalogPreviewOpensDialog({ preview: planPreview })) {
+				setCreateConfirm({
+					preview: planPreview,
+					plans,
+					onSaved: finishCreate,
+				});
+				return;
 			}
 
-			invalidate();
-
-			if (onSuccess) {
-				await onSuccess(created);
-			} else {
-				navigateTo(`/products/${created.id}`, navigate);
-			}
-			setOpen(false);
+			await finishCreate(
+				await CatalogV2Service.update(axiosInstance, { plans }),
+			);
 		} catch (error) {
 			toast.error(getBackendErr(error as AxiosError, "Failed to create plan"));
+		} finally {
+			setLoading(false);
 		}
-		setLoading(false);
 	};
 
 	return (
@@ -205,6 +233,16 @@ function CreateProductFormContent({
 				)}
 			</div>
 
+			{createConfirm && (
+				<PlanChangeDialog
+					createConfirm={createConfirm}
+					open
+					setOpen={(nextOpen) => {
+						if (!nextOpen) setCreateConfirm(null);
+					}}
+				/>
+			)}
+
 			<SheetFooter>
 				<ShortcutButton
 					variant="secondary"
@@ -216,6 +254,7 @@ function CreateProductFormContent({
 				</ShortcutButton>
 				<ShortcutButton
 					disabled={
+						!!createConfirm ||
 						(product.planType === "paid" &&
 							product.basePriceType !== "usage" &&
 							!basePrice?.price) ||

--- a/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
+++ b/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
@@ -129,6 +129,16 @@ describe("buildUpdateCatalogPlanParams", () => {
 		expect(() => UpdateCatalogPlanParamsSchema.parse(body)).not.toThrow();
 	});
 
+	test("rename sends new_plan_id and keeps the original plan_id", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: { ...editedProduct, id: "pro_plus" },
+			features,
+		});
+		expect(params.plan_id).toBe("pro");
+		expect(params.new_plan_id).toBe("pro_plus");
+	});
+
 	test("new_version and all_versions omit the version pin", () => {
 		const minted = buildUpdateCatalogPlanParams({
 			baseProduct,

--- a/vite/tests/views/products/plan/catalog/catalog-plan-preview.test.ts
+++ b/vite/tests/views/products/plan/catalog/catalog-plan-preview.test.ts
@@ -8,8 +8,12 @@ import {
 	buildCatalogMigrateTargets,
 	buildCatalogPropagate,
 	buildSelectedLicenseParentPropagate,
+	catalogPreviewAliasReplacements,
+	catalogPreviewHasPlanIdChange,
 	catalogPreviewOpensDialog,
+	catalogPreviewPlanIdChange,
 	emptyCatalogPlanChangeDiff,
+	isConfirmOnlyPlanChangeDialog,
 	hasCatalogMigrationTargets,
 	isCatalogMetadataOnly,
 	planChangeToTargetDiff,
@@ -85,12 +89,113 @@ describe("catalog plan preview helpers", () => {
 		).toBeUndefined();
 	});
 
-	test("catalogPreviewOpensDialog follows options, variants, and license parents", () => {
+	test("catalogPreviewOpensDialog follows options, variants, license parents, alias replacement, and plan id change", () => {
 		expect(catalogPreviewOpensDialog({ preview: undefined })).toBe(false);
 		expect(catalogPreviewOpensDialog({ preview: planPreview() })).toBe(false);
 		expect(
-			previewOpensStrategyStep({
+			catalogPreviewOpensDialog({
 				preview: planPreview({
+					alias_replacement: { alias_id: "pro", plan_id: "pro_new" },
+				}),
+			}),
+		).toBe(true);
+		expect(
+			catalogPreviewOpensDialog({
+				preview: planPreview({
+					plan_change: {
+						item_changes: [],
+						previous_attributes: { id: "pro" },
+					},
+				}),
+			}),
+		).toBe(true);
+		expect(
+			catalogPreviewOpensDialog({
+				preview: planPreview({
+					plan_change: {
+						item_changes: [],
+						previous_attributes: { name: "Pro" },
+					},
+				}),
+			}),
+		).toBe(false);
+		expect(
+			catalogPreviewHasPlanIdChange({
+				preview: planPreview({
+					plan_change: {
+						item_changes: [],
+						previous_attributes: { id: "pro" },
+					},
+				}),
+			}),
+		).toBe(true);
+		expect(
+			catalogPreviewPlanIdChange({
+				preview: planPreview({
+					plan_change: {
+						item_changes: [],
+						previous_attributes: { id: "pro" },
+					},
+				}),
+				nextPlanId: "pro_plus",
+			}),
+		).toEqual({ from: "pro", to: "pro_plus" });
+		expect(
+			isConfirmOnlyPlanChangeDialog({
+				preview: planPreview({
+					plan_change: {
+						item_changes: [],
+						previous_attributes: { id: "pro" },
+					},
+				}),
+				showVersionStrategy: false,
+				showVariantScope: false,
+				showLicenseParentScope: false,
+			}),
+		).toBe(true);
+		expect(
+			isConfirmOnlyPlanChangeDialog({
+				preview: planPreview({
+					plan_change: {
+						item_changes: [],
+						customize: { items: [] },
+						previous_attributes: { id: "pro" },
+					},
+				}),
+				showVersionStrategy: true,
+				showVariantScope: false,
+				showLicenseParentScope: false,
+			}),
+		).toBe(false);
+		expect(
+			catalogPreviewAliasReplacements({
+				preview: planPreview({
+					variants: [
+						{
+							plan_id: "pro_eu",
+							version: 1,
+							state: { has_customers: false, will_archive: false },
+							alias_replacement: { alias_id: "pro", plan_id: "pro_new" },
+						},
+					],
+				}),
+			}),
+		).toEqual([{ alias_id: "pro", plan_id: "pro_new" }]);
+		const versioningOnly = planPreview({
+			versioning: {
+				current_version: 1,
+				new_version: null,
+				resolved: "existing",
+				options: ["existing"],
+			},
+		});
+		expect(previewOpensStrategyStep({ preview: versioningOnly })).toBe(true);
+		expect(isCatalogMetadataOnly({ preview: versioningOnly })).toBe(true);
+		expect(catalogPreviewOpensDialog({ preview: versioningOnly })).toBe(false);
+		expect(
+			catalogPreviewOpensDialog({
+				preview: planPreview({
+					plan_change: { item_changes: [], customize: { items: [] } },
 					versioning: {
 						current_version: 1,
 						new_version: null,
@@ -103,6 +208,7 @@ describe("catalog plan preview helpers", () => {
 		expect(
 			catalogPreviewOpensDialog({
 				preview: planPreview({
+					plan_change: { item_changes: [], customize: { items: [] } },
 					variants: [
 						{
 							plan_id: "pro_eu",
@@ -116,6 +222,16 @@ describe("catalog plan preview helpers", () => {
 		expect(
 			catalogPreviewOpensDialog({
 				preview: planPreview({
+					plan_change: {
+						item_changes: [],
+						license_changes: [
+							{
+								license_plan_id: "seat",
+								action: "updated",
+								previous_attributes: null,
+							},
+						],
+					},
 					license_parents: [
 						{
 							plan_id: "team",


### PR DESCRIPTION
## Summary
- After a plan id rename (`pro` → `proNew`), keep the old public id as an alias so existing API calls still resolve — without rewriting `customer_products`.
- Ingress rewrite (path, body, Stripe checkout metadata) maps alias → canonical; responses stay the live id. Dashboard skips rewrite.
- Catalog preview/execute claims a reserved alias with a warning; re-rename replaces the previous alias. Dashboard Plan Change dialog explains the id change and any alias that will stop working.

## Test plan
- [x] Unit: `plan-id-alias-rewrite` + `forceJsonBody`
- [x] Integration: `plans/aliases/*`, `rename-plan-aliases`, `rename-plan-alias-replacement` (incl. `new_version` claim), `rename-plan-alias-reclaim`
- [x] Vite: `catalog-plan-preview`
- [ ] Staging: migrate `0068` (done) + deploy this branch and smoke-test dashboard rename + alias claim
- [ ] Confirm REST `POST /products` of a reserved alias still 400; catalog create/rename can claim it


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep old plan IDs as org/env aliases and rewrite requests to the canonical plan so clients keep working without rewriting customer_products. After a rename, handlers, previews, and responses use the live ID; invoices keep snapshot IDs when a product row is gone.

- Schema: add `product_aliases` (migration 0068). Load the alias map into org context as `planAliases`.
- Ingress: add `planAliasMiddleware` on `/v1/*` and Vercel webhooks. Rewrite known plan-id fields in JSON bodies and `product_id`/`productId` path params; skip `new_plan_id` and create identity fields. Rewrite Stripe checkout metadata.
- Catalog: rename writes alias (old → new); re-rename replaces it. Execute remaps public IDs for downstream actions and rewrites Vercel allowlists; results use the new ID. Preview stamps `alias_replacement`; variant-level `new_plan_id` is supported.
- Alias claims: REST create and cross-org copy reject IDs reserved as aliases; catalog create/rename may claim them. Execute deletes the claimed alias in the same transaction as the create to avoid split-commit state.
- Invoices: resolve live public IDs from internal ids and merge with snapshot `product_ids` when a product row is gone.
- Rollout: run migration 0068. Deploy and smoke-test rename, alias claim, Vercel allowlist rewrite, and 400 on REST create of a reserved alias.

<sup>Written for commit 0864188ec1040289772985a6b55a3d77d1c24e8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves renamed plan IDs as aliases so existing API calls continue resolving while responses use the current canonical ID.

- **[API changes]** Rewrites recognized plan IDs in API paths, request bodies, Stripe checkout metadata, and Vercel requests from aliases to canonical IDs.
- **[Improvements]** Stores plan aliases by organization and environment, supports alias claims and replacements during catalog updates, and displays rename implications in catalog previews and the dashboard.
- **[Bug fixes]** Resolves invoice plan IDs against live product records while retaining snapshot IDs for deleted products.
- **[Bug fixes]** Makes alias deletion and product creation atomic when a catalog create claims a reserved alias.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported alias-claim atomicity failure has been resolved.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts | Claims a reserved alias by deleting it and inserting the new product within one database transaction, resolving the previously reported partial-commit issue. |
| server/src/internal/catalogV2/execute/executeRenamePlans.ts | Renames plan references, updates the Vercel allowlist, and replaces the plan's alias mapping in one SQL operation. |
| server/src/honoMiddlewares/planAliasMiddleware.ts | Canonicalizes aliased plan IDs in supported request paths and JSON fields while preserving identity fields on create routes. |
| shared/models/productModels/productAliasTable.ts | Defines organization- and environment-scoped alias mappings with uniqueness constraints. |
| server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts | Combines current product IDs with invoice snapshots so deleted products retain their historical IDs. |
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Explains plan ID changes and alias replacement effects in the dashboard. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Rename[Rename plan: pro to proNew] --> Store[Store alias: pro to proNew]
  Request[API request using pro] --> Middleware[Alias middleware]
  Store --> Middleware
  Middleware --> Canonical[Process request using proNew]
  Canonical --> Response[Return live ID proNew]
  Claim[Catalog claims reserved alias pro] --> Transaction[Delete alias and create plan atomically]
  Transaction --> LivePlan[Plan now owns ID pro]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: keep execute and invoices consisten..."](https://github.com/useautumn/autumn/commit/0864188ec1040289772985a6b55a3d77d1c24e8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55827686)</sub>

<!-- /greptile_comment -->