### PR TITLE
feat: rename plan ids in one statement without rewriting customer_products

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan.ts
@@ -1,0 +1,25 @@
+import type { UpdateCatalogParams } from "@autumn/shared";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/renameProductPlan";
+
+/**
+ * One rename per existing plan with a differing new_plan_id. Creates carry
+ * the new id on the row itself — no references exist yet, nothing to move.
+ */
+export const computeRenameProductIdsPlan = ({
+	params,
+	productStatesContext,
+}: {
+	params: UpdateCatalogParams;
+	productStatesContext: ProductStatesContext;
+}): RenameProductPlan[] =>
+	params.plans.flatMap((planParams) => {
+		if (!planParams.new_plan_id) return [];
+		if (planParams.new_plan_id === planParams.plan_id) return [];
+
+		const versions =
+			productStatesContext.versionsByPlanId[planParams.plan_id] ?? [];
+		if (versions.length === 0) return [];
+
+		return [{ planId: planParams.plan_id, toId: planParams.new_plan_id }];
+	});

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpdateCatalogPlan.ts
@@ -7,6 +7,7 @@ import { computeInsertFeaturesPlan } from "@/internal/catalogV2/actions/updateCa
 import { computeMigrationDraftPlans } from "@/internal/catalogV2/actions/updateCatalog/compute/computeMigrationDraftPlans/computeMigrationDraftPlans";
 import { computeRemoveFeaturesPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeRemoveFeaturesPlan/computeRemoveFeaturesPlan";
 import { computeRemoveProductsPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/computeRemoveProductsPlan";
+import { computeRenameProductIdsPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeRenameProductIdsPlan/computeRenameProductIdsPlan";
 import { computeUpdateFeaturesPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpdateFeaturesPlan/computeUpdateFeaturesPlan";
 import { computeUpsertProductsPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -87,6 +88,10 @@ export const computeUpdateCatalogPlan = ({
 	const plan = compute.toPlan();
 	return {
 		...plan,
+		renamePlans: computeRenameProductIdsPlan({
+			params,
+			productStatesContext: catalogContext.productStatesContext,
+		}),
 		migrationDrafts: computeMigrationDraftPlans({
 			upsertProductPlans: plan.upsertProducts,
 			params,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -10,7 +10,7 @@ import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCa
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 
 /** Throws on anything that should fail the whole batch before any write. */
-export const handleUpdateCatalogErrors = ({
+export const handleUpdateCatalogErrors = async ({
 	ctx,
 	catalogContext,
 	updateCatalogPlan,
@@ -20,7 +20,7 @@ export const handleUpdateCatalogErrors = ({
 	catalogContext: UpdateCatalogContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 	params: UpdateCatalogParams;
-}): void => {
+}): Promise<void> => {
 	handleUpdateFeatureErrors({ ctx, catalogContext, updateCatalogPlan });
 	handleRemoveFeatureErrors({ updateCatalogPlan });
 	handleRemovePlanErrors({
@@ -31,7 +31,8 @@ export const handleUpdateCatalogErrors = ({
 		params,
 		productStatesContext: catalogContext.productStatesContext,
 	});
-	handleUpsertProductRenameErrors({
+	await handleUpsertProductRenameErrors({
+		ctx,
 		params,
 		productStatesContext: catalogContext.productStatesContext,
 		updateCatalogPlan,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors.ts
@@ -1,11 +1,12 @@
 import {
 	ErrCode,
-	productKeyToString,
 	RecaseError,
 	type UpdateCatalogParams,
 } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+import { hasVercelCustomerOnProduct } from "@/internal/customers/cusProducts/repos/hasVercelCustomerOnProduct";
 
 /**
  * Ids a rename may not take: every id in the projected catalog and every
@@ -47,18 +48,24 @@ const takenPlanIdsForRename = ({
 	]);
 };
 
-/** Block new_plan_id when occupied, or when any version has customers or reward programs. */
-export const handleUpsertProductRenameErrors = ({
+/**
+ * Block new_plan_id when the target id is occupied, or when a Vercel-installed
+ * customer is live on the plan (its id is their Vercel billing plan id).
+ */
+export const handleUpsertProductRenameErrors = async ({
+	ctx,
 	params,
 	productStatesContext,
 	updateCatalogPlan,
 }: {
+	ctx: AutumnContext;
 	params: UpdateCatalogParams;
 	productStatesContext: ProductStatesContext;
 	updateCatalogPlan: UpdateCatalogPlan;
-}): void => {
+}): Promise<void> => {
 	for (const planParams of params.plans) {
 		if (!planParams.new_plan_id) continue;
+		if (planParams.new_plan_id === planParams.plan_id) continue;
 
 		if (
 			takenPlanIdsForRename({
@@ -75,31 +82,19 @@ export const handleUpsertProductRenameErrors = ({
 			});
 		}
 
-		const versions =
-			productStatesContext.versionsByPlanId[planParams.plan_id] ?? [];
-		const hasCustomers = versions.some((product) => {
-			const state =
-				productStatesContext.statesByPlanVersion[
-					productKeyToString({
-						productKey: { planId: product.id, version: product.version },
-					})
-				];
-			return state?.customerUsage.hasAnyCustomerProducts ?? false;
+		if (!ctx.org.processor_configs?.vercel) continue;
+
+		const hasVercelCustomer = await hasVercelCustomerOnProduct({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			internalProductIds: (
+				productStatesContext.versionsByPlanId[planParams.plan_id] ?? []
+			).map((product) => product.internal_id),
 		});
-
-		if (hasCustomers) {
+		if (hasVercelCustomer) {
 			throw new RecaseError({
-				message: `Cannot change product ID because it has existing customers (plan_id=${planParams.plan_id})`,
-				code: ErrCode.InvalidRequest,
-				statusCode: 400,
-			});
-		}
-
-		const rewardPrograms =
-			productStatesContext.rewardProgramsByPlanId[planParams.plan_id] ?? [];
-		if (rewardPrograms.length > 0) {
-			throw new RecaseError({
-				message: `Cannot change product ID because existing reward programs are linked to it (plan_id=${planParams.plan_id})`,
+				message: `Cannot change product ID while Vercel customers are subscribed to this plan (plan_id=${planParams.plan_id})`,
 				code: ErrCode.InvalidRequest,
 				statusCode: 400,
 			});

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/catalogComputeState.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/catalogComputeState.ts
@@ -50,6 +50,7 @@ export const toUpdateCatalogPlan = ({
 	state: CatalogComputeState;
 }): UpdateCatalogPlan => ({
 	...state.plan,
+	renamePlans: [],
 	migrationDrafts: [],
 	projected: state.projected,
 });

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/renameProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/renameProductPlan.ts
@@ -1,0 +1,9 @@
+/**
+ * Plan-scoped id change — every version row moves, plus plan-id references
+ * (reward programs, rewards, RevenueCat mappings). customer_products.product_id
+ * stays untouched: it is a historical snapshot, readers match on internal ids.
+ */
+export type RenameProductPlan = {
+	planId: string;
+	toId: string;
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan.ts
@@ -1,5 +1,6 @@
 import type { CatalogMigration, Feature, FullProduct } from "@autumn/shared";
 import type { ProjectedCatalog } from "@/internal/catalogV2/actions/updateCatalog/types/catalogComputeState";
+import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/renameProductPlan";
 import type { UpdateFeaturePlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateFeaturePlan";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 
@@ -35,6 +36,8 @@ export type UpdateCatalogPlan = {
 	removeFeatures: RemoveFeaturePlan[];
 	/** Ordered product-row ops — create / update / none (execute order). */
 	upsertProducts: UpsertProductPlan[];
+	/** Plan-id changes — executed first so every later write sees the new id. */
+	renamePlans: RenameProductPlan[];
 	removePlans: RemovePlanPlan[];
 	/** At most one draft covering every requesting plan; empty when none qualify. */
 	migrationDrafts: CatalogMigration[];

--- a/server/src/internal/catalogV2/actions/updateCatalog/updateCatalogV2.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/updateCatalogV2.ts
@@ -56,7 +56,7 @@ export async function updateCatalogV2({
 	});
 
 	// 3. Errors
-	handleUpdateCatalogErrors({
+	await handleUpdateCatalogErrors({
 		ctx,
 		catalogContext,
 		updateCatalogPlan,

--- a/server/src/internal/catalogV2/execute/executeRenamePlans.ts
+++ b/server/src/internal/catalogV2/execute/executeRenamePlans.ts
@@ -1,0 +1,92 @@
+import { type SQL, sql } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import type { RenameProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/renameProductPlan";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+
+/**
+ * One statement of data-modifying CTEs = the whole rename is atomic without a
+ * long transaction. Moves every version row of the plan (including siblings
+ * outside this batch) plus every plan-id reference. Same-table touches are
+ * merged — Postgres rejects updating a row twice in one statement.
+ */
+const buildPlanRenameSql = ({
+	orgId,
+	env,
+	renamePlan,
+}: {
+	orgId: string;
+	env: string;
+	renamePlan: RenameProductPlan;
+}): SQL => {
+	const { planId, toId } = renamePlan;
+
+	return sql`
+		WITH upd_products AS (
+			UPDATE products
+			SET id = ${toId}
+			WHERE org_id = ${orgId} AND env = ${env} AND id = ${planId}
+			RETURNING 1
+		),
+		upd_reward_programs AS (
+			UPDATE reward_programs
+			SET product_ids = array_replace(product_ids, ${planId}, ${toId})
+			WHERE org_id = ${orgId} AND env = ${env}
+				AND ${planId} = ANY(product_ids)
+			RETURNING 1
+		),
+		upd_rewards AS (
+			UPDATE rewards
+			SET
+				free_product_id = CASE
+					WHEN free_product_id = ${planId} THEN ${toId}
+					ELSE free_product_id
+				END,
+				discount_config = CASE
+					WHEN discount_config -> 'product_ids' ? ${planId}
+					THEN jsonb_set(
+						discount_config,
+						'{product_ids}',
+						(
+							SELECT to_jsonb(array_agg(
+								CASE WHEN elem = ${planId} THEN ${toId} ELSE elem END
+							))
+							FROM jsonb_array_elements_text(discount_config -> 'product_ids') AS elem
+						)
+					)
+					ELSE discount_config
+				END
+			WHERE org_id = ${orgId} AND env = ${env}
+				AND (
+					free_product_id = ${planId}
+					OR discount_config -> 'product_ids' ? ${planId}
+				)
+			RETURNING 1
+		),
+		upd_revenuecat_mappings AS (
+			UPDATE revenuecat_mappings
+			SET autumn_product_id = ${toId}
+			WHERE org_id = ${orgId} AND env = ${env}
+				AND autumn_product_id = ${planId}
+			RETURNING 1
+		)
+		SELECT 1
+	`;
+};
+
+export const executeRenamePlans = async ({
+	ctx,
+	updateCatalogPlan,
+}: {
+	ctx: AutumnContext;
+	updateCatalogPlan: UpdateCatalogPlan;
+}) => {
+	for (const renamePlan of updateCatalogPlan.renamePlans) {
+		await ctx.db.execute(
+			buildPlanRenameSql({
+				orgId: ctx.org.id,
+				env: ctx.env,
+				renamePlan,
+			}),
+		);
+	}
+};

--- a/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
+++ b/server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts
@@ -13,6 +13,7 @@ import {
 import { initStripeResourcesForCatalog } from "@/internal/catalogV2/execute/executeInitStripeResources/initStripeResourcesForCatalog";
 import { executeMigrationDrafts } from "@/internal/catalogV2/execute/executeMigrationDrafts";
 import { executeRemovePlans } from "@/internal/catalogV2/execute/executeRemovePlans";
+import { executeRenamePlans } from "@/internal/catalogV2/execute/executeRenamePlans";
 import { executeUpsertProducts } from "@/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts";
 import { queueRewardMigrations } from "@/internal/catalogV2/execute/queueRewardMigrations";
 import { FeatureService } from "@/internal/features/FeatureService.js";
@@ -158,6 +159,14 @@ export const executeUpdateCatalogPlan = async ({
 	updateCatalogPlan: UpdateCatalogPlan;
 	phases: CatalogPhases;
 }): Promise<CatalogResult> => {
+	// Identity moves first: atomic per plan, so a later failure can never
+	// leave references split between old and new ids.
+	await timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "execute.rename_plans",
+		run: () => executeRenamePlans({ ctx, updateCatalogPlan }),
+	});
 	await timeCatalogPhase({
 		ctx,
 		phases,

--- a/server/src/internal/customers/cusProducts/repos/hasVercelCustomerOnProduct.ts
+++ b/server/src/internal/customers/cusProducts/repos/hasVercelCustomerOnProduct.ts
@@ -1,0 +1,70 @@
+import {
+	type AppEnv,
+	customerProducts,
+	customers,
+	VERSIONABLE_CUSTOMER_STATUSES,
+} from "@autumn/shared";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+
+/**
+ * EXISTS: a live Vercel-installed customer sits on this product version.
+ * `->>` (not `->`) is required so Postgres uses idx_customers_processors_vercel;
+ * `->` has no stats and walks the plan's cusProduct rows instead.
+ */
+export const hasVercelCustomerOnProductQuery = ({
+	db,
+	orgId,
+	env,
+	internalProductId,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	internalProductId: string;
+}) =>
+	db
+		.select({ id: customerProducts.id })
+		.from(customers)
+		.innerJoin(
+			customerProducts,
+			eq(customerProducts.internal_customer_id, customers.internal_id),
+		)
+		.where(
+			and(
+				eq(customers.org_id, orgId),
+				eq(customers.env, env),
+				sql`${customers.processors} ->> 'vercel' IS NOT NULL`,
+				eq(customerProducts.internal_product_id, internalProductId),
+				inArray(customerProducts.status, VERSIONABLE_CUSTOMER_STATUSES),
+			),
+		)
+		.limit(1);
+
+export const hasVercelCustomerOnProduct = async ({
+	db,
+	orgId,
+	env,
+	internalProductIds,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	internalProductIds: string[];
+}): Promise<boolean> => {
+	if (internalProductIds.length === 0) return false;
+
+	const hits = await Promise.all(
+		internalProductIds.map(async (internalProductId) => {
+			const [row] = await hasVercelCustomerOnProductQuery({
+				db,
+				orgId,
+				env,
+				internalProductId,
+			});
+			return row != null;
+		}),
+	);
+
+	return hits.some(Boolean);
+};

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -148,6 +148,14 @@ free vs priced so the billing-model matrix stays navigable.
 | `new_plan_id` clean rename (no customers): id changes, versions & rows intact | ✓ |
 | auto_enable true on free plan → `is_default` persisted; auto_enable false clears | ✓ |
 
+### Rename with references — `update/rename-plan-refs.test.ts`
+
+| Case | Status |
+|---|---|
+| Rename with customers: every version row renamed (incl. siblings outside the batch); `customer_products.product_id` snapshot untouched, `internal_product_id` link intact | ✓ |
+| Rename rewrites `reward_programs.product_ids`, and `rewards.free_product_id` + `discount_config.product_ids` on ONE row (merged single UPDATE) | ✓ |
+| Rename rewrites `revenuecat_mappings.autumn_product_id` key | ✓ |
+
 ## 5. Item/price update lanes — `update/update-plan-items.test.ts`
 
 Omit-semantics + per-facet shape changes, no customers. Assert via
@@ -334,8 +342,7 @@ Preview `options` include `new_version` when the latest version has customers
 | Two unpinned entries for same plan_id → error | ✓ |
 | Version gap (declare v3 when max is v1) → error | ✓ |
 | Create without `name` → error | ✓ |
-| `new_plan_id` rename blocked when plan has customers | ✓ |
-| `new_plan_id` rename blocked when reward program references plan | ✓ |
+| `new_plan_id` rename blocked when a Vercel install is on the plan; allowed for other plans on the same Vercel org | ✓ |
 | Invalid item shape passes through Zod errors (amount+tiers both set; volume flat_amount on graduated; `tiers[0].to <= included`; proration on usage_based; reset/price interval mismatch on non-prepaid) | ✓ |
 
 ## 11. Plan × plan batch — `batch/batch-ops.test.ts`

--- a/server/tests/integration/catalog-v2/plans/update/rename-plan-refs.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/rename-plan-refs.test.ts
@@ -1,0 +1,215 @@
+/**
+ * catalogV2.update — new_plan_id with existing references. Renames move every
+ * version row plus plan-id refs (reward programs, rewards, RevenueCat
+ * mappings) atomically; customer_products.product_id stays as a historical
+ * snapshot and customers keep resolving via internal_product_id.
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	customerProducts,
+	products,
+	ResetInterval,
+	revenuecatMappings,
+	rewardPrograms,
+	rewards,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { and, eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+	expectDbPlansAbsent,
+} from "../utils/expectCatalogPlans.js";
+import {
+	cleanupRefs,
+	seedCustomerProductRef,
+	seedRevenueCatMappingRef,
+	seedRewardProgramRef,
+} from "../utils/seedPlanRefs.js";
+
+const getPlanVersionRows = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) =>
+	ctx.db
+		.select()
+		.from(products)
+		.where(
+			and(
+				eq(products.org_id, ctx.org.id),
+				eq(products.env, ctx.env),
+				eq(products.id, planId),
+			),
+		);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rename refs: rename with customers moves every version row, cus product snapshot untouched")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ren_cus");
+		const newPlanId = uniqueTestId("cv2_ren_cus_new");
+		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Rename With Customers",
+						price: { amount: 10, interval: BillingInterval.Month },
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 50,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+			const { cusProductId } = await seedCustomerProductRef({ ctx, planId });
+
+			// Mint a second version; the rename must move both rows.
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						items: [
+							{
+								feature_id: TestFeature.Messages,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+			});
+
+			await expectDbPlansAbsent({ ctx, planIds: [planId] });
+			const renamedRows = await getPlanVersionRows({ ctx, planId: newPlanId });
+			expect(renamedRows.map((row) => row.version).sort()).toEqual([1, 2]);
+			const renamedV1 = renamedRows.find((row) => row.version === 1);
+			expect(renamedV1).toBeDefined();
+
+			const [cusProduct] = await ctx.db
+				.select()
+				.from(customerProducts)
+				.where(eq(customerProducts.id, cusProductId));
+			expect(cusProduct.product_id).toBe(planId);
+			expect(cusProduct.internal_product_id).toBe(renamedV1!.internal_id);
+
+			await expectCatalogPlansCorrect({
+				autumn: autumnV2_3,
+				expected: [
+					{ id: newPlanId, name: "Rename With Customers", version: 2 },
+				],
+			});
+		} finally {
+			await cleanupRefs({ ctx, planIds: [planId, newPlanId] });
+			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rename refs: reward program, reward free_product_id + discount_config rewritten")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ren_rew");
+		const newPlanId = uniqueTestId("cv2_ren_rew_new");
+		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		let rewardId: string | undefined;
+		let programId: string | undefined;
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Reward Linked",
+						price: { amount: 20, interval: BillingInterval.Month },
+					},
+				],
+			});
+			({ rewardId, programId } = await seedRewardProgramRef({ ctx, planId }));
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+			});
+
+			const [program] = await ctx.db
+				.select()
+				.from(rewardPrograms)
+				.where(eq(rewardPrograms.id, programId!));
+			expect(program.product_ids).toEqual([newPlanId]);
+
+			// One reward row referencing the plan via both columns — proves the
+			// rewrite merges same-row touches into a single UPDATE.
+			const [reward] = await ctx.db
+				.select()
+				.from(rewards)
+				.where(eq(rewards.id, rewardId!));
+			expect(reward.free_product_id).toBe(newPlanId);
+			expect(reward.discount_config?.product_ids).toEqual([newPlanId]);
+		} finally {
+			await cleanupRefs({
+				ctx,
+				planIds: [planId, newPlanId],
+				rewardId,
+				programId,
+			});
+			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 rename refs: revenuecat mapping key rewritten")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_ren_rc");
+		const newPlanId = uniqueTestId("cv2_ren_rc_new");
+		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "RC Mapped" }],
+			});
+			await seedRevenueCatMappingRef({ ctx, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+			});
+
+			const mappings = await ctx.db
+				.select()
+				.from(revenuecatMappings)
+				.where(
+					and(
+						eq(revenuecatMappings.org_id, ctx.org.id),
+						eq(revenuecatMappings.env, ctx.env),
+					),
+				);
+			expect(
+				mappings.some((row) => row.autumn_product_id === newPlanId),
+			).toBe(true);
+			expect(
+				mappings.some((row) => row.autumn_product_id === planId),
+			).toBe(false);
+		} finally {
+			await cleanupRefs({ ctx, planIds: [planId, newPlanId] });
+			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/utils/seedPlanRefs.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/seedPlanRefs.ts
@@ -1,0 +1,196 @@
+/**
+ * Seeds rows that reference a plan by public id (customer products, reward
+ * programs, rewards, RevenueCat mappings) for rename / gate tests.
+ */
+
+import {
+	CouponDurationType,
+	CusProductStatus,
+	customerProducts,
+	customers,
+	RewardTriggerEvent,
+	RewardType,
+	revenuecatMappings,
+	rewardPrograms,
+	rewards,
+} from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+
+export const seedCustomerProductRef = async ({
+	ctx,
+	planId,
+	vercelInstall,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	/** Marks the customer as a Vercel install (customers.processors.vercel). */
+	vercelInstall?: boolean;
+}) => {
+	const full = await ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	const customerId = uniqueTestId("cv2_cus");
+	const internalCustomerId = generateId("cus");
+	const cusProductId = generateId("cus_prod");
+
+	await ctx.db.insert(customers).values({
+		internal_id: internalCustomerId,
+		id: customerId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		name: customerId,
+		email: `${customerId}@test.com`,
+		processors: vercelInstall
+			? {
+					vercel: {
+						installation_id: `icfg_${customerId}`,
+						access_token: "test_token",
+						account_id: `acct_${customerId}`,
+					},
+				}
+			: undefined,
+	});
+
+	await ctx.db.insert(customerProducts).values({
+		id: cusProductId,
+		internal_customer_id: internalCustomerId,
+		product_id: planId,
+		internal_product_id: full.internal_id,
+		status: CusProductStatus.Active,
+		created_at: Date.now(),
+		starts_at: Date.now(),
+		quantity: 1,
+		options: [],
+		is_custom: false,
+	});
+
+	return { customerId, internalCustomerId, cusProductId };
+};
+
+/** One reward referencing the plan via BOTH free_product_id and discount_config. */
+export const seedRewardProgramRef = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const rewardId = uniqueTestId("cv2_rew");
+	const internalRewardId = generateId("rew");
+	const programId = uniqueTestId("cv2_rp");
+	const internalProgramId = generateId("rp");
+
+	await ctx.db.insert(rewards).values({
+		internal_id: internalRewardId,
+		id: rewardId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		name: rewardId,
+		type: RewardType.PercentageDiscount,
+		free_product_id: planId,
+		discount_config: {
+			discount_value: 10,
+			duration_type: CouponDurationType.OneOff,
+			duration_value: 1,
+			apply_to_all: false,
+			product_ids: [planId],
+		},
+	});
+
+	await ctx.db.insert(rewardPrograms).values({
+		internal_id: internalProgramId,
+		id: programId,
+		org_id: ctx.org.id,
+		env: ctx.env,
+		created_at: Date.now(),
+		internal_reward_id: internalRewardId,
+		product_ids: [planId],
+		when: RewardTriggerEvent.Checkout,
+		max_redemptions: 1,
+		unlimited_redemptions: false,
+		exclude_trial: false,
+	});
+
+	return { rewardId, programId, internalRewardId, internalProgramId };
+};
+
+export const seedRevenueCatMappingRef = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	await ctx.db.insert(revenuecatMappings).values({
+		org_id: ctx.org.id,
+		env: ctx.env,
+		autumn_product_id: planId,
+		revenuecat_product_ids: [`rc_${planId}`],
+	});
+};
+
+export const deleteRevenueCatMappingRefs = async ({
+	ctx,
+	planIds,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+}) => {
+	for (const planId of planIds) {
+		await ctx.db
+			.delete(revenuecatMappings)
+			.where(
+				and(
+					eq(revenuecatMappings.org_id, ctx.org.id),
+					eq(revenuecatMappings.env, ctx.env),
+					eq(revenuecatMappings.autumn_product_id, planId),
+				),
+			);
+	}
+};
+
+export const cleanupRefs = async ({
+	ctx,
+	planIds,
+	rewardId,
+	programId,
+}: {
+	ctx: AutumnContext;
+	planIds: string[];
+	rewardId?: string;
+	programId?: string;
+}) => {
+	if (programId) {
+		await ctx.db.delete(rewardPrograms).where(eq(rewardPrograms.id, programId));
+	}
+	if (rewardId) {
+		await ctx.db.delete(rewards).where(eq(rewards.id, rewardId));
+	}
+
+	await deleteRevenueCatMappingRefs({ ctx, planIds });
+
+	for (const planId of planIds) {
+		const cusProds = await ctx.db
+			.select()
+			.from(customerProducts)
+			.where(eq(customerProducts.product_id, planId));
+
+		for (const row of cusProds) {
+			await ctx.db
+				.delete(customerProducts)
+				.where(eq(customerProducts.id, row.id));
+			await ctx.db
+				.delete(customers)
+				.where(eq(customers.internal_id, row.internal_customer_id));
+		}
+	}
+};

--- a/server/tests/integration/catalog-v2/plans/validation/plan-errors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/validation/plan-errors.test.ts
@@ -10,164 +10,22 @@ import { test } from "bun:test";
 import {
 	BillingInterval,
 	BillingMethod,
-	CouponDurationType,
-	CusProductStatus,
-	customerProducts,
-	customers,
 	ErrCode,
 	OnDecrease,
 	OnIncrease,
 	ResetInterval,
-	RewardTriggerEvent,
-	RewardType,
-	rewardPrograms,
-	rewards,
 	TierBehavior,
 	TierInfinite,
+	VercelMarketplaceMode,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
-import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
-import { eq } from "drizzle-orm";
-import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { ProductService } from "@/internal/products/ProductService.js";
-import { generateId } from "@/utils/genUtils.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 import { uniqueTestId } from "../../utils/uniqueTestId.js";
 import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
-
-const getFull = async ({
-	ctx,
-	planId,
-}: {
-	ctx: AutumnContext;
-	planId: string;
-}) =>
-	ProductService.getFull({
-		db: ctx.db,
-		idOrInternalId: planId,
-		orgId: ctx.org.id,
-		env: ctx.env,
-	});
-
-const seedCustomerProductRef = async ({
-	ctx,
-	planId,
-}: {
-	ctx: AutumnContext;
-	planId: string;
-}) => {
-	const full = await getFull({ ctx, planId });
-	const customerId = uniqueTestId("cv2_cus");
-	const internalCustomerId = generateId("cus");
-	const cusProductId = generateId("cus_prod");
-
-	await ctx.db.insert(customers).values({
-		internal_id: internalCustomerId,
-		id: customerId,
-		org_id: ctx.org.id,
-		env: ctx.env,
-		created_at: Date.now(),
-		name: customerId,
-		email: `${customerId}@test.com`,
-	});
-
-	await ctx.db.insert(customerProducts).values({
-		id: cusProductId,
-		internal_customer_id: internalCustomerId,
-		product_id: planId,
-		internal_product_id: full.internal_id,
-		status: CusProductStatus.Active,
-		created_at: Date.now(),
-		starts_at: Date.now(),
-		quantity: 1,
-		options: [],
-		is_custom: false,
-	});
-
-	return { customerId, internalCustomerId, cusProductId };
-};
-
-const seedRewardProgramRef = async ({
-	ctx,
-	planId,
-}: {
-	ctx: AutumnContext;
-	planId: string;
-}) => {
-	const rewardId = uniqueTestId("cv2_rew");
-	const internalRewardId = generateId("rew");
-	const programId = uniqueTestId("cv2_rp");
-	const internalProgramId = generateId("rp");
-
-	await ctx.db.insert(rewards).values({
-		internal_id: internalRewardId,
-		id: rewardId,
-		org_id: ctx.org.id,
-		env: ctx.env,
-		created_at: Date.now(),
-		name: rewardId,
-		type: RewardType.PercentageDiscount,
-		discount_config: {
-			discount_value: 10,
-			duration_type: CouponDurationType.OneOff,
-			duration_value: 1,
-			apply_to_all: false,
-			product_ids: [planId],
-		},
-	});
-
-	await ctx.db.insert(rewardPrograms).values({
-		internal_id: internalProgramId,
-		id: programId,
-		org_id: ctx.org.id,
-		env: ctx.env,
-		created_at: Date.now(),
-		internal_reward_id: internalRewardId,
-		product_ids: [planId],
-		when: RewardTriggerEvent.Checkout,
-		max_redemptions: 1,
-		unlimited_redemptions: false,
-		exclude_trial: false,
-	});
-
-	return { rewardId, programId, internalRewardId, internalProgramId };
-};
-
-const cleanupRefs = async ({
-	ctx,
-	planIds,
-	rewardId,
-	programId,
-}: {
-	ctx: AutumnContext;
-	planIds: string[];
-	rewardId?: string;
-	programId?: string;
-}) => {
-	if (programId) {
-		await ctx.db.delete(rewardPrograms).where(eq(rewardPrograms.id, programId));
-	}
-	if (rewardId) {
-		await ctx.db.delete(rewards).where(eq(rewards.id, rewardId));
-	}
-
-	for (const planId of planIds) {
-		const cusProds = await ctx.db
-			.select()
-			.from(customerProducts)
-			.where(eq(customerProducts.product_id, planId));
-
-		for (const row of cusProds) {
-			await ctx.db
-				.delete(customerProducts)
-				.where(eq(customerProducts.id, row.id));
-			await ctx.db
-				.delete(customers)
-				.where(eq(customers.internal_id, row.internal_customer_id));
-		}
-	}
-};
+import { cleanupRefs, seedCustomerProductRef } from "../utils/seedPlanRefs.js";
 
 test.concurrent(
 	`${chalk.yellowBright("catalogV2 plan-errors: new_version + explicit version → 400")}`,
@@ -381,68 +239,69 @@ test.concurrent(
 );
 
 test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-errors: new_plan_id blocked when plan has customers")}`,
+	`${chalk.yellowBright("catalogV2 plan-errors: new_plan_id blocked only for plans with Vercel installs")}`,
 	async () => {
-		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
-		const planId = uniqueTestId("cv2_err_ren_cus");
-		const newPlanId = uniqueTestId("cv2_err_ren_cus_new");
-		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
-		try {
-			await autumnV2_3.catalogV2.update({
-				plans: [{ plan_id: planId, name: "Rename Me" }],
-			});
-			await seedCustomerProductRef({ ctx, planId });
-
-			await expectAutumnError({
-				errCode: ErrCode.InvalidRequest,
-				func: () =>
-					autumnV2_3.catalogV2.update({
-						plans: [{ plan_id: planId, new_plan_id: newPlanId }],
-					}),
-			});
-		} finally {
-			await cleanupRefs({ ctx, planIds: [planId, newPlanId] });
-			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
-		}
-	},
-);
-
-test.concurrent(
-	`${chalk.yellowBright("catalogV2 plan-errors: new_plan_id blocked when reward program references plan")}`,
-	async () => {
-		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
-		const planId = uniqueTestId("cv2_err_ren_rp");
-		const newPlanId = uniqueTestId("cv2_err_ren_rp_new");
-		await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
-		let rewardId: string | undefined;
-		let programId: string | undefined;
+		// Sub-org: the gate reads org.processor_configs, which we mutate here.
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [s.platform.create({})],
+			actions: [],
+		});
+		const vercelPlanId = uniqueTestId("cv2_err_ren_vercel");
+		const vercelNewPlanId = uniqueTestId("cv2_err_ren_vercel_new");
+		const freePlanId = uniqueTestId("cv2_err_ren_novercel");
+		const freeNewPlanId = uniqueTestId("cv2_err_ren_novercel_new");
+		const allPlanIds = [
+			vercelPlanId,
+			vercelNewPlanId,
+			freePlanId,
+			freeNewPlanId,
+		];
 		try {
 			await autumnV2_3.catalogV2.update({
 				plans: [
-					{
-						plan_id: planId,
-						name: "Reward Linked",
-						price: { amount: 20, interval: BillingInterval.Month },
-					},
+					{ plan_id: vercelPlanId, name: "Vercel Locked" },
+					{ plan_id: freePlanId, name: "No Installs" },
 				],
 			});
-			({ rewardId, programId } = await seedRewardProgramRef({ ctx, planId }));
+			await OrgService.update({
+				db: ctx.db,
+				orgId: ctx.org.id,
+				updates: {
+					processor_configs: {
+						...ctx.org.processor_configs,
+						vercel: {
+							client_integration_id: "test_integration",
+							client_secret: "test_secret",
+							webhook_url: "https://example.com/webhook",
+							marketplace_mode: VercelMarketplaceMode.Installation,
+						},
+					},
+				},
+			});
+			await seedCustomerProductRef({
+				ctx,
+				planId: vercelPlanId,
+				vercelInstall: true,
+			});
+			await seedCustomerProductRef({ ctx, planId: freePlanId });
 
 			await expectAutumnError({
 				errCode: ErrCode.InvalidRequest,
+				errMessage:
+					"Cannot change product ID while Vercel customers are subscribed",
 				func: () =>
 					autumnV2_3.catalogV2.update({
-						plans: [{ plan_id: planId, new_plan_id: newPlanId }],
+						plans: [{ plan_id: vercelPlanId, new_plan_id: vercelNewPlanId }],
 					}),
 			});
-		} finally {
-			await cleanupRefs({
-				ctx,
-				planIds: [planId, newPlanId],
-				rewardId,
-				programId,
+
+			// Non-Vercel customers don't trip the gate, even on a Vercel org.
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: freePlanId, new_plan_id: freeNewPlanId }],
 			});
-			await deleteDbPlans({ ctx, planIds: [planId, newPlanId] });
+		} finally {
+			await cleanupRefs({ ctx, planIds: allPlanIds });
+			await deleteDbPlans({ ctx, planIds: allPlanIds });
 		}
 	},
 );


### PR DESCRIPTION
Moves products.id plus reward, discount, and RevenueCat refs atomically; customer_products and invoices stay as historical snapshots.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames plan IDs atomically and rewrites plan-id references without changing `customer_products` or invoices. Previously, any customers or reward programs blocked renames; now only plans with Vercel-installed customers are blocked.

- Compute enqueues `renamePlans` only when an existing plan’s `new_plan_id` differs and versions exist; creates use the final id and do not enqueue a rename.
- Execution runs renames first; one data-modifying CTE moves all product-version rows and rewrites `reward_programs.product_ids`, `rewards.free_product_id` and `discount_config.product_ids`, and `revenuecat_mappings.autumn_product_id`.
- Validation blocks when the target id is taken or when a Vercel-installed customer is subscribed (indexed `->>` check across all versions); other customers and reward programs no longer block.
- `customer_products.product_id` remains a historical snapshot; `internal_product_id` preserves reader correctness. Tests cover multi-version moves, reference rewrites, and the Vercel-only gate.

Rollout
- No migration required. To rename, clients send `new_plan_id`. The target id must be free; renames are disallowed only for plans with Vercel installs.

<sup>Written for commit 794fb68095f38f2bc577631d1c3060a0239ba6d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds atomic plan-ID renaming while preserving customer-product and invoice snapshots.
- **API changes, Improvements:** Accepts `new_plan_id` for existing plans and computes explicit rename operations.
- **Improvements:** Renames every product version and rewrites reward, discount, and RevenueCat references in one database statement.
- **Bug fixes, Improvements:** Restricts the rename validation block to plans with active Vercel-installed customers.
- **Improvements:** Adds integration coverage for historical customer snapshots, multi-version plans, rewritten references, and Vercel validation.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because downstream work can use a removed plan ID and Vercel allowlists can hide a renamed plan.

Renames execute before later catalog phases without translating their precomputed plan IDs, and the atomic rewrite omits the Vercel allowlist fields used to filter billing plans.

**Files Needing Attention:** server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts, server/src/internal/catalogV2/execute/executeRenamePlans.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/execute/executeRenamePlans.ts | Adds the atomic SQL statement that renames all product versions and selected plan-ID references. |
| server/src/internal/catalogV2/execute/executeUpdateCatalogPlan.ts | Introduces the rename phase before the existing catalog execution phases. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors.ts | Replaces the broad customer and reward-program rename blocks with a targeted active-Vercel-customer check. |
| server/src/internal/customers/cusProducts/repos/hasVercelCustomerOnProduct.ts | Adds an indexed lookup for active Vercel-installed customers across plan versions. |
| server/tests/integration/catalog-v2/plans/update/rename-plan-refs.test.ts | Covers multi-version renames, historical customer-product snapshots, and reward and RevenueCat reference rewrites. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Catalog as Catalog update
    participant Validator
    participant DB
    Client->>Catalog: Update with new_plan_id
    Catalog->>Validator: Validate target ID and Vercel usage
    Validator-->>Catalog: Rename allowed
    Catalog->>DB: Atomic plan-ID and reference rewrite
    DB-->>Catalog: Rename complete
    Catalog->>DB: Execute remaining catalog operations
    Catalog-->>Client: Catalog result
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat: rename plan ids in one statement w..."](https://github.com/useautumn/autumn/commit/794fb68095f38f2bc577631d1c3060a0239ba6d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55827936)</sub>

<!-- /greptile_comment -->