### PR TITLE
fix(dashboard): stop truncating plan names at a fixed character count

### DIFF
--- a/vite/src/views/products/plan/components/plan-card/PlanCardHeader.tsx
+++ b/vite/src/views/products/plan/components/plan-card/PlanCardHeader.tsx
@@ -37,13 +37,13 @@ export const PlanCardHeader = () => {
 	return (
 		<CardHeader>
 			<div className="flex flex-row items-center justify-between w-full">
-				<div className="flex flex-row items-center gap-2">
-					<AdminHover texts={adminHoverText()} side="top">
-						<span className="text-main-sec w-fit whitespace-nowrap">
-							{product.name.length > MAX_PLAN_NAME_LENGTH
-								? `${product.name.slice(0, MAX_PLAN_NAME_LENGTH)}...`
-								: product.name}
-						</span>
+				<div className="flex flex-row items-center gap-2 min-w-0">
+					<AdminHover
+						texts={adminHoverText()}
+						side="top"
+						triggerClassName="min-w-0"
+					>
+						<span className="text-main-sec truncate">{product.name}</span>
 					</AdminHover>
 					<PlanTypeBadges
 						product={product}


### PR DESCRIPTION
## Problem
The plan detail card header truncated `product.name` via manual JS slicing at a fixed 20 characters, so names like "Standard Unlimited - Monthly" always showed as "Standard Unlimited -..." even when the card had plenty of room to render the full name.

## Fix
Swap the hardcoded slice+ellipsis for CSS-based truncation (`truncate` + `min-w-0` on the flex chain, including AdminHover's trigger wrapper), so the name only clips when the container is genuinely too narrow — matching how the page-level title/breadcrumb already render it in full.

## Testing
- `biome check` on the changed file: clean
- `tsc --noEmit` in `vite/`: no errors
- Manually confirmed the bug on app.useautumn.com/products before the fix

Fixes #3015 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forcing plan name truncation in PlanCardHeader. Previously names longer than 20 chars were sliced with an ellipsis regardless of space; now CSS truncation shows the full name when space allows and only clips when the container is too narrow.

- Replace manual slice+ellipsis with `truncate` on the name span.
- Add `min-w-0` to the flex container and to `AdminHover` via `triggerClassName` to allow proper flex overflow.
- Behavior now matches the page title/breadcrumb; no API or data changes.

<sup>Written for commit d70ab0346c5bc66e580e2c2a730b9183b1518234. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

