### PR TITLE
Keep Capy emulator callbacks on preview origin

### DIFF
--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -19,6 +19,15 @@ const frontendUrl = process.env.VITE_FRONTEND_URL || "";
 const isCapyDev = process.env.CAPY_DEV === "1";
 if (isCapyDev) process.env.VITE_BACKEND_URL = "/__autumn_api";
 
+function relativeRedirectLocation(location: string): string {
+	try {
+		const url = new URL(location);
+		return `${url.pathname}${url.search}${url.hash}`;
+	} catch {
+		return location;
+	}
+}
+
 function printPortlessUrl(): Plugin {
 	return {
 		name: "print-portless-url",
@@ -160,6 +169,13 @@ export default defineConfig({
 					"/o/oauth2": {
 						target: "http://127.0.0.1:4000",
 						changeOrigin: false,
+						configure: (proxy) => {
+							proxy.on("proxyRes", (response) => {
+								const location = response.headers.location;
+								if (!location) return;
+								response.headers.location = relativeRedirectLocation(location);
+							});
+						},
 					},
 					"/_emulate": {
 						target: "http://127.0.0.1:4000",


### PR DESCRIPTION
Keeps the Google emulator's post-selection navigation inside the active Capy preview iframe.

The Capy-only Vite proxy now converts the emulator's absolute `Location` header into an origin-relative callback path, preventing redirects to raw sandbox hosts or insecure localhost origins.

Verified with Biome, Vite typechecking, and live proxy probes confirming:
- forwarded preview headers produce the signed OAuth callback origin;
- emulator selection returns `/api/auth/callback/google?...` rather than an absolute host.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Google emulator OAuth callbacks inside the Capy preview by rewriting absolute redirect Locations to origin‑relative paths in the Capy-only `vite` proxy. Previously, emulator selections could redirect to sandbox or localhost hosts; now they stay same‑origin with the preview iframe.

- Applies only in Capy dev (`CAPY_DEV=1`) via the `/o/oauth2` proxy; production is unaffected.
- Rewrites the response `Location` header using a safe `relativeRedirectLocation` helper; leaves non-URL values unchanged.
- Verified that emulator navigation returns `/api/auth/callback/google?...` under the preview origin.

<sup>Written for commit f0081ba2b29c8ac1d8309230527ec14706d59c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/2999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR keeps Google emulator callbacks inside the active Capy preview by converting absolute redirect locations into origin-relative paths.
- **[Bug fixes]** Rewrites emulator OAuth response locations so account selection returns to the preview iframe instead of localhost or a raw sandbox host.
- **[Improvements]** Preserves the callback path, query string, and fragment while removing the upstream origin.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking concern that its redirect-normalization contract is not protected by an automated test.

The proxy rewrite matches the intended same-origin callback flow, and no reachable correctness or security failure was established; only regression coverage is missing.

**Files Needing Attention:** vite/vite.config.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/vite.config.ts | Adds Capy-only OAuth response normalization that preserves callback components but lacks automated regression coverage. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as Capy preview
    participant V as Vite proxy
    participant E as Google emulator
    U->>V: /o/oauth2/v2/auth
    V->>E: Proxy authorization request
    E-->>V: Location: absolute callback URL
    V-->>U: Location: /api/auth/callback/google?...
    U->>U: Navigate within preview origin
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/vite.config.ts:20-27
**Redirect normalization lacks coverage**

The new `relativeRedirectLocation` branches and proxy response rewrite have no automated regression test, so a later change can stop preserving the callback path, query, or fragment and send Capy users to localhost or a raw sandbox host without being detected.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(capy): keep emulator callback same-o..."](https://github.com/useautumn/autumn/commit/f0081ba2b29c8ac1d8309230527ec14706d59c56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55838544)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->