### PR TITLE
fix: resolve current plan ids from products, not denormalized customer_product/invoice snapshots

### DIFF
--- a/server/src/external/vercel/handlers/handleUpdateBillingPlan.ts
+++ b/server/src/external/vercel/handlers/handleUpdateBillingPlan.ts
@@ -29,7 +29,7 @@ export const handleUpdateVercelBillingPlan = createRoute({
 			});
 		} else {
 			if (
-				customer.customer_products.find((cp) => cp.product_id === billingPlanId)
+				customer.customer_products.find((cp) => cp.product.id === billingPlanId)
 			) {
 				return c.json(
 					{

--- a/server/src/internal/billing/v2/actions/sync/logs/logSyncPlan.ts
+++ b/server/src/internal/billing/v2/actions/sync/logs/logSyncPlan.ts
@@ -12,10 +12,8 @@ const formatSubscriptionIds = (subscriptions?: Subscription[]) => {
 	return subscriptions.map((subscription) => subscription.stripe_id).join(", ");
 };
 
-const formatCustomerProduct = (cp: {
-	product_id: string;
-	product: { name: string };
-}) => `${cp.product.name} (${cp.product_id})`;
+const formatCustomerProduct = (cp: { product: { id: string; name: string } }) =>
+	`${cp.product.name} (${cp.product.id})`;
 
 export const logSyncPlan = ({
 	ctx,

--- a/server/src/internal/billing/v2/utils/logs/logAutumnBillingPlan.ts
+++ b/server/src/internal/billing/v2/utils/logs/logAutumnBillingPlan.ts
@@ -21,9 +21,8 @@ export const logAutumnBillingPlan = ({
 	});
 
 	const formatCustomerProduct = (cp: {
-		product_id: string;
-		product: { name: string };
-	}) => `${cp.product.name} (${cp.product_id})`;
+		product: { id: string; name: string };
+	}) => `${cp.product.name} (${cp.product.id})`;
 
 	addToExtraLogs({
 		ctx,

--- a/server/src/internal/customers/CusSearchService.ts
+++ b/server/src/internal/customers/CusSearchService.ts
@@ -29,7 +29,13 @@ const dashboardProductFilterToRawSql = ({
 	env: AppEnv;
 }) =>
 	isCustomDashboardProductFilter(filter)
-		? sql`(${customerProducts.product_id} = ${filter.productId} AND ${customerProducts.is_custom} = true)`
+		? sql`(${customerProducts.internal_product_id} IN (
+				SELECT p_lookup.internal_id
+				FROM products p_lookup
+				WHERE p_lookup.org_id = ${orgId}
+					AND p_lookup.env = ${env}
+					AND p_lookup.id = ${filter.productId}
+			) AND ${customerProducts.is_custom} = true)`
 		: sql`(${customerProducts.internal_product_id} IN (
 				SELECT p_lookup.internal_id
 				FROM products p_lookup
@@ -244,10 +250,17 @@ export const buildSearchPredicates = ({
 							case "free_trial":
 								return sql`(${customerProducts.trial_ends_at} > ${Date.now()} AND ${customerProducts.free_trial_id} IS NOT NULL AND ${customerProducts.canceled_at} IS NULL AND ${activeProdRaw})`;
 							case CusProductStatus.Expired:
+								// "Same plan" = same public product id (any version), resolved
+								// through the products join rather than the denormalized
+								// customer_products.product_id snapshot.
 								return sql`(${customerProducts.status} = ${CusProductStatus.Expired} AND ${customerProducts.canceled_at} IS NULL AND NOT EXISTS (
 									SELECT 1 FROM customer_products cp_alias
+									JOIN products p_alias ON p_alias.internal_id = cp_alias.internal_product_id
+									JOIN products p_cur ON p_cur.internal_id = ${customerProducts.internal_product_id}
 									WHERE cp_alias.internal_customer_id = ${customerProducts.internal_customer_id}
-									  AND cp_alias.product_id = ${customerProducts.product_id}
+									  AND p_alias.id = p_cur.id
+									  AND p_alias.org_id = p_cur.org_id
+									  AND p_alias.env = p_cur.env
 									  AND (cp_alias.status = ${CusProductStatus.Active} OR cp_alias.status = ${CusProductStatus.PastDue})
 								))`;
 							default:

--- a/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts
+++ b/server/src/internal/customers/attach/attachUtils/handleAttachErrors/handleMultiAttachErrors.ts
@@ -4,7 +4,6 @@ import {
 	ErrCode,
 	isUsagePrice,
 	notNullish,
-	nullish,
 	type Price,
 	RecaseError,
 } from "@autumn/shared";
@@ -44,17 +43,11 @@ export const handleMultiAttachErrors = async ({
 	const cusProducts = attachParams.customer.customer_products;
 	for (const prodOptions of productsList!) {
 		const newQuantity = prodOptions.quantity || 1;
-		const curCusQuantity =
-			cusProducts.find(
-				(cp) =>
-					cp.product_id === prodOptions.product_id &&
-					nullish(cp.internal_entity_id),
-			)?.quantity || 0;
 
 		const curEntityQuantity =
 			cusProducts.filter(
 				(cp) =>
-					cp.product_id === prodOptions.product_id &&
+					cp.product.id === prodOptions.product_id &&
 					notNullish(cp.internal_entity_id),
 			)?.length || 0;
 

--- a/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
+++ b/server/src/internal/customers/cursorPaginatedFullCusQuery.ts
@@ -11,6 +11,7 @@ import {
 } from "@autumn/shared";
 import { type Column, type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
+import { resolvedProductIdsSql } from "@/internal/invoices/repos/utils/resolvedProductIdsSql.js";
 import { activeStatusListSql, monthlyBasePriceExpr } from "./basePriceSql.js";
 import {
 	cpStatusInClause,
@@ -213,7 +214,7 @@ export const getCursorPaginatedFullCusQuery = ({
 				SELECT i.internal_customer_id, row_to_json(i) AS row_json
 				FROM cr
 				JOIN LATERAL (
-					SELECT i.*
+					SELECT i.*, ${resolvedProductIdsSql({ invoiceAlias: "i" })} AS resolved_product_ids
 					FROM invoices i
 					WHERE i.internal_customer_id = cr.internal_id
 					ORDER BY i.created_at DESC, i.id DESC

--- a/server/src/internal/customers/cusProducts/CusProdReadService.ts
+++ b/server/src/internal/customers/cusProducts/CusProdReadService.ts
@@ -12,25 +12,16 @@ export class CusProdReadService {
 	static async existsForProduct({
 		db,
 		internalProductId,
-		productId,
 	}: {
 		db: DrizzleCli;
-		internalProductId?: string;
-		productId?: string;
+		internalProductId: string;
 	}) {
 		const result = await db
 			.select({
 				id: customerProducts.id,
 			})
 			.from(customerProducts)
-			.where(
-				and(
-					productId ? eq(customerProducts.product_id, productId) : undefined,
-					internalProductId
-						? eq(customerProducts.internal_product_id, internalProductId)
-						: undefined,
-				),
-			)
+			.where(eq(customerProducts.internal_product_id, internalProductId))
 			.limit(1);
 
 		return result.length > 0;

--- a/server/src/internal/customers/getFullCusQuery.ts
+++ b/server/src/internal/customers/getFullCusQuery.ts
@@ -8,6 +8,7 @@ import {
 } from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
+import { resolvedProductIdsSql } from "@/internal/invoices/repos/utils/resolvedProductIdsSql.js";
 import { looseEntitlementIsLiveSql } from "./looseEntitlementSql.js";
 
 const RECURRING_BILLING_INTERVALS = [
@@ -152,7 +153,15 @@ const dashboardProductFilterToCustomerListSql = (
 	{ orgId, env }: { orgId?: string; env?: string } = {},
 ): SQL =>
 	isCustomDashboardProductFilter(filter)
-		? sql`(cp_dash.product_id = ${filter.productId} AND cp_dash.is_custom = true)`
+		? orgId && env
+			? sql`(cp_dash.internal_product_id IN (
+					SELECT p_lookup.internal_id
+					FROM products p_lookup
+					WHERE p_lookup.org_id = ${orgId}
+						AND p_lookup.env = ${env}
+						AND p_lookup.id = ${filter.productId}
+				) AND cp_dash.is_custom = true)`
+			: sql`(p_dash.id = ${filter.productId} AND cp_dash.is_custom = true)`
 		: orgId && env
 			? sql`cp_dash.internal_product_id IN (
 					SELECT p_lookup.internal_id
@@ -457,7 +466,7 @@ const buildInvoicesCTE = (hasEntityCTE: boolean) => {
           '[]'::json
         ) AS invoices
       FROM (
-        SELECT *
+        SELECT i.*, ${resolvedProductIdsSql({ invoiceAlias: "i" })} AS resolved_product_ids
         FROM invoices i
         WHERE i.internal_customer_id = (SELECT internal_id FROM customer_record)
         ${entityFilter}
@@ -953,7 +962,7 @@ export const getPaginatedFullCusQuery = ({
         ) AS invoices
       FROM customer_records cr
       LEFT JOIN LATERAL (
-        SELECT *
+        SELECT i.*, ${resolvedProductIdsSql({ invoiceAlias: "i" })} AS resolved_product_ids
         FROM invoices i
         WHERE i.internal_customer_id = cr.internal_id
         ORDER BY i.created_at DESC, i.id DESC
@@ -1152,7 +1161,6 @@ export const getCustomerListFilterSql = ({
 	const hasStatus = statusFilters && statusFilters.length > 0;
 	const hasProductFilter = productFilters.length > 0;
 	const hasInterval = intervals.length > 0;
-	const hasVersion = productFilters.some(isVersionDashboardProductFilter);
 	const canUseProductCandidateSet =
 		orgId && env && productFilters.every(isVersionDashboardProductFilter);
 	if (hasStatus || hasProductFilter || hasInterval) {
@@ -1182,10 +1190,17 @@ export const getCustomerListFilterSql = ({
 					case "free_trial":
 						return sql`(cp_dash.trial_ends_at > ${Date.now()} AND cp_dash.free_trial_id IS NOT NULL AND cp_dash.canceled_at IS NULL AND (cp_dash.status = ${CusProductStatus.Active} OR cp_dash.status = ${CusProductStatus.PastDue}))`;
 					case "expired":
+						// "Same plan" = same public product id (any version), resolved
+						// through the products join rather than the denormalized
+						// customer_products.product_id snapshot.
 						return sql`(cp_dash.status = ${CusProductStatus.Expired} AND cp_dash.canceled_at IS NULL AND NOT EXISTS (
 							SELECT 1 FROM customer_products cp_alias
+							JOIN products p_alias ON p_alias.internal_id = cp_alias.internal_product_id
+							JOIN products p_cur ON p_cur.internal_id = cp_dash.internal_product_id
 							WHERE cp_alias.internal_customer_id = cp_dash.internal_customer_id
-								AND cp_alias.product_id = cp_dash.product_id
+								AND p_alias.id = p_cur.id
+								AND p_alias.org_id = p_cur.org_id
+								AND p_alias.env = p_cur.env
 								AND (cp_alias.status = ${CusProductStatus.Active} OR cp_alias.status = ${CusProductStatus.PastDue})
 						))`;
 					default:
@@ -1216,7 +1231,7 @@ export const getCustomerListFilterSql = ({
 		}
 
 		const joinProducts =
-			hasVersion && !(orgId && env)
+			hasProductFilter && !(orgId && env)
 				? sql`JOIN products p_dash ON cp_dash.internal_product_id = p_dash.internal_id`
 				: sql``;
 

--- a/server/src/internal/customers/internalHandlers/handleSearchCustomers.ts
+++ b/server/src/internal/customers/internalHandlers/handleSearchCustomers.ts
@@ -72,7 +72,9 @@ export const handleSearchCustomers = createRoute({
 			customer_products: c.customer_products.map((cp: FullCusProduct) => ({
 				id: cp.id,
 				internal_product_id: cp.internal_product_id,
-				product_id: cp.product_id,
+				// Live plan id from the joined product (stays correct across renames),
+				// not the denormalized customer_products.product_id snapshot.
+				product_id: cp.product?.id ?? cp.product_id,
 				canceled_at: cp.canceled_at,
 				status: cp.status,
 				trial_ends_at: cp.trial_ends_at,

--- a/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
+++ b/server/src/internal/customers/repos/getFullSubject/getFullSubjectRowsQuery.ts
@@ -5,6 +5,7 @@ import {
 } from "@autumn/shared";
 import { type SQL, sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
+import { resolvedProductIdsSql } from "@/internal/invoices/repos/utils/resolvedProductIdsSql.js";
 import { notLicenseAssignmentSql } from "@/internal/licenses/repos/licenseAssignmentRepo.js";
 import { looseEntitlementIsLiveSql } from "../../looseEntitlementSql.js";
 import { composeCustomerLicensesCtes } from "./composeCustomerLicensesCtes.js";
@@ -167,7 +168,7 @@ export const getFullSubjectRowsQuery = ({
 		? sql`,
 
 		customer_invoices AS (
-			SELECT *
+			SELECT i.*, ${resolvedProductIdsSql({ invoiceAlias: "i" })} AS resolved_product_ids
 			FROM invoices i
 			WHERE i.internal_customer_id IN (
 				SELECT internal_customer_id

--- a/server/src/internal/invoices/InvoiceService.ts
+++ b/server/src/internal/invoices/InvoiceService.ts
@@ -25,6 +25,7 @@ import { Autumn } from "autumn-js";
 import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { resolvedProductIdsForColumn } from "./repos/utils/resolvedProductIdsSql.js";
 
 export const processInvoice = ({
 	invoice,
@@ -39,8 +40,10 @@ export const processInvoice = ({
 	const isStripe = processorType === ProcessorType.Stripe;
 
 	return {
-		// product_ids: invoice.product_ids,
-		plan_ids: invoice.product_ids,
+		// Current ids from the hydration query; snapshot if nothing resolved.
+		plan_ids: invoice.resolved_product_ids?.length
+			? invoice.resolved_product_ids
+			: (invoice.product_ids ?? []),
 		stripe_id: invoice.stripe_id,
 		processor_type: processorType,
 		status: invoice.status ?? "",
@@ -161,6 +164,9 @@ export class InvoiceService {
 		const results = await ctx.db
 			.select({
 				invoice: invoices,
+				resolved_product_ids: resolvedProductIdsForColumn({
+					internalProductIds: invoices.internal_product_ids,
+				}),
 				customer_id: customers.id,
 				entity_id: entities.id,
 			})
@@ -175,11 +181,16 @@ export class InvoiceService {
 			.limit(query.limit + 1);
 
 		const hasMore = results.length > query.limit;
-		const rows = (hasMore ? results.slice(0, query.limit) : results) as {
-			invoice: Invoice;
-			customer_id: string | null;
-			entity_id: string | null;
-		}[];
+		const rows = (hasMore ? results.slice(0, query.limit) : results).map(
+			(row) => ({
+				invoice: {
+					...row.invoice,
+					resolved_product_ids: row.resolved_product_ids,
+				} as Invoice,
+				customer_id: row.customer_id,
+				entity_id: row.entity_id,
+			}),
+		);
 
 		const last = rows[rows.length - 1];
 		const nextCursor =
@@ -247,18 +258,31 @@ export class InvoiceService {
 		internalEntityId?: string;
 		limit?: number;
 	}) {
-		return (await db.query.invoices.findMany({
-			where: and(
-				eq(invoices.internal_customer_id, internalCustomerId),
-				internalEntityId
-					? or(
-							eq(invoices.internal_entity_id, internalEntityId),
-							isNull(invoices.internal_entity_id),
-						)
-					: undefined,
-			),
-			orderBy: [desc(invoices.created_at), desc(invoices.id)],
-			limit,
+		const rows = await db
+			.select({
+				invoice: invoices,
+				resolved_product_ids: resolvedProductIdsForColumn({
+					internalProductIds: invoices.internal_product_ids,
+				}),
+			})
+			.from(invoices)
+			.where(
+				and(
+					eq(invoices.internal_customer_id, internalCustomerId),
+					internalEntityId
+						? or(
+								eq(invoices.internal_entity_id, internalEntityId),
+								isNull(invoices.internal_entity_id),
+							)
+						: undefined,
+				),
+			)
+			.orderBy(desc(invoices.created_at), desc(invoices.id))
+			.limit(limit);
+
+		return rows.map((row) => ({
+			...row.invoice,
+			resolved_product_ids: row.resolved_product_ids,
 		})) as Invoice[];
 	}
 

--- a/server/src/internal/invoices/invoiceUtils.ts
+++ b/server/src/internal/invoices/invoiceUtils.ts
@@ -109,17 +109,14 @@ export const insertInvoiceFromAttach = async ({
 	}
 };
 
-export const invoicesToResponse = ({ invoices }: { invoices: Invoice[] }) => {
-	const response = invoices.map((i) =>
+export const invoicesToResponse = ({ invoices }: { invoices: Invoice[] }) =>
+	invoices.map((i) =>
 		processInvoice({
 			invoice: i,
 			withItems: false,
 			features: [],
 		}),
 	);
-
-	return response;
-};
 
 export const getInvoiceItems = async ({
 	stripeInvoice,

--- a/server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts
+++ b/server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts
@@ -1,0 +1,27 @@
+import { type AnyColumn, sql } from "drizzle-orm";
+
+/**
+ * Current public plan ids for an invoice row, resolved from
+ * `internal_product_ids` via the products table. NULL when nothing
+ * resolves (legacy rows / deleted products) — consumers fall back to
+ * the `product_ids` snapshot.
+ */
+export const resolvedProductIdsSql = ({
+	invoiceAlias,
+}: {
+	invoiceAlias: string;
+}) => sql<string[] | null>`(
+	SELECT array_agg(DISTINCT rp.id)
+	FROM products rp
+	WHERE rp.internal_id = ANY(${sql.raw(`${invoiceAlias}.internal_product_ids`)})
+)`;
+
+export const resolvedProductIdsForColumn = ({
+	internalProductIds,
+}: {
+	internalProductIds: AnyColumn;
+}) => sql<string[] | null>`(
+	SELECT array_agg(DISTINCT rp.id)
+	FROM products rp
+	WHERE rp.internal_id = ANY(${internalProductIds})
+)`;

--- a/server/src/internal/migrations/v2/handlers/handlePreviewMigrationFilter.ts
+++ b/server/src/internal/migrations/v2/handlers/handlePreviewMigrationFilter.ts
@@ -227,7 +227,9 @@ async function enrichCustomers(db: DrizzleCli, ids: string[]) {
 			customer_product: {
 				id: customerProducts.id,
 				internal_product_id: customerProducts.internal_product_id,
-				product_id: customerProducts.product_id,
+				// Live plan id from the products join (stays correct across renames),
+				// not the denormalized customer_products.product_id snapshot.
+				product_id: products.id,
 				canceled_at: customerProducts.canceled_at,
 				status: customerProducts.status,
 				trial_ends_at: customerProducts.trial_ends_at,

--- a/server/src/internal/products/handlers/handleGetPlanDeleteInfo.ts
+++ b/server/src/internal/products/handlers/handleGetPlanDeleteInfo.ts
@@ -23,9 +23,11 @@ export const handleGetPlanDeleteInfo = createRoute({
 		}
 
 		const [allVersions, latestVersion, deletionText] = await Promise.all([
-			CusProdReadService.existsForProduct({
+			CusProdReadService.existsForProductVersions({
 				db,
 				productId: product_id,
+				orgId: org.id,
+				env,
 			}),
 			CusProdReadService.existsForProduct({
 				db,

--- a/server/src/internal/products/handlers/handleGetProductDeleteInfo.ts
+++ b/server/src/internal/products/handlers/handleGetProductDeleteInfo.ts
@@ -24,9 +24,11 @@ export const handleGetProductDeleteInfo = createRoute({
 		}
 
 		const [allVersions, latestVersion, deletionText] = await Promise.all([
-			CusProdReadService.existsForProduct({
+			CusProdReadService.existsForProductVersions({
 				db,
 				productId,
+				orgId: org.id,
+				env,
 			}),
 			CusProdReadService.existsForProduct({
 				db,

--- a/server/src/utils/importUtils/addProductFromSubs.ts
+++ b/server/src/utils/importUtils/addProductFromSubs.ts
@@ -48,7 +48,7 @@ export const addProductFromSubs = async ({
 	const mainCusProduct = cusProducts.find(
 		(cp) =>
 			!cp.product.is_add_on &&
-			cp.product_id === autumnProduct.id &&
+			cp.product.id === autumnProduct.id &&
 			(notNullish(entity)
 				? cp.internal_entity_id === entity!.internal_id
 				: true),

--- a/server/src/utils/scriptUtils/testUtils/createSharedProduct.ts
+++ b/server/src/utils/scriptUtils/testUtils/createSharedProduct.ts
@@ -3,6 +3,7 @@ import {
 	customerProducts,
 	customers,
 	type ProductV2,
+	products as productsTable,
 } from "@autumn/shared";
 import { createProducts } from "@tests/utils/productUtils.js";
 import type { TestContext } from "@tests/utils/testInitUtils/createTestContext.js";
@@ -19,16 +20,29 @@ export const createSharedProducts = async ({
 }) => {
 	const { db } = ctx;
 
-	let cusProducts = await ctx.db.query.customerProducts.findMany({
-		where: inArray(
-			customerProducts.product_id,
-			products.map((p) => p.id),
+	const productRows = await ctx.db.query.products.findMany({
+		where: and(
+			inArray(
+				productsTable.id,
+				products.map((p) => p.id),
+			),
+			eq(productsTable.org_id, ctx.org.id),
+			eq(productsTable.env, ctx.env),
 		),
-		with: {
-			product: true,
-		},
 	});
-	cusProducts = cusProducts.filter((cp) => cp.product.org_id === ctx.org.id);
+
+	const cusProducts =
+		productRows.length > 0
+			? await ctx.db.query.customerProducts.findMany({
+					where: inArray(
+						customerProducts.internal_product_id,
+						productRows.map((p) => p.internal_id),
+					),
+					with: {
+						product: true,
+					},
+				})
+			: [];
 
 	if (cusProducts.length > 10) {
 		throw new Error("Too many customers under shared default free product");

--- a/server/tests/unit/customers/dashboard-product-filter.test.ts
+++ b/server/tests/unit/customers/dashboard-product-filter.test.ts
@@ -38,10 +38,37 @@ describe("dashboard product filters", () => {
 			}),
 		);
 
-		expect(normalize(query)).toContain("cp_dash.product_id = $3");
+		// Without org scope the plan id resolves through the products join,
+		// never the denormalized customer_products.product_id snapshot.
+		expect(normalize(query)).toContain("p_dash.id = $3");
 		expect(normalize(query)).toContain("cp_dash.is_custom = true");
-		expect(normalize(query)).not.toContain("JOIN products p_dash");
+		expect(normalize(query)).toContain("JOIN products p_dash");
+		expect(normalize(query)).not.toContain("cp_dash.product_id");
 		expect(params).toEqual(["active", "past_due", "pro"]);
+	});
+
+	test("org-scoped custom plan selection resolves internal product ids", () => {
+		const { sql: query, params } = render(
+			getCustomerListFilterSql({
+				orgId: "org_target",
+				env: AppEnv.Live,
+				productVersionFilters: [{ productId: "pro", custom: true }],
+			}),
+		);
+
+		const normalized = normalize(query);
+		expect(normalized).toContain("cp_dash.internal_product_id IN");
+		expect(normalized).toContain("p_lookup.org_id =");
+		expect(normalized).toContain("p_lookup.env =");
+		expect(normalized).toContain("cp_dash.is_custom = true");
+		expect(normalized).not.toContain("cp_dash.product_id");
+		expect(params).toEqual([
+			"active",
+			"past_due",
+			"org_target",
+			AppEnv.Live,
+			"pro",
+		]);
 	});
 
 	test("custom and numbered selections share the product filter group", () => {

--- a/server/tests/unit/invoices/processInvoice.test.ts
+++ b/server/tests/unit/invoices/processInvoice.test.ts
@@ -125,3 +125,33 @@ describe("processInvoice — hosted_invoice_url processor gating", () => {
 		);
 	});
 });
+
+describe("processInvoice — plan_ids from hydration", () => {
+	test("resolved_product_ids wins over the snapshot", () => {
+		const wire = processInvoice({
+			invoice: buildBaseInvoice({
+				product_ids: ["pro"],
+				internal_product_ids: ["prod_abc"],
+				resolved_product_ids: ["pro-new"],
+			}),
+		});
+		expect(wire.plan_ids).toEqual(["pro-new"]);
+	});
+
+	test("empty resolved_product_ids falls back to the snapshot", () => {
+		const wire = processInvoice({
+			invoice: buildBaseInvoice({
+				product_ids: ["pro"],
+				resolved_product_ids: [],
+			}),
+		});
+		expect(wire.plan_ids).toEqual(["pro"]);
+	});
+
+	test("missing resolved_product_ids falls back to the snapshot", () => {
+		const wire = processInvoice({
+			invoice: buildBaseInvoice({ product_ids: ["pro"] }),
+		});
+		expect(wire.plan_ids).toEqual(["pro"]);
+	});
+});

--- a/shared/models/cusModels/invoiceModels/invoiceModels.ts
+++ b/shared/models/cusModels/invoiceModels/invoiceModels.ts
@@ -32,6 +32,8 @@ export const InvoiceSchema = z.object({
 	internal_entity_id: z.string().nullable(),
 	product_ids: z.array(z.string()),
 	internal_product_ids: z.array(z.string()),
+	/** Read-time only: current public plan ids from internal_product_ids. */
+	resolved_product_ids: z.array(z.string()).nullish(),
 
 	// Stripe fields
 	stripe_id: z.string(),

--- a/shared/models/cusProductModels/cusProductModels.ts
+++ b/shared/models/cusProductModels/cusProductModels.ts
@@ -33,6 +33,9 @@ export const BillingCycleAnchorConfig = z.object({
 export const CusProductSchema = z.object({
 	id: z.string(),
 	internal_product_id: z.string(),
+	/** @deprecated Snapshot of the public plan id at write time. Do not
+	 * read or match on this — use `internal_product_id`, or the live
+	 * `product.id` from the products join. */
 	product_id: z.string(),
 	internal_customer_id: z.string(),
 	customer_id: z.string().nullish(),

--- a/shared/models/cusProductModels/cusProductTable.ts
+++ b/shared/models/cusProductModels/cusProductTable.ts
@@ -40,6 +40,9 @@ export const customerProducts = pgTable(
 		starts_at: numeric({ mode: "number" }),
 		access_starts_at: numeric({ mode: "number" }),
 		options: jsonb().array(),
+		/** @deprecated Snapshot of the public plan id at write time. Do not
+		 * read or match on this — use `internal_product_id`, or the live
+		 * `product.id` from the products join. */
 		product_id: text("product_id"),
 		free_trial_id: text("free_trial_id"),
 		trial_ends_at: numeric({ mode: "number" }),


### PR DESCRIPTION
A later planId rename can flip products.id without rewriting millions of customer_products rows.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve current plan IDs from the canonical products table via internal_product_id instead of denormalized snapshots. Old behavior returned snapshot plan IDs; new behavior returns current IDs at read time and falls back to the snapshot only when none resolve, making plan-ID renames safe without rewriting customer rows.

- Invoice reads hydrate resolved_product_ids across queries and `InvoiceService`; `processInvoice` sets `plan_ids` from resolved_product_ids, else uses the snapshot.
- Dashboard product filters and “expired/same plan” checks compare by `products.id` via joins. Org/env‑scoped filters resolve public IDs to internal_product_id; unscoped filters join `products`.
- Replace `customer_products.product_id` reads with the joined `product.id` in runtime checks, logs, attach/import paths, and API responses; add `resolved_product_ids` to the invoice model and deprecate `customer_products.product_id`.
- Product deletion safety checks detect any version in use; `existsForProduct` matches only on internal_product_id.

Required migration: stop matching on `customer_products.product_id`. Persist `internal_product_id` and compare against the joined `product.id`. No data rewrites required.

<sup>Written for commit bf7557bbd218aa3cf86e233b3c6324355246085a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes customer and invoice reads to resolve current public plan IDs through canonical product records instead of stale snapshots.
- **Bug fixes, API changes:** Hydrates invoice responses with current plan IDs and updates customer filtering and projections to follow renamed plans.
- **Improvements:** Makes product usage and deletion checks rely on stable internal product identities and marks the old customer-product plan ID snapshot as deprecated.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because invoice reads can omit plans and can change the order or multiplicity of an invoice's plan IDs.

Invoice hydration replaces the stored snapshot whenever any product resolves, which still loses deleted plans, while its DISTINCT unordered aggregation can also collapse repeated plans or reorder multi-plan invoices.

**Files Needing Attention:** server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts, server/src/internal/invoices/InvoiceService.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts | Adds canonical invoice plan-ID resolution, but partial matches still drop deleted plans and DISTINCT aggregation loses stored order and multiplicity. |
| server/src/internal/invoices/InvoiceService.ts | Wires resolved IDs into invoice reads and prefers them over snapshots, exposing incomplete or reshaped aggregate results. |
| server/src/internal/customers/getFullCusQuery.ts | Resolves invoice plan IDs in customer queries and updates plan filtering to use canonical product identities. |
| shared/models/cusModels/invoiceModels/invoiceModels.ts | Adds the nullable read-time resolved_product_ids field to the shared invoice model. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  I[Invoice internal_product_ids] --> R[Resolve through products]
  R --> P[resolved_product_ids]
  P --> A[API plan_ids]
  R -. missing product .-> S[Snapshot fallback]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/invoices/repos/utils/resolvedProductIdsSql.ts:14
**Resolved plan arrays lose shape**

When an invoice contains multiple ordered plan IDs or repeats a plan, `array_agg(DISTINCT rp.id)` removes duplicates and does not preserve the stored array order, causing later invoice reads to return different `plan_ids` than the insertion response. For example, `["pro", "pro", "free"]` is returned without the repeated `pro`, while a duplicate-free multi-plan invoice can return its plans in a different order.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: resolve current plan ids from produ..."](https://github.com/useautumn/autumn/commit/bf7557bbd218aa3cf86e233b3c6324355246085a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55827922)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)
- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)
- Knowledge Base — [Database schema, relations, and migrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/database-schema-and-migrations.md)
</details>


<!-- /greptile_comment -->