### PR TITLE
Trust forwarded preview origin in Capy auth

### DIFF
--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -148,13 +148,16 @@ const options = {
 	telemetry: {
 		enabled: false,
 	},
-	...(isHttpsBaseUrl && {
+	...((isHttpsBaseUrl || isCapyDev) && {
 		advanced: {
-			useSecureCookies: true,
-			defaultCookieAttributes: {
-				sameSite: "none" as const,
-				secure: true,
-			},
+			...(isCapyDev && { trustedProxyHeaders: true }),
+			...(isHttpsBaseUrl && {
+				useSecureCookies: true,
+				defaultCookieAttributes: {
+					sameSite: "none" as const,
+					secure: true,
+				},
+			}),
 		},
 	}),
 


### PR DESCRIPTION
Makes Better Auth trust `x-forwarded-host` and `x-forwarded-proto` only in Capy development mode, so Google OAuth callbacks retain the signed preview origin instead of redirecting to the raw sandbox host.

Existing HTTPS cookie behavior remains unchanged outside Capy. No regression test was added by request.

Verified with Biome and the server TypeScript build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trusts forwarded preview origin in Capy development for auth, so Google OAuth callbacks keep the preview domain instead of redirecting to the raw sandbox host. Secure cookie defaults still apply only when the base URL is HTTPS; behavior outside Capy is unchanged.

- Enables `advanced.trustedProxyHeaders` only when `isCapyDev` to accept `x-forwarded-host` and `x-forwarded-proto`; keeps `useSecureCookies` and `defaultCookieAttributes` only when `isHttpsBaseUrl`.
- Review/QA: In a Capy preview, complete Google sign-in and confirm the redirect returns to the preview domain; verify production cookies remain `SameSite=None; Secure` and that non-Capy environments do not trust forwarded headers.

<sup>Written for commit b0f8f97be18e458d819804ced2ddf1c19fa4d827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Better Auth’s Capy development configuration so OAuth callbacks can retain the forwarded preview origin while preserving the existing HTTPS cookie configuration.
- **[Bug fixes]** Trust forwarded host and protocol headers only when Capy development mode is active.
- **[Improvements]** Build the advanced authentication options independently for proxy trust and HTTPS cookie behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue established.

The proxy-header behavior is limited to non-production Capy mode, and the existing HTTPS cookie settings remain conditional on the same HTTPS URL check as before.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/utils/auth.ts | Adds Capy-only forwarded-header trust while retaining secure, cross-site cookie attributes whenever the configured browser authentication URL uses HTTPS. |

<sub>Reviews (1): Last reviewed commit: ["fix(capy): trust forwarded auth origin"](https://github.com/useautumn/autumn/commit/b0f8f97be18e458d819804ced2ddf1c19fa4d827) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55836874)</sub>

<!-- /greptile_comment -->