### PR TITLE
Stop logging test organization secret keys

### DIFF
--- a/scripts/setup/setup-test.ts
+++ b/scripts/setup/setup-test.ts
@@ -99,8 +99,7 @@ async function runEnsureKey(): Promise<void> {
 	const { key, generated } = await ensureTestOrgSecretKey({ db });
 	persistTestKeysToEnvLocal({ secretKey: key, allowCreate: generated });
 
-	console.log(chalk.greenBright("\n✅ ensure-test-org-key complete"));
-	console.log(chalk.whiteBright(`  key:  ${key}\n`));
+	console.log(chalk.greenBright("\n✅ ensure-test-org-key complete\n"));
 }
 
 async function runFullSetup({ yes }: { yes: boolean }): Promise<void> {
@@ -132,8 +131,7 @@ async function runFullSetup({ yes }: { yes: boolean }): Promise<void> {
 	console.log(chalk.greenBright("\n✅ setup-test complete"));
 	console.log(chalk.cyan("Org:"));
 	console.log(chalk.whiteBright(`  slug: ${TEST_ORG_CONFIG.slug}`));
-	console.log(chalk.whiteBright(`  id:   ${TEST_ORG_CONFIG.id}`));
-	console.log(chalk.whiteBright(`  key:  ${autumnSecretKey}\n`));
+	console.log(chalk.whiteBright(`  id:   ${TEST_ORG_CONFIG.id}\n`));
 }
 
 /** Create unit-test-org if missing; if present, only ensure the API key. */


### PR DESCRIPTION
## Summary

- Removes plaintext test API keys from `setup-test` completion output.
- Keeps the existing success and persistence messages so setup remains observable without placing credentials in preserved machine or snapshot logs.

## Verification

- `bunx biome check --write scripts/setup/setup-test.ts`
- `bun test scripts/capy/command.test.ts scripts/setupTestUtils/ensure-test-org-secret-key.test.ts`
- `bun -F @autumn/server ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops logging the test org secret key during `setup-test` so secrets don’t leak into CI or snapshot logs. Previously the key was printed in both ensure and full setup; now only success, slug, and id are shown.

- Keeps persisting the key to `.env.local` via `persistTestKeysToEnvLocal`; setup behavior and exit codes are unchanged.
- If any tooling scraped stdout to capture the key, update it to read `.env.local` or call `ensureTestOrgSecretKey` directly.

<sup>Written for commit fc8839e6e71180255e5ecb1780cd922d2a6356b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents test organization secret keys from being written to setup command output while preserving successful completion and organization details.
- **Bug fixes:** Removes plaintext secret keys from both `--ensure-key` and full setup completion logs.
- **Improvements:** Keeps setup observable through success messages and non-sensitive organization information.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it removes sensitive output without breaking any identified caller or documented output contract.

Existing callers inherit setup output but depend only on command success, while downstream consumers retrieve the key from the environment or persisted `.env.local` file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/setup/setup-test.ts | Removes secret-key values from two completion logs without changing key generation, persistence, command exit behavior, or downstream key retrieval. |

<sub>Reviews (1): Last reviewed commit: ["fix(setup): stop logging test API keys"](https://github.com/useautumn/autumn/commit/fc8839e6e71180255e5ecb1780cd922d2a6356b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56011451)</sub>

<!-- /greptile_comment -->