### PR TITLE
Fix Capy Google OAuth emulator tunnel

### DIFF
--- a/scripts/capy/command.ts
+++ b/scripts/capy/command.ts
@@ -174,7 +174,7 @@ function ensureAppProcess(): void {
 	const env: Record<string, string> = {
 		...process.env,
 		CAPY_DEV: "1",
-		VITE_BACKEND_URL: "/__autumn_api",
+		VITE_EMULATE_GOOGLE_PROXY: "1",
 	} as Record<string, string>;
 	const { app: appLog } = capyLogPaths();
 	mkdirSync(dirname(appLog), { recursive: true, mode: 0o700 });

--- a/scripts/capy/provision.ts
+++ b/scripts/capy/provision.ts
@@ -357,6 +357,10 @@ function writeEnvFiles(
 		AUTUMN_API_URL: serverUrl,
 		AUTUMN_PUBLIC_API_URL: serverUrl,
 		CLIENT_URL: viteUrl,
+		EMULATE_GOOGLE_URL: "http://localhost:4000",
+		EMULATE_GOOGLE_FETCH_URL: "http://127.0.0.1:4000",
+		GOOGLE_CLIENT_ID: "capy-emulate",
+		GOOGLE_CLIENT_SECRET: "capy-emulate",
 		STRIPE_WEBHOOK_SKIP_VERIFY: "true",
 		// Login flow that works without external services: dev `sendOTPEmail`
 		// prints the OTP to the server log. The README documents this path.

--- a/vite/src/lib/googleOAuthProxy.ts
+++ b/vite/src/lib/googleOAuthProxy.ts
@@ -1,0 +1,13 @@
+export function googleOAuthUrlForBrowser({
+	providerUrl,
+	browserOrigin,
+}: {
+	providerUrl: string;
+	browserOrigin: string;
+}): string {
+	const provider = new URL(providerUrl);
+	return new URL(
+		`${provider.pathname}${provider.search}${provider.hash}`,
+		browserOrigin,
+	).toString();
+}

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { CustomToaster } from "@/components/general/CustomToaster";
 import { authClient, signIn, useSession } from "@/lib/auth-client";
+import { googleOAuthUrlForBrowser } from "@/lib/googleOAuthProxy";
 import { isSafeSsoRedirectUrl } from "@/lib/sso/ssoCallback";
 import { getSsoHint } from "@/lib/sso/ssoHint";
 import { resolveSso } from "@/lib/sso/ssoResolve";
@@ -140,13 +141,24 @@ export const SignIn = () => {
 				oauthRedirectUrl || `${frontendUrl}${defaultPath}`;
 			const googleNewUserUrl =
 				oauthRedirectUrl || `${frontendUrl}${defaultPath}`;
-			const { error } = await signIn.social({
+			const useEmulateProxy = import.meta.env.VITE_EMULATE_GOOGLE_PROXY === "1";
+			const { data, error } = await signIn.social({
 				provider: "google",
 				callbackURL: googleCallbackUrl,
 				newUserCallbackURL: googleNewUserUrl,
+				disableRedirect: useEmulateProxy,
 			});
 			if (error) {
 				toast.error(error.message || "Failed to sign in with Google");
+				return;
+			}
+			if (useEmulateProxy && data?.url) {
+				window.location.assign(
+					googleOAuthUrlForBrowser({
+						providerUrl: data.url,
+						browserOrigin: frontendUrl,
+					}),
+				);
 			}
 		} catch (error) {
 			toast.error(getBackendErr(error, "Failed to sign in with Google"));

--- a/vite/tests/lib/google-oauth-proxy.test.ts
+++ b/vite/tests/lib/google-oauth-proxy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { googleOAuthUrlForBrowser } from "@/lib/googleOAuthProxy";
+
+describe("googleOAuthUrlForBrowser", () => {
+	test("routes the emulator authorization request through the browser origin", () => {
+		expect(
+			googleOAuthUrlForBrowser({
+				providerUrl:
+					"http://localhost:4000/o/oauth2/v2/auth?client_id=capy&state=test",
+				browserOrigin: "https://machine.capysandbox.net",
+			}),
+		).toBe(
+			"https://machine.capysandbox.net/o/oauth2/v2/auth?client_id=capy&state=test",
+		);
+	});
+});

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -17,8 +17,7 @@ const vitePort = process.env.VITE_PORT
 	: 3000;
 const frontendUrl = process.env.VITE_FRONTEND_URL || "";
 const isCapyDev = process.env.CAPY_DEV === "1";
-const backendUrl = process.env.VITE_BACKEND_URL || "";
-const useSameOriginProxy = isCapyDev && backendUrl.startsWith("/");
+if (isCapyDev) process.env.VITE_BACKEND_URL = "/__autumn_api";
 
 function printPortlessUrl(): Plugin {
 	return {
@@ -147,7 +146,7 @@ export default defineConfig({
 			".ngrok.app",
 			".ngrok-free.app",
 		],
-		proxy: useSameOriginProxy
+		proxy: isCapyDev
 			? {
 					"/__autumn_api": {
 						target: "http://127.0.0.1:8080",
@@ -156,6 +155,14 @@ export default defineConfig({
 					},
 					"/api/auth": {
 						target: "http://127.0.0.1:8080",
+						changeOrigin: false,
+					},
+					"/o/oauth2": {
+						target: "http://127.0.0.1:4000",
+						changeOrigin: false,
+					},
+					"/_emulate": {
+						target: "http://127.0.0.1:4000",
 						changeOrigin: false,
 					},
 				}


### PR DESCRIPTION
Fixes Google sign-in for Capy-hosted development dashboards while keeping a single exposed port.

- Provisions the local Google emulator endpoint and non-secret emulator client values for Better Auth.
- Forces Capy browser API traffic through Vite's same-origin proxy and tunnels the emulator UI routes from port 3000 to port 4000.
- Rewrites the emulator authorization URL to the active browser origin so CapySandbox sessions never navigate to their own `localhost`.
- Adds focused coverage for the authorization URL rewrite.

Verified with Biome, the Capy handoff and OAuth proxy unit tests, Vite typechecking, and an end-to-end fake Google sign-in through the tunneled emulator UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tunnels the Google OAuth emulator through the app origin for Capy dev dashboards. Previously sign-in redirected to localhost:4000 and broke CapySandbox; now the app rewrites the authorization URL to the current origin and proxies emulator routes, keeping a single exposed port.

- Dev proxy forwards /o/oauth2 and /_emulate to 127.0.0.1:4000; backend remains at /__autumn_api.
- Sign-in sets a dev flag to disable redirect, rewrite the provider URL to the browser origin, and navigate locally.
- Provision adds emulator URLs and non-secret client credentials for Better Auth.
- Capy dev sets the backend same-origin path automatically.
- Adds a focused unit test for the URL rewrite.

<sup>Written for commit acd747cadbd50a11a354976d3fa7d213d02689be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes Google sign-in in Capy development dashboards by routing browser-facing OAuth traffic through the single exposed Vite port.
- **Bug fixes:** Provisions the local Google emulator and configures Better Auth with development-only client values.
- **Bug fixes, Improvements:** Rewrites the emulator authorization URL to the active browser origin and adds same-origin proxy routes for backend and emulator traffic.
- **Improvements:** Adds focused coverage for the browser-facing authorization URL rewrite.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The Capy environment, browser-origin rewrite, backend proxy, and emulator routes form a consistent same-origin OAuth flow, and the investigated alternatives did not establish a reachable failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/capy/command.ts | Enables the browser-side emulator proxy mode for the Capy development process. |
| scripts/capy/provision.ts | Provisions emulator endpoints and non-secret development OAuth credentials. |
| vite/src/lib/googleOAuthProxy.ts | Rebuilds emulator authorization URLs against the active browser origin while preserving their path and parameters. |
| vite/src/views/auth/SignIn.tsx | Uses a manual same-origin redirect for Google sign-in when running through the Capy emulator proxy. |
| vite/vite.config.ts | Forces Capy API traffic through Vite and tunnels the browser-facing emulator routes to port 4000. |
| vite/tests/lib/google-oauth-proxy.test.ts | Verifies that an emulator authorization URL is rewritten to the Capy browser origin. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Browser[Capy browser] -->|Google sign-in| Vite[Vite tunnel on port 3000]
  Vite -->|/api/auth and /__autumn_api| Backend[Backend on port 8080]
  Backend -->|Emulator authorization URL| Browser
  Browser -->|/o/oauth2 via same origin| Vite
  Vite -->|Proxy| Emulator[Google emulator on port 4000]
  Emulator -->|OAuth callback| Vite
  Vite --> Backend
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(capy): tunnel Google OAuth emulator"](https://github.com/useautumn/autumn/commit/acd747cadbd50a11a354976d3fa7d213d02689be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55832996)</sub>

<!-- /greptile_comment -->