### PR TITLE
Fix billing-control create failing on null previous arrays

### DIFF
--- a/server/tests/integration/catalog-v2/plans/preview/changes/changes-billing-control-lanes.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/changes/changes-billing-control-lanes.test.ts
@@ -82,7 +82,7 @@ test.concurrent(
 					expected: {
 						planId,
 						action: "update",
-						previousAttributes: { billing_controls: { [key]: [] } },
+						previousAttributes: null,
 						customize: null,
 						itemChanges: [],
 						priceChange: null,
@@ -163,7 +163,7 @@ test.concurrent(
 				preview.plans[0]?.plan_change?.previous_attributes
 					?.billing_controls ?? {};
 			expect(JSON.stringify(billingControls)).not.toContain("null");
-			expect(billingControls.spend_limits).toEqual([]);
+			expect(billingControls.spend_limits).toBeUndefined();
 			PreviewUpdateCatalogResponseSchema.parse(preview);
 		} finally {
 			await deleteDbPlans({ ctx, planIds: [planId] });

--- a/server/tests/integration/catalog-v2/plans/preview/changes/changes-billing-control-lanes.test.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/changes/changes-billing-control-lanes.test.ts
@@ -1,0 +1,172 @@
+/**
+ * catalogV2.preview_update + update — create and delete each billing-control
+ * lane from a plan that had none. Preview must parse (no null arrays).
+ */
+
+import { expect, test } from "bun:test";
+import {
+	PreviewUpdateCatalogResponseSchema,
+	ResetInterval,
+} from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { expectCatalogResultsCorrect } from "../../../utils/expectCatalogUpdate.js";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	deleteDbPlans,
+	expectCatalogPlansCorrect,
+} from "../../utils/expectCatalogPlans.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../utils/expectPlanPreview.js";
+
+const lanes = {
+	auto_topups: [
+		{
+			feature_id: TestFeature.Messages,
+			enabled: true,
+			threshold: 10,
+			quantity: 100,
+		},
+	],
+	spend_limits: [
+		{
+			feature_id: TestFeature.Messages,
+			overage_limit: 50,
+			enabled: true,
+		},
+	],
+	usage_limits: [
+		{
+			feature_id: TestFeature.Messages,
+			enabled: true,
+			limit: 1000,
+			interval: ResetInterval.Month,
+		},
+	],
+	usage_alerts: [
+		{
+			feature_id: TestFeature.Messages,
+			enabled: true,
+			threshold: 80,
+			threshold_type: "usage_percentage" as const,
+		},
+	],
+	overage_allowed: [{ feature_id: TestFeature.Messages, enabled: true }],
+} as const;
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 billing-control lanes: preview+update create and delete each type")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_bc_lanes");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "BC Lanes" }],
+			});
+
+			for (const [key, items] of Object.entries(lanes)) {
+				const createPreview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: [
+							{ plan_id: planId, billing_controls: { [key]: items } },
+						],
+					}),
+				);
+				PreviewUpdateCatalogResponseSchema.parse(createPreview);
+				expectPlanPreviewRowCorrect({
+					preview: createPreview,
+					expected: {
+						planId,
+						action: "update",
+						previousAttributes: { billing_controls: { [key]: [] } },
+						customize: null,
+						itemChanges: [],
+						priceChange: null,
+					},
+				});
+
+				const created = await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, billing_controls: { [key]: items } }],
+				});
+				expectCatalogResultsCorrect({
+					response: created,
+					plans: [{ id: planId, action: "update" }],
+				});
+				await expectCatalogPlansCorrect({
+					autumn: autumnV2_3,
+					expected: [{ id: planId, billingControls: { [key]: items } }],
+				});
+
+				const deletePreview = parsePlanPreview(
+					await autumnV2_3.catalogV2.previewUpdate({
+						plans: [
+							{ plan_id: planId, billing_controls: { [key]: [] } },
+						],
+					}),
+				);
+				PreviewUpdateCatalogResponseSchema.parse(deletePreview);
+				expectPlanPreviewRowCorrect({
+					preview: deletePreview,
+					expected: {
+						planId,
+						action: "update",
+						previousAttributes: { billing_controls: { [key]: items } },
+						customize: null,
+						itemChanges: [],
+						priceChange: null,
+					},
+				});
+
+				const deleted = await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: planId, billing_controls: { [key]: [] } }],
+				});
+				expectCatalogResultsCorrect({
+					response: deleted,
+					plans: [{ id: planId, action: "update" }],
+				});
+				await expectCatalogPlansCorrect({
+					autumn: autumnV2_3,
+					expected: [{ id: planId, billingControlsExact: { [key]: [] } }],
+				});
+			}
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 billing-control lanes: null previous arrays never appear in preview")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_bc_null");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, name: "BC Null" }],
+			});
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [
+						{
+							plan_id: planId,
+							billing_controls: { spend_limits: lanes.spend_limits },
+						},
+					],
+				}),
+			);
+			const billingControls =
+				preview.plans[0]?.plan_change?.previous_attributes
+					?.billing_controls ?? {};
+			expect(JSON.stringify(billingControls)).not.toContain("null");
+			expect(billingControls.spend_limits).toEqual([]);
+			PreviewUpdateCatalogResponseSchema.parse(preview);
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
+++ b/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
@@ -3,8 +3,10 @@ import {
 	ApiFeatureType,
 	type ApiPlanV1,
 	BillingInterval,
+	BILLING_CONTROL_KEYS,
 	diffPlanV1,
 	diffPlanV1PreviewFields,
+	PlanPreviousAttributesV0Schema,
 	ResetInterval,
 } from "@autumn/shared";
 
@@ -265,3 +267,83 @@ test("billing_controls: skip_overage_billing true vs unset is a change", () => {
 		billing_controls: from.billing_controls,
 	});
 });
+
+const createdLanes = {
+	auto_topups: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			threshold: 10,
+			quantity: 100,
+		},
+	],
+	spend_limits: [
+		{ feature_id: "messages", enabled: true, overage_limit: 50 },
+	],
+	usage_limits: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			limit: 1000,
+			interval: ResetInterval.Month,
+		},
+	],
+	usage_alerts: [
+		{
+			feature_id: "messages",
+			enabled: true,
+			threshold: 80,
+			threshold_type: "usage_percentage" as const,
+		},
+	],
+	overage_allowed: [{ feature_id: "messages", enabled: true }],
+} as const;
+
+for (const key of BILLING_CONTROL_KEYS) {
+	test(`billing_controls: creating ${key} from unset previous is [] (not null)`, () => {
+		const diff = diffPlanV1PreviewFields({
+			from: plan({ billing_controls: {} }),
+			to: plan({ billing_controls: { [key]: createdLanes[key] } }),
+		});
+
+		expect(diff.previous_attributes).toEqual({
+			billing_controls: { [key]: [] },
+		});
+		expect(
+			PlanPreviousAttributesV0Schema.parse(diff.previous_attributes),
+		).toEqual({
+			billing_controls: { [key]: [] },
+		});
+	});
+
+	test(`billing_controls: creating ${key} from a null lane is [] (not null)`, () => {
+		const diff = diffPlanV1PreviewFields({
+			from: plan({
+				billing_controls: { [key]: null } as ApiPlanV1["billing_controls"],
+			}),
+			to: plan({ billing_controls: { [key]: createdLanes[key] } }),
+		});
+
+		expect(diff.previous_attributes).toEqual({
+			billing_controls: { [key]: [] },
+		});
+		expect(() =>
+			PlanPreviousAttributesV0Schema.parse(diff.previous_attributes),
+		).not.toThrow();
+	});
+
+	test(`billing_controls: deleting ${key} keeps the previous array`, () => {
+		const previous = createdLanes[key];
+		const diff = diffPlanV1PreviewFields({
+			from: plan({ billing_controls: { [key]: previous } }),
+			to: plan({ billing_controls: { [key]: [] } }),
+		});
+
+		expect(diff.previous_attributes).toEqual({
+			billing_controls: { [key]: previous },
+		});
+		expect(() =>
+			PlanPreviousAttributesV0Schema.parse(diff.previous_attributes),
+		).not.toThrow();
+	});
+}

--- a/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
+++ b/server/tests/unit/shared/diffPlanV1PreviewFields.test.ts
@@ -300,27 +300,29 @@ const createdLanes = {
 } as const;
 
 for (const key of BILLING_CONTROL_KEYS) {
-	test(`billing_controls: creating ${key} from unset previous is [] (not null)`, () => {
+	test(`billing_controls: creating ${key} from unset omits the lane`, () => {
 		const diff = diffPlanV1PreviewFields({
 			from: plan({ billing_controls: {} }),
 			to: plan({ billing_controls: { [key]: createdLanes[key] } }),
 		});
 
-		expect(diff.previous_attributes).toEqual({
-			billing_controls: { [key]: [] },
-		});
-		expect(
-			PlanPreviousAttributesV0Schema.parse(diff.previous_attributes),
-		).toEqual({
-			billing_controls: { [key]: [] },
-		});
+		expect(diff.previous_attributes).toBeNull();
 	});
 
-	test(`billing_controls: creating ${key} from a null lane is [] (not null)`, () => {
+	test(`billing_controls: creating ${key} from a null lane omits the lane`, () => {
 		const diff = diffPlanV1PreviewFields({
 			from: plan({
 				billing_controls: { [key]: null } as ApiPlanV1["billing_controls"],
 			}),
+			to: plan({ billing_controls: { [key]: createdLanes[key] } }),
+		});
+
+		expect(diff.previous_attributes).toBeNull();
+	});
+
+	test(`billing_controls: creating ${key} from an empty array keeps []`, () => {
+		const diff = diffPlanV1PreviewFields({
+			from: plan({ billing_controls: { [key]: [] } }),
 			to: plan({ billing_controls: { [key]: createdLanes[key] } }),
 		});
 

--- a/shared/models/cusModels/billingControls/customerBillingControls.ts
+++ b/shared/models/cusModels/billingControls/customerBillingControls.ts
@@ -238,16 +238,24 @@ export const billingControlsFromColumns = (
 export const normalizeBillingControlsForCompare = (
 	billingControls: CustomerBillingControls | null | undefined,
 ): CustomerBillingControls | undefined => {
-	if (!billingControls?.spend_limits) return billingControls ?? undefined;
+	if (!billingControls) return undefined;
 
-	return {
-		...billingControls,
-		spend_limits: billingControls.spend_limits.map((spendLimit) => {
-			if (spendLimit.skip_overage_billing === true) return spendLimit;
-			const { skip_overage_billing: _dropped, ...rest } = spendLimit;
-			return rest;
+	const spendLimits = billingControls.spend_limits?.map((spendLimit) => {
+		if (spendLimit.skip_overage_billing === true) return spendLimit;
+		const { skip_overage_billing: _dropped, ...rest } = spendLimit;
+		return rest;
+	});
+
+	const normalized = Object.fromEntries(
+		BILLING_CONTROL_KEYS.flatMap((key) => {
+			const value =
+				key === "spend_limits" ? spendLimits : billingControls[key];
+			if (value == null || value.length === 0) return [];
+			return [[key, value]];
 		}),
-	};
+	) as CustomerBillingControls;
+
+	return Object.keys(normalized).length > 0 ? normalized : undefined;
 };
 
 export const mergeBillingControls = (

--- a/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
@@ -102,12 +102,8 @@ export const diffPlanV1PreviousAttributes = ({
 
 		// Nested billing_controls: only emit keys that actually changed.
 		if (key === "billing_controls") {
-			if (fromValue == null) {
-				previous.billing_controls = null;
-				continue;
-			}
-			const sparse = sparsePreviousRecord({
-				from: fromValue as Record<string, unknown>,
+			const sparse = sparsePreviousBillingControls({
+				from: (fromValue ?? {}) as Record<string, unknown>,
 				to: (toValue ?? {}) as Record<string, unknown>,
 			});
 			if (Object.keys(sparse).length > 0) {
@@ -124,7 +120,11 @@ export const diffPlanV1PreviousAttributes = ({
 	return Object.keys(previous).length > 0 ? previous : null;
 };
 
-const sparsePreviousRecord = ({
+/** Unset/null lanes become `[]` — the preview schema rejects null arrays. */
+const previousBillingControlLane = (value: unknown): unknown[] =>
+	Array.isArray(value) ? value : [];
+
+const sparsePreviousBillingControls = ({
 	from,
 	to,
 }: {
@@ -135,7 +135,7 @@ const sparsePreviousRecord = ({
 	const keys = new Set([...Object.keys(from), ...Object.keys(to)]);
 	for (const key of keys) {
 		if (!valuesEqual(from[key], to[key])) {
-			previous[key] = from[key] === undefined ? null : from[key];
+			previous[key] = previousBillingControlLane(from[key]);
 		}
 	}
 	return previous;

--- a/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
+++ b/shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts
@@ -103,8 +103,8 @@ export const diffPlanV1PreviousAttributes = ({
 		// Nested billing_controls: only emit keys that actually changed.
 		if (key === "billing_controls") {
 			const sparse = sparsePreviousBillingControls({
-				from: (fromValue ?? {}) as Record<string, unknown>,
-				to: (toValue ?? {}) as Record<string, unknown>,
+				from: (from.billing_controls ?? {}) as Record<string, unknown>,
+				to: (to.billing_controls ?? {}) as Record<string, unknown>,
 			});
 			if (Object.keys(sparse).length > 0) {
 				previous.billing_controls = sparse;
@@ -120,10 +120,7 @@ export const diffPlanV1PreviousAttributes = ({
 	return Object.keys(previous).length > 0 ? previous : null;
 };
 
-/** Unset/null lanes become `[]` — the preview schema rejects null arrays. */
-const previousBillingControlLane = (value: unknown): unknown[] =>
-	Array.isArray(value) ? value : [];
-
+/** Unset lanes stay omitted. `[]` only when the previous lane was actually empty. */
 const sparsePreviousBillingControls = ({
 	from,
 	to,
@@ -134,8 +131,9 @@ const sparsePreviousBillingControls = ({
 	const previous: Record<string, unknown> = {};
 	const keys = new Set([...Object.keys(from), ...Object.keys(to)]);
 	for (const key of keys) {
+		if (from[key] == null) continue;
 		if (!valuesEqual(from[key], to[key])) {
-			previous[key] = previousBillingControlLane(from[key]);
+			previous[key] = from[key];
 		}
 	}
 	return previous;

--- a/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
+++ b/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
@@ -299,6 +299,59 @@ describe("buildUpdateCatalogPlanParams", () => {
 		expect(params.billing_controls).toEqual({ spend_limits: spendLimits });
 	});
 
+	test("creating each billing-control lane sends that array only", () => {
+		const created = {
+			auto_topups: [
+				{
+					feature_id: "messages",
+					enabled: true,
+					threshold: 10,
+					quantity: 100,
+				},
+			],
+			spend_limits: [
+				{
+					feature_id: "messages",
+					enabled: true,
+					limit_type: "absolute" as const,
+					overage_limit: 50,
+				},
+			],
+			usage_limits: [
+				{
+					feature_id: "messages",
+					enabled: true,
+					limit: 1000,
+					interval: "month" as const,
+				},
+			],
+			usage_alerts: [
+				{
+					feature_id: "messages",
+					enabled: true,
+					threshold: 80,
+					threshold_type: "usage_percentage" as const,
+				},
+			],
+			overage_allowed: [{ feature_id: "messages", enabled: true }],
+		} as const;
+
+		for (const [key, items] of Object.entries(created)) {
+			const params = buildUpdateCatalogPlanParams({
+				baseProduct,
+				editedProduct: {
+					...editedProduct,
+					billing_controls: { [key]: items },
+				},
+				features,
+			});
+			expect(params.billing_controls).toEqual({ [key]: items });
+			expect(
+				JSON.stringify(params.billing_controls).includes("null"),
+			).toBe(false);
+		}
+	});
+
 	test("cleared billing_controls send empty arrays so every lane is removed", () => {
 		const params = buildUpdateCatalogPlanParams({
 			baseProduct: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Creating a billing control from Plan Settings failed on save:

`plans.0.plan_change.previous_attributes.billing_controls.spend_limits: Invalid input: expected array, received null`

The earlier clear-toggle fix did **not** cover this. Save always previews first. When a lane was previously unset, `diffPlanV1PreviousAttributes` wrote `null` so the key survived JSON, but `CustomerBillingControlsSchema` only allows arrays.

## Fix

- Treat null / empty lanes as absent when comparing billing controls
- Omit unset lanes from `previous_attributes` (never emit `null`); emit `[]` only when the previous value was actually `[]`
- Same path covers create and delete for every lane: auto_topups, spend_limits, usage_limits, usage_alerts, overage_allowed

## CI typecheck

`@autumn/scripts#ts` failed after `@types/bun` 1.4.0: `Process.off` is only typed for `memoryPressure`, so `process.off("SIGINT" | "SIGTERM")` did not typecheck. Detach those handlers through a small cast helper.

## Tests

- Unit: create from `{}` and from `{ lane: null }`, plus delete, for all 5 lanes — result must parse `PlanPreviousAttributesV0Schema`
- Integration: catalogV2 preview+update create and delete each lane
- Frontend: creating each lane sends that array only (no nulls)
- `cd scripts && bunx tsgo --build --noEmit` exits 0

Stacked on the merged #3004 clear-toggle fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c04dc896-97c5-4bf6-9907-bd2f5fecfaae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c04dc896-97c5-4bf6-9907-bd2f5fecfaae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes billing-control create from Plan Settings by ensuring previews never emit null arrays. Previously, preview returned null for unset lanes and failed schema validation; now unset lanes are omitted, and [] appears only when the prior value was actually an empty array.

- Normalize billing_controls before compare: drop null/empty lanes; strip spend_limits.skip_overage_billing when false; keep true.
- previous_attributes now omits unset billing-control lanes and preserves arrays on delete; [] is only emitted when the previous lane was []. Applies to auto_topups, spend_limits, usage_limits, usage_alerts, and overage_allowed.
- Output conforms to `PlanPreviousAttributesV0Schema` and `PreviewUpdateCatalogResponseSchema` in `@autumn/shared`; no API changes.
- Tests: unit for create from {} and { lane: null }, create from [], and delete for all lanes; integration preview+update create/delete per lane; frontend ensures only the changed lane is sent and no nulls.

<sup>Written for commit 9a180efe80d0bc26163e7dca59bba4b1b65704e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes catalog preview validation when creating billing controls whose previous lane was unset or null.

- **Bug fixes:** Omits null or unset previous billing-control lanes while preserving explicitly empty arrays and populated arrays.
- **Improvements:** Normalizes all five billing-control lanes consistently before comparison.
- **Improvements:** Adds unit, integration, and frontend coverage for creating and deleting each supported lane.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/models/cusModels/billingControls/customerBillingControls.ts | Normalizes all supported billing-control lanes by removing null and empty values while preserving meaningful arrays. |
| shared/utils/planV1Utils/diff/diffPlanV1PreviewFields.ts | Produces schema-valid sparse previous attributes without serializing unset billing-control lanes as null. |
| server/tests/unit/shared/diffPlanV1PreviewFields.test.ts | Covers creation from missing, null, and empty prior lanes plus deletion across all five lane types. |
| server/tests/integration/catalog-v2/plans/preview/changes/changes-billing-control-lanes.test.ts | Verifies preview and update behavior for creating and deleting every billing-control lane. |
| vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts | Confirms frontend update parameters contain only the created lane and no null values. |

<sub>Reviews (2): Last reviewed commit: ["Omit unset billing-control lanes from pr..."](https://github.com/useautumn/autumn/commit/9a180efe80d0bc26163e7dca59bba4b1b65704e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56176391)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->