### PR TITLE
Fix billing controls not persisting when cleared from Plan Settings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2842,7 +2842,7 @@
 
     "@types/buffer-from": ["@types/buffer-from@1.1.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-2lq4YC9uLUMGHkl2IDtX4tCXSo2+hwMpOJcY1qiIk1kybc31rIlPyM1HCVJhkPFIo75a/pOVxqyvwuf5TpCG/w=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -7446,6 +7446,8 @@
 
     "@types/buffer-from/@types/node": ["@types/node@25.9.5", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
 
+    "@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
     "@types/cacheable-request/@types/node": ["@types/node@25.9.5", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
 
     "@types/chai-http/@types/node": ["@types/node@25.9.5", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
@@ -8998,6 +9000,8 @@
 
     "@types/buffer-from/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
+    "@types/bun/bun-types/@types/node": ["@types/node@25.9.5", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
+
     "@types/cacheable-request/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@types/chai-http/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
@@ -9963,6 +9967,8 @@
     "@trigger.dev/core/socket.io/engine.io/cookie": ["cookie@0.4.2", "", {}, "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="],
 
     "@trigger.dev/core/socket.io/engine.io/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "@types/bun/bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@useautumn/gateway/ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.1.1", "", {}, "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ=="],
 

--- a/vite/src/components/billing-controls/clearedBillingControls.ts
+++ b/vite/src/components/billing-controls/clearedBillingControls.ts
@@ -1,0 +1,23 @@
+import {
+	BILLING_CONTROL_KEYS,
+	type CustomerBillingControls,
+} from "@autumn/shared";
+
+/** Every lane present as `[]` — catalogV2 treats omitted keys as "keep". */
+export const EMPTY_BILLING_CONTROLS: CustomerBillingControls = {
+	auto_topups: [],
+	spend_limits: [],
+	usage_limits: [],
+	usage_alerts: [],
+	overage_allowed: [],
+};
+
+export const toCatalogBillingControls = (
+	billingControls?: CustomerBillingControls,
+): CustomerBillingControls => {
+	const hasAny = BILLING_CONTROL_KEYS.some(
+		(key) => (billingControls?.[key]?.length ?? 0) > 0,
+	);
+	if (!hasAny) return { ...EMPTY_BILLING_CONTROLS };
+	return billingControls ?? { ...EMPTY_BILLING_CONTROLS };
+};

--- a/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
+++ b/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
@@ -9,6 +9,7 @@ import type {
 	ProductItem,
 	UpdateCatalogPlanParamsInput,
 } from "@autumn/shared";
+import { toCatalogBillingControls } from "@/components/billing-controls/clearedBillingControls";
 import { alignTierCurrencyShapes } from "../utils/currencyUtils";
 import { frontendProductToApiPlanV1 } from "../versioning/buildMigrationDraft";
 
@@ -100,7 +101,7 @@ export const buildUpdateCatalogPlanParams = ({
 				}
 			: {}),
 		config: plan.config,
-		billing_controls: plan.billing_controls,
+		billing_controls: toCatalogBillingControls(plan.billing_controls),
 		...(licenses !== undefined ? { licenses } : {}),
 		...(propagate !== undefined ? { propagate } : {}),
 		...(migration !== undefined ? { migration } : {}),

--- a/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
@@ -16,6 +16,7 @@ import {
 import { useState } from "react";
 import { useParams } from "react-router";
 import { hasBillingControls } from "@/components/billing-controls/BillingControlsDisplay";
+import { EMPTY_BILLING_CONTROLS } from "@/components/billing-controls/clearedBillingControls";
 import { ConfigRow } from "@/components/forms/shared/ConfigRow";
 import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
 import { useVariantLinkVisibility } from "../../hooks/useVariantLinkVisibility";
@@ -196,7 +197,10 @@ export const MoreSettingsSection = () => {
 											setBillingControlsOpened(true);
 										} else {
 											setBillingControlsOpened(false);
-											setProduct({ ...product, billing_controls: {} });
+											setProduct({
+												...product,
+												billing_controls: { ...EMPTY_BILLING_CONTROLS },
+											});
 										}
 									}}
 								/>

--- a/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
+++ b/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
@@ -278,6 +278,81 @@ describe("buildUpdateCatalogPlanParams", () => {
 		});
 	});
 
+	test("populated billing_controls pass through without filling other lanes", () => {
+		const spendLimits = [
+			{
+				feature_id: "messages",
+				enabled: true,
+				limit_type: "absolute" as const,
+				overage_limit: 0,
+				skip_overage_billing: true,
+			},
+		];
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: {
+				...editedProduct,
+				billing_controls: { spend_limits: spendLimits },
+			},
+			features,
+		});
+		expect(params.billing_controls).toEqual({ spend_limits: spendLimits });
+	});
+
+	test("cleared billing_controls send empty arrays so every lane is removed", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct: {
+				...baseProduct,
+				billing_controls: {
+					spend_limits: [
+						{
+							feature_id: "messages",
+							enabled: true,
+							limit_type: "absolute",
+							overage_limit: 0,
+							skip_overage_billing: true,
+						},
+					],
+				},
+			},
+			editedProduct: {
+				...baseProduct,
+				billing_controls: {},
+			},
+			features,
+		});
+
+		expect(params.billing_controls).toEqual({
+			auto_topups: [],
+			spend_limits: [],
+			usage_limits: [],
+			usage_alerts: [],
+			overage_allowed: [],
+		});
+
+		const afterDeletingLast = buildUpdateCatalogPlanParams({
+			baseProduct: {
+				...baseProduct,
+				billing_controls: {
+					spend_limits: [
+						{
+							feature_id: "messages",
+							enabled: true,
+							limit_type: "absolute",
+							overage_limit: 0,
+						},
+					],
+				},
+			},
+			editedProduct: {
+				...baseProduct,
+				billing_controls: { spend_limits: [] },
+			},
+			features,
+		});
+		expect(afterDeletingLast.billing_controls).toEqual(params.billing_controls);
+	});
+
 	test("create omits version and versioning", () => {
 		const params = buildUpdateCatalogPlanParams({
 			editedProduct: { ...editedProduct, is_default: true },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Toggling off plan billing controls (or deleting the last one) looked like it saved, but a refresh brought them back and the version/migration dialog never appeared.

**Cause:** Plan Settings wrote `billing_controls: {}`. catalogV2 treats omitted keys as preserve, so `pickBillingControlColumns({})` is a no-op. Preview sees no change → no version dialog → toast still fires.

```
toggle off          save payload              catalogV2
billing_controls    billing_controls: {}  →   omit every lane
= {}                                          = keep spend_limits
```

**Fix:** When the editor has no controls left, send empty arrays for every lane (`auto_topups`, `spend_limits`, `usage_limits`, `usage_alerts`, `overage_allowed`) so the write actually clears them.

The Plan Settings sheet footer “Save” still only closes the sheet — the bottom bar is the persist. After this fix that bar save removes the control and, if the plan has customers, preview can open the version/migration dialog.

Executor/Axiom were not available in this environment, so this is from the frontend save path + catalogV2 contract, not a prod log pull.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c04dc896-97c5-4bf6-9907-bd2f5fecfaae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c04dc896-97c5-4bf6-9907-bd2f5fecfaae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cleared plan billing controls not persisting from Plan Settings and restores the version/migration dialog when applicable. Previously, saving `billing_controls: {}` preserved existing lanes, so cleared controls reappeared after refresh.

- Normalize cleared controls to explicit empty arrays for all lanes via `toCatalogBillingControls` and `EMPTY_BILLING_CONTROLS`; populated lanes pass through unchanged. Tests cover both paths.
- `buildUpdateCatalogPlanParams` now uses `toCatalogBillingControls`; `MoreSettingsSection` writes `EMPTY_BILLING_CONTROLS` when toggled off.
- Behavior: the bottom bar Save persists changes and may open the version/migration dialog; the sheet “Save” still only closes the sheet.
- Refresh `bun.lock` to pin `@types/bun@1.4.0` to unblock CI.

<sup>Written for commit bb472e470ce28af8d93ce86f4b01abbebbf55940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Clearing all billing controls in Plan Settings now produces explicit empty arrays so catalog updates persist the removal and trigger version previews when needed.

- **[Bug fixes]** Normalize fully cleared billing controls into explicit empty arrays for every catalog lane.
- **[Bug fixes]** Use the normalized controls in plan-update requests and when disabling controls in Plan Settings.
- **[Improvements]** Add coverage for populated controls, clearing every control, and deleting the final control.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/billing-controls/clearedBillingControls.ts | Adds a shared empty-controls shape and converts fully cleared editor state into explicit empty catalog lanes. |
| vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts | Normalizes billing controls before constructing catalog plan update parameters. |
| vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx | Stores explicit empty billing-control lanes when the Plan Settings toggle is disabled. |
| vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts | Covers populated controls, complete clearing, and deletion of the final control. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[User clears billing controls] --> B[Plan editor stores empty lanes]
  B --> C[Update builder normalizes all lanes to empty arrays]
  C --> D[Catalog preview detects the change]
  D --> E[Catalog update clears persisted controls]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Refresh bun.lock for @types/bun 1.4.0"](https://github.com/useautumn/autumn/commit/bb472e470ce28af8d93ce86f4b01abbebbf55940) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56169435)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->