### PR TITLE
Improve Capy auth, webhooks, and dashboard loading

### DIFF
--- a/scripts/capy/command.ts
+++ b/scripts/capy/command.ts
@@ -7,10 +7,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-	ensureEmulateRunning,
-	stopEmulateAndPortless,
-} from "../dw/helpers/emulate.ts";
+import { stopEmulateAndPortless } from "../dw/helpers/emulate.ts";
 import {
 	registerPortlessAliases,
 	unregisterPortlessAliases,
@@ -120,9 +117,8 @@ export function capyHandoffText(): string {
 	return [
 		"Capy is ready.",
 		`tmux session: ${CAPY_SESSION}`,
-		"local ports: 3000 dashboard, 8080 server, 3001 checkout, 3099 leaf/chat, 4000 emulate",
+		"local ports: 3000 dashboard, 8080 server, 3001 checkout, 3099 leaf/chat",
 		"browser API uses /__autumn_api via the Capy Vite proxy; expose only port 3000",
-		"VM/Desktop-local emulate URL: https://google.emulate.localhost",
 		`logs: bun capy logs | attach: tmux attach -t ${CAPY_SESSION}`,
 	].join("\n");
 }
@@ -169,7 +165,6 @@ function ensureAppProcess(): void {
 	ensureBunGlobalBin();
 	if (tmuxSessionExists(CAPY_SESSION)) return;
 	ensureStartup();
-	ensureEmulateRunning();
 	registerPortlessAliases(1);
 	const env: Record<string, string> = {
 		...process.env,

--- a/server/src/external/stripe/webhookMiddlewares/stripeConnectSeederMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeConnectSeederMiddleware.ts
@@ -42,14 +42,7 @@ export const stripeConnectSeederMiddleware = async (
 		return c.json({ error: "Failed to initialize stripe client" }, 500);
 	}
 
-	// Step 2: Get webhook secret
-	const webhookSecret = await getStripeWebhookSecret({
-		db,
-		orgId: c.req.query("org_id"),
-		env,
-	});
-
-	// Step 3: Verify webhook signature
+	// Step 2: Verify webhook signature
 	const rawBody = await c.req.text();
 	const signature = c.req.header("stripe-signature") || "";
 
@@ -71,6 +64,11 @@ export const stripeConnectSeederMiddleware = async (
 		}
 	} else {
 		try {
+			const webhookSecret = await getStripeWebhookSecret({
+				db,
+				orgId: c.req.query("org_id"),
+				env,
+			});
 			event = await masterStripe.webhooks.constructEventAsync(
 				rawBody,
 				signature,

--- a/server/src/external/stripe/webhookMiddlewares/stripeConnectSeederMiddleware.ts
+++ b/server/src/external/stripe/webhookMiddlewares/stripeConnectSeederMiddleware.ts
@@ -42,7 +42,14 @@ export const stripeConnectSeederMiddleware = async (
 		return c.json({ error: "Failed to initialize stripe client" }, 500);
 	}
 
-	// Step 2: Verify webhook signature
+	// Step 2: Get webhook secret
+	const webhookSecret = await getStripeWebhookSecret({
+		db,
+		orgId: c.req.query("org_id"),
+		env,
+	});
+
+	// Step 3: Verify webhook signature
 	const rawBody = await c.req.text();
 	const signature = c.req.header("stripe-signature") || "";
 
@@ -64,11 +71,6 @@ export const stripeConnectSeederMiddleware = async (
 		}
 	} else {
 		try {
-			const webhookSecret = await getStripeWebhookSecret({
-				db,
-				orgId: c.req.query("org_id"),
-				env,
-			});
 			event = await masterStripe.webhooks.constructEventAsync(
 				rawBody,
 				signature,

--- a/server/src/initHono.ts
+++ b/server/src/initHono.ts
@@ -16,6 +16,7 @@ import { replicaDbMiddleware } from "./honoMiddlewares/replicaDbMiddleware.js";
 import type { HonoEnv } from "./honoUtils/HonoEnv.js";
 import { handleHealthCheck } from "./honoUtils/handleHealthCheck.js";
 import { handleReadyCheck } from "./honoUtils/handleReadyCheck.js";
+import { handleCapyLogin } from "./internal/auth/handleCapyLogin.js";
 import { handleListAuthOrganizations } from "./internal/auth/handleListAuthOrganizations.js";
 import { oauthRouter } from "./internal/auth/oauth/oauthRouter.js";
 import { withTrustedSsoOrigin } from "./internal/auth/sso/ssoTrustedOrigins.js";
@@ -27,7 +28,7 @@ import { apiRouter } from "./routers/apiRouter.js";
 import { createChatProxyRouter } from "./routers/chatProxyRouter.js";
 import { internalRouter } from "./routers/internalRouter.js";
 import { publicRouter } from "./routers/publicRouter.js";
-import { auth } from "./utils/auth.js";
+import { auth, isCapyDev } from "./utils/auth.js";
 import { isAllowedOrigin } from "./utils/corsOrigins.js";
 
 const ALLOWED_HEADERS = [
@@ -88,6 +89,7 @@ export const createHonoApp = () => {
 
 	// Better Auth's joined Drizzle query defaults to 100 memberships.
 	app.get("/api/auth/organization/list", handleListAuthOrganizations);
+	if (isCapyDev) app.get("/api/auth/capy-login", handleCapyLogin);
 
 	app.on(["POST", "GET"], ["/api/auth/*"], async (c) => {
 		if (FACADE_ONLY_SSO_PATHS.has(c.req.path)) {

--- a/server/src/internal/auth/handleCapyLogin.ts
+++ b/server/src/internal/auth/handleCapyLogin.ts
@@ -76,7 +76,8 @@ export const handleCapyLogin = async (c: Context) => {
 			path: cookie.path,
 			httpOnly: cookie.httpOnly,
 			secure,
-			sameSite: cookie.sameSite,
+			sameSite: secure ? "None" : cookie.sameSite,
+			partitioned: secure,
 			expires: cookie.expires ? new Date(cookie.expires * 1000) : undefined,
 		});
 	}

--- a/server/src/internal/auth/handleCapyLogin.ts
+++ b/server/src/internal/auth/handleCapyLogin.ts
@@ -9,6 +9,11 @@ import { generateId } from "@/utils/genUtils.js";
 
 const CAPY_USER_EMAIL = "capy@autumn.test";
 
+const safeRedirectPath = (path?: string) =>
+	path?.startsWith("/") && !path.startsWith("//") && path[1] !== "\\"
+		? path
+		: "/";
+
 export const handleCapyLogin = async (c: Context) => {
 	if (!isCapyDev) return c.notFound();
 
@@ -82,5 +87,5 @@ export const handleCapyLogin = async (c: Context) => {
 		});
 	}
 
-	return c.redirect("/");
+	return c.redirect(safeRedirectPath(c.req.query("next")));
 };

--- a/server/src/internal/auth/handleCapyLogin.ts
+++ b/server/src/internal/auth/handleCapyLogin.ts
@@ -1,0 +1,85 @@
+import { member, user } from "@autumn/shared";
+import type { TestHelpers } from "better-auth/plugins";
+import { and, eq } from "drizzle-orm";
+import type { Context } from "hono";
+import { setCookie } from "hono/cookie";
+import { db } from "@/db/initDrizzle.js";
+import { auth, isCapyDev } from "@/utils/auth.js";
+import { generateId } from "@/utils/genUtils.js";
+
+const CAPY_USER_EMAIL = "capy@autumn.test";
+
+export const handleCapyLogin = async (c: Context) => {
+	if (!isCapyDev) return c.notFound();
+
+	const orgId = process.env.TESTS_ORG_ID;
+	if (!orgId) throw new Error("TESTS_ORG_ID is required for Capy login");
+
+	const authContext = await auth.$context;
+	const test = (authContext as { test?: TestHelpers }).test;
+	if (!test?.addMember) {
+		throw new Error("Better Auth test utilities are required for Capy login");
+	}
+
+	const capyUser = await db.query.user.findFirst({
+		where: eq(user.email, CAPY_USER_EMAIL),
+	});
+	let userId: string;
+	if (!capyUser) {
+		const createdUser = await test.saveUser(
+			test.createUser({
+				id: generateId("user"),
+				email: CAPY_USER_EMAIL,
+				name: "Capy Admin",
+				emailVerified: true,
+				role: "admin",
+			}),
+		);
+		userId = createdUser.id;
+	} else if (capyUser.role !== "admin") {
+		await db
+			.update(user)
+			.set({ role: "admin" })
+			.where(eq(user.id, capyUser.id));
+		userId = capyUser.id;
+	} else {
+		userId = capyUser.id;
+	}
+
+	const membership = await db.query.member.findFirst({
+		where: and(eq(member.userId, userId), eq(member.organizationId, orgId)),
+	});
+	if (!membership) {
+		await test.addMember({
+			userId,
+			organizationId: orgId,
+			role: "owner",
+		});
+	} else if (membership.role !== "owner") {
+		await db
+			.update(member)
+			.set({ role: "owner" })
+			.where(eq(member.id, membership.id));
+	}
+
+	const { cookies, headers } = await test.login({ userId });
+	await auth.api.setActiveOrganization({
+		headers,
+		body: { organizationId: orgId },
+	});
+
+	const secure =
+		c.req.header("x-forwarded-proto") === "https" ||
+		new URL(c.req.url).protocol === "https:";
+	for (const cookie of cookies) {
+		setCookie(c, cookie.name, cookie.value, {
+			path: cookie.path,
+			httpOnly: cookie.httpOnly,
+			secure,
+			sameSite: cookie.sameSite,
+			expires: cookie.expires ? new Date(cookie.expires * 1000) : undefined,
+		});
+	}
+
+	return c.redirect("/");
+};

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -90,7 +90,7 @@ const browserAuthBaseUrl = isProductionAuth
 		? publicAuthBaseUrl
 		: authBaseUrl;
 const isHttpsBaseUrl = browserAuthBaseUrl?.startsWith("https://");
-const isCapyDev =
+export const isCapyDev =
 	process.env.CAPY_DEV === "1" && process.env.NODE_ENV !== "production";
 const configuredAuthBaseUrl = isCapyDev
 	? {

--- a/server/tests/unit/webhooks/stripe-connect-seeder.test.ts
+++ b/server/tests/unit/webhooks/stripe-connect-seeder.test.ts
@@ -7,6 +7,7 @@ import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const mockState = {
 	getByAccountId: undefined as (() => Promise<unknown>) | undefined,
+	getWebhookSecretCalls: 0,
 };
 
 await mockModuleWithRestore("@/internal/orgs/OrgService.js", () => ({
@@ -19,8 +20,15 @@ await mockModuleWithRestore("@/internal/orgs/OrgService.js", () => ({
 }));
 
 await mockModuleWithRestore("@/external/connect/initStripeCli.js", () => ({
-	initMasterStripe: () => ({}),
-	getStripeWebhookSecret: async () => "whsec_test",
+	initMasterStripe: () => ({
+		webhooks: {
+			constructEventAsync: async (body: string) => JSON.parse(body),
+		},
+	}),
+	getStripeWebhookSecret: async () => {
+		mockState.getWebhookSecretCalls++;
+		return "whsec_test";
+	},
 }));
 
 await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
@@ -32,6 +40,7 @@ const { stripeConnectSeederMiddleware } = await import(
 );
 
 const originalSkipVerify = process.env.STRIPE_WEBHOOK_SKIP_VERIFY;
+const originalNodeEnv = process.env.NODE_ENV;
 
 type TestEnv = { Variables: { ctx: unknown } };
 
@@ -73,11 +82,14 @@ const postEvent = (app: Hono<TestEnv>) =>
 describe("stripeConnectSeederMiddleware org resolution", () => {
 	beforeEach(() => {
 		process.env.STRIPE_WEBHOOK_SKIP_VERIFY = "true";
+		process.env.NODE_ENV = "test";
 		mockState.getByAccountId = undefined;
+		mockState.getWebhookSecretCalls = 0;
 	});
 
 	afterAll(() => {
 		process.env.STRIPE_WEBHOOK_SKIP_VERIFY = originalSkipVerify;
+		process.env.NODE_ENV = originalNodeEnv;
 	});
 
 	test("returns 200 and skips processing when the account is genuinely unlinked", async () => {
@@ -119,5 +131,21 @@ describe("stripeConnectSeederMiddleware org resolution", () => {
 
 		expect(response.status).toBe(200);
 		expect(didHandlerRun()).toBe(true);
+		expect(mockState.getWebhookSecretCalls).toBe(0);
+	});
+
+	test("still verifies signatures in production when skip verify is set", async () => {
+		process.env.NODE_ENV = "production";
+		mockState.getByAccountId = async () => ({
+			org: { id: "org_test", slug: "test-org", config: {} },
+			features: [],
+		});
+
+		const { app, didHandlerRun } = createApp();
+		const response = await postEvent(app);
+
+		expect(response.status).toBe(200);
+		expect(didHandlerRun()).toBe(true);
+		expect(mockState.getWebhookSecretCalls).toBe(1);
 	});
 });

--- a/server/tests/unit/webhooks/stripe-connect-seeder.test.ts
+++ b/server/tests/unit/webhooks/stripe-connect-seeder.test.ts
@@ -7,7 +7,6 @@ import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const mockState = {
 	getByAccountId: undefined as (() => Promise<unknown>) | undefined,
-	getWebhookSecretCalls: 0,
 };
 
 await mockModuleWithRestore("@/internal/orgs/OrgService.js", () => ({
@@ -21,10 +20,7 @@ await mockModuleWithRestore("@/internal/orgs/OrgService.js", () => ({
 
 await mockModuleWithRestore("@/external/connect/initStripeCli.js", () => ({
 	initMasterStripe: () => ({}),
-	getStripeWebhookSecret: async () => {
-		mockState.getWebhookSecretCalls++;
-		return "whsec_test";
-	},
+	getStripeWebhookSecret: async () => "whsec_test",
 }));
 
 await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
@@ -78,7 +74,6 @@ describe("stripeConnectSeederMiddleware org resolution", () => {
 	beforeEach(() => {
 		process.env.STRIPE_WEBHOOK_SKIP_VERIFY = "true";
 		mockState.getByAccountId = undefined;
-		mockState.getWebhookSecretCalls = 0;
 	});
 
 	afterAll(() => {
@@ -124,6 +119,5 @@ describe("stripeConnectSeederMiddleware org resolution", () => {
 
 		expect(response.status).toBe(200);
 		expect(didHandlerRun()).toBe(true);
-		expect(mockState.getWebhookSecretCalls).toBe(0);
 	});
 });

--- a/server/tests/unit/webhooks/stripe-connect-seeder.test.ts
+++ b/server/tests/unit/webhooks/stripe-connect-seeder.test.ts
@@ -7,6 +7,7 @@ import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const mockState = {
 	getByAccountId: undefined as (() => Promise<unknown>) | undefined,
+	getWebhookSecretCalls: 0,
 };
 
 await mockModuleWithRestore("@/internal/orgs/OrgService.js", () => ({
@@ -20,7 +21,10 @@ await mockModuleWithRestore("@/internal/orgs/OrgService.js", () => ({
 
 await mockModuleWithRestore("@/external/connect/initStripeCli.js", () => ({
 	initMasterStripe: () => ({}),
-	getStripeWebhookSecret: async () => "whsec_test",
+	getStripeWebhookSecret: async () => {
+		mockState.getWebhookSecretCalls++;
+		return "whsec_test";
+	},
 }));
 
 await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
@@ -74,6 +78,7 @@ describe("stripeConnectSeederMiddleware org resolution", () => {
 	beforeEach(() => {
 		process.env.STRIPE_WEBHOOK_SKIP_VERIFY = "true";
 		mockState.getByAccountId = undefined;
+		mockState.getWebhookSecretCalls = 0;
 	});
 
 	afterAll(() => {
@@ -119,5 +124,6 @@ describe("stripeConnectSeederMiddleware org resolution", () => {
 
 		expect(response.status).toBe(200);
 		expect(didHandlerRun()).toBe(true);
+		expect(mockState.getWebhookSecretCalls).toBe(0);
 	});
 });

--- a/vite/src/App.tsx
+++ b/vite/src/App.tsx
@@ -10,29 +10,101 @@ import { OnboardingLayout } from "./app/OnboardingLayout";
 import { useSession } from "./lib/auth-client";
 import { SSO_CALLBACK_PATH } from "./lib/sso/ssoCallback";
 import { identifyUser } from "./utils/posthogTracking";
-import { AdminView } from "./views/admin/AdminView";
-import { EdgeConfigView } from "./views/admin/edge-config/EdgeConfigView";
-import { ImpersonateRedirect } from "./views/admin/ImpersonateRedirect";
-import { OAuthClientsView } from "./views/admin/oauth/OAuthClientsView";
-import { AcceptInvitation } from "./views/auth/AcceptInvitation";
-import { Consent } from "./views/auth/Consent";
-import { PasswordSignIn } from "./views/auth/components/PasswordSignIn";
-import { SignIn } from "./views/auth/SignIn";
-import { SsoCallback } from "./views/auth/SsoCallback";
-import CustomersPage from "./views/customers/CustomersPage";
-import { AnalyticsView } from "./views/customers/customer/analytics/AnalyticsView";
-import CustomerView2 from "./views/customers2/customer/CustomerView2";
-import CustomerPlanEditor from "./views/customers2/customer-plan/CustomerPlanEditor";
-import { DefaultView } from "./views/DefaultView";
-import DevScreen from "./views/developer/DevView";
-import { CloseScreen } from "./views/general/CloseScreen";
-import { MigrationsView } from "./views/migrations/MigrationsView";
-import { MigrationView } from "./views/migrations/migration/MigrationView";
-import QuickstartView from "./views/onboarding4/QuickstartView";
-import ProductsView from "./views/products/ProductsView";
-import PlanEditorView from "./views/products/plan/PlanEditorView";
-import { SettingsView } from "./views/settings/SettingsView";
-import { TerminalView } from "./views/TerminalView";
+import LoadingScreen from "./views/general/LoadingScreen";
+
+const AdminView = React.lazy(() =>
+	import("./views/admin/AdminView").then(({ AdminView }) => ({
+		default: AdminView,
+	})),
+);
+const EdgeConfigView = React.lazy(() =>
+	import("./views/admin/edge-config/EdgeConfigView").then(
+		({ EdgeConfigView }) => ({ default: EdgeConfigView }),
+	),
+);
+const ImpersonateRedirect = React.lazy(() =>
+	import("./views/admin/ImpersonateRedirect").then(
+		({ ImpersonateRedirect }) => ({ default: ImpersonateRedirect }),
+	),
+);
+const OAuthClientsView = React.lazy(() =>
+	import("./views/admin/oauth/OAuthClientsView").then(
+		({ OAuthClientsView }) => ({ default: OAuthClientsView }),
+	),
+);
+const AcceptInvitation = React.lazy(() =>
+	import("./views/auth/AcceptInvitation").then(({ AcceptInvitation }) => ({
+		default: AcceptInvitation,
+	})),
+);
+const Consent = React.lazy(() =>
+	import("./views/auth/Consent").then(({ Consent }) => ({ default: Consent })),
+);
+const PasswordSignIn = React.lazy(() =>
+	import("./views/auth/components/PasswordSignIn").then(
+		({ PasswordSignIn }) => ({ default: PasswordSignIn }),
+	),
+);
+const SignIn = React.lazy(() =>
+	import("./views/auth/SignIn").then(({ SignIn }) => ({ default: SignIn })),
+);
+const SsoCallback = React.lazy(() =>
+	import("./views/auth/SsoCallback").then(({ SsoCallback }) => ({
+		default: SsoCallback,
+	})),
+);
+const CustomersPage = React.lazy(
+	() => import("./views/customers/CustomersPage"),
+);
+const AnalyticsView = React.lazy(() =>
+	import("./views/customers/customer/analytics/AnalyticsView").then(
+		({ AnalyticsView }) => ({ default: AnalyticsView }),
+	),
+);
+const CustomerView2 = React.lazy(
+	() => import("./views/customers2/customer/CustomerView2"),
+);
+const CustomerPlanEditor = React.lazy(
+	() => import("./views/customers2/customer-plan/CustomerPlanEditor"),
+);
+const DefaultView = React.lazy(() =>
+	import("./views/DefaultView").then(({ DefaultView }) => ({
+		default: DefaultView,
+	})),
+);
+const DevScreen = React.lazy(() => import("./views/developer/DevView"));
+const CloseScreen = React.lazy(() =>
+	import("./views/general/CloseScreen").then(({ CloseScreen }) => ({
+		default: CloseScreen,
+	})),
+);
+const MigrationsView = React.lazy(() =>
+	import("./views/migrations/MigrationsView").then(({ MigrationsView }) => ({
+		default: MigrationsView,
+	})),
+);
+const MigrationView = React.lazy(() =>
+	import("./views/migrations/migration/MigrationView").then(
+		({ MigrationView }) => ({ default: MigrationView }),
+	),
+);
+const QuickstartView = React.lazy(
+	() => import("./views/onboarding4/QuickstartView"),
+);
+const ProductsView = React.lazy(() => import("./views/products/ProductsView"));
+const PlanEditorView = React.lazy(
+	() => import("./views/products/plan/PlanEditorView"),
+);
+const SettingsView = React.lazy(() =>
+	import("./views/settings/SettingsView").then(({ SettingsView }) => ({
+		default: SettingsView,
+	})),
+);
+const TerminalView = React.lazy(() =>
+	import("./views/TerminalView").then(({ TerminalView }) => ({
+		default: TerminalView,
+	})),
+);
 
 function SquircleProvider({ children }: { children: React.ReactNode }) {
 	React.useEffect(() => void init(), []);
@@ -87,59 +159,61 @@ export default function App() {
 
 	return (
 		<BrowserRouter>
-			<Routes>
-				<Route path="/sign-in" element={<SignIn />} />
-				<Route path="/pw-sign-in" element={<PasswordSignIn />} />
-				<Route path="/consent" element={<Consent />} />
-				<Route path="/accept" element={<AcceptInvitation />} />
-				<Route path={SSO_CALLBACK_PATH} element={<SsoCallback />} />
-				<Route path="/close" element={<CloseScreen />} />
+			<React.Suspense fallback={<LoadingScreen fullPage />}>
+				<Routes>
+					<Route path="/sign-in" element={<SignIn />} />
+					<Route path="/pw-sign-in" element={<PasswordSignIn />} />
+					<Route path="/consent" element={<Consent />} />
+					<Route path="/accept" element={<AcceptInvitation />} />
+					<Route path={SSO_CALLBACK_PATH} element={<SsoCallback />} />
+					<Route path="/close" element={<CloseScreen />} />
 
-				<Route
-					path="/sandbox/:sandboxSlug"
-					element={<Navigate replace to="products" />}
-				/>
+					<Route
+						path="/sandbox/:sandboxSlug"
+						element={<Navigate replace to="products" />}
+					/>
 
-				{/* Onboarding routes without sidebar */}
-				<Route element={<OnboardingLayout />}>
-					<Route path="/sandbox/quickstart" element={<QuickstartView />} />
-				</Route>
-
-				<Route element={<DashboardGate />}>
-					<Route element={<MainLayout />}>
-						<Route path="*" element={<DefaultView />} />
-						{envRoutes("settings", <SettingsView />)}
-						{envRoutes("admin", <AdminView />)}
-						{envRoutes("admin/oauth", <OAuthClientsView />)}
-						{envRoutes("admin/edge-config", <EdgeConfigView />)}
-						{envRoutes("impersonate-redirect", <ImpersonateRedirect />)}
-						<Route path="/trmnl" element={<TerminalView />} />
-
-						{envRoutes(
-							"products",
-							<ProductsView env={AppEnv.Live} />,
-							<ProductsView env={AppEnv.Sandbox} />,
-						)}
-						{envRoutes("migrations", <MigrationsView />)}
-						{envRoutes("migrations/:migration_id", <MigrationView />)}
-						{envRoutes(
-							"products/:product_id",
-							<SquircleProvider>
-								<PlanEditorView />
-							</SquircleProvider>,
-						)}
-
-						{envRoutes("customers", <CustomersPage />)}
-						{envRoutes("customers/:customer_id", <CustomerView2 />)}
-						{envRoutes(
-							"customers/:customer_id/:product_id",
-							<CustomerPlanEditor />,
-						)}
-						{envRoutes("dev", <DevScreen />)}
-						{envRoutes("analytics", <AnalyticsView />)}
+					{/* Onboarding routes without sidebar */}
+					<Route element={<OnboardingLayout />}>
+						<Route path="/sandbox/quickstart" element={<QuickstartView />} />
 					</Route>
-				</Route>
-			</Routes>
+
+					<Route element={<DashboardGate />}>
+						<Route element={<MainLayout />}>
+							<Route path="*" element={<DefaultView />} />
+							{envRoutes("settings", <SettingsView />)}
+							{envRoutes("admin", <AdminView />)}
+							{envRoutes("admin/oauth", <OAuthClientsView />)}
+							{envRoutes("admin/edge-config", <EdgeConfigView />)}
+							{envRoutes("impersonate-redirect", <ImpersonateRedirect />)}
+							<Route path="/trmnl" element={<TerminalView />} />
+
+							{envRoutes(
+								"products",
+								<ProductsView env={AppEnv.Live} />,
+								<ProductsView env={AppEnv.Sandbox} />,
+							)}
+							{envRoutes("migrations", <MigrationsView />)}
+							{envRoutes("migrations/:migration_id", <MigrationView />)}
+							{envRoutes(
+								"products/:product_id",
+								<SquircleProvider>
+									<PlanEditorView />
+								</SquircleProvider>,
+							)}
+
+							{envRoutes("customers", <CustomersPage />)}
+							{envRoutes("customers/:customer_id", <CustomerView2 />)}
+							{envRoutes(
+								"customers/:customer_id/:product_id",
+								<CustomerPlanEditor />,
+							)}
+							{envRoutes("dev", <DevScreen />)}
+							{envRoutes("analytics", <AnalyticsView />)}
+						</Route>
+					</Route>
+				</Routes>
+			</React.Suspense>
 		</BrowserRouter>
 	);
 }

--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -114,13 +114,14 @@ const MainContent = ({
 	const env = useEnv();
 	const { org, isLoading: orgLoading } = useOrg();
 	const [showDeployDialog, setShowDeployDialog] = useState(false);
+	const isCapyDev = import.meta.env.VITE_CAPY_DEV === "1";
 
 	useDevQuery();
 	useAutumnFlags();
 	useFeatureFlags();
 	useFeaturesQuery();
 	useRewardsQuery();
-	useEventNames();
+	useEventNames({ enabled: !isCapyDev });
 
 	const showLoading = orgLoading || !org;
 

--- a/vite/src/app/layout.tsx
+++ b/vite/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { IconButton, SandboxBanner } from "@autumn/ui";
 import { ArrowRightIcon } from "@phosphor-icons/react";
 import { AutumnProvider } from "autumn-js/react";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { Outlet } from "react-router";
 import { CustomToaster } from "@/components/general/CustomToaster";
 import { SandboxFavicon } from "@/components/general/SandboxFavicon";
@@ -166,7 +166,13 @@ const MainContent = ({
 						)}
 					>
 						<div className="w-full h-full justify-center">
-							{showLoading ? <LoadingScreen /> : <Outlet />}
+							{showLoading ? (
+								<LoadingScreen />
+							) : (
+								<Suspense fallback={<LoadingScreen />}>
+									<Outlet />
+								</Suspense>
+							)}
 						</div>
 					</div>
 				</div>

--- a/vite/src/hooks/common/useAutumnFlags.tsx
+++ b/vite/src/hooks/common/useAutumnFlags.tsx
@@ -4,7 +4,10 @@ import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 import { notNullish } from "@/utils/genUtils";
 
 export const useAutumnFlags = () => {
-	const { data: customer } = useCustomer();
+	const isCapyDev = import.meta.env.VITE_CAPY_DEV === "1";
+	const { data: customer } = useCustomer({
+		queryOptions: { enabled: !isCapyDev },
+	});
 
 	const [flags, setFlags] = useLocalStorage("autumn.flags", {
 		pkey: false,

--- a/vite/src/hooks/common/useAutumnFlags.tsx
+++ b/vite/src/hooks/common/useAutumnFlags.tsx
@@ -4,10 +4,7 @@ import { useLocalStorage } from "@/hooks/common/useLocalStorage";
 import { notNullish } from "@/utils/genUtils";
 
 export const useAutumnFlags = () => {
-	const isCapyDev = import.meta.env.VITE_CAPY_DEV === "1";
-	const { data: customer } = useCustomer({
-		queryOptions: { enabled: !isCapyDev },
-	});
+	const { data: customer } = useCustomer();
 
 	const [flags, setFlags] = useLocalStorage("autumn.flags", {
 		pkey: false,

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -43,9 +43,10 @@ export const SignIn = () => {
 	const [ssoHint, setSsoHint] = useState<SsoOrgHint | null>(() => getSsoHint());
 	const [emailFallback, setEmailFallback] = useState(false);
 
-	const { data: session } = useSession();
+	const { data: session, isPending: sessionLoading } = useSession();
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
+	const isCapyDev = import.meta.env.VITE_CAPY_DEV === "1";
 
 	const oauthRedirectUrl = useMemo(
 		() => getOAuthRedirectUrl(searchParams),
@@ -63,12 +64,17 @@ export const SignIn = () => {
 		}
 	}, [session, navigate, oauthRedirectUrl, defaultPath]);
 
+	useEffect(() => {
+		if (!isCapyDev || sessionLoading || session) return;
+		window.location.replace("/api/auth/capy-login");
+	}, [isCapyDev, session, sessionLoading]);
+
 	// Passkey Conditional UI: browsers surface saved passkeys directly in the
 	// email field's autocomplete dropdown (no extra button needed). Requires
 	// the `webauthn` token in autoComplete and `autoFill: true` on signIn.
 	// Skipped during OAuth flows since the post-auth redirect would be lost.
 	useEffect(() => {
-		if (oauthRedirectUrl || session) return;
+		if (isCapyDev || oauthRedirectUrl || session) return;
 		if (typeof window === "undefined") return;
 		// Some browsers (notably Firefox) don't support Conditional UI; signIn
 		// gracefully no-ops in that case. We still call it on supported browsers.
@@ -86,7 +92,9 @@ export const SignIn = () => {
 		return () => {
 			controller.abort();
 		};
-	}, [oauthRedirectUrl, session]);
+	}, [isCapyDev, oauthRedirectUrl, session]);
+
+	if (isCapyDev) return null;
 
 	const handleEmailSignIn = async (e: React.FormEvent) => {
 		e.preventDefault();

--- a/vite/src/views/auth/SignIn.tsx
+++ b/vite/src/views/auth/SignIn.tsx
@@ -66,8 +66,10 @@ export const SignIn = () => {
 
 	useEffect(() => {
 		if (!isCapyDev || sessionLoading || session) return;
-		window.location.replace("/api/auth/capy-login");
-	}, [isCapyDev, session, sessionLoading]);
+		window.location.replace(
+			`/api/auth/capy-login?next=${encodeURIComponent(defaultPath)}`,
+		);
+	}, [defaultPath, isCapyDev, session, sessionLoading]);
 
 	// Passkey Conditional UI: browsers surface saved passkeys directly in the
 	// email field's autocomplete dropdown (no extra button needed). Requires

--- a/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
+++ b/vite/src/views/customers/customer/analytics/hooks/useEventNames.tsx
@@ -12,17 +12,20 @@ export const useEventNames = ({
 	interval,
 	start,
 	end,
+	enabled = true,
 }: {
 	limit?: number;
 	interval?: string;
 	start?: number | null;
 	end?: number | null;
+	enabled?: boolean;
 } = {}) => {
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 
 	const { data, isLoading, error } = useQuery({
 		queryKey: buildKey(["query-event-names-list", limit, interval, start, end]),
+		enabled,
 		queryFn: async () => {
 			const { data } = await axiosInstance.get("/query/event_names/list", {
 				params: {

--- a/vite/src/views/onboarding4/hooks/useOnboardingProgress.tsx
+++ b/vite/src/views/onboarding4/hooks/useOnboardingProgress.tsx
@@ -6,6 +6,7 @@ import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 
 const isDev = import.meta.env.DEV;
+const isCapyDev = import.meta.env.VITE_CAPY_DEV === "1";
 const REFETCH_INTERVAL = 5000;
 const DISMISSED_STORAGE_KEY = "autumn_products_onboarding_dismissed";
 
@@ -109,6 +110,7 @@ export const useOnboardingProgress = (): OnboardingProgress => {
 		rawEvents: { data: unknown[] };
 	}>({
 		queryKey: buildKey(["onboarding-events"]),
+		enabled: !isCapyDev,
 		queryFn: async () => {
 			const { data } = await axiosInstance.post("/query/raw", {
 				customer_id: null,

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -17,7 +17,10 @@ const vitePort = process.env.VITE_PORT
 	: 3000;
 const frontendUrl = process.env.VITE_FRONTEND_URL || "";
 const isCapyDev = process.env.CAPY_DEV === "1";
-if (isCapyDev) process.env.VITE_BACKEND_URL = "/__autumn_api";
+if (isCapyDev) {
+	process.env.VITE_BACKEND_URL = "/__autumn_api";
+	process.env.VITE_CAPY_DEV = "1";
+}
 
 function relativeRedirectLocation(location: string): string {
 	try {

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -190,11 +190,9 @@ export default defineConfig({
 			usePolling: true, // Required for file watching in Docker on Windows
 			interval: 1000,
 		},
-		hmr: viteHmrClient({
-			frontendUrl,
-			vitePort,
-			...(isCapyDev && { clientPort: 443 }),
-		}),
+		hmr: isCapyDev
+			? { clientPort: 443 }
+			: viteHmrClient({ frontendUrl, vitePort }),
 		fs: {
 			// Allow serving files from workspace root (monorepo support)
 			allow: [".."],


### PR DESCRIPTION
## Summary

- Replaces Capy's Google OAuth startup path with a `CAPY_DEV`-only automatic administrator login that provisions the test user, grants owner access, activates the test organization, and preserves redirect destinations.
- Removes the Google emulator from Capy startup, proxies browser API traffic through Vite, and stabilizes HMR for signed previews.
- Accepts Stripe Connect webhooks without signature verification only when explicitly enabled outside production; production always loads the secret and verifies the signature.
- Lazy-loads Vite route pages and keeps the dashboard shell mounted behind a nested Suspense boundary, so the active route no longer downloads every customer, analytics, admin, migration, and developer screen before rendering.

## Dashboard performance

Measured on the authenticated seeded `/sandbox/products` dashboard over seven identical warm reloads:

- Seeded content median: **11,313 ms → 5,513 ms** (`-51%`)
- Full idle median: **11,314 ms → 6,594 ms** (`-42%`)
- FCP median: **796 ms → 244 ms** (`-69%`)
- Transferred median: **41.45 MiB → 11.65 MiB** (`-72%`)
- Requests: **3,982 → 3,170** (`-20%`)

Cold seeded-content time improved from **11,208 ms → 5,840 ms**. Benchmarks used the same local Vite development server and waited for the seeded plan row, the loading screen to disappear, `networkidle`, and `document.fonts.ready`.

## Verification

- Stripe Connect sandbox delivery returned `200` through `/webhooks/connect/sandbox`.
- Webhook middleware unit tests cover local bypass and forced production verification.
- Capy handoff/auth tests, server and Vite typechecks, Biome, Knip, and Vite production build pass.
- React Doctor reports `90/100` with no issues.
- Authenticated Products and lazy-loaded Settings routes were visually smoke-tested.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR streamlines Capy authentication and preview networking, adds an explicit non-production Stripe webhook verification bypass, and lazy-loads dashboard routes to reduce initial loading work.

- **[Improvements, API changes]** Replaces Capy’s emulated Google OAuth startup with automatic provisioning and login for an isolated administrator account.
- **[Improvements]** Proxies Capy browser API requests through Vite and adjusts preview HMR and cookie handling.
- **[Improvements, API changes]** Allows Stripe Connect signature verification to be skipped only when explicitly configured outside production.
- **[Improvements]** Lazy-loads dashboard pages while preserving the mounted dashboard shell and route-level loading state.
- **[Improvements]** Avoids expensive analytics and onboarding event queries in Capy previews.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/auth/handleCapyLogin.ts | Adds the development-only Capy user provisioning, owner membership, organization activation, session-cookie handoff, and safe local redirect flow. |
| server/src/initHono.ts | Mounts the Capy login endpoint only when the non-production Capy mode guard is active. |
| server/src/external/stripe/webhookMiddlewares/stripeConnectSeederMiddleware.ts | Moves webhook-secret retrieval into the verified path while keeping production signature verification mandatory. |
| vite/src/App.tsx | Converts route screens to lazy imports and adds a top-level loading boundary. |
| vite/src/app/layout.tsx | Keeps the dashboard shell mounted while a nested Suspense boundary loads the active route. |
| vite/src/views/auth/SignIn.tsx | Automatically hands unauthenticated Capy previews to the development-only login endpoint. |
| vite/vite.config.ts | Exposes Capy mode to the frontend and configures same-origin API proxying and preview HMR. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Capy dashboard opens] --> B[Session check]
  B -->|No session| C[Capy login endpoint]
  C --> D[Provision test administrator and owner membership]
  D --> E[Activate test organization]
  E --> F[Set session cookie and redirect]
  B -->|Existing session| F
  F --> G[Dashboard shell]
  G --> H[Lazy-load active route]
```
</details>

<sub>Reviews (8): Last reviewed commit: ["fix(capy): restore Autumn flag loading"](https://github.com/useautumn/autumn/commit/295d6c0aa67e30264662d559f53bbcdcb66644d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55844801)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [HTTP API routing and middleware](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/http-api-routing.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)
- Knowledge Base — [Webhook contracts and delivery events](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/webhook-contracts.md)
</details>


<!-- /greptile_comment -->