### PR TITLE
feat(catalog): keep version identity stable across mint and slug rename

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/initProductRow.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/initProductRow.ts
@@ -34,15 +34,16 @@ export const initProductRow = ({
 			planParams,
 			current: base,
 		});
+		const willBeActive = planParams.active === true;
 		return {
 			...base,
 			...patch,
 			version,
-			// Mint fresh version identity — the base's slug/active must not ride
-			// along on the spread (a cloned slug would collide with the base row
-			// on unique_product_version_slug).
-			version_slug: `v${version}`,
-			active: true,
+			// Fresh slug/active — cloning the base's would collide on
+			// unique_product_version_slug / unique_active_product.
+			version_slug: planParams.new_version_slug ?? `v${version}`,
+			active: willBeActive,
+			is_default: willBeActive ? (patch.is_default ?? base.is_default) : false,
 			internal_id: generateId("prod"),
 			created_at: Date.now(),
 			group: (patch.group ?? base.group) || "",
@@ -60,8 +61,8 @@ export const initProductRow = ({
 		is_add_on: patch.is_add_on ?? false,
 		is_default: patch.is_default ?? false,
 		version,
-		version_slug: `v${version}`,
-		active: true,
+		version_slug: planParams.new_version_slug ?? `v${version}`,
+		active: planParams.active !== false,
 		group: patch.group || "",
 
 		env: ctx.env,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
@@ -31,6 +31,9 @@ export const planParamsToProductRowPatch = ({
 		patch.is_default = planParams.auto_enable;
 	}
 	if (planParams.archived !== undefined) patch.archived = planParams.archived;
+	if (planParams.new_version_slug !== undefined) {
+		patch.version_slug = planParams.new_version_slug;
+	}
 	if (planParams.config !== undefined) {
 		patch.config = {
 			ignore_past_due:

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/computeVariantPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/computeVariantPlan.ts
@@ -10,13 +10,16 @@ import { deriveVariantMints } from "./mints/deriveVariantMints";
 
 /** Creates + mints + edits for a folded base. Nested-base skip lives in derive. */
 export const computeVariantPlan = ({
+	intent,
 	upsert,
 	projectedProductStatesContext,
 }: {
+	intent: ProductUpsertIntent;
 	upsert: UpsertProductPlan;
 	projectedProductStatesContext: ProductStatesContext;
 }): ProductUpsertIntent[] => {
 	const mints = deriveVariantMints({
+		intent,
 		upsert,
 		projectedProductStatesContext,
 	});

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
@@ -59,9 +59,11 @@ const mintablePlanIds = ({
 
 /** Parent `new_version` → mint max+1 when the active row has customers. */
 export const deriveVariantMints = ({
+	intent,
 	upsert,
 	projectedProductStatesContext,
 }: {
+	intent: ProductUpsertIntent;
 	upsert: UpsertProductPlan;
 	projectedProductStatesContext: ProductStatesContext;
 }): ProductUpsertIntent[] => {
@@ -126,6 +128,7 @@ export const deriveVariantMints = ({
 				plan_id: planId,
 				version,
 				versioning: "new_version",
+				...(intent.planParams.active === true ? { active: true } : {}),
 				...settingsPatch,
 			},
 			source: "variant_propagation",

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { activeVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeVersionForPlan";
 import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
+import { versionForSlug } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug";
 
 const hasExplicitVersion = (
 	planParams: UpdateCatalogPlanParams,
@@ -28,8 +29,27 @@ const groupPlanParamsByPlanId = ({
 	return byPlanId;
 };
 
-/** Explicit versions ascending, then omit→active (or v1 if plan absent).
- * `new_version` always mints at max+1 (requires an existing plan — guarded elsewhere). */
+/** Numeric pin, or the version that owns `version_slug`. Unknown slugs stay unresolved. */
+const resolvePinnedVersion = ({
+	planParams,
+	planId,
+	productStatesContext,
+}: {
+	planParams: UpdateCatalogPlanParams;
+	planId: string;
+	productStatesContext: ProductStatesContext;
+}): number | undefined => {
+	if (planParams.version !== undefined) return planParams.version;
+	if (planParams.version_slug === undefined) return undefined;
+	return versionForSlug({
+		planId,
+		versionSlug: planParams.version_slug,
+		productStatesContext,
+	});
+};
+
+/** Explicit pins first (incl. resolved slugs), then omit→active / new_version max+1.
+ * Unknown `version_slug` is excluded here; versioning errors reject it. */
 const resolveVersionsForPlan = ({
 	planId,
 	planParamsList,
@@ -39,7 +59,16 @@ const resolveVersionsForPlan = ({
 	planParamsList: UpdateCatalogPlanParams[];
 	productStatesContext: ProductStatesContext;
 }): ResolvedPlanParams[] => {
-	const withExplicitVersion = planParamsList
+	const resolved = planParamsList.map((planParams) => {
+		const version = resolvePinnedVersion({
+			planParams,
+			planId,
+			productStatesContext,
+		});
+		return version !== undefined ? { ...planParams, version } : planParams;
+	});
+
+	const withExplicitVersion = resolved
 		.filter(hasExplicitVersion)
 		.sort((a, b) => a.version - b.version);
 
@@ -48,8 +77,12 @@ const resolveVersionsForPlan = ({
 		activeVersionForPlan({ planId, productStatesContext }) ??
 		(maxVersion || 1);
 
-	const targetingLatest = planParamsList
-		.filter((planParams) => !hasExplicitVersion(planParams))
+	const targetingLatest = resolved
+		.filter(
+			(planParams) =>
+				!hasExplicitVersion(planParams) &&
+				planParams.version_slug === undefined,
+		)
 		.map((planParams) => ({
 			...planParams,
 			version:

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
@@ -8,6 +8,7 @@ import type {
 
 /** Links-only pin for parent versions not already in the batch. Skip all_versions plans — siblings cover them. */
 export const deriveLicenseParentIntents = ({
+	intent,
 	upsert,
 	projectedProductStatesContext,
 	allVersionsPlanIds,
@@ -26,6 +27,7 @@ export const deriveLicenseParentIntents = ({
 
 	return [
 		...deriveLicenseParentMintIntents({
+			intent,
 			upsert,
 			productStatesContext: projectedProductStatesContext,
 		}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents.ts
@@ -12,9 +12,11 @@ import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/ut
 const licenseParentMintIntent = ({
 	planId,
 	productStatesContext,
+	sourceActive,
 }: {
 	planId: string;
 	productStatesContext: ProductStatesContext;
+	sourceActive: boolean;
 }): ProductUpsertIntent | undefined => {
 	const active = activeFullProductForPlan({ planId, productStatesContext });
 	if (!active) return undefined;
@@ -32,6 +34,7 @@ const licenseParentMintIntent = ({
 			plan_id: planId,
 			version,
 			versioning: "new_version",
+			...(sourceActive ? { active: true } : {}),
 		},
 		source: "license_adopt",
 	};
@@ -39,9 +42,11 @@ const licenseParentMintIntent = ({
 
 /** `propagate.license_parents` `new_version` → mint the parent. Direct claims win. */
 export const deriveLicenseParentMintIntents = ({
+	intent,
 	upsert,
 	productStatesContext,
 }: {
+	intent: ProductUpsertIntent;
 	upsert: UpsertProductPlan;
 	productStatesContext: ProductStatesContext;
 }): ProductUpsertIntent[] => {
@@ -55,6 +60,7 @@ export const deriveLicenseParentMintIntents = ({
 		const mintIntent = licenseParentMintIntent({
 			planId: target.plan_id,
 			productStatesContext,
+			sourceActive: intent.planParams.active === true,
 		});
 		if (!mintIntent) continue;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVariantIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVariantIntents.ts
@@ -11,6 +11,7 @@ import type {
  * Nested bases emit nothing.
  */
 export const deriveVariantIntents = ({
+	intent,
 	upsert,
 	projectedProductStatesContext,
 }: {
@@ -21,6 +22,7 @@ export const deriveVariantIntents = ({
 	if (upsert.row.nextFullProduct.base_internal_product_id) return [];
 
 	return computeVariantPlan({
+		intent,
 		upsert,
 		projectedProductStatesContext,
 	});

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/detectVersionSlugCollisions.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/detectVersionSlugCollisions.ts
@@ -1,0 +1,36 @@
+import type { FullProduct } from "@autumn/shared";
+
+export type VersionSlugCollision = {
+	planId: string;
+	versionSlug: string;
+	versions: number[];
+};
+
+/** Projected (plan id, version_slug) owned by more than one version. Null slugs ignored. */
+export const detectVersionSlugCollisions = ({
+	products,
+}: {
+	products: FullProduct[];
+}): VersionSlugCollision[] => {
+	const owners = new Map<string, FullProduct[]>();
+	for (const product of products) {
+		if (product.version_slug == null) continue;
+		const key = `${product.id}\0${product.version_slug}`;
+		const group = owners.get(key) ?? [];
+		group.push(product);
+		owners.set(key, group);
+	}
+
+	return [...owners.values()]
+		.filter((group) => {
+			const internalIds = new Set(group.map((product) => product.internal_id));
+			return internalIds.size > 1;
+		})
+		.map((group) => ({
+			planId: group[0].id,
+			versionSlug: group[0].version_slug as string,
+			versions: [...new Set(group.map((product) => product.version))].sort(
+				(a, b) => a - b,
+			),
+		}));
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -6,6 +6,7 @@ import { handleUpdateFeatureErrors } from "@/internal/catalogV2/actions/updateCa
 import { handleUpsertProductErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors";
 import { handleUpsertProductRenameErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors";
 import { handleUpsertProductVersioningErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors";
+import { handleUpsertProductVersionSlugErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersionSlugErrors";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
 
@@ -37,6 +38,7 @@ export const handleUpdateCatalogErrors = async ({
 		productStatesContext: catalogContext.productStatesContext,
 		updateCatalogPlan,
 	});
+	handleUpsertProductVersionSlugErrors({ updateCatalogPlan });
 	handleUpsertProductErrors({
 		updateCatalogPlan,
 		productStatesContext: catalogContext.productStatesContext,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersionSlugErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersionSlugErrors.ts
@@ -1,0 +1,21 @@
+import { ErrCode, RecaseError } from "@autumn/shared";
+import { detectVersionSlugCollisions } from "@/internal/catalogV2/actions/updateCatalog/errors/detectVersionSlugCollisions";
+import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+
+/** Block projected version_slug clashes on the same plan id (swap-safe: final set). */
+export const handleUpsertProductVersionSlugErrors = ({
+	updateCatalogPlan,
+}: {
+	updateCatalogPlan: UpdateCatalogPlan;
+}): void => {
+	const [collision] = detectVersionSlugCollisions({
+		products: updateCatalogPlan.projected.products,
+	});
+	if (!collision) return;
+
+	throw new RecaseError({
+		message: `Cannot set version_slug to ${collision.versionSlug}: another version of plan_id=${collision.planId} already has that slug`,
+		code: ErrCode.DuplicateVersionSlug,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors.ts
@@ -6,19 +6,22 @@ import {
 } from "@autumn/shared";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
+import { versionForSlug } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug";
 
 const rejectStrategyPlusExplicitVersion = ({
 	planId,
 	versioning,
 	version,
+	versionSlug,
 }: {
 	planId: string;
 	versioning: CatalogPlanVersioningStrategy | undefined;
 	version: number | undefined;
+	versionSlug?: string;
 }): void => {
 	if (
 		(versioning === "all_versions" || versioning === "new_version") &&
-		version !== undefined
+		(version !== undefined || versionSlug !== undefined)
 	) {
 		throw new RecaseError({
 			message: `versioning "${versioning}" cannot be combined with an explicit version (plan_id=${planId}). Omit version to target latest.`,
@@ -26,6 +29,26 @@ const rejectStrategyPlusExplicitVersion = ({
 			statusCode: 400,
 		});
 	}
+};
+
+const claimPinnedVersion = ({
+	planId,
+	version,
+	seenPinned,
+}: {
+	planId: string;
+	version: number;
+	seenPinned: Set<string>;
+}): void => {
+	const pinKey = `${planId}@${version}`;
+	if (seenPinned.has(pinKey)) {
+		throw new RecaseError({
+			message: `Duplicate plan entry for plan_id=${planId} version=${version}`,
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+	seenPinned.add(pinKey);
 };
 
 const rejectNewVersionOnMissingPlan = ({
@@ -63,6 +86,7 @@ export const handleUpsertProductVersioningErrors = ({
 			planId: planParams.plan_id,
 			versioning: planParams.versioning,
 			version: planParams.version,
+			versionSlug: planParams.version_slug,
 		});
 
 		const existingVersions =
@@ -126,15 +150,11 @@ export const handleUpsertProductVersioningErrors = ({
 		}
 
 		if (planParams.version !== undefined) {
-			const pinKey = `${planParams.plan_id}@${planParams.version}`;
-			if (seenPinned.has(pinKey)) {
-				throw new RecaseError({
-					message: `Duplicate plan entry for plan_id=${planParams.plan_id} version=${planParams.version}`,
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
-			seenPinned.add(pinKey);
+			claimPinnedVersion({
+				planId: planParams.plan_id,
+				version: planParams.version,
+				seenPinned,
+			});
 
 			const maxVersion = maxVersionForPlan({
 				planId: planParams.plan_id,
@@ -147,6 +167,24 @@ export const handleUpsertProductVersioningErrors = ({
 					statusCode: 400,
 				});
 			}
+		} else if (planParams.version_slug !== undefined) {
+			const version = versionForSlug({
+				planId: planParams.plan_id,
+				versionSlug: planParams.version_slug,
+				productStatesContext,
+			});
+			if (version === undefined) {
+				throw new RecaseError({
+					message: `Unknown version_slug "${planParams.version_slug}" for plan_id=${planParams.plan_id}`,
+					code: ErrCode.InvalidRequest,
+					statusCode: 400,
+				});
+			}
+			claimPinnedVersion({
+				planId: planParams.plan_id,
+				version,
+				seenPinned,
+			});
 		} else {
 			if (unpinnedPlanIds.has(planParams.plan_id)) {
 				throw new RecaseError({

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildLicenseParentsPreview.ts
@@ -8,6 +8,7 @@ import type {
 } from "@autumn/shared";
 import { productToProductKey } from "@autumn/shared";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
+import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import { childPropagatesToParent } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { withCatalogConflicts } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/conflicts/withCatalogConflicts";
 import { customerUsageForPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage";
@@ -202,8 +203,15 @@ const buildParentVersionPreview = ({
 	});
 	const planChange = parentPlanChange({ parentUpsert });
 	const preview = {
-		plan_id: stateKey.planId,
-		version: previewVersion,
+		...catalogRowIdentity({
+			planId: stateKey.planId,
+			version: previewVersion,
+			current:
+				parentUpsert?.row.op === "create"
+					? null
+					: (parentUpsert?.row.currentFullProduct ?? parentProduct),
+			next: parentUpsert?.row.nextFullProduct ?? parentProduct,
+		}),
 		name: parentProduct.name,
 		state: {
 			has_customers: parentState.customerUsage.hasVersionableCustomerProducts,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildPlansPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildPlansPreview.ts
@@ -6,6 +6,7 @@ import { buildRemovePlansPreview } from "@/internal/catalogV2/actions/updateCata
 import { aliasReplacementForPlan } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/aliasReplacementForPlan";
 import { buildVariantsPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildVariantsPreview";
 import { buildPlanVersioning } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildPlanVersioning";
+import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import { buildSiblingVersionsPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview";
 import { buildPlanUsage } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -73,8 +74,12 @@ export const buildPlansPreview = ({
 
 		return [
 			{
-				plan_id: upsert.row.planId,
-				version: upsert.row.version,
+				...catalogRowIdentity({
+					planId: upsert.row.planId,
+					version: upsert.row.version,
+					current: upsert.row.currentFullProduct,
+					next: upsert.row.nextFullProduct,
+				}),
 				name: upsert.row.nextFullProduct.name,
 				action: upsertOpToAction({ op: upsert.row.op }),
 				state: {

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildRemovePlansPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildRemovePlansPreview.ts
@@ -1,4 +1,8 @@
 import type { PreviewUpdateCatalogResponse } from "@autumn/shared";
+import {
+	catalogRowIdentity,
+	defaultVersionSlug,
+} from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import { buildPlanUsage } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage";
 import { formatPlanUsageMessages } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/formatPlanUsageMessages";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
@@ -41,9 +45,18 @@ const buildRemovePlanPreview = ({
 		productStatesContext: catalogContext.productStatesContext,
 	});
 	const name = first.current?.name ?? first.planId;
+	const current = first.current;
 	return {
-		plan_id: first.planId,
-		version: first.version,
+		...catalogRowIdentity({
+			planId: first.planId,
+			version: first.version,
+			current,
+			next: current ?? {
+				id: first.planId,
+				version_slug: defaultVersionSlug({ version: first.version }),
+				active: false,
+			},
+		}),
 		name,
 		action: "delete",
 		state: {

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
@@ -1,6 +1,7 @@
 import type { CatalogSiblingVersionPreview, FullProduct } from "@autumn/shared";
 import { productToProductKey } from "@autumn/shared";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
+import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import { withCatalogConflicts } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/conflicts/withCatalogConflicts";
 import { customerUsageForPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage";
 import type {
@@ -33,8 +34,12 @@ const selectedSiblingFromUpsert = ({
 
 	return withCatalogConflicts({
 		preview: {
-			plan_id: sibling.row.planId,
-			version: sibling.row.version,
+			...catalogRowIdentity({
+				planId: sibling.row.planId,
+				version: sibling.row.version,
+				current: sibling.row.currentFullProduct,
+				next: sibling.row.nextFullProduct,
+			}),
 			state: {
 				has_customers: sibling.state.hasCustomers,
 				will_archive: false,
@@ -67,8 +72,12 @@ const unselectedSiblingFromVersion = ({
 }): CatalogSiblingVersionPreview =>
 	withCatalogConflicts({
 		preview: {
-			plan_id: product.id,
-			version: product.version,
+			...catalogRowIdentity({
+				planId: product.id,
+				version: product.version,
+				current: product,
+				next: product,
+			}),
 			state: {
 				has_customers: productKeyToState({
 					productKey: productToProductKey({ product }),

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildVariantsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildVariantsPreview.ts
@@ -7,6 +7,7 @@ import type {
 	FullProduct,
 } from "@autumn/shared";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
+import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
 import { latestVariantsOfBase } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/variantPlanUtils";
 import { withVariantConflicts } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/conflicts/withVariantConflicts";
 import { customerUsageForPreview } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/planUsage/buildPlanUsage";
@@ -211,8 +212,12 @@ const siblingVersionsForVariant = ({
 			});
 			const planChange = variantPlanChange({ variantUpsert: siblingUpsert });
 			const preview: CatalogVariantVersionPreview = {
-				plan_id: product.id,
-				version: product.version,
+				...catalogRowIdentity({
+					planId: product.id,
+					version: product.version,
+					current: product,
+					next: siblingUpsert?.row.nextFullProduct ?? product,
+				}),
 				state: variantPreviewState({
 					planId: product.id,
 					version: product.version,
@@ -293,8 +298,12 @@ export const buildVariantsPreview = ({
 				base: directUpsert,
 			});
 			const preview = {
-				plan_id: variant.id,
-				version: previewVersion,
+				...catalogRowIdentity({
+					planId: variant.id,
+					version: previewVersion,
+					current: mintUpsert ? null : variant,
+					next: variantUpsert?.row.nextFullProduct ?? variant,
+				}),
 				versioning: variantVersioning({
 					variant,
 					mintUpsert,

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity.ts
@@ -1,0 +1,42 @@
+export const defaultVersionSlug = ({ version }: { version: number }) =>
+	`v${version}`;
+
+type IdentityProduct = {
+	id: string;
+	version_slug?: string | null;
+	active: boolean;
+};
+
+/** Identity trio for a preview row — `new_*` only when that field actually changes. */
+export const catalogRowIdentity = ({
+	planId,
+	version,
+	current,
+	next,
+}: {
+	planId: string;
+	version: number;
+	current?: IdentityProduct | null;
+	next: IdentityProduct;
+}): {
+	plan_id: string;
+	version: number;
+	version_slug: string;
+	active: boolean;
+	new_plan_id?: string;
+	new_version_slug?: string;
+} => {
+	const fallbackSlug = defaultVersionSlug({ version });
+	const versionSlug = current?.version_slug ?? fallbackSlug;
+	const nextSlug = next.version_slug ?? fallbackSlug;
+	const currentPlanId = current?.id ?? planId;
+
+	return {
+		plan_id: planId,
+		version,
+		version_slug: versionSlug,
+		active: next.active,
+		...(next.id !== currentPlanId ? { new_plan_id: next.id } : {}),
+		...(nextSlug !== versionSlug ? { new_version_slug: nextSlug } : {}),
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/versionForSlug.ts
@@ -1,0 +1,15 @@
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+
+/** Version number for this plan_id + version_slug, or undefined if no row owns it. */
+export const versionForSlug = ({
+	planId,
+	versionSlug,
+	productStatesContext,
+}: {
+	planId: string;
+	versionSlug: string;
+	productStatesContext: ProductStatesContext;
+}): number | undefined =>
+	(productStatesContext.versionsByPlanId[planId] ?? []).find(
+		(product) => product.version_slug === versionSlug,
+	)?.version;

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
@@ -34,6 +34,7 @@ export const applyProductDetailsUpdate = async ({
 			is_add_on: product.is_add_on,
 			is_default: product.is_default,
 			archived: product.archived,
+			version_slug: product.version_slug,
 			config: product.config,
 			metadata: product.metadata,
 			auto_topups: product.auto_topups,

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
@@ -8,10 +8,11 @@ import { deleteClaimedPlanAliases } from "@/internal/catalogV2/execute/deleteCla
 import { ProductService } from "@/internal/products/ProductService.js";
 import { applyEntitlementPricesPlan } from "./applyEntitlementPricesPlan";
 import { applyFreeTrialPlan } from "./applyFreeTrialPlan";
-import { executePlanLicensesPlan } from "./executePlanLicensesPlan";
 import { applyProductDetailsUpdate } from "./applyProductDetailsUpdate";
 import { clearDefaultFlagFromOtherVersions } from "./clearDefaultFlagFromOtherVersions";
+import { executePlanLicensesPlan } from "./executePlanLicensesPlan";
 import { syncPlanMetadataAcrossVersions } from "./syncPlanMetadataAcrossVersions";
+import { vacateRenamedVersionSlugs } from "./vacateRenamedVersionSlugs";
 
 const executeUpsertProduct = async ({
 	ctx,
@@ -59,21 +60,29 @@ export const executeUpsertProducts = async ({
 	ctx: AutumnContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 }): Promise<CatalogAppliedResult[]> => {
-	const results: CatalogAppliedResult[] = [];
+	return await ctx.db.transaction(async (tx) => {
+		const txCtx = { ...ctx, db: tx as unknown as DrizzleCli };
+		const results: CatalogAppliedResult[] = [];
 
-	// Pass 1: write product rows (details, items, trial).
-	for (const upsert of updateCatalogPlan.upsertProducts) {
-		await executeUpsertProduct({ ctx, upsert });
-		results.push({
-			id: upsert.row.planId,
-			action: upsertOpToAction({ op: upsert.row.op }),
+		await vacateRenamedVersionSlugs({
+			ctx: txCtx,
+			upsertProducts: updateCatalogPlan.upsertProducts,
 		});
-	}
 
-	// Pass 2: replay plan_license writes after every child row exists.
-	for (const upsert of updateCatalogPlan.upsertProducts) {
-		await executePlanLicensesPlan({ ctx, upsert });
-	}
+		// Pass 1: write product rows (details, items, trial).
+		for (const upsert of updateCatalogPlan.upsertProducts) {
+			await executeUpsertProduct({ ctx: txCtx, upsert });
+			results.push({
+				id: upsert.row.planId,
+				action: upsertOpToAction({ op: upsert.row.op }),
+			});
+		}
 
-	return results;
+		// Pass 2: replay plan_license writes after every child row exists.
+		for (const upsert of updateCatalogPlan.upsertProducts) {
+			await executePlanLicensesPlan({ ctx: txCtx, upsert });
+		}
+
+		return results;
+	});
 };

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/vacateRenamedVersionSlugs.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/vacateRenamedVersionSlugs.ts
@@ -1,0 +1,24 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+/** unique_product_version_slug is immediate — clear first so a same-call swap can land. */
+export const vacateRenamedVersionSlugs = async ({
+	ctx,
+	upsertProducts,
+}: {
+	ctx: AutumnContext;
+	upsertProducts: UpsertProductPlan[];
+}): Promise<void> => {
+	for (const upsert of upsertProducts) {
+		if (upsert.row.op !== "update" || !upsert.details) continue;
+		const previous = upsert.details.previousAttributes?.version_slug;
+		const next = upsert.details.product.version_slug;
+		if (previous == null || next == null || previous === next) continue;
+		await ProductService.updateByInternalId({
+			db: ctx.db,
+			internalId: upsert.details.product.internal_id,
+			update: { version_slug: null },
+		});
+	}
+};

--- a/server/tests/integration/billing/attach/version-identity-attach.test.ts
+++ b/server/tests/integration/billing/attach/version-identity-attach.test.ts
@@ -91,7 +91,7 @@ test.concurrent(
 			plans: [
 				{
 					plan_id: pro.id,
-					versioning: "new_version",
+					versioning: "new_version", active: true,
 					items: [monthlyMessagesItem(500)],
 				},
 			],
@@ -129,7 +129,7 @@ test.concurrent(
 			plans: [
 				{
 					plan_id: pro.id,
-					versioning: "new_version",
+					versioning: "new_version", active: true,
 					items: [monthlyMessagesItem(500)],
 				},
 			],

--- a/server/tests/integration/catalog-v2/plans/create/stripe-init.test.ts
+++ b/server/tests/integration/catalog-v2/plans/create/stripe-init.test.ts
@@ -341,7 +341,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						price: { amount: 30, interval: BillingInterval.Month },
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/integration/catalog-v2/plans/create/version-identity-stripe-reuse.test.ts
+++ b/server/tests/integration/catalog-v2/plans/create/version-identity-stripe-reuse.test.ts
@@ -67,7 +67,7 @@ const seedPaidBaseAndV2 = async ({
 		plans: [
 			{
 				plan_id: baseId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				price: { amount: 30, interval: BillingInterval.Month },
 			},
 		],

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/compose-parent-plans.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/compose-parent-plans.test.ts
@@ -155,7 +155,7 @@ test.concurrent(
 						{
 							plan_id: parentId,
 							name: "Renamed",
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 						},
 					],
 				});

--- a/server/tests/integration/catalog-v2/plans/licenses/mix/declared-exclusive-vs-propagate.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/mix/declared-exclusive-vs-propagate.test.ts
@@ -222,7 +222,7 @@ test.concurrent(
 						{
 							plan_id: childId,
 							items: [messagesItem(200)],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 						},
 						{
 							plan_id: parentId,

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-customize.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-customize.test.ts
@@ -239,7 +239,7 @@ test.concurrent(
 					plans: [
 						{
 							plan_id: parentId,
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							licenses: [
 								{
 									license_plan_id: childId,

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-follow.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/license-changes-follow.test.ts
@@ -142,7 +142,7 @@ test.concurrent(
 							{
 								plan_id: childId,
 								items: [messagesItem(200)],
-								versioning: "new_version",
+								versioning: "new_version", active: true,
 							},
 							{ plan_id: parentId },
 						],

--- a/server/tests/integration/catalog-v2/plans/licenses/preview/license-parent-versioning.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/preview/license-parent-versioning.test.ts
@@ -55,7 +55,7 @@ test.concurrent(
 								items: [messagesItem(200)],
 								propagate: {
 									license_parents: [
-										{ plan_id: parentId, versioning: "new_version" },
+										{ plan_id: parentId, versioning: "new_version", active: true },
 									],
 								},
 							},
@@ -122,7 +122,7 @@ test.concurrent(
 								items: [messagesItem(200)],
 								propagate: {
 									license_parents: [
-										{ plan_id: parentId, versioning: "new_version" },
+										{ plan_id: parentId, versioning: "new_version", active: true },
 									],
 								},
 							},

--- a/server/tests/integration/catalog-v2/plans/licenses/propagated/follower-mint-active.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/propagated/follower-mint-active.test.ts
@@ -1,0 +1,138 @@
+/**
+ * catalogV2.update — license-parent follower mint follows the child's planParams.active.
+ *
+ * Contract:
+ *   child new_version omit active + propagate.license_parents new_version
+ *     → minted parent is draft
+ *   same with child active:true → minted parent is active
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../../migrations/utils/seedVersionableCustomer.js";
+import { expectVersionIdentityCorrect } from "../../utils/expectVersionIdentity.js";
+import {
+	messagesItem,
+	seedTwoParentVersions,
+	withCatalogPlans,
+} from "../utils/seedLicensePlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: follower mint without child active stays a draft")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_fma_d_p");
+		const childId = uniqueTestId("cv2_lic_fma_d_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				await seedVersionableCustomer({
+					ctx,
+					planId: parentId,
+					version: 2,
+				});
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+							propagate: {
+								license_parents: [
+									{ plan_id: parentId, versioning: "new_version" },
+								],
+							},
+						},
+					],
+				});
+
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: childId,
+					version: 2,
+					active: false,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: parentId,
+					version: 2,
+					active: true,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: parentId,
+					version: 3,
+					active: false,
+					isDefault: false,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: follower mint with child active:true is active")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_fma_a_p");
+		const childId = uniqueTestId("cv2_lic_fma_a_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedTwoParentVersions({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				await seedVersionableCustomer({
+					ctx,
+					planId: parentId,
+					version: 2,
+				});
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							items: [messagesItem(200)],
+							versioning: "new_version",
+							active: true,
+							propagate: {
+								license_parents: [
+									{ plan_id: parentId, versioning: "new_version" },
+								],
+							},
+						},
+					],
+				});
+
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: childId,
+					version: 2,
+					active: true,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: parentId,
+					version: 2,
+					active: false,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: parentId,
+					version: 3,
+					active: true,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/utils/seedLicensePlans.ts
@@ -141,7 +141,7 @@ export const seedParentVersionWithLicense = async ({
 		plans: [
 			{
 				plan_id: parentId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				licenses: [{ license_plan_id: childId, included }],
 			},
 		],
@@ -235,6 +235,7 @@ export const bumpChild = async ({
 				plan_id: childId,
 				items: items ?? [messagesItem(included)],
 				...(versioning ? { versioning } : {}),
+				...(versioning === "new_version" ? { active: true } : {}),
 				...(propagate ? { propagate } : {}),
 			},
 			...(parentPlans ?? []),

--- a/server/tests/integration/catalog-v2/plans/migrations/filter-collapse.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/filter-collapse.test.ts
@@ -87,7 +87,7 @@ test.concurrent(
 				included: 100,
 			});
 			await autumnV2_3.catalogV2.update({
-				plans: [{ plan_id: planId, versioning: "new_version" }],
+				plans: [{ plan_id: planId, versioning: "new_version", active: true }],
 			});
 			await seedVersionableCustomer({ ctx, planId, version: 1 });
 

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/pinned/pin-omits-parent-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/pinned/pin-omits-parent-drafts.test.ts
@@ -126,7 +126,7 @@ test.concurrent(
 						{
 							plan_id: childId,
 							items: [messagesItem(200)],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 						},
 					],
 					expected: [],

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-and-parent-versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-and-parent-versioning-drafts.test.ts
@@ -291,7 +291,7 @@ test.concurrent(
 						{
 							plan_id: childId,
 							items: [messagesItem(200)],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							propagate: {
 								license_parents: [
 									{ plan_id: teamId, versioning: "all_versions" },
@@ -342,7 +342,7 @@ test.concurrent(
 						},
 						{
 							plan_id: teamId,
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							name: "Team v2",
 						},
 					],

--- a/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/licenses/versioning/child-versioning-drafts.test.ts
@@ -252,7 +252,7 @@ test.concurrent(
 						{
 							plan_id: childId,
 							items: [messagesItem(200)],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							propagate: { license_parents: [{ plan_id: teamId }] },
 						},
 					],

--- a/server/tests/integration/catalog-v2/plans/migrations/variants/versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/variants/versioning-drafts.test.ts
@@ -47,6 +47,7 @@ const followDashboard = ({
 	propagate: { variants: [{ plan_id: variantId }] },
 	migration: { draft: true as const },
 	...(versioning ? { versioning } : {}),
+	...(versioning === "new_version" ? { active: true } : {}),
 });
 
 test.concurrent(

--- a/server/tests/integration/catalog-v2/plans/migrations/versioning-drafts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/migrations/versioning-drafts.test.ts
@@ -342,7 +342,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: minted,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						items: [messagesItem({ included: 500 })],
 					},
 					{

--- a/server/tests/integration/catalog-v2/plans/preview/preview-state-versioning.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/preview-state-versioning.test.ts
@@ -353,7 +353,7 @@ test.concurrent(
 						{
 							plan_id: planId,
 							name: "New Name",
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 						},
 					],
 				}),

--- a/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
@@ -62,6 +62,12 @@ type ExpectedPlanPreviewRow = {
 	currentVersion?: number;
 	action?: PlanPreviewRow["action"];
 	name?: string;
+	versionSlug?: string;
+	/** Pass `null` to assert `new_version_slug` is omitted. */
+	newVersionSlug?: string | null;
+	/** Pass `null` to assert `new_plan_id` is omitted. */
+	newPlanId?: string | null;
+	active?: boolean;
 	hasCustomers?: boolean;
 	customerCount?: number;
 	willArchive?: boolean;
@@ -285,6 +291,26 @@ export const expectPlanPreviewRowCorrect = ({
 		} else {
 			expect(row.alias_replacement).toEqual(expected.aliasReplacement);
 		}
+	}
+	if (expected.versionSlug !== undefined) {
+		expect(row.version_slug).toBe(expected.versionSlug);
+	}
+	if (expected.newVersionSlug !== undefined) {
+		if (expected.newVersionSlug === null) {
+			expect(row.new_version_slug).toBeUndefined();
+		} else {
+			expect(row.new_version_slug).toBe(expected.newVersionSlug);
+		}
+	}
+	if (expected.newPlanId !== undefined) {
+		if (expected.newPlanId === null) {
+			expect(row.new_plan_id).toBeUndefined();
+		} else {
+			expect(row.new_plan_id).toBe(expected.newPlanId);
+		}
+	}
+	if (expected.active !== undefined) {
+		expect(row.active).toBe(expected.active);
 	}
 	if (expected.hasCustomers !== undefined) {
 		expect(row.state.has_customers).toBe(expected.hasCustomers);

--- a/server/tests/integration/catalog-v2/plans/remove/remove-plans-errors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/remove/remove-plans-errors.test.ts
@@ -112,7 +112,7 @@ test.concurrent(
 				plans: [{ plan_id: planId, name: "Historical" }],
 			});
 			await autumnV2_3.catalogV2.update({
-				plans: [{ plan_id: planId, versioning: "new_version" }],
+				plans: [{ plan_id: planId, versioning: "new_version", active: true }],
 			});
 
 			const params = { remove_plans: [{ plan_id: planId, version: 1 }] };

--- a/server/tests/integration/catalog-v2/plans/remove/remove-plans-repoint.test.ts
+++ b/server/tests/integration/catalog-v2/plans/remove/remove-plans-repoint.test.ts
@@ -38,7 +38,7 @@ const seedBaseV2WithVariant = async ({
 }) => {
 	await seedBaseWithVariant({ autumn, baseId, variantId });
 	await autumn.catalogV2.update({
-		plans: [{ plan_id: baseId, versioning: "new_version" }],
+		plans: [{ plan_id: baseId, versioning: "new_version", active: true }],
 	});
 };
 

--- a/server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts
+++ b/server/tests/integration/catalog-v2/plans/remove/version-identity-remove.test.ts
@@ -47,7 +47,7 @@ const seedV1AndV2 = async ({
 		plans: [{ plan_id: planId, name: "V1" }],
 	});
 	await autumn.catalogV2.update({
-		plans: [{ plan_id: planId, versioning: "new_version", name: "V2" }],
+		plans: [{ plan_id: planId, versioning: "new_version", active: true, name: "V2" }],
 	});
 };
 

--- a/server/tests/integration/catalog-v2/plans/update/metadata-versions.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/metadata-versions.test.ts
@@ -55,7 +55,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: planId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						price: { amount: 30, interval: BillingInterval.Month },
 					},
 				],
@@ -99,7 +99,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: planId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						price: { amount: 30, interval: BillingInterval.Month },
 						metadata: { tier: "b" },
 					},
@@ -140,7 +140,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: planId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						price: { amount: 30, interval: BillingInterval.Month },
 					},
 				],
@@ -188,7 +188,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: planId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						price: { amount: 30, interval: BillingInterval.Month },
 					},
 				],

--- a/server/tests/integration/catalog-v2/plans/update/reward-migration.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/reward-migration.test.ts
@@ -204,7 +204,7 @@ test.concurrent(
 				{
 					plan_id: pro.id,
 					price: { amount: 50, interval: "month" },
-					versioning: "new_version" as const,
+					versioning: "new_version", active: true as const,
 				},
 			],
 		});

--- a/server/tests/integration/catalog-v2/plans/update/stripe-price-immutability.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/stripe-price-immutability.test.ts
@@ -144,7 +144,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						name: "Team V2",
-						versioning: "new_version" as const,
+						versioning: "new_version", active: true as const,
 					},
 				],
 			});

--- a/server/tests/integration/catalog-v2/plans/update/stripe-reuse-mint.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/stripe-reuse-mint.test.ts
@@ -1,5 +1,5 @@
 /**
- * catalogV2.update — Stripe id carry on versioning: "new_version" mint.
+ * catalogV2.update — Stripe id carry on versioning: "new_version", active: true mint.
  *
  * Pre-seeds real Stripe resources via initPlanStripeResources, then mints v2
  * and asserts reuse levels. Plan-level processor.id is copied onto the v2 row.
@@ -97,7 +97,7 @@ test.concurrent(
 						plan_id: planId,
 						name: "Stripe Mint Same V2",
 						items: [prepaidMessagesItem({ amount: 10 })],
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -146,7 +146,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						items: [usageMessagesItem({ amount: 0.9 })],
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -197,7 +197,7 @@ test.concurrent(
 							{ feature_id: TestFeature.Dashboard },
 							prepaidMessagesItem({ amount: 10 }),
 						],
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/integration/catalog-v2/plans/update/stripe-reuse.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/stripe-reuse.test.ts
@@ -492,7 +492,7 @@ test.concurrent(
 						plan_id: planId,
 						name: "Stripe Mint V2",
 						items: [prepaidMessagesItem({ amount: 10 })],
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/integration/catalog-v2/plans/utils/expectAttachedPlanVersion.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/expectAttachedPlanVersion.ts
@@ -1,0 +1,80 @@
+import { expect } from "bun:test";
+import { customerProducts } from "@autumn/shared";
+import { and, eq } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+/** cusProduct rows for one customer on one plan, any version. */
+export const fetchAttachedPlanRows = async ({
+	ctx,
+	internalCustomerId,
+	planId,
+}: {
+	ctx: AutumnContext;
+	internalCustomerId: string;
+	planId: string;
+}) =>
+	ctx.db
+		.select()
+		.from(customerProducts)
+		.where(
+			and(
+				eq(customerProducts.internal_customer_id, internalCustomerId),
+				eq(customerProducts.product_id, planId),
+			),
+		);
+
+/** Exactly one attached version unless `count` is passed; match version / entity only when set. */
+export const expectAttachedPlanVersionCorrect = async ({
+	ctx,
+	internalCustomerId,
+	planId,
+	version,
+	count,
+	entityId,
+}: {
+	ctx: AutumnContext;
+	internalCustomerId: string;
+	planId: string;
+	version?: number;
+	count?: number;
+	/** `true` = any entity_id; a string = that exact entity id. */
+	entityId?: string | true;
+}) => {
+	const rows = await fetchAttachedPlanRows({
+		ctx,
+		internalCustomerId,
+		planId,
+	});
+
+	if (count !== undefined) {
+		expect(
+			rows,
+			"exactly one version of the default plan may attach",
+		).toHaveLength(count);
+	} else if (version !== undefined) {
+		expect(
+			rows,
+			"exactly one version of the default plan may attach",
+		).toHaveLength(1);
+	}
+
+	if (version !== undefined) {
+		const product = await ProductService.get({
+			db: ctx.db,
+			id: planId,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			version,
+		});
+		expect(product, `missing ${planId} v${version}`).toBeDefined();
+		if (!product) return;
+		expect(rows[0]?.internal_product_id).toBe(product.internal_id);
+	}
+
+	if (entityId === true) {
+		expect(rows[0]?.entity_id).toBeTruthy();
+	} else if (entityId !== undefined) {
+		expect(rows[0]?.entity_id).toBe(entityId);
+	}
+};

--- a/server/tests/integration/catalog-v2/plans/utils/expectVersionIdentity.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/expectVersionIdentity.ts
@@ -1,0 +1,77 @@
+import { expect } from "bun:test";
+import { invalidateProductsCache } from "@/external/redis/actions/productsCache/productsCache.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+/** DB identity columns for one plan version — assert only fields passed. */
+export const expectVersionIdentityCorrect = async ({
+	ctx,
+	planId,
+	version,
+	versionSlug,
+	active,
+	isDefault,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+	versionSlug?: string;
+	active?: boolean;
+	isDefault?: boolean;
+}) => {
+	const product = await ProductService.get({
+		db: ctx.db,
+		id: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		version,
+	});
+	expect(product, `missing ${planId} v${version}`).toBeDefined();
+	expect(product?.version).toBe(version);
+	if (versionSlug !== undefined) {
+		expect(product?.version_slug).toBe(versionSlug);
+	}
+	if (active !== undefined) {
+		expect(product?.active).toBe(active);
+	}
+	if (isDefault !== undefined) {
+		expect(product?.is_default).toBe(isDefault);
+	}
+};
+
+/** Flip the active pointer in DB (test-only — not a catalogV2 promote). */
+export const forceActiveVersion = async ({
+	ctx,
+	planId,
+	version,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+	version: number;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	for (const product of versions) {
+		if (product.active && product.version !== version) {
+			await ProductService.updateByInternalId({
+				db: ctx.db,
+				internalId: product.internal_id,
+				update: { active: false },
+			});
+		}
+	}
+	const target = versions.find((product) => product.version === version);
+	expect(target).toBeDefined();
+	await ProductService.updateByInternalId({
+		db: ctx.db,
+		internalId: target!.internal_id,
+		update: { active: true },
+	});
+	await invalidateProductsCache({ orgId: ctx.org.id, env: ctx.env });
+};

--- a/server/tests/integration/catalog-v2/plans/validation/plan-errors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/validation/plan-errors.test.ts
@@ -47,7 +47,7 @@ test.concurrent(
 								plan_id: planId,
 								version: 1,
 								name: "Next",
-								versioning: "new_version",
+								versioning: "new_version", active: true,
 							},
 						],
 					}),
@@ -77,7 +77,7 @@ test.concurrent(
 						plans: [
 							{
 								plan_id: planId,
-								versioning: "new_version",
+								versioning: "new_version", active: true,
 								name: "Next",
 								migration: { draft: true },
 							},
@@ -106,7 +106,7 @@ test.concurrent(
 							{
 								plan_id: planId,
 								name: "Ghost",
-								versioning: "new_version",
+								versioning: "new_version", active: true,
 							},
 						],
 					}),

--- a/server/tests/integration/catalog-v2/plans/variants/pointer/pointer-on-base-mint.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/pointer/pointer-on-base-mint.test.ts
@@ -41,7 +41,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: baseId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						items: [messagesItem(100), dashboardItem()],
 					},
 				],
@@ -87,7 +87,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: baseId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						items: [messagesItem(100), dashboardItem()],
 						propagate: { variants: [{ plan_id: variantId }] },
 					},
@@ -128,7 +128,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: baseId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						items: [messagesItem(100), dashboardItem()],
 					},
 				],

--- a/server/tests/integration/catalog-v2/plans/variants/preview/parent-versioning-options-pinned.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/preview/parent-versioning-options-pinned.test.ts
@@ -37,7 +37,7 @@ test.concurrent(
 					variantId,
 				});
 				await autumnV2_3.catalogV2.update({
-					plans: [{ plan_id: baseId, versioning: "new_version" }],
+					plans: [{ plan_id: baseId, versioning: "new_version", active: true }],
 				});
 				await seedVersionableCustomer({
 					ctx,

--- a/server/tests/integration/catalog-v2/plans/variants/preview/variants-preview.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/preview/variants-preview.test.ts
@@ -424,7 +424,7 @@ test.concurrent(
 						{
 							plan_id: baseId,
 							items: [messagesItem(100), dashboardItem()],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							propagate: { variants: [{ plan_id: variantId }] },
 						},
 					],
@@ -462,7 +462,7 @@ test.concurrent(
 						{
 							plan_id: baseId,
 							items: [messagesItem(100), dashboardItem()],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							propagate: { variants: [{ plan_id: variantId }] },
 						},
 					],

--- a/server/tests/integration/catalog-v2/plans/variants/settings/billing-controls.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/settings/billing-controls.test.ts
@@ -207,7 +207,7 @@ test.concurrent(
 				plans: [
 					{
 						plan_id: variantId,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 						metadata: { stamp: "v2" },
 					},
 				],

--- a/server/tests/integration/catalog-v2/plans/variants/utils/seedVariantPlans.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/utils/seedVariantPlans.ts
@@ -87,7 +87,7 @@ export const seedVariantNewVersion = async ({
 	variantId: string;
 }) => {
 	await autumn.catalogV2.update({
-		plans: [{ plan_id: variantId, versioning: "new_version" }],
+		plans: [{ plan_id: variantId, versioning: "new_version", active: true }],
 	});
 };
 

--- a/server/tests/integration/catalog-v2/plans/variants/versioning/follower-mint-active.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/versioning/follower-mint-active.test.ts
@@ -1,0 +1,130 @@
+/**
+ * catalogV2.update — variant follower mint follows the base's planParams.active.
+ *
+ * Contract:
+ *   base new_version omit active + propagate.variants → minted variant is draft
+ *   same with base active:true → minted variant is active
+ */
+
+import { test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { seedVersionableCustomer } from "../../migrations/utils/seedVersionableCustomer.js";
+import {
+	dashboardItem,
+	messagesItem,
+	withCatalogPlans,
+} from "../../licenses/utils/seedLicensePlans.js";
+import { expectVersionIdentityCorrect } from "../../utils/expectVersionIdentity.js";
+import { seedBaseWithVariant } from "../utils/seedVariantPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: follower mint without base active stays a draft")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_fma_d");
+		const variantId = uniqueTestId("cv2_var_fma_d_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							items: [messagesItem(100), dashboardItem()],
+							versioning: "new_version",
+							propagate: { variants: [{ plan_id: variantId }] },
+						},
+					],
+				});
+
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: baseId,
+					version: 1,
+					active: true,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: baseId,
+					version: 2,
+					active: false,
+					isDefault: false,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: variantId,
+					version: 1,
+					active: true,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: variantId,
+					version: 2,
+					active: false,
+					isDefault: false,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: follower mint with base active:true is active")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_fma_a");
+		const variantId = uniqueTestId("cv2_var_fma_a_eu");
+		await withCatalogPlans({
+			ctx,
+			planIds: [baseId, variantId],
+			run: async () => {
+				await seedBaseWithVariant({
+					autumn: autumnV2_3,
+					baseId,
+					variantId,
+				});
+				await seedVersionableCustomer({ ctx, planId: variantId, version: 1 });
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: baseId,
+							items: [messagesItem(100), dashboardItem()],
+							versioning: "new_version",
+							active: true,
+							propagate: { variants: [{ plan_id: variantId }] },
+						},
+					],
+				});
+
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: baseId,
+					version: 2,
+					active: true,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: variantId,
+					version: 1,
+					active: false,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: variantId,
+					version: 2,
+					active: true,
+					isDefault: false,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/variants/versioning/mixed-customers.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/versioning/mixed-customers.test.ts
@@ -44,7 +44,7 @@ test.concurrent(
 						{
 							plan_id: baseId,
 							items: [messagesItem(100), dashboardItem()],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							propagate: {
 								variants: [{ plan_id: euId }, { plan_id: ukId }],
 							},
@@ -100,7 +100,7 @@ test.concurrent(
 							{
 								plan_id: baseId,
 								items: [messagesItem(100), dashboardItem()],
-								versioning: "new_version",
+								versioning: "new_version", active: true,
 								propagate: {
 									variants: [{ plan_id: euId }, { plan_id: ukId }],
 								},

--- a/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-versioning-errors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-versioning-errors.test.ts
@@ -46,7 +46,7 @@ test.concurrent(
 											{
 												plan_id: variantId,
 												version: 1,
-												versioning: "new_version",
+												versioning: "new_version", active: true,
 											},
 										],
 									},
@@ -132,7 +132,7 @@ test.concurrent(
 									items: [messagesItem(100), dashboardItem()],
 									propagate: {
 										variants: [
-											{ plan_id: missingId, versioning: "new_version" },
+											{ plan_id: missingId, versioning: "new_version", active: true },
 										],
 									},
 								},
@@ -171,7 +171,7 @@ test.concurrent(
 									items: [messagesItem(100), dashboardItem()],
 									propagate: {
 										variants: [
-											{ plan_id: variantId, versioning: "new_version" },
+											{ plan_id: variantId, versioning: "new_version", active: true },
 										],
 									},
 									migration: { draft: true },

--- a/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-versioning.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/versioning/propagate-versioning.test.ts
@@ -154,7 +154,7 @@ test.concurrent(
 						{
 							plan_id: baseId,
 							items: [messagesItem(100), dashboardItem()],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							propagate: { variants: [{ plan_id: variantId }] },
 						},
 					],
@@ -198,7 +198,7 @@ test.concurrent(
 						{
 							plan_id: baseId,
 							items: [messagesItem(100), dashboardItem()],
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 							propagate: { variants: [{ plan_id: variantId }] },
 						},
 					],
@@ -280,7 +280,7 @@ test.concurrent(
 					variantId,
 				});
 				await autumnV2_3.catalogV2.update({
-					plans: [{ plan_id: baseId, versioning: "new_version" }],
+					plans: [{ plan_id: baseId, versioning: "new_version", active: true }],
 				});
 				await seedVariantNewVersion({ autumn: autumnV2_3, variantId });
 				await autumnV2_3.catalogV2.update({

--- a/server/tests/integration/catalog-v2/plans/versions/all-versions-items.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/all-versions-items.test.ts
@@ -147,7 +147,7 @@ const seedV1AndMintV2 = async ({
 				plan_id: planId,
 				name: "V2",
 				items: [messagesItem(150)],
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 			},
 		],
 	});
@@ -322,7 +322,7 @@ test.concurrent(
 						plan_id: planId,
 						name: "V2",
 						items: [messagesItem(100), dashboardItem],
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/integration/catalog-v2/plans/versions/default-follows-active.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/default-follows-active.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Default flag follows the active pointer on a free auto_enable plan.
+ *
+ * Contract:
+ *   Promote existing draft (`version_slug` + `active: true`) → that row is
+ *   active + is_default; the previous pointer loses both.
+ *   Same for a custom slug (e.g. "summer"): pointer and default move together.
+ *
+ * Draft-mint identity (omit `active` → v2 inactive, v1 keeps default) lives in
+ * version-identity-mint.test.ts — asserted here only as the pre-promote state.
+ *
+ * Unit 5 / slug targeting may be unwired; these tests document the contract.
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { expectVersionIdentityCorrect } from "../utils/expectVersionIdentity.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const seedDefaultFreeV1 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "Free Default V1",
+				auto_enable: true,
+				items: [messagesItem(100)],
+			},
+		],
+	});
+};
+
+const mintDraftV2 = async ({
+	autumn,
+	planId,
+	newVersionSlug,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+	newVersionSlug?: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				name: "V2 Draft",
+				...(newVersionSlug ? { new_version_slug: newVersionSlug } : {}),
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 defaults: promoting a draft via version_slug makes it default")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_def_promo");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultFreeV1({ autumn: autumnV2_3, planId });
+			await mintDraftV2({ autumn: autumnV2_3, planId });
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: true,
+				isDefault: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: false,
+				isDefault: false,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "v2", active: true }],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+				isDefault: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+				isDefault: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 defaults: promoting a custom slug moves pointer and default")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_def_slug");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultFreeV1({ autumn: autumnV2_3, planId });
+			await mintDraftV2({
+				autumn: autumnV2_3,
+				planId,
+				newVersionSlug: "summer",
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: true,
+				isDefault: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "summer",
+				active: false,
+				isDefault: false,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "summer", active: true }],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+				isDefault: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "summer",
+				active: true,
+				isDefault: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/default-version-attach.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/default-version-attach.test.ts
@@ -1,7 +1,14 @@
 /**
- * Default plans × versioning — creating a customer must attach exactly ONE
- * version of a default plan: the active pointer. Covers the normal mint flow
- * (flag moves to v2) and the bad state where both versions are flagged is_default.
+ * Default plans × versioning — attach exactly ONE version: the active pointer.
+ *
+ * Contract:
+ *   Lockstep mint → new customer gets v2; earlier customer stays on v1.
+ *   Both rows is_default → customers.create (createWithDefaults) attaches active.
+ *   Both rows is_default, v1 forced active → customers.create attaches v1.
+ *   Both rows is_default → entities.create (handleCreateEntity) attaches active.
+ *
+ * Draft mint / promote / slug-promote (default follows the pointer) live in
+ * default-follows-active.test.ts.
  */
 
 import { expect, test } from "bun:test";
@@ -12,9 +19,11 @@ import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { and, eq } from "drizzle-orm";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { OrgService } from "@/internal/orgs/OrgService.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import { uniqueTestId } from "../../utils/uniqueTestId.js";
 import { cleanupPlanCustomerRefs } from "../utils/cleanupPlanCustomerRefs.js";
+import { expectAttachedPlanVersionCorrect } from "../utils/expectAttachedPlanVersion.js";
 import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
 
 const getFull = async ({
@@ -71,7 +80,7 @@ const mintV2 = async ({
 		plans: [
 			{
 				plan_id: planId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				items: [
 					{
 						feature_id: TestFeature.Messages,
@@ -103,6 +112,24 @@ const fetchAttachedPlanRows = async ({
 				eq(customerProducts.product_id, planId),
 			),
 		);
+
+/** Entity defaults only attach when this org flag is on; restore after — it is org-wide. */
+const setDefaultAppliesToEntities = async ({
+	ctx,
+	enabled,
+}: {
+	ctx: AutumnContext;
+	enabled: boolean;
+}) => {
+	const org = await OrgService.get({ db: ctx.db, orgId: ctx.org.id });
+	await OrgService.update({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		updates: {
+			config: { ...org.config, default_applies_to_entities: enabled },
+		},
+	});
+};
 
 test.concurrent(
 	`${chalk.yellowBright("catalogV2 defaults: customer after mint gets v2 only; earlier customer stays on v1")}`,
@@ -242,6 +269,69 @@ test.concurrent(
 		} finally {
 			await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
 			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test(
+	`${chalk.yellowBright("catalogV2 defaults: both is_default → entity create attaches active")}`,
+	async () => {
+		const { autumnV1, autumnV2_3, ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_def_ent");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+
+		const orgBefore = await OrgService.get({ db: ctx.db, orgId: ctx.org.id });
+		const previousAppliesToEntities =
+			orgBefore.config.default_applies_to_entities ?? false;
+
+		try {
+			await seedDefaultFreeV1({ autumn: autumnV2_3, planId });
+			await mintV2({ autumn: autumnV2_3, planId });
+
+			const v1 = await getFull({ ctx, planId, version: 1 });
+			await ctx.db
+				.update(products)
+				.set({ is_default: true })
+				.where(eq(products.internal_id, v1.internal_id));
+
+			const customerId = uniqueTestId("cv2_defcus_ent");
+			const customer = await autumnV1.customers.create({
+				id: customerId,
+				email: `${planId}-ent@test.com`,
+				withAutumnId: true,
+			});
+
+			await setDefaultAppliesToEntities({ ctx, enabled: true });
+			const entityId = uniqueTestId("cv2_defent");
+			await autumnV1.entities.create(customerId, {
+				id: entityId,
+				name: "Default entity",
+				feature_id: TestFeature.Users,
+				customer_data: {
+					internal_options: { default_group: `g_${planId}` },
+				},
+			});
+
+			await expectAttachedPlanVersionCorrect({
+				ctx,
+				internalCustomerId: customer.autumn_id as string,
+				planId,
+				version: 2,
+				entityId,
+			});
+		} finally {
+			try {
+				await setDefaultAppliesToEntities({
+					ctx,
+					enabled: previousAppliesToEntities,
+				});
+			} finally {
+				await cleanupPlanCustomerRefs({ ctx, planIds: [planId] });
+				await deleteDbPlans({ ctx, planIds: [planId] });
+			}
 		}
 	},
 );

--- a/server/tests/integration/catalog-v2/plans/versions/mixed-versioning-strategies.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/mixed-versioning-strategies.test.ts
@@ -96,7 +96,7 @@ test.concurrent(
 					{
 						plan_id: planA,
 						name: "A V3",
-						versioning: "new_version" as const,
+						versioning: "new_version", active: true as const,
 					},
 					{
 						plan_id: planB,
@@ -214,7 +214,7 @@ test.concurrent(
 						{
 							plan_id: planA,
 							name: "A V3",
-							versioning: "new_version",
+							versioning: "new_version", active: true,
 						},
 						{
 							plan_id: planB,

--- a/server/tests/integration/catalog-v2/plans/versions/new-version-free-trial.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/new-version-free-trial.test.ts
@@ -1,5 +1,5 @@
 /**
- * catalogV2.update — free_trial on versioning: "new_version" mint.
+ * catalogV2.update — free_trial on versioning: "new_version", active: true mint.
  *
  * Omitted trial is copied onto v2 with a new free_trials row id; null removes
  * it from v2 only; a changed shape lands on v2. v1's trial row is never touched.
@@ -111,7 +111,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						name: "Trial V2",
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -173,7 +173,7 @@ test.concurrent(
 						plan_id: planId,
 						name: "Trial V2",
 						free_trial: null,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -234,7 +234,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						free_trial: trial14d,
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/integration/catalog-v2/plans/versions/new-version-mint.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/new-version-mint.test.ts
@@ -1,5 +1,5 @@
 /**
- * catalogV2.update — versioning: "new_version" mint mechanics.
+ * catalogV2.update — versioning: "new_version", active: true mint mechanics.
  *
  * Clones latest (same id, version max+1, new internal_id), copies ents/prices
  * with fresh row ids, applies param changes on top. Old version is untouched.
@@ -90,7 +90,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						name: "Mint V2",
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -164,7 +164,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						items: [messagesItem(200), dashboardItem],
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -232,7 +232,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						name: "Carry V2",
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -308,7 +308,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						name: "Default V2",
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -347,7 +347,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						name: "No Cus V2",
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});
@@ -389,7 +389,7 @@ test.concurrent(
 			await autumnV2_3.catalogV2.update({ plans: [seed] });
 
 			const response = await autumnV2_3.catalogV2.update({
-				plans: [{ ...seed, versioning: "new_version" }],
+				plans: [{ ...seed, versioning: "new_version", active: true }],
 			});
 			expectCatalogResultsCorrect({
 				response,

--- a/server/tests/integration/catalog-v2/plans/versions/plan-versions.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/plan-versions.test.ts
@@ -577,7 +577,7 @@ test.concurrent(
 								reset: { interval: ResetInterval.Month },
 							},
 						],
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-mint.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-mint.test.ts
@@ -1,0 +1,284 @@
+/**
+ * catalogV2 version identity — mint (units 1–2).
+ *
+ * Contract:
+ *   new_version omit active → draft (v2 inactive, v1 keeps pointer + is_default)
+ *   new_version active:true → lockstep (v2 takes pointer + is_default)
+ *   new_version_slug stamps the minted row; omit → v{n}
+ *   first create new_version_slug stamps v1
+ *   preview: version_slug / active always; new_* only when that field changes
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { expectVersionIdentityCorrect } from "../utils/expectVersionIdentity.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../preview/utils/expectPlanPreview.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const seedDefaultV1 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "V1",
+				auto_enable: true,
+				items: [messagesItem(100)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity mint: new_version omit active leaves a draft")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_draft");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultV1({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						name: "V2 Draft",
+						items: [messagesItem(200)],
+					},
+				],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: true,
+				isDefault: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: false,
+				isDefault: false,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity mint: new_version active:true takes the pointer")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_lock");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultV1({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						active: true,
+						name: "V2 Live",
+						items: [messagesItem(200)],
+					},
+				],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+				isDefault: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+				isDefault: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity mint: new_version_slug stamps the minted row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_slug");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultV1({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						new_version_slug: "summer",
+						name: "Summer",
+					},
+				],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "summer",
+				active: false,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity mint: first create new_version_slug stamps v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_v1slug");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Launch",
+						new_version_slug: "launch",
+						items: [messagesItem(50)],
+					},
+				],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "launch",
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity mint: preview draft vs stamped+active")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const draftId = uniqueTestId("cv2_vid_pvd");
+		const liveId = uniqueTestId("cv2_vid_pvl");
+		const renameId = uniqueTestId("cv2_vid_pvr");
+		const renamedId = `${renameId}_2`;
+		await deleteDbPlans({
+			ctx,
+			planIds: [draftId, liveId, renameId, renamedId],
+		});
+		try {
+			await seedDefaultV1({ autumn: autumnV2_3, planId: draftId });
+			await seedDefaultV1({ autumn: autumnV2_3, planId: liveId });
+			await seedDefaultV1({ autumn: autumnV2_3, planId: renameId });
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: draftId,
+							versioning: "new_version",
+							name: "Draft",
+						},
+						{
+							plan_id: liveId,
+							versioning: "new_version",
+							active: true,
+							new_version_slug: "summer",
+							name: "Summer",
+						},
+						{
+							plan_id: renameId,
+							new_plan_id: renamedId,
+							name: "Renamed",
+						},
+					],
+				}),
+			);
+
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: draftId,
+					action: "create",
+					versionSlug: "v2",
+					newVersionSlug: null,
+					newPlanId: null,
+					active: false,
+				},
+			});
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: liveId,
+					action: "create",
+					versionSlug: "v2",
+					newVersionSlug: "summer",
+					newPlanId: null,
+					active: true,
+				},
+			});
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: renameId,
+					action: "update",
+					versionSlug: "v1",
+					newVersionSlug: null,
+					newPlanId: renamedId,
+					active: true,
+				},
+			});
+		} finally {
+			await deleteDbPlans({
+				ctx,
+				planIds: [draftId, liveId, renameId, renamedId],
+			});
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-rename-slug.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-rename-slug.test.ts
@@ -1,0 +1,183 @@
+/**
+ * catalogV2 version identity — new_version_slug rename on an existing row (unit 4).
+ *
+ * Contract:
+ *   omit-target + new_version_slug renames the active row
+ *   slug-target + new_version_slug renames that non-active row; active slug unchanged
+ *   preview: version_slug = current, new_version_slug only when it changes
+ *   rename to the slug this row already has is a no-op
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { expectVersionIdentityCorrect } from "../utils/expectVersionIdentity.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../preview/utils/expectPlanPreview.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const seedV1AndV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, name: "V1", items: [messagesItem(100)] }],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				active: true,
+				name: "V2",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity rename: omit-target renames the active row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_ract");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, new_version_slug: "summer" }],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "summer",
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity rename: slug-target renames the non-active row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_rpin");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version_slug: "v1",
+						new_version_slug: "winter",
+					},
+				],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "winter",
+				active: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity rename: preview trio + same-slug no-op")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const renameId = uniqueTestId("cv2_vid_rpv");
+		const noopId = uniqueTestId("cv2_vid_rnp");
+		await deleteDbPlans({ ctx, planIds: [renameId, noopId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId: renameId });
+			await seedV1AndV2({ autumn: autumnV2_3, planId: noopId });
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: renameId,
+							version_slug: "v1",
+							new_version_slug: "winter",
+						},
+						{ plan_id: noopId, new_version_slug: "v2" },
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: renameId,
+					action: "update",
+					versionSlug: "v1",
+					newVersionSlug: "winter",
+					active: false,
+				},
+			});
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: noopId,
+					action: "none",
+					versionSlug: "v2",
+					newVersionSlug: null,
+					active: true,
+				},
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: noopId, new_version_slug: "v2" }],
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: noopId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [renameId, noopId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-slug-conflicts.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-slug-conflicts.test.ts
@@ -1,0 +1,203 @@
+/**
+ * catalogV2 version identity — projected version_slug collisions (unit 4).
+ *
+ * Contract:
+ *   rename to a sibling's current slug → DuplicateVersionSlug
+ *   two entries of the same plan both take "summer" → DuplicateVersionSlug
+ *   in-place keeps v1 while another entry takes v1 → DuplicateVersionSlug
+ *   mint stamp "summer" + sibling rename to "summer" → DuplicateVersionSlug
+ *   two different plan_ids both "summer" → allowed
+ *   swap slugs in one call → allowed (final projected set)
+ */
+
+import { test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { expectVersionIdentityCorrect } from "../utils/expectVersionIdentity.js";
+
+const seedV1AndV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, name: "V1" }],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				active: true,
+				name: "V2",
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity slug-conflicts: sibling + two-entries + keep-vs-take")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const siblingId = uniqueTestId("cv2_vid_csib");
+		const twoId = uniqueTestId("cv2_vid_ctwo");
+		const keepId = uniqueTestId("cv2_vid_ckep");
+		await deleteDbPlans({ ctx, planIds: [siblingId, twoId, keepId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId: siblingId });
+			await seedV1AndV2({ autumn: autumnV2_3, planId: twoId });
+			await seedV1AndV2({ autumn: autumnV2_3, planId: keepId });
+
+			await expectAutumnError({
+				errCode: ErrCode.DuplicateVersionSlug,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: siblingId,
+								version_slug: "v1",
+								new_version_slug: "v2",
+							},
+						],
+					}),
+			});
+			await expectAutumnError({
+				errCode: ErrCode.DuplicateVersionSlug,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: twoId,
+								version_slug: "v1",
+								new_version_slug: "summer",
+							},
+							{
+								plan_id: twoId,
+								version_slug: "v2",
+								new_version_slug: "summer",
+							},
+						],
+					}),
+			});
+			await expectAutumnError({
+				errCode: ErrCode.DuplicateVersionSlug,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: keepId, version_slug: "v1", name: "Keep" },
+							{
+								plan_id: keepId,
+								version_slug: "v2",
+								new_version_slug: "v1",
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [siblingId, twoId, keepId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity slug-conflicts: mint stamp vs sibling rename")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_cmint");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await expectAutumnError({
+				errCode: ErrCode.DuplicateVersionSlug,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								versioning: "new_version",
+								new_version_slug: "summer",
+								name: "Minted",
+							},
+							{
+								plan_id: planId,
+								version_slug: "v1",
+								new_version_slug: "summer",
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity slug-conflicts: cross-plan share + swap allowed")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_vid_cxa");
+		const planB = uniqueTestId("cv2_vid_cxb");
+		const swapId = uniqueTestId("cv2_vid_csw");
+		await deleteDbPlans({ ctx, planIds: [planA, planB, swapId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId: planA });
+			await seedV1AndV2({ autumn: autumnV2_3, planId: planB });
+			await seedV1AndV2({ autumn: autumnV2_3, planId: swapId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planA, new_version_slug: "summer" },
+					{ plan_id: planB, new_version_slug: "summer" },
+				],
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: planA,
+				version: 2,
+				versionSlug: "summer",
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: planB,
+				version: 2,
+				versionSlug: "summer",
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: swapId,
+						version_slug: "v1",
+						new_version_slug: "v2",
+					},
+					{
+						plan_id: swapId,
+						version_slug: "v2",
+						new_version_slug: "v1",
+					},
+				],
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: swapId,
+				version: 1,
+				versionSlug: "v2",
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: swapId,
+				version: 2,
+				versionSlug: "v1",
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB, swapId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-slug-errors.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-slug-errors.test.ts
@@ -1,0 +1,143 @@
+/**
+ * catalogV2 version identity — targeting validation (unit 3).
+ *
+ * Contract:
+ *   version + version_slug together → 400 (even if they agree)
+ *   unknown version_slug → 400 InvalidRequest
+ *   all_versions / new_version + slug pin → 400 (same as numeric pin)
+ *   duplicate same slug twice → 400 InvalidRequest
+ */
+
+import { test } from "bun:test";
+import { ErrCode } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+
+const seedV1 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, name: "V1" }],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity slug-errors: both version and version_slug → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_eboth");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1({ autumn: autumnV2_3, planId });
+			await expectAutumnError({
+				errMessage: "Cannot specify both version and version_slug",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								version: 1,
+								version_slug: "v1",
+								name: "Agree",
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity slug-errors: unknown version_slug → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_eunk");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1({ autumn: autumnV2_3, planId });
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: 'Unknown version_slug "missing"',
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planId, version_slug: "missing", name: "Ghost" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity slug-errors: strategy+slug pin and duplicate slug")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const allId = uniqueTestId("cv2_vid_eall");
+		const mintId = uniqueTestId("cv2_vid_emint");
+		const dupId = uniqueTestId("cv2_vid_edup");
+		await deleteDbPlans({ ctx, planIds: [allId, mintId, dupId] });
+		try {
+			await seedV1({ autumn: autumnV2_3, planId: allId });
+			await seedV1({ autumn: autumnV2_3, planId: mintId });
+			await seedV1({ autumn: autumnV2_3, planId: dupId });
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage:
+					'versioning "all_versions" cannot be combined with an explicit version',
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: allId,
+								version_slug: "v1",
+								versioning: "all_versions",
+								name: "Propagate",
+							},
+						],
+					}),
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage:
+					'versioning "new_version" cannot be combined with an explicit version',
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: mintId,
+								version_slug: "v1",
+								versioning: "new_version",
+								name: "Mint",
+							},
+						],
+					}),
+			});
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: `Duplicate plan entry for plan_id=${dupId} version=1`,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: dupId, version_slug: "v1", name: "A" },
+							{ plan_id: dupId, version_slug: "v1", name: "B" },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [allId, mintId, dupId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-target-slug.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-target-slug.test.ts
@@ -1,0 +1,289 @@
+/**
+ * catalogV2 version identity — target by version_slug (unit 3).
+ *
+ * Contract:
+ *   version_slug of a non-active row edits that row only (siblings untouched)
+ *   omit both version keys still edits the active row
+ *   two slugs same plan → both rows; no sibling auto-propagate; no leak to another plan
+ *   archived slug pin matches numeric pin (row is editable)
+ *   slug pin does not move active / is_default
+ *   preview sibling_versions lists others unselected; all_versions stays in options
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectDbPlansCorrect,
+} from "../utils/expectCatalogPlans.js";
+import {
+	expectVersionIdentityCorrect,
+	forceActiveVersion,
+} from "../utils/expectVersionIdentity.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../preview/utils/expectPlanPreview.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const seedV1AndV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: planId, name: "V1", items: [messagesItem(100)] }],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				active: true,
+				name: "V2",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("version identity target: slug pin edits v1 only; siblings unselected")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_tpin");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							version_slug: "v1",
+							name: "V1 Pinned",
+							items: [messagesItem(150)],
+						},
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					versionSlug: "v1",
+					newVersionSlug: null,
+					active: false,
+					versioningOptions: ["existing", "all_versions"],
+					siblingVersions: [
+						{ version: 2, hasPlanChange: false },
+					],
+				},
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version_slug: "v1",
+						name: "V1 Pinned",
+						items: [messagesItem(150)],
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1 Pinned",
+						allowances: { [TestFeature.Messages]: 150 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2",
+						allowances: { [TestFeature.Messages]: 200 },
+					},
+				],
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+				isDefault: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity target: omit both keys still edits the active row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_tomit");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await forceActiveVersion({ ctx, planId, version: 1 });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "V1 via omit",
+						items: [messagesItem(175)],
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "V1 via omit",
+						allowances: { [TestFeature.Messages]: 175 },
+					},
+					{
+						id: planId,
+						version: 2,
+						name: "V2",
+						allowances: { [TestFeature.Messages]: 200 },
+					},
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity target: two slugs update both rows; no leak to another plan")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_vid_ta");
+		const planB = uniqueTestId("cv2_vid_tb");
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId: planA });
+			await seedV1AndV2({ autumn: autumnV2_3, planId: planB });
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{ plan_id: planA, version_slug: "v1", name: "A1" },
+						{ plan_id: planA, version_slug: "v2", name: "A2" },
+						{ plan_id: planB, version_slug: "v1", name: "B1 only" },
+					],
+				}),
+			);
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: planA,
+					currentVersion: 1,
+					action: "update",
+					siblingVersions: null,
+				},
+			});
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId: planA,
+					currentVersion: 2,
+					action: "update",
+					siblingVersions: null,
+				},
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planA, version_slug: "v1", name: "A1" },
+					{ plan_id: planA, version_slug: "v2", name: "A2" },
+					{ plan_id: planB, version_slug: "v1", name: "B1 only" },
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{ id: planA, version: 1, name: "A1" },
+					{ id: planA, version: 2, name: "A2" },
+					{ id: planB, version: 1, name: "B1 only" },
+					{ id: planB, version: 2, name: "V2" },
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("version identity target: archived slug pin still edits that row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_vid_tarch");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndV2({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version: 1, archived: true }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version_slug: "v1",
+						name: "Archived Edited",
+					},
+				],
+			});
+
+			await expectDbPlansCorrect({
+				ctx,
+				expected: [
+					{
+						id: planId,
+						version: 1,
+						name: "Archived Edited",
+						archived: true,
+					},
+					{ id: planId, version: 2, name: "V2", archived: false },
+				],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/version-identity-update.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/version-identity-update.test.ts
@@ -81,7 +81,7 @@ const seedV1AndV2 = async ({
 		plans: [
 			{
 				plan_id: planId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				name: "V2",
 				items: [messagesItem(200)],
 			},
@@ -189,7 +189,7 @@ test.concurrent(
 					{
 						plan_id: planId,
 						name: "V3",
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/integration/crud/plans/versioning/version-identity-dual-write.test.ts
+++ b/server/tests/integration/crud/plans/versioning/version-identity-dual-write.test.ts
@@ -137,7 +137,7 @@ test.concurrent(
 				{
 					plan_id: planId,
 					items: [monthlyMessagesItem(700)],
-					versioning: "new_version",
+					versioning: "new_version", active: true,
 				},
 			],
 		});

--- a/server/tests/integration/crud/plans/versioning/version-identity-fetch.test.ts
+++ b/server/tests/integration/crud/plans/versioning/version-identity-fetch.test.ts
@@ -76,7 +76,7 @@ const setupVersionedPlan = async (testId: string) => {
 			{
 				plan_id: base.id,
 				items: [monthlyMessagesItem(500)],
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 			},
 		],
 	});
@@ -101,7 +101,7 @@ test.concurrent(
 				{
 					plan_id: base.id,
 					items: [monthlyMessagesItem(500)],
-					versioning: "new_version",
+					versioning: "new_version", active: true,
 				},
 			],
 		});

--- a/server/tests/integration/crud/plans/versioning/version-identity-legacy-update.test.ts
+++ b/server/tests/integration/crud/plans/versioning/version-identity-legacy-update.test.ts
@@ -90,7 +90,7 @@ const setupVersionedPlan = async (testId: string) => {
 				plan_id: base.id,
 				name: "V2",
 				items: [monthlyMessagesItem(200)],
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 			},
 		],
 	});

--- a/server/tests/integration/invoices/version-identity-insert.test.ts
+++ b/server/tests/integration/invoices/version-identity-insert.test.ts
@@ -54,7 +54,7 @@ test.concurrent(
 		});
 
 		await autumnV2_3.catalogV2.update({
-			plans: [{ plan_id: pro.id, versioning: "new_version" }],
+			plans: [{ plan_id: pro.id, versioning: "new_version", active: true }],
 		});
 
 		await autumnV2_3.post("/invoices.insert", {
@@ -99,7 +99,7 @@ test.concurrent(
 		});
 
 		await autumnV2_3.catalogV2.update({
-			plans: [{ plan_id: pro.id, versioning: "new_version" }],
+			plans: [{ plan_id: pro.id, versioning: "new_version", active: true }],
 		});
 		await forceActiveVersion({ ctx, planId: pro.id, version: 1 });
 

--- a/server/tests/integration/products/list-full-variants.test.ts
+++ b/server/tests/integration/products/list-full-variants.test.ts
@@ -37,7 +37,7 @@ test.concurrent(
 					{
 						plan_id: variantId,
 						name: "Pro v2",
-						versioning: "new_version",
+						versioning: "new_version", active: true,
 					},
 				],
 			});

--- a/server/tests/scenarios/catalog/licenses/versions.test.ts
+++ b/server/tests/scenarios/catalog/licenses/versions.test.ts
@@ -34,7 +34,7 @@ test(`${chalk.yellowBright("catalog-qa: Team v1+v2 both offer Seat")}`, async ()
 		plans: [
 			{
 				plan_id: teamId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				items: [messagesItem(200)],
 				licenses: [{ license_plan_id: seatId, included: 2 }],
 			},

--- a/server/tests/scenarios/catalog/plans/versions.test.ts
+++ b/server/tests/scenarios/catalog/plans/versions.test.ts
@@ -42,7 +42,7 @@ test(`${chalk.yellowBright("catalog-qa: multi-version plans")}`, async () => {
 			plans: [
 				{
 					plan_id: planId,
-					versioning: "new_version",
+					versioning: "new_version", active: true,
 					items: [messagesItem(200)],
 				},
 			],

--- a/server/tests/scenarios/catalog/variants/team-eu-seat-versions.test.ts
+++ b/server/tests/scenarios/catalog/variants/team-eu-seat-versions.test.ts
@@ -34,7 +34,7 @@ test(`${chalk.yellowBright("catalog-qa: Team+EU+Seat all versioned")}`, async ()
 		plans: [
 			{
 				plan_id: euId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				licenses: [{ license_plan_id: seatId, included: 2 }],
 			},
 		],
@@ -43,7 +43,7 @@ test(`${chalk.yellowBright("catalog-qa: Team+EU+Seat all versioned")}`, async ()
 		plans: [
 			{
 				plan_id: teamId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				items: [messagesItem(200)],
 				licenses: [{ license_plan_id: seatId, included: 2 }],
 			},
@@ -53,7 +53,7 @@ test(`${chalk.yellowBright("catalog-qa: Team+EU+Seat all versioned")}`, async ()
 		plans: [
 			{
 				plan_id: seatId,
-				versioning: "new_version",
+				versioning: "new_version", active: true,
 				items: [messagesItem(20)],
 			},
 		],

--- a/server/tests/scenarios/catalog/variants/team-eu-versions.test.ts
+++ b/server/tests/scenarios/catalog/variants/team-eu-versions.test.ts
@@ -26,7 +26,7 @@ test(`${chalk.yellowBright("catalog-qa: Team v2 + EU pointing at v2")}`, async (
 		],
 	});
 	await autumnV2_3.catalogV2.update({
-		plans: [{ plan_id: teamId, versioning: "new_version" }],
+		plans: [{ plan_id: teamId, versioning: "new_version", active: true }],
 	});
 	await seedNamedCustomer({
 		ctx,

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
@@ -56,6 +56,17 @@ describe("productDetailsAreSame / diffProductDetails", () => {
 		});
 	});
 
+	test("version_slug change diffs with previous value", () => {
+		const current = row({ version_slug: "v1" });
+		const next = row({ version_slug: "summer" });
+		expect(productDetailsAreSame({ product1: current, product2: next })).toBe(
+			false,
+		);
+		expect(diffProductDetails({ current, next })).toEqual({
+			version_slug: "v1",
+		});
+	});
+
 	test("description nullish-normalizes", () => {
 		const current = row({ description: null });
 		const next = row({ description: undefined as unknown as null });

--- a/server/tests/unit/catalogV2/planUpdate/catalogVersionIdentity.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/catalogVersionIdentity.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CatalogCorePreviewSchema,
+	UpdateCatalogPlanParamsSchema,
+} from "@autumn/shared";
+import { catalogRowIdentity } from "@/internal/catalogV2/actions/updateCatalog/preview/plans/catalogRowIdentity";
+
+const previewState = { has_customers: false };
+
+describe("UpdateCatalogPlanParams version identity", () => {
+	test("omitted identity fields stay undefined", () => {
+		const parsed = UpdateCatalogPlanParamsSchema.parse({ plan_id: "pro" });
+		expect(parsed.active).toBeUndefined();
+		expect(parsed.version_slug).toBeUndefined();
+		expect(parsed.new_version_slug).toBeUndefined();
+	});
+
+	test("accepts active, version_slug, and new_version_slug", () => {
+		const parsed = UpdateCatalogPlanParamsSchema.parse({
+			plan_id: "pro",
+			active: true,
+			version_slug: "abc",
+			new_version_slug: "summer",
+		});
+		expect(parsed.active).toBe(true);
+		expect(parsed.version_slug).toBe("abc");
+		expect(parsed.new_version_slug).toBe("summer");
+	});
+
+	test("rejects a version_slug that fails idRegex", () => {
+		const result = UpdateCatalogPlanParamsSchema.safeParse({
+			plan_id: "pro",
+			version_slug: "bad slug",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a new_version_slug that fails idRegex", () => {
+		const result = UpdateCatalogPlanParamsSchema.safeParse({
+			plan_id: "pro",
+			new_version_slug: "bad slug",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects version and version_slug together even when they agree", () => {
+		const result = UpdateCatalogPlanParamsSchema.safeParse({
+			plan_id: "pro",
+			version: 1,
+			version_slug: "v1",
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("CatalogCorePreview version identity", () => {
+	test("requires version_slug and active", () => {
+		const parsed = CatalogCorePreviewSchema.parse({
+			plan_id: "pro",
+			version: 2,
+			version_slug: "v2",
+			active: false,
+			state: previewState,
+		});
+		expect(parsed.version_slug).toBe("v2");
+		expect(parsed.active).toBe(false);
+		expect(parsed.new_plan_id).toBeUndefined();
+		expect(parsed.new_version_slug).toBeUndefined();
+	});
+
+	test("rejects a kernel missing version_slug", () => {
+		const result = CatalogCorePreviewSchema.safeParse({
+			plan_id: "pro",
+			version: 1,
+			active: true,
+			state: previewState,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("keeps new_plan_id and new_version_slug when present", () => {
+		const parsed = CatalogCorePreviewSchema.parse({
+			plan_id: "pro",
+			new_plan_id: "pro_2",
+			version: 2,
+			version_slug: "v2",
+			new_version_slug: "summer",
+			active: true,
+			state: previewState,
+		});
+		expect(parsed.new_plan_id).toBe("pro_2");
+		expect(parsed.new_version_slug).toBe("summer");
+	});
+});
+
+describe("catalogRowIdentity", () => {
+	test("mint without slug override: version_slug is v{n}, no new_*", () => {
+		expect(
+			catalogRowIdentity({
+				planId: "pro",
+				version: 2,
+				current: null,
+				next: { id: "pro", version_slug: "v2", active: false },
+			}),
+		).toEqual({
+			plan_id: "pro",
+			version: 2,
+			version_slug: "v2",
+			active: false,
+		});
+	});
+
+	test("mint with slug override: version_slug is v{n}, new_version_slug is the stamp", () => {
+		expect(
+			catalogRowIdentity({
+				planId: "pro",
+				version: 2,
+				current: null,
+				next: { id: "pro", version_slug: "summer", active: true },
+			}),
+		).toEqual({
+			plan_id: "pro",
+			version: 2,
+			version_slug: "v2",
+			new_version_slug: "summer",
+			active: true,
+		});
+	});
+
+	test("existing rename emits new_version_slug only", () => {
+		expect(
+			catalogRowIdentity({
+				planId: "pro",
+				version: 1,
+				current: { id: "pro", version_slug: "abc", active: true },
+				next: { id: "pro", version_slug: "newSlug", active: true },
+			}),
+		).toEqual({
+			plan_id: "pro",
+			version: 1,
+			version_slug: "abc",
+			new_version_slug: "newSlug",
+			active: true,
+		});
+	});
+
+	test("plan id rename emits new_plan_id only", () => {
+		expect(
+			catalogRowIdentity({
+				planId: "pro",
+				version: 1,
+				current: { id: "pro", version_slug: "v1", active: true },
+				next: { id: "pro_2", version_slug: "v1", active: true },
+			}),
+		).toEqual({
+			plan_id: "pro",
+			version: 1,
+			version_slug: "v1",
+			new_plan_id: "pro_2",
+			active: true,
+		});
+	});
+});

--- a/server/tests/unit/catalogV2/planUpdate/derive-direct-intents-slug.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/derive-direct-intents-slug.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { deriveDirectIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { products } from "@tests/utils/fixtures/db/products";
+
+const v1 = {
+	...products.createFull({ id: "pro" }),
+	internal_id: "internal_pro_v1",
+	version: 1,
+	version_slug: "v1",
+	active: false,
+};
+const v2 = {
+	...products.createFull({ id: "pro" }),
+	internal_id: "internal_pro_v2",
+	version: 2,
+	version_slug: "summer",
+	active: true,
+};
+
+const productStatesContext: ProductStatesContext = {
+	statesByPlanVersion: {},
+	versionsByPlanId: { pro: [v2, v1] },
+	rewardProgramsByPlanId: {},
+};
+
+describe("deriveDirectIntents version_slug targeting", () => {
+	test("version_slug resolves to that row, not the active pointer", () => {
+		const [intent] = deriveDirectIntents({
+			params: {
+				plans: [{ plan_id: "pro", version_slug: "v1", name: "Pinned" }],
+				features: [],
+				remove_features: [],
+				remove_plans: [],
+			},
+			productStatesContext,
+		});
+		expect(intent?.productKey).toEqual({ planId: "pro", version: 1 });
+	});
+
+	test("unknown version_slug is not fall-through-to-active", () => {
+		expect(
+			deriveDirectIntents({
+				params: {
+					plans: [{ plan_id: "pro", version_slug: "missing", name: "Ghost" }],
+					features: [],
+					remove_features: [],
+					remove_plans: [],
+				},
+				productStatesContext,
+			}),
+		).toEqual([]);
+	});
+
+	test("omit both targets the active row", () => {
+		const [intent] = deriveDirectIntents({
+			params: {
+				plans: [{ plan_id: "pro", name: "Active" }],
+				features: [],
+				remove_features: [],
+				remove_plans: [],
+			},
+			productStatesContext,
+		});
+		expect(intent?.productKey).toEqual({ planId: "pro", version: 2 });
+	});
+});

--- a/server/tests/unit/catalogV2/planUpdate/detectVersionSlugCollisions.test.ts
+++ b/server/tests/unit/catalogV2/planUpdate/detectVersionSlugCollisions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import type { FullProduct } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/db/products";
+import { detectVersionSlugCollisions } from "@/internal/catalogV2/actions/updateCatalog/errors/detectVersionSlugCollisions";
+
+const row = ({
+	id,
+	version,
+	versionSlug,
+}: {
+	id: string;
+	version: number;
+	versionSlug: string | null;
+}): FullProduct =>
+	({
+		...products.createFull({ id }),
+		internal_id: `internal_${id}_v${version}`,
+		version,
+		version_slug: versionSlug,
+	}) as FullProduct;
+
+describe("detectVersionSlugCollisions", () => {
+	test("swap is consistent — each slug owned once at end of call", () => {
+		expect(
+			detectVersionSlugCollisions({
+				products: [
+					row({ id: "pro", version: 1, versionSlug: "v2" }),
+					row({ id: "pro", version: 2, versionSlug: "v1" }),
+				],
+			}),
+		).toEqual([]);
+	});
+
+	test("same slug on two versions of one plan is a collision", () => {
+		expect(
+			detectVersionSlugCollisions({
+				products: [
+					row({ id: "pro", version: 1, versionSlug: "summer" }),
+					row({ id: "pro", version: 2, versionSlug: "summer" }),
+				],
+			}),
+		).toEqual([{ planId: "pro", versionSlug: "summer", versions: [1, 2] }]);
+	});
+
+	test("same slug on two plan ids is allowed", () => {
+		expect(
+			detectVersionSlugCollisions({
+				products: [
+					row({ id: "pro", version: 1, versionSlug: "summer" }),
+					row({ id: "free", version: 1, versionSlug: "summer" }),
+				],
+			}),
+		).toEqual([]);
+	});
+});

--- a/server/tests/unit/catalogV2/variants/derive-variant-intents.test.ts
+++ b/server/tests/unit/catalogV2/variants/derive-variant-intents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { deriveVariantIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveVariantIntents";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { emptyVersioningFlags } from "@/internal/customers/cusProducts/repos/getVersioningUsage.js";
 import { products } from "@tests/utils/fixtures/db/products";
 
 const emptyStates = ({
@@ -19,6 +20,72 @@ const baseProduct = {
 	entitlements: [],
 	prices: [],
 	free_trial: null,
+};
+
+const mintVariantFromBase = ({
+	sourceActive,
+}: {
+	sourceActive: boolean | undefined;
+}) => {
+	const oldBase = { ...baseProduct, internal_id: "internal_team_v1" };
+	const newBase = {
+		...baseProduct,
+		internal_id: "internal_team_v2",
+		version: 2,
+		active: sourceActive === true,
+	};
+	const variant = {
+		...baseProduct,
+		id: "team-eu",
+		internal_id: "internal_team-eu",
+		base_internal_product_id: oldBase.internal_id,
+	};
+
+	const intents = deriveVariantIntents({
+		intent: {
+			productKey: { planId: "team", version: 2 },
+			planParams: {
+				plan_id: "team",
+				version: 2,
+				versioning: "new_version",
+				...(sourceActive === true ? { active: true } : {}),
+			},
+			source: "direct",
+		},
+		upsert: {
+			row: {
+				planId: "team",
+				version: 2,
+				op: "create",
+				source: "direct",
+				versioning: "new_version",
+				currentFullProduct: null,
+				baseFullProduct: oldBase,
+				nextFullProduct: newBase,
+			},
+			propagate: { variants: [{ plan_id: "team-eu" }] },
+			state: { hasCustomers: false },
+		} as UpsertProductPlan,
+		projectedProductStatesContext: {
+			...emptyStates({ planIds: ["team", "team-eu"] }),
+			versionsByPlanId: {
+				team: [newBase, oldBase],
+				"team-eu": [variant],
+			},
+			statesByPlanVersion: {
+				"team-eu@1": {
+					productKey: { planId: "team-eu", version: 1 },
+					currentFullProduct: variant,
+					customerUsage: {
+						...emptyVersioningFlags(),
+						hasVersionableCustomerProducts: true,
+					},
+				},
+			},
+		},
+	});
+
+	return { intents };
 };
 
 describe("deriveVariantIntents", () => {
@@ -244,7 +311,7 @@ describe("deriveVariantIntents", () => {
 				planParams: {
 					plan_id: "team",
 					version: 2,
-					versioning: "new_version",
+					versioning: "new_version", active: true,
 				},
 				source: "direct",
 			},
@@ -254,7 +321,7 @@ describe("deriveVariantIntents", () => {
 					version: 2,
 					op: "create",
 					source: "direct",
-					versioning: "new_version",
+					versioning: "new_version", active: true,
 					currentFullProduct: null,
 					baseFullProduct: oldBase,
 					nextFullProduct: newBase,
@@ -274,5 +341,27 @@ describe("deriveVariantIntents", () => {
 		expect(intents[0]?.source).toBe("repoint");
 		expect(intents[0]?.baseInternalProductId).toBe(newBase.internal_id);
 		expect(intents[0]?.editDiff).toBeUndefined();
+	});
+
+	test("base new_version without active mints variant as a draft", () => {
+		const { intents } = mintVariantFromBase({ sourceActive: undefined });
+		const mint = intents.find(
+			(intent) =>
+				intent.source === "variant_propagation" &&
+				intent.planParams.versioning === "new_version",
+		);
+		expect(mint).toBeDefined();
+		expect(mint?.planParams.active).toBeUndefined();
+	});
+
+	test("base new_version with active:true mints variant as active", () => {
+		const { intents } = mintVariantFromBase({ sourceActive: true });
+		const mint = intents.find(
+			(intent) =>
+				intent.source === "variant_propagation" &&
+				intent.planParams.versioning === "new_version",
+		);
+		expect(mint).toBeDefined();
+		expect(mint?.planParams.active).toBe(true);
 	});
 });

--- a/server/tests/unit/catalogV2/variants/variant-models.test.ts
+++ b/server/tests/unit/catalogV2/variants/variant-models.test.ts
@@ -77,12 +77,16 @@ describe("variant preview + params", () => {
 		const parsed = CatalogVariantPreviewSchema.parse({
 			plan_id: "team-eu",
 			version: 2,
+			version_slug: "v2",
+			active: true,
 			state: { has_customers: false, will_archive: false },
 			variant_action: "propagated",
 			sibling_versions: [
 				{
 					plan_id: "team-eu",
 					version: 1,
+					version_slug: "v1",
+					active: false,
 					state: { has_customers: false, will_archive: false },
 					variant_action: "unchanged",
 				},
@@ -94,6 +98,8 @@ describe("variant preview + params", () => {
 		const plan = CatalogPlanUpdatePreviewSchema.parse({
 			plan_id: "team",
 			version: 1,
+			version_slug: "v1",
+			active: true,
 			action: "update",
 			state: { has_customers: false, will_archive: false },
 			versioning: null,

--- a/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
@@ -46,6 +46,10 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 	archived: z.boolean().optional().meta({
 		description: "Archive or unarchive the plan.",
 	}),
+	active: z.boolean().optional().meta({
+		description:
+			"Take the active pointer. On `new_version`, omit to mint a draft; `true` promotes the minted row immediately.",
+	}),
 	price: BasePriceParamsSchema.nullable().optional().meta({
 		description:
 			"Base recurring price. Omit to leave unchanged; null removes it.",
@@ -69,11 +73,20 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 	// ── Catalog update ────────────────────────────────────────────────────
 	version: z.number().int().min(1).optional().meta({
 		description:
-			"Explicit version row this entry declares — an existing row to edit, or a version to create (versions must stay contiguous from 1). Repeat plan_id with different versions to declare multiple rows; at most one entry per plan_id may omit version (targets latest).",
+			"Deprecated. Use `version_slug` to target a row. Omit both to target the active row.",
+		deprecated: true,
+	}),
+	version_slug: z.string().nonempty().regex(idRegex).optional().meta({
+		description:
+			"Target this version row by slug. At most one of `version` / `version_slug`; omit both to target the active row.",
+	}),
+	new_version_slug: z.string().nonempty().regex(idRegex).optional().meta({
+		description:
+			"Set or rename this row's version slug. On `new_version`, stamps the minted row (default `v{n}`).",
 	}),
 	versioning: CatalogPlanVersioningStrategySchema.optional().meta({
 		description:
-			"How this entry applies across versions. Omit or `existing` = the resolved row only; `all_versions` = also apply to every other existing version of this plan; `new_version` = mint max+1 cloned from latest (customers stay on old).",
+			"How this entry applies across versions. Omit or `existing` = the resolved row only; `all_versions` = also apply to every other existing version of this plan; `new_version` = mint max+1 as a draft unless `active` is true (customers stay on old).",
 	}),
 	propagate: CatalogPropagateParamsSchema.optional().meta({
 		internal: true,
@@ -105,7 +118,14 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 		description:
 			"Base plan id to attach this plan to. `null` detaches it from its base. Omit to leave the pointer unchanged. Nesting under the base's variants[] also links.",
 	}),
-});
+}).refine(
+	(data) => data.version === undefined || data.version_slug === undefined,
+	{
+		message:
+			"Cannot specify both version and version_slug. Use one, or omit both to target the active row.",
+		path: ["version_slug"],
+	},
+);
 
 export type UpdateCatalogPlanParams = z.infer<
 	typeof UpdateCatalogPlanParamsSchema

--- a/shared/api/catalogV2/planUpdate/preview/catalogCorePreview.ts
+++ b/shared/api/catalogV2/planUpdate/preview/catalogCorePreview.ts
@@ -17,7 +17,20 @@ export const CatalogPreviewStateSchema = z.object({
 /** Shared kernel for a plan row in catalog preview (direct, sibling, or license parent). */
 export const CatalogCorePreviewSchema = z.object({
 	plan_id: z.string(),
+	new_plan_id: z.string().optional().meta({
+		description: "Present only when this row's public plan id changes.",
+	}),
 	version: z.number().int().min(1),
+	version_slug: z.string().meta({
+		description:
+			"Current slug of this row. On mint, the default `v{n}` it would receive.",
+	}),
+	new_version_slug: z.string().optional().meta({
+		description: "Present only when this row's version slug changes.",
+	}),
+	active: z.boolean().meta({
+		description: "Whether this row holds the active pointer after apply.",
+	}),
 	state: CatalogPreviewStateSchema,
 	plan_change: PlanChangeV0Schema.nullish().meta({
 		description:

--- a/shared/enums/ErrCode.ts
+++ b/shared/enums/ErrCode.ts
@@ -201,6 +201,7 @@ export const ErrCode = {
 	NestedVariantNotAllowed: "nested_variant_not_allowed",
 	CannotForkArchivedBase: "cannot_fork_archived_base",
 	ProductIdAlreadyExists: "product_id_already_exists",
+	DuplicateVersionSlug: "duplicate_version_slug",
 	CannotPreviewOnVariant: "cannot_preview_on_variant",
 	InvalidPropagationTarget: "invalid_propagation_target",
 	TooManyVariants: "too_many_variants",

--- a/shared/utils/productUtils/compareProduct/productDetailsAreSame.ts
+++ b/shared/utils/productUtils/compareProduct/productDetailsAreSame.ts
@@ -14,6 +14,7 @@ export const PRODUCT_DETAIL_KEYS = [
 	"is_add_on",
 	"is_default",
 	"archived",
+	"version_slug",
 	"config",
 	"metadata",
 	"auto_topups",
@@ -87,6 +88,7 @@ export const productDetailComparators: {
 	is_add_on: strictEqual(),
 	is_default: strictEqual(),
 	archived: strictEqual(),
+	version_slug: ({ left, right }) => (left ?? null) === (right ?? null),
 	config: ({ left, right }) =>
 		compareConfig({ newConfig: left, curConfig: right }),
 	metadata: ({ left, right }) =>


### PR DESCRIPTION
Target versions by slug, follow the active row on mint, and vacate renamed slugs in one transaction so uniqueness holds without losing Stripe reuse.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps plan version identity stable across mint and slug rename. Previously, "new_version" always promoted and moved default; versions were targeted by number and slug renames could collide. Now mints are drafts by default, promotion is explicit with active: true, and you can target by version_slug with swap-safe uniqueness.

- Adds plan params: active, version_slug (pin a specific row), and new_version_slug (rename or stamp on mint). Validates that version_slug/version are not combined with "new_version"/"all_versions"; unknown slugs error.
- Mint behavior: omit active → draft; active: true → takes the active pointer and default. Default follows the pointer on promote.
- Variant and license-parent follower mints inherit the source entry’s active flag.
- Enforces projected uniqueness of (plan_id, version_slug) with ErrCode.DuplicateVersionSlug; detects collisions before apply. Allows same-call slug swaps by vacating renamed slugs inside one DB transaction while preserving Stripe id reuse.
- Persists version_slug on apply. Previews include version_slug and active, and only show new_version_slug/new_plan_id when those change (`CatalogCorePreview`).

- Required migration
  - If you relied on lockstep promotion, pass active: true with versioning "new_version".
  - When renaming or stamping slugs, ensure per-plan uniqueness or perform a swap in one call; handle ErrCode.DuplicateVersionSlug.
  - Update preview consumers to read version_slug and active; treat new_version_slug/new_plan_id as optional.

<sup>Written for commit c7252b472c6563809fe2ecac7d6824e93ef03871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Makes plan-version identity stable across minting and slug renames while adding explicit draft/promotion behavior.
- **[API changes]** Adds slug-based version targeting, version-slug assignment, and explicit active-version promotion.
- **[Improvements]** Preserves version identity through related variants and license plans, and exposes identity fields in previews.
- **[Bug fixes, Improvements]** Detects duplicate version slugs and vacates renamed slugs transactionally to support same-request swaps.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a failed catalog transaction can leave Stripe renamed while Autumn retains the previous name.

The database transaction still performs an irreversible Stripe rename before all later catalog and license writes have succeeded, so a subsequent database failure rolls back only Autumn’s state and leaves the two systems inconsistent.

**Files Needing Attention:** server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts; server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts | Extends plan updates with slug targeting, slug replacement, and explicit active-version control. |
| server/src/internal/catalogV2/actions/updateCatalog/derive/deriveDirectIntents.ts | Resolves version-slug targets into stable numeric row identities before planning updates. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/detectVersionSlugCollisions.ts | Detects duplicate projected version-slug ownership within each plan. |
| server/src/internal/catalogV2/execute/executeUpsertProducts/vacateRenamedVersionSlugs.ts | Temporarily clears changing slugs so swaps can satisfy the immediate uniqueness constraint. |
| server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts | Applies product and license changes in one transaction to preserve database consistency during slug swaps. |
| shared/api/catalogV2/planUpdate/preview/catalogCorePreview.ts | Expands preview identity information and makes replacement identity fields conditional on actual changes. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Catalog as Catalog update
    participant DB
    participant Stripe
    Client->>Catalog: Update plans by version slug
    Catalog->>Catalog: Resolve targets and validate projected slugs
    Catalog->>DB: Begin transaction
    Catalog->>DB: Vacate renamed slugs
    Catalog->>DB: Apply product rows and relationships
    Catalog->>Stripe: Reuse or rename processor products
    Catalog->>DB: Commit catalog changes
    Catalog-->>Client: Return applied plan identities
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(catalog): keep version identity sta..."](https://github.com/useautumn/autumn/commit/c7252b472c6563809fe2ecac7d6824e93ef03871) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55991033)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->