### PR TITLE
feat: support OpenRouter models via EVE_MODEL prefix

### DIFF
--- a/apps/leaf/agent/agent.ts
+++ b/apps/leaf/agent/agent.ts
@@ -1,5 +1,9 @@
 import { defineAgent } from "eve";
-import { leafModel, leafReasoning } from "./lib/model.js";
+import {
+	leafModel,
+	leafModelContextWindowTokens,
+	leafReasoning,
+} from "./lib/model.js";
 
 const workflowWorld =
 	process.env.EVE_WORKFLOW_WORLD ??
@@ -7,6 +11,7 @@ const workflowWorld =
 
 export default defineAgent({
 	model: leafModel("orchestrator"),
+	modelContextWindowTokens: leafModelContextWindowTokens("orchestrator"),
 	reasoning: leafReasoning("orchestrator"),
 	...(workflowWorld
 		? {

--- a/apps/leaf/agent/lib/model.ts
+++ b/apps/leaf/agent/lib/model.ts
@@ -1,6 +1,13 @@
 import { anthropic } from "@ai-sdk/anthropic";
-import { openai } from "@ai-sdk/openai";
+import { createOpenAI, openai } from "@ai-sdk/openai";
 import type { LeafAgentConnection } from "./toolAllowlists.js";
+
+// .chat pins chat-completions — OpenRouter does not serve the responses API.
+const openrouter = (model: string) =>
+	createOpenAI({
+		apiKey: process.env.OPENROUTER_API_KEY,
+		baseURL: "https://openrouter.ai/api/v1",
+	}).chat(model);
 
 const resolveModel = (value: string | undefined) => {
 	if (!value) return undefined;
@@ -8,6 +15,7 @@ const resolveModel = (value: string | undefined) => {
 	const model = rest.join("/");
 	if (provider === "openai" && model) return openai(model);
 	if (provider === "anthropic" && model) return anthropic(model);
+	if (provider === "openrouter" && model) return openrouter(model);
 	// Any other prefix is treated as a Vercel AI Gateway model id string.
 	return value;
 };
@@ -17,7 +25,7 @@ const resolveModel = (value: string | undefined) => {
  * (gateway string) and EVE_ANTHROPIC_MODEL move everyone together. */
 export const leafModel = (agent: LeafAgentConnection) =>
 	resolveModel(process.env[`EVE_MODEL_${agent.toUpperCase()}`]) ??
-	process.env.EVE_MODEL ??
+	resolveModel(process.env.EVE_MODEL) ??
 	(process.env.EVE_OPENAI_MODEL
 		? openai(process.env.EVE_OPENAI_MODEL)
 		: anthropic(process.env.EVE_ANTHROPIC_MODEL ?? "claude-sonnet-5"));

--- a/apps/leaf/agent/lib/model.ts
+++ b/apps/leaf/agent/lib/model.ts
@@ -41,3 +41,15 @@ const REASONING_BY_AGENT: Record<LeafAgentConnection, "minimal" | "none"> = {
 
 export const leafReasoning = (agent: LeafAgentConnection) =>
 	REASONING_BY_AGENT[agent];
+
+const DEFAULT_OPENROUTER_CONTEXT_WINDOW_TOKENS = 1_000_000;
+
+/** Eve resolves context windows from AI Gateway metadata, which has no entries
+ * for OpenRouter models — supply the window explicitly to keep compaction alive. */
+export const leafModelContextWindowTokens = (agent: LeafAgentConnection) => {
+	const value =
+		process.env[`EVE_MODEL_${agent.toUpperCase()}`] ?? process.env.EVE_MODEL;
+	if (!value?.startsWith("openrouter/")) return undefined;
+	const configured = Number(process.env.EVE_MODEL_CONTEXT_WINDOW ?? "");
+	return configured > 0 ? configured : DEFAULT_OPENROUTER_CONTEXT_WINDOW_TOKENS;
+};

--- a/apps/leaf/agent/subagents/billing/agent.ts
+++ b/apps/leaf/agent/subagents/billing/agent.ts
@@ -1,9 +1,14 @@
 import { defineAgent } from "eve";
-import { leafModel, leafReasoning } from "../../lib/model.js";
+import {
+	leafModel,
+	leafModelContextWindowTokens,
+	leafReasoning,
+} from "../../lib/model.js";
 
 export default defineAgent({
 	description:
 		"Autumn billing specialist. Delegate every billing action here: attaching plans, updating subscriptions (quantities, cancels, custom terms), creating schedules, and balance grants. Pack the full task into the message — customer and plan ids, quantities, customize terms, timing, invoice settings, and any investigator findings.",
 	model: leafModel("billing"),
+	modelContextWindowTokens: leafModelContextWindowTokens("billing"),
 	reasoning: leafReasoning("billing"),
 });

--- a/apps/leaf/agent/subagents/investigator/agent.ts
+++ b/apps/leaf/agent/subagents/investigator/agent.ts
@@ -1,9 +1,14 @@
 import { defineAgent } from "eve";
-import { leafModel, leafReasoning } from "../../lib/model.js";
+import {
+	leafModel,
+	leafModelContextWindowTokens,
+	leafReasoning,
+} from "../../lib/model.js";
 
 export default defineAgent({
 	description:
 		"Read-only Autumn investigator. Delegate questions about a customer's current state (plans, entities, balances, trials, past-due subscriptions) and what-happened questions answered from request logs. Always delegate here before changing a customer whose state is unclear.",
 	model: leafModel("investigator"),
+	modelContextWindowTokens: leafModelContextWindowTokens("investigator"),
 	reasoning: leafReasoning("investigator"),
 });


### PR DESCRIPTION
Adds an `openrouter/<slug>` prefix to the leaf model resolver, served through the existing `@ai-sdk/openai` provider pointed at OpenRouter's chat-completions endpoint (no new dependency, no SDK migration). `EVE_MODEL` now also runs through `resolveModel`, so `EVE_MODEL=openrouter/openai/gpt-5.6-luna` moves every agent to GPT-5.6 Luna; unknown prefixes still fall through as Vercel AI Gateway strings.

Verified with a live `generateText` call through `leafModel("orchestrator")` against `openai/gpt-5.6-luna` using the dev `OPENROUTER_API_KEY`. Set `EVE_MODEL` in Infisical dev to try it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `openrouter/<slug>` model support and explicit context-window handling so OpenRouter models work end-to-end and keep compaction working. Previously `EVE_MODEL` was used verbatim; now provider-prefixed values resolve to the correct client, with unknown prefixes unchanged.

- Routes OpenRouter via `@ai-sdk/openai` using `createOpenAI({ baseURL: "https://openrouter.ai/api/v1", apiKey: OPENROUTER_API_KEY }).chat(model)`; no new dependency or SDK migration.
- Supplies `modelContextWindowTokens` for OpenRouter models: uses `EVE_MODEL_CONTEXT_WINDOW` if set, else 1,000,000; only applied when the selected model starts with `openrouter/`.
- `EVE_MODEL` and `EVE_MODEL_<AGENT>` accept `openrouter/...`; non-prefixed or unknown prefixes behave as before. Defaults via `EVE_OPENAI_MODEL` / `EVE_ANTHROPIC_MODEL` are unchanged.
- Required to use OpenRouter: set `OPENROUTER_API_KEY` and choose `openrouter/<slug>` (e.g., `openrouter/openai/gpt-5.6-luna`).

<sup>Written for commit 78f3bc24c5d6607cf9e8b1e10a5f0945f076f10e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds direct OpenRouter model selection for Leaf agents and supplies explicit context-window metadata for those models.

- [Improvements, API changes] Resolves `openrouter/<slug>` values through an OpenRouter-compatible OpenAI client.
- [Improvements] Applies provider-aware resolution to global and agent-specific model configuration.
- [Bug fixes] Supplies context-window metadata to the orchestrator, billing, and investigator agents so OpenRouter configurations retain compaction support.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/agent/lib/model.ts | Adds OpenRouter client resolution, resolves the global model override, and provides configurable context-window metadata. |
| apps/leaf/agent/agent.ts | Passes resolved model context-window metadata to the orchestrator agent. |
| apps/leaf/agent/subagents/billing/agent.ts | Passes resolved model context-window metadata to the billing agent. |
| apps/leaf/agent/subagents/investigator/agent.ts | Passes resolved model context-window metadata to the investigator agent. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config[EVE_MODEL or agent override] --> Resolver[resolveModel]
  Resolver -->|openrouter/slug| OpenRouter[OpenRouter chat-completions]
  Resolver -->|openai/model| OpenAI[Direct OpenAI client]
  Resolver -->|anthropic/model| Anthropic[Direct Anthropic client]
  Resolver -->|other value| Gateway[Vercel AI Gateway model ID]
  Config --> Context[Context-window resolver]
  Context --> Agent[Leaf agent configuration]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 supply context window for openro..."](https://github.com/useautumn/autumn/commit/78f3bc24c5d6607cf9e8b1e10a5f0945f076f10e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56178990)</sub>

<!-- /greptile_comment -->