### PR TITLE
test: lock agent-bundle externals to declared leaf dependencies

### DIFF
--- a/apps/leaf/tests/unit/agent/agentBundleImports.test.ts
+++ b/apps/leaf/tests/unit/agent/agentBundleImports.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const LEAF_ROOT = resolve(import.meta.dir, "../../..");
+
+const tsFilesUnder = (dir: string): string[] =>
+	readdirSync(dir).flatMap((entry) => {
+		const path = resolve(dir, entry);
+		if (statSync(path).isDirectory()) return tsFilesUnder(path);
+		return path.endsWith(".ts") ? [path] : [];
+	});
+
+const resolveRelative = (fromFile: string, specifier: string) => {
+	const target = resolve(dirname(fromFile), specifier);
+	for (const candidate of [
+		target.replace(/\.js$/, ".ts"),
+		`${target}.ts`,
+		resolve(target, "index.ts"),
+	]) {
+		try {
+			statSync(candidate);
+			return candidate;
+		} catch {}
+	}
+	return null;
+};
+
+const packageNameOf = (specifier: string) =>
+	specifier.startsWith("@")
+		? specifier.split("/").slice(0, 2).join("/")
+		: specifier.split("/")[0];
+
+/** The eve agent bundle resolves imports from a cache path where only leaf's
+ * OWN dependencies are guaranteed present — a transitive workspace dep (pino
+ * via @autumn/logging broke prod boot) resolves only by image-layout luck. */
+describe("agent bundle import closure", () => {
+	test("every runtime external is a declared leaf dependency", () => {
+		const manifest = JSON.parse(
+			readFileSync(resolve(LEAF_ROOT, "package.json"), "utf8"),
+		) as { dependencies?: Record<string, string> };
+		const declared = new Set(Object.keys(manifest.dependencies ?? {}));
+		const queue = tsFilesUnder(resolve(LEAF_ROOT, "agent"));
+		const seen = new Set<string>();
+		const offenders = new Set<string>();
+		while (queue.length) {
+			const file = queue.pop() as string;
+			if (seen.has(file)) continue;
+			seen.add(file);
+			const source = readFileSync(file, "utf8");
+			for (const match of source.matchAll(
+				/import\s+(type\s+)?[^;]*?from\s+"([^"]+)"/g,
+			)) {
+				const [, typeOnly, specifier] = match;
+				if (typeOnly) continue;
+				if (specifier.startsWith(".")) {
+					const resolved = resolveRelative(file, specifier);
+					if (resolved) queue.push(resolved);
+					continue;
+				}
+				if (specifier.startsWith("node:")) continue;
+				const packageName = packageNameOf(specifier);
+				if (!declared.has(packageName)) {
+					offenders.add(
+						`${file.slice(LEAF_ROOT.length + 1)} -> ${packageName}`,
+					);
+				}
+			}
+		}
+		expect(seen.size).toBeGreaterThan(30);
+		expect([...offenders].sort()).toEqual([]);
+	});
+});


### PR DESCRIPTION
Recovers the regression guard that was lost when #2977 was closed unmerged (its pino fix reached dev via the #2976 main→dev sync, but this test only existed on that branch).

Walks the eve agent bundle's full import closure and fails CI if any runtime external isn't a declared `apps/leaf` dependency — transitive workspace deps (pino via @autumn/logging broke prod boot on Aug 21) only resolve from the authored-modules cache by image-layout luck. Type-only imports and `node:` builtins are exempt; a size floor keeps a broken walker from passing vacuously. Test-only change; passes against current dev.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores a regression guard by adding a unit test that fails CI when the agent bundle imports runtime externals not declared in `apps/leaf` dependencies. This prevents transitive workspace deps (e.g., `pino` via `@autumn/logging`) from slipping in and breaking boot when they aren’t present in the agent’s cache.

- Walks the agent’s TypeScript import closure, follows relative imports, and collects external package imports.
- Fails CI if any external package isn’t listed in `apps/leaf/package.json` dependencies, printing offending "file -> package" edges.
- Ignores type-only imports and `node:` builtins; includes a size floor to avoid vacuous passes if the walker breaks.
- Test-only change; no runtime behavior.
- Required action if failing: add the missing package to `apps/leaf` dependencies.

<sup>Written for commit 55a1d1c498be5c97fed033572dc5b384cad95a72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This test restores a CI guard intended to prevent the Leaf agent bundle from relying on undeclared runtime dependencies.

- **Improvements, Bug fixes:** Recursively scans the agent's TypeScript import graph and compares runtime package imports with Leaf's declared dependencies.
- **Improvements:** Exempts type-only imports and Node built-ins and adds a minimum graph-size assertion to prevent vacuous success.
- **Improvements:** The scanner should cover or reject unsupported module-edge syntax so the dependency guard cannot silently inspect only part of the bundle.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking gap in the import scanner that can allow future bundle dependencies to escape the regression guard.

The added test correctly checks the currently used static import form, but it does not truly walk every supported runtime module edge and can silently pass after a dependency is introduced through an omitted syntax.

**Files Needing Attention:** apps/leaf/tests/unit/agent/agentBundleImports.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/tests/unit/agent/agentBundleImports.test.ts | Adds the dependency regression guard, but its regex silently omits runtime module edges such as re-exports and dynamic or side-effect imports. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/tests/unit/agent/agentBundleImports.test.ts:51-53
**Import scanner skips module edges**

The regex recognizes only double-quoted `import ... from` statements, so runtime edges such as the existing `export ... from` declarations are silently excluded from the closure. A module reached only through one of these declarations can introduce an undeclared package without failing this regression guard.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: 💍 lock agent-bundle externals to ..."](https://github.com/useautumn/autumn/commit/55a1d1c498be5c97fed033572dc5b384cad95a72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56176915)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->