### PR TITLE
feat(catalog): take the active pointer on an existing version

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/mergeRemoveRepointUpserts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeRemoveProductsPlan/mergeRemoveRepointUpserts.ts
@@ -1,6 +1,6 @@
 import type { FullProduct } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { computeUpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan";
+import { intentToUpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan";
 import type { ProjectedCatalog } from "@/internal/catalogV2/actions/updateCatalog/types/catalogComputeState";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { RemovePlanPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
@@ -152,7 +152,7 @@ export const mergeRemoveRepointUpserts = ({
 						upsert: existing,
 						baseInternalProductId: surviving.internal_id,
 					})
-				: computeUpsertProductPlan({
+				: intentToUpsertProductPlan({
 						ctx,
 						productStatesContext: catalogContext.productStatesContext,
 						intent: {

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/computePlanLicensesPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/computePlanLicensesPlan.ts
@@ -93,20 +93,19 @@ export const computePlanLicensesPlan = ({
 			});
 		}
 
-		const planLicenses = [
-			...computePinnedPlanLicenses({
-				ctx,
-				parent: upsert,
-				upsertProducts,
-				productStatesContext,
-			}),
-			...computePropagatedPlanLicenses({
-				ctx,
-				parent: upsert,
-				upsertProducts,
-				productStatesContext,
-			}),
-		];
+		const pinned = computePinnedPlanLicenses({
+			ctx,
+			parent: upsert,
+			upsertProducts,
+			productStatesContext,
+		});
+		const propagated = computePropagatedPlanLicenses({
+			ctx,
+			parent: upsert,
+			upsertProducts,
+			productStatesContext,
+		});
+		const planLicenses = [...pinned, ...propagated];
 		if (planLicenses.length === 0) return upsert;
 
 		return withPlanLicenseRowPlans({

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils.ts
@@ -17,14 +17,20 @@ export const upsertProductPlanToLicenses = ({
 	upsert.row.baseFullProduct?.licenses ??
 	[];
 
-/** The child row this link currently points at — base on a version mint. */
-const childSourceInternalId = ({
+/** Child rows this parent may still be linked to — current, mint source, or demoted. */
+const childSourceInternalIds = ({
 	child,
 }: {
 	child: UpsertProductPlan;
-}): string | undefined =>
-	child.row.currentFullProduct?.internal_id ??
-	child.row.baseFullProduct?.internal_id;
+}): string[] => [
+	...new Set(
+		[
+			child.row.currentFullProduct?.internal_id,
+			child.row.baseFullProduct?.internal_id,
+			child.previousActiveInternalId,
+		].filter((internalId): internalId is string => internalId !== undefined),
+	),
+];
 
 export const parentLicenseLinkForChild = ({
 	parent,
@@ -33,12 +39,12 @@ export const parentLicenseLinkForChild = ({
 	parent: UpsertProductPlan;
 	child: UpsertProductPlan;
 }): FullPlanLicense | undefined => {
-	const sourceInternalId = childSourceInternalId({ child });
+	const sourceInternalIds = childSourceInternalIds({ child });
 	return upsertProductPlanToLicenses({ upsert: parent }).find(
 		(link) =>
 			link.product.id === child.row.planId &&
-			(sourceInternalId === undefined ||
-				link.license_internal_product_id === sourceInternalId),
+			(sourceInternalIds.length === 0 ||
+				sourceInternalIds.includes(link.license_internal_product_id)),
 	);
 };
 
@@ -100,6 +106,30 @@ export const childPropagatesToParent = ({
 	);
 };
 
+/** True when this row takes the unique active pointer (mint+active or existing promote). */
+export const movesActivePointer = ({
+	upsert,
+}: {
+	upsert: UpsertProductPlan;
+}): boolean => {
+	const nextIsActive = upsert.row.nextFullProduct.active;
+	const mintedNewRow = upsert.row.versioning === "new_version";
+	const promotedExisting = upsert.previousActiveInternalId != null;
+	return nextIsActive && (mintedNewRow || promotedExisting);
+};
+
+/** In-place item writes, or the child taking the pointer. Draft-mint clones do not. */
+export const childTriggersLicenseRewrite = ({
+	child,
+}: {
+	child: UpsertProductPlan;
+}): boolean => {
+	const mintedNewRow = child.row.versioning === "new_version";
+	const childHasItemWrites = child.entitlementPricesPlan != null;
+	const inPlaceItemWrites = childHasItemWrites && !mintedNewRow;
+	return inPlaceItemWrites || movesActivePointer({ upsert: child });
+};
+
 export const shouldPropagate = ({
 	parent,
 	child,
@@ -109,10 +139,17 @@ export const shouldPropagate = ({
 	child: UpsertProductPlan;
 	productStatesContext: ProductStatesContext;
 }): boolean => {
-	if (parent.declaredLicenses !== undefined) return false;
-	if (!child.entitlementPricesPlan) return false;
-	if (!childPropagatesToParent({ child, parent, productStatesContext }))
-		return false;
+	const hasDeclaredLicenses = parent.declaredLicenses !== undefined;
+	const rewritesLicenses = childTriggersLicenseRewrite({ child });
+	const listedForPropagate = childPropagatesToParent({
+		child,
+		parent,
+		productStatesContext,
+	});
+
+	if (hasDeclaredLicenses) return false;
+	if (!rewritesLicenses) return false;
+	if (!listedForPropagate) return false;
 	return true;
 };
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts
@@ -1,18 +1,27 @@
-import type { FullPlanLicense } from "@autumn/shared";
+import type { FullPlanLicense, FullProduct } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type {
 	PlanLicensePlan,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+import { isExistingRowPromote } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote";
 import { getEntsWithFeature } from "@/internal/products/entitlements/entitlementUtils.js";
 import {
+	childTriggersLicenseRewrite,
 	needsRepoint,
 	parentLicenseLinkForChild,
 	shouldPropagate,
 	upsertProductPlansToChildPlans,
 } from "../licensePlanUtils";
 import { cloneFrozenChildAsLicenseOverlay } from "./cloneFrozenChildAsLicenseOverlay";
+
+const childIsPromote = ({ child }: { child: UpsertProductPlan }): boolean =>
+	isExistingRowPromote({
+		current: child.row.currentFullProduct,
+		next: child.row.nextFullProduct,
+	});
 
 const shouldPin = ({
 	parent,
@@ -25,28 +34,57 @@ const shouldPin = ({
 	currentPlanLicense: FullPlanLicense;
 	productStatesContext: ProductStatesContext;
 }): boolean => {
-	if (parent.declaredLicenses !== undefined) return false;
-	if (!child.entitlementPricesPlan) return false;
-	if (shouldPropagate({ parent, child, productStatesContext })) return false;
+	const hasDeclaredLicenses = parent.declaredLicenses !== undefined;
+	const rewritesLicenses = childTriggersLicenseRewrite({ child });
+	const promote = childIsPromote({ child });
+	const followsViaPropagate = shouldPropagate({
+		parent,
+		child,
+		productStatesContext,
+	});
+	const alreadyCustomized = currentPlanLicense.customized;
+	const alreadyPinnedToNext = !needsRepoint({ currentPlanLicense, child });
 
-	if (
-		currentPlanLicense.customized &&
-		!needsRepoint({ currentPlanLicense, child })
-	)
-		return false;
+	if (hasDeclaredLicenses) return false;
+	if (followsViaPropagate) return false;
+	if (!rewritesLicenses) return false;
+	if (promote && alreadyCustomized) return false;
+	if (alreadyCustomized && alreadyPinnedToNext) return false;
 	return true;
+};
+
+const pinTargetProduct = ({
+	child,
+	productStatesContext,
+}: {
+	child: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
+}): FullProduct => {
+	const promote = childIsPromote({ child });
+	const demotedInternalId = child.previousActiveInternalId;
+	if (promote && demotedInternalId) {
+		return (
+			findFullProductByInternalId({
+				internalId: demotedInternalId,
+				productStatesContext,
+			}) ?? child.row.nextFullProduct
+		);
+	}
+	return child.row.nextFullProduct;
 };
 
 const pinnedPlanLicense = ({
 	ctx,
 	currentPlanLicense,
 	child,
+	productStatesContext,
 }: {
 	ctx: AutumnContext;
 	currentPlanLicense: FullPlanLicense;
 	child: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
 }): PlanLicensePlan | undefined => {
-	const childProduct = child.row.nextFullProduct;
+	const childProduct = pinTargetProduct({ child, productStatesContext });
 	const entitlementPricesPlan = currentPlanLicense.customized
 		? undefined
 		: cloneFrozenChildAsLicenseOverlay({
@@ -54,11 +92,10 @@ const pinnedPlanLicense = ({
 				frozenChildProduct: currentPlanLicense.product,
 				childProduct,
 			});
-	if (
-		!needsRepoint({ currentPlanLicense, child }) &&
-		!entitlementPricesPlan
-	)
-		return undefined;
+	const writesLink =
+		currentPlanLicense.license_internal_product_id !==
+		childProduct.internal_id;
+	if (!writesLink && !entitlementPricesPlan) return undefined;
 
 	return {
 		op: "update",
@@ -112,6 +149,7 @@ export const computePinnedPlanLicenses = ({
 			ctx,
 			currentPlanLicense,
 			child,
+			productStatesContext,
 		});
 		if (planLicense) pinned.push(planLicense);
 	}

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan.ts
@@ -1,11 +1,13 @@
 import {
 	type FullProduct,
+	isEligibleDefaultProduct,
 	isEmptyObject,
 	type Product,
 	type UpdateCatalogPlanParams,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductDetailsPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { isExistingRowPromote } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote";
 import { diffProductDetails } from "./diffProductDetails";
 import { initProductRow } from "./initProductRow";
 import { planParamsToProductRowPatch } from "./planParamsToProductRowPatch";
@@ -22,6 +24,8 @@ export const computeProductDetailsPlan = ({
 	baseFullProduct,
 	baseInternalProductId,
 	baseProcessor,
+	currentActive,
+	latestExistingVersion,
 }: {
 	ctx: AutumnContext;
 	planParams: UpdateCatalogPlanParams;
@@ -33,6 +37,9 @@ export const computeProductDetailsPlan = ({
 	baseInternalProductId?: string | null;
 	/** Variant create: share the base's Stripe Product. */
 	baseProcessor?: Product["processor"];
+	/** Pre-fold pointer — default follows only when this row is eligible. */
+	currentActive?: FullProduct | null;
+	latestExistingVersion?: number;
 }): ProductDetailsPlan => {
 	if (!currentFullProduct) {
 		return {
@@ -54,6 +61,20 @@ export const computeProductDetailsPlan = ({
 		planParams,
 		current: currentFullProduct,
 	});
+	if (
+		isExistingRowPromote({
+			current: currentFullProduct,
+			next: { ...currentFullProduct, ...patch },
+		}) &&
+		planParams.is_default === undefined &&
+		currentActive?.is_default &&
+		isEligibleDefaultProduct({
+			product: currentFullProduct,
+			latestExistingVersion,
+		})
+	) {
+		patch.is_default = true;
+	}
 	const next: Product = {
 		...currentFullProduct,
 		...patch,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/planParamsToProductRowPatch.ts
@@ -31,6 +31,7 @@ export const planParamsToProductRowPatch = ({
 		patch.is_default = planParams.auto_enable;
 	}
 	if (planParams.archived !== undefined) patch.archived = planParams.archived;
+	if (planParams.active !== undefined) patch.active = planParams.active;
 	if (planParams.new_version_slug !== undefined) {
 		patch.version_slug = planParams.new_version_slug;
 	}

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/computeDemotedProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/computeDemotedProductPlan.ts
@@ -1,0 +1,54 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { intentToUpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import {
+	claimNewIntents,
+	type UpsertProductPlan,
+} from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+
+/** The product that currently holds `active`, as an upsert that sets `active: false`. */
+export const computeDemotedProductPlan = ({
+	ctx,
+	targetProductPlan,
+	productStatesContext,
+	claimedProductKeys,
+}: {
+	ctx: AutumnContext;
+	targetProductPlan: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
+	claimedProductKeys: Set<string>;
+}): UpsertProductPlan | undefined => {
+	if (!targetProductPlan.previousActiveInternalId) return undefined;
+
+	const currentActive = findFullProductByInternalId({
+		internalId: targetProductPlan.previousActiveInternalId,
+		productStatesContext,
+	});
+	if (!currentActive) return undefined;
+
+	const handsOffDefault =
+		currentActive.is_default &&
+		targetProductPlan.row.nextFullProduct.is_default;
+	const [intent] = claimNewIntents({
+		intents: [
+			{
+				productKey: {
+					planId: currentActive.id,
+					version: currentActive.version,
+				},
+				planParams: {
+					plan_id: currentActive.id,
+					version: currentActive.version,
+					active: false,
+					...(handsOffDefault ? { is_default: false } : {}),
+				},
+				source: "demoted_product",
+			},
+		],
+		claimedProductKeys,
+	});
+	if (!intent) return undefined;
+
+	return intentToUpsertProductPlan({ ctx, intent, productStatesContext });
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/computeUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/computeUpsertProductPlan.ts
@@ -1,0 +1,45 @@
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { computeDemotedProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/computeDemotedProductPlan";
+import { intentToUpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type {
+	ProductUpsertIntent,
+	UpsertProductPlan,
+} from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+
+/** One intent → the target plan plus the demoted plan when this row takes `active`. */
+export const computeUpsertProductPlan = ({
+	ctx,
+	intent,
+	productStatesContext,
+	claimedProductKeys,
+	declaredVariantPlanIdsByBasePlanId,
+}: {
+	ctx: AutumnContext;
+	intent: ProductUpsertIntent;
+	productStatesContext: ProductStatesContext;
+	claimedProductKeys: Set<string>;
+	declaredVariantPlanIdsByBasePlanId?: Map<string, Set<string>>;
+}): {
+	targetProductPlan: UpsertProductPlan;
+	upsertProductPlans: UpsertProductPlan[];
+} => {
+	const targetProductPlan = intentToUpsertProductPlan({
+		ctx,
+		intent,
+		productStatesContext,
+		declaredVariantPlanIdsByBasePlanId,
+	});
+	const demotedProductPlan = computeDemotedProductPlan({
+		ctx,
+		targetProductPlan,
+		productStatesContext,
+		claimedProductKeys,
+	});
+	return {
+		targetProductPlan,
+		upsertProductPlans: demotedProductPlan
+			? [demotedProductPlan, targetProductPlan]
+			: [targetProductPlan],
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/intentToUpsertProductPlan.ts
@@ -18,6 +18,7 @@ import type {
 import { planParamsFromEditDiff } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/planParamsFromEditDiff";
 import { activeFullProductForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/activeFullProductForPlan";
 import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+import { maxVersionForPlan } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/maxVersionForPlan";
 import { productKeyToState } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/productKeyToState";
 import { resolveAliasReplacement } from "@/internal/catalogV2/productAliases/resolveAliasReplacement";
 
@@ -36,8 +37,8 @@ const planHasVersionableCustomers = ({
 			}).customerUsage.hasVersionableCustomerProducts,
 	);
 
-/** One intent → UpsertProductPlan against productStatesContext. */
-export const computeUpsertProductPlan = ({
+/** One intent → one UpsertProductPlan. Demoted sibling attaches in `computeUpsertProductPlan`. */
+export const intentToUpsertProductPlan = ({
 	ctx,
 	intent,
 	productStatesContext,
@@ -92,12 +93,22 @@ export const computeUpsertProductPlan = ({
 				})
 			: null;
 
+	const currentActive = activeFullProductForPlan({
+		planId: productKey.planId,
+		productStatesContext,
+	});
+	const maxVersion = maxVersionForPlan({
+		planId: productKey.planId,
+		productStatesContext,
+	});
 	const details = computeProductDetailsPlan({
 		ctx,
 		planParams,
 		currentFullProduct,
 		version: productKey.version,
 		baseFullProduct,
+		currentActive,
+		latestExistingVersion: maxVersion === 0 ? undefined : maxVersion,
 		...(pointer !== undefined ? { baseInternalProductId: pointer } : {}),
 		...(variantBaseFullProduct
 			? { baseProcessor: variantBaseFullProduct.processor }
@@ -190,6 +201,11 @@ export const computeUpsertProductPlan = ({
 			? { createInStripe: planParams.create_in_stripe }
 			: {}),
 		...(aliasReplacement ? { aliasReplacement } : {}),
+		...(details.product.active &&
+		currentActive &&
+		currentActive.internal_id !== details.product.internal_id
+			? { previousActiveInternalId: currentActive.internal_id }
+			: {}),
 		state: {
 			hasCustomers:
 				versioning === "new_version"

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductsPlan.ts
@@ -1,7 +1,7 @@
 import type { UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { computePlanLicensesPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/computePlanLicensesPlan";
-import { computeUpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan";
+import { computeUpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/computeUpsertProductPlan";
 import { indexDeclaredVariantPlanIds } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/shouldUnlinkDirectVariant";
 import { deriveDirectIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveDirectIntents";
 import { deriveIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveIntents";
@@ -47,20 +47,23 @@ export const computeUpsertProductsPlan = ({
 
 	// Apply each plan's own changes: direct entries plus derived versions/variants.
 	for (const intent of pendingIntents) {
-		const upsert = computeUpsertProductPlan({
+		const { targetProductPlan, upsertProductPlans } = computeUpsertProductPlan({
 			ctx,
 			intent,
 			productStatesContext: fold.projected,
+			claimedProductKeys,
 			declaredVariantPlanIdsByBasePlanId,
 		});
 
-		upsertProducts.push(upsert);
-		fold.advance({ upsert });
+		for (const upsert of upsertProductPlans) {
+			upsertProducts.push(upsert);
+			fold.advance({ upsert });
+		}
 
 		pendingIntents.push(
 			...deriveIntents({
 				intent,
-				upsert,
+				upsert: targetProductPlan,
 				projectedProductStatesContext: fold.projected,
 				claimedProductKeys,
 				allVersionsPlanIds,

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
@@ -109,7 +109,12 @@ export const deriveVariantEdits = ({
 		current: baseCurrent,
 		next: upsert.row.nextFullProduct,
 	});
-	const newBasePointer = baseRowMinted({ upsert })
+	const nextIsActive = upsert.row.nextFullProduct.active;
+	const mintedNewBase = baseRowMinted({ upsert });
+	const promotedExisting = upsert.previousActiveInternalId != null;
+	const movesActiveBasePointer =
+		nextIsActive && (mintedNewBase || promotedExisting);
+	const newBasePointer = movesActiveBasePointer
 		? upsert.row.nextFullProduct.internal_id
 		: undefined;
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/variantPlanUtils.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/variantPlanUtils.ts
@@ -27,6 +27,7 @@ export const latestVariantsOfBase = ({
 			upsert.row.currentFullProduct?.internal_id,
 			upsert.row.baseFullProduct?.internal_id,
 			upsert.row.nextFullProduct.internal_id,
+			upsert.previousActiveInternalId,
 		].filter((internalId): internalId is string => internalId !== undefined),
 	);
 

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentIntents.ts
@@ -1,10 +1,44 @@
 import { productKeyToString, productToProductKey } from "@autumn/shared";
+import { childTriggersLicenseRewrite } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/licensePlanUtils";
 import { deriveLicenseParentMintIntents } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/derive/deriveLicenseParentMintIntents";
 import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type {
 	ProductUpsertIntent,
 	UpsertProductPlan,
 } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
+
+/** Incoming links on the upserted child plus the demoted pointer (promote). */
+const reverseLinksForChild = ({
+	upsert,
+	productStatesContext,
+}: {
+	upsert: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
+}) => {
+	const previousActive = upsert.previousActiveInternalId
+		? findFullProductByInternalId({
+				internalId: upsert.previousActiveInternalId,
+				productStatesContext,
+			})
+		: null;
+	const seen = new Set<string>();
+	return [
+		upsert.row.currentFullProduct,
+		upsert.row.baseFullProduct,
+		previousActive,
+	].flatMap((product) => {
+		if (!product) return [];
+		return (product.parent_plan_licenses ?? []).filter((link) => {
+			const key = productKeyToString({
+				productKey: productToProductKey({ product: link.product }),
+			});
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		});
+	});
+};
 
 /** Links-only pin for parent versions not already in the batch. Skip all_versions plans — siblings cover them. */
 export const deriveLicenseParentIntents = ({
@@ -18,12 +52,13 @@ export const deriveLicenseParentIntents = ({
 	projectedProductStatesContext: ProductStatesContext;
 	allVersionsPlanIds: Set<string>;
 }): ProductUpsertIntent[] => {
-	if (!upsert.entitlementPricesPlan) return [];
+	const rewritesLicenses = childTriggersLicenseRewrite({ child: upsert });
+	if (!rewritesLicenses) return [];
 
-	const reverseLinks =
-		upsert.row.currentFullProduct?.parent_plan_licenses ??
-		upsert.row.baseFullProduct?.parent_plan_licenses ??
-		[];
+	const reverseLinks = reverseLinksForChild({
+		upsert,
+		productStatesContext: projectedProductStatesContext,
+	});
 
 	return [
 		...deriveLicenseParentMintIntents({

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -3,6 +3,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { handleRemoveFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemoveFeatureErrors/handleRemoveFeatureErrors";
 import { handleRemovePlanErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleRemovePlanErrors/handleRemovePlanErrors";
 import { handleUpdateFeatureErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/handleUpdateFeatureErrors";
+import { handleUpsertProductActiveErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductActiveErrors";
 import { handleUpsertProductErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors";
 import { handleUpsertProductRenameErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductRenameErrors";
 import { handleUpsertProductVersioningErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersioningErrors";
@@ -39,6 +40,7 @@ export const handleUpdateCatalogErrors = async ({
 		updateCatalogPlan,
 	});
 	handleUpsertProductVersionSlugErrors({ updateCatalogPlan });
+	handleUpsertProductActiveErrors({ params });
 	handleUpsertProductErrors({
 		updateCatalogPlan,
 		productStatesContext: catalogContext.productStatesContext,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductActiveErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductActiveErrors.ts
@@ -1,0 +1,44 @@
+import { ErrCode, RecaseError, type UpdateCatalogParams } from "@autumn/shared";
+
+/** Promote is take-the-pointer only. `active: false` needs a same-call successor. */
+export const handleUpsertProductActiveErrors = ({
+	params,
+}: {
+	params: UpdateCatalogParams;
+}): void => {
+	const planIdsTakingPointer = new Set<string>();
+
+	for (const planParams of params.plans) {
+		const allVersionsActive =
+			planParams.versioning === "all_versions" && planParams.active === true;
+		if (allVersionsActive) {
+			throw new RecaseError({
+				message: "Cannot set active on all_versions",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		if (planParams.active !== true) continue;
+		const alreadyTakingPointer = planIdsTakingPointer.has(planParams.plan_id);
+		if (alreadyTakingPointer) {
+			throw new RecaseError({
+				message: "Cannot set active on two versions of the same plan",
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+		planIdsTakingPointer.add(planParams.plan_id);
+	}
+
+	for (const planParams of params.plans) {
+		if (planParams.active !== false) continue;
+		if (planIdsTakingPointer.has(planParams.plan_id)) continue;
+
+		throw new RecaseError({
+			message: "Cannot set active to false",
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+	}
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleDefaultFlagErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleDefaultFlagErrors.ts
@@ -1,29 +1,40 @@
 import {
 	ErrCode,
 	type FullProduct,
-	isFreeProduct,
+	isEligibleDefaultProduct,
 	RecaseError,
 } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
 
-/** is_default guards: never on a historical version, never on a paid plan. */
+/** is_default guards: never *set* on a historical version or paid plan. Preserving an existing flag is fine. */
 export const handleDefaultFlagErrors = ({
 	nextFullProduct,
+	currentFullProduct,
 	latestExistingVersion,
 }: {
 	nextFullProduct: FullProduct;
+	currentFullProduct?: FullProduct | null;
 	/** Newest existing version for this plan_id; undefined if plan is new. */
 	latestExistingVersion: number | undefined;
 }): void => {
-	if (nextFullProduct.base_internal_product_id && nextFullProduct.is_default) {
+	if (!nextFullProduct.is_default) return;
+	if (currentFullProduct?.is_default) return;
+	if (
+		isEligibleDefaultProduct({
+			product: nextFullProduct,
+			latestExistingVersion,
+		})
+	) {
+		return;
+	}
+
+	if (nextFullProduct.base_internal_product_id) {
 		throw new RecaseError({
 			code: ErrCode.VariantCannotBeDefault,
 			message: `Cannot set is_default on variant plan ${nextFullProduct.id}`,
 			statusCode: StatusCodes.BAD_REQUEST,
 		});
 	}
-
-	if (!nextFullProduct.is_default) return;
 
 	if (
 		latestExistingVersion !== undefined &&
@@ -36,14 +47,10 @@ export const handleDefaultFlagErrors = ({
 		});
 	}
 
-	const isFree = isFreeProduct({ prices: nextFullProduct.prices });
-	const isCardlessTrial = nextFullProduct.free_trial?.card_required === false;
-	if (!isFree && !isCardlessTrial) {
-		throw new RecaseError({
-			code: ErrCode.InvalidRequest,
-			message:
-				"Default plans must be free or have a free trial with card_required false",
-			statusCode: StatusCodes.BAD_REQUEST,
-		});
-	}
+	throw new RecaseError({
+		code: ErrCode.InvalidRequest,
+		message:
+			"Default plans must be free or have a free trial with card_required false",
+		statusCode: StatusCodes.BAD_REQUEST,
+	});
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleLicenseParentPropagationErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleLicenseParentPropagationErrors.ts
@@ -1,20 +1,34 @@
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { StatusCodes } from "http-status-codes";
+import type { ProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
+import { findFullProductByInternalId } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/findFullProductByInternalId";
 
 /** propagate.license_parents must name plans that already offer this child. */
 export const handleLicenseParentPropagationErrors = ({
 	upsert,
+	productStatesContext,
 }: {
 	upsert: UpsertProductPlan;
+	productStatesContext: ProductStatesContext;
 }): void => {
 	const targets = upsert.propagate?.license_parents ?? [];
 	if (targets.length === 0) return;
 
-	const parentProduct =
-		upsert.row.currentFullProduct ?? upsert.row.baseFullProduct;
+	const previousActive = upsert.previousActiveInternalId
+		? findFullProductByInternalId({
+				internalId: upsert.previousActiveInternalId,
+				productStatesContext,
+			})
+		: null;
 	const parentIds = new Set(
-		(parentProduct?.parent_plan_licenses ?? []).map((link) => link.product.id),
+		[
+			upsert.row.currentFullProduct,
+			upsert.row.baseFullProduct,
+			previousActive,
+		].flatMap((product) =>
+			(product?.parent_plan_licenses ?? []).map((link) => link.product.id),
+		),
 	);
 
 	for (const target of targets) {

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductErrors/handleUpsertProductErrors.ts
@@ -34,12 +34,19 @@ export const handleUpsertProductErrors = ({
 		handleFreeTrialErrors({ nextFullProduct });
 
 		// 2. Default flag errors (historical version; paid default; never on a variant)
-		handleDefaultFlagErrors({ nextFullProduct, latestExistingVersion });
+		handleDefaultFlagErrors({
+			nextFullProduct,
+			currentFullProduct: upsert.row.currentFullProduct,
+			latestExistingVersion,
+		});
 
 		// 3. Declared variants[] create / nest / id-collision
 		handleVariantErrors({ upsert, productStatesContext, directPlanIds });
 		handleArchivedPropagationErrors({ upsert, productStatesContext });
-		handleLicenseParentPropagationErrors({ upsert });
+		handleLicenseParentPropagationErrors({
+			upsert,
+			productStatesContext,
+		});
 
 		// 4. Declared plan_license link guards
 		handlePlanLicenseErrors({ upsert });

--- a/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/preview/plans/buildSiblingVersionsPreview.ts
@@ -149,14 +149,26 @@ export const buildSiblingVersionsPreview = ({
 
 	return (productStatesContext.versionsByPlanId[planId] ?? [])
 		.filter((product) => product.version !== version)
-		.map((product) =>
-			unselectedSiblingFromVersion({
-				product,
-				productStatesContext,
-				editedCurrent,
-				editedNext,
-				previewContext,
-			}),
-		)
+		.map((product) => {
+			const sibling = upsertProducts.find(
+				(upsert) =>
+					upsert.row.planId === product.id &&
+					upsert.row.version === product.version,
+			);
+			return sibling
+				? selectedSiblingFromUpsert({
+						sibling,
+						editedCurrent,
+						editedNext,
+						previewContext,
+					})
+				: unselectedSiblingFromVersion({
+						product,
+						productStatesContext,
+						editedCurrent,
+						editedNext,
+						previewContext,
+					});
+		})
 		.sort(byVersionAscending);
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan/upsertProductPlan.ts
@@ -22,7 +22,8 @@ export type UpsertProductSource =
 	| "variant_link"
 	| "license_pin"
 	| "license_adopt"
-	| "repoint";
+	| "repoint"
+	| "demoted_product";
 
 /** Which product row this plan writes, and its before/after FullProduct. */
 export type UpsertProductRow = {
@@ -71,6 +72,8 @@ export type UpsertProductPlan = {
 	createInStripe?: boolean;
 	/** Set when this row's id claims a reserved alias — execute deletes that row. */
 	aliasReplacement?: PlanAliasReplacement;
+	/** Product that currently holds `active` — pairs a demoted product plan. */
+	previousActiveInternalId?: string;
 
 	state: { hasCustomers: boolean };
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote.ts
@@ -1,0 +1,12 @@
+/** True when an existing row takes the active pointer (not a mint). */
+export const isExistingRowPromote = ({
+	current,
+	next,
+}: {
+	current: { active: boolean; internal_id: string } | null;
+	next: { active: boolean; internal_id: string };
+}): boolean =>
+	current != null &&
+	current.internal_id === next.internal_id &&
+	!current.active &&
+	next.active;

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
@@ -1,6 +1,7 @@
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { UpsertProductPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { ProductService } from "@/internal/products/ProductService.js";
+import { deactivateOtherActiveProducts } from "@/internal/products/repos/activateHighestRemainingProduct";
 import { updateStripeProductNames } from "@/internal/products/stripeResourceUtils/updateStripeProductNames.js";
 
 /** Rename syncs to Stripe only for bases — variants share the base's Stripe Product. */
@@ -23,6 +24,10 @@ export const applyProductDetailsUpdate = async ({
 	if (!details || upsert.row.op !== "update") return;
 
 	const { product } = details;
+	if (product.active) {
+		await deactivateOtherActiveProducts({ db: ctx.db, product });
+	}
+
 	await ProductService.updateByInternalId({
 		db: ctx.db,
 		internalId: product.internal_id,
@@ -34,6 +39,7 @@ export const applyProductDetailsUpdate = async ({
 			is_add_on: product.is_add_on,
 			is_default: product.is_default,
 			archived: product.archived,
+			active: product.active,
 			version_slug: product.version_slug,
 			config: product.config,
 			metadata: product.metadata,

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/executeUpsertProducts.ts
@@ -21,8 +21,8 @@ const executeUpsertProduct = async ({
 	ctx: AutumnContext;
 	upsert: UpsertProductPlan;
 }) => {
+	const product = upsert.details?.product ?? upsert.row.nextFullProduct;
 	if (upsert.row.op === "create") {
-		const product = upsert.details?.product ?? upsert.row.nextFullProduct;
 		await ctx.db.transaction(async (tx) => {
 			const db = tx as unknown as DrizzleCli;
 			await deleteClaimedPlanAliases({
@@ -33,11 +33,11 @@ const executeUpsertProduct = async ({
 			});
 			await ProductService.insert({ db, product });
 		});
-		await clearDefaultFlagFromOtherVersions({ ctx, product });
 	}
 
 	await applyEntitlementPricesPlan({ ctx, upsert });
 	await applyProductDetailsUpdate({ ctx, upsert });
+	await clearDefaultFlagFromOtherVersions({ ctx, product });
 	await syncPlanMetadataAcrossVersions({ ctx, upsert });
 	await applyFreeTrialPlan({ ctx, upsert });
 };

--- a/server/src/internal/products/repos/activateHighestRemainingProduct.ts
+++ b/server/src/internal/products/repos/activateHighestRemainingProduct.ts
@@ -1,5 +1,5 @@
 import { type AppEnv, products } from "@autumn/shared";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 
 export type ProductWriteDb = {
@@ -22,6 +22,30 @@ const samePlan = ({
 		eq(products.env, env),
 		eq(products.id, productId),
 	);
+
+/** Clear every other `active` row of this plan so a later activate cannot unique-violate. */
+export const deactivateOtherActiveProducts = async ({
+	db,
+	product,
+}: {
+	db: ProductWriteDb;
+	product: { internal_id: string; id: string; org_id: string; env: AppEnv };
+}): Promise<void> => {
+	await db
+		.update(products)
+		.set({ active: false })
+		.where(
+			and(
+				samePlan({
+					orgId: product.org_id,
+					env: product.env,
+					productId: product.id,
+				}),
+				eq(products.active, true),
+				ne(products.internal_id, product.internal_id),
+			),
+		);
+};
 
 /**
  * Point `active` at the highest non-archived version of this plan, if any.

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -1301,3 +1301,37 @@ Own-reclaim (`proNew → pro`) still allowed; preview includes
 | Execute variant `new_plan_id` → `products.id` + alias CTE; `customer_products.product_id` untouched | ✓ t2 |
 | REST create of reserved id still 400 | ✓ t3 |
 
+## 24. Unit 5 — Promote / active pointer
+
+`active: true` on an existing row takes the unique pointer; the vacated sibling
+folds `active: false`. Default follows only when `isEligibleDefaultProduct`.
+Draft mint (`new_version` without `active`) does not take the pointer.
+
+| Case | Status |
+|---|---|
+| Back-promote v1 while v2 is live — one pointer; default stays on latest | ✓ `versions/promote-pointer.test.ts` |
+| `active: false` on the pointer with no successor → 400 | ✓ `versions/promote-pointer.test.ts` |
+| Same-call rename of the taker still demotes the old pointer | ✓ `versions/promote-pointer.test.ts` |
+| `active: false` is ok when another entry takes the pointer | ✓ `versions/promote-pointer.test.ts` |
+| Numeric `{ version: 1, active: true }` promotes the same as `version_slug` | ✓ `versions/promote-pointer.test.ts` |
+| Preview: promote draft v2 → v2 `active: true`, sibling v1 `active: false` | ✓ `versions/promote-preview.test.ts` |
+| Preview back-promote: v1 `active: true`, sibling v2 `active: false` | ✓ `versions/promote-preview.test.ts` |
+| Promote does not mint a new version number | ✓ `versions/promote-preview.test.ts` |
+| Idempotent `active: true` on already-active v1 (draft still idle) | ✓ `versions/promote-preview.test.ts` |
+| Idempotent `active: true` on already-active v2 | ✓ `versions/promote-preview.test.ts` |
+| Two `active: true` same `plan_id` in one call → 400 | ✓ `versions/promote-guards.test.ts` |
+| Two different plans promoting in one batch → both succeed | ✓ `versions/promote-guards.test.ts` |
+| `versioning: "all_versions"` + `active: true` → 400 | ✓ `versions/promote-guards.test.ts` |
+| Free auto_enable draft promote → default follows the pointer | ✓ `versions/default-follows-active.test.ts` |
+| Custom slug promote moves pointer and default | ✓ `versions/default-follows-active.test.ts` |
+| Paid draft promote: pointer moves, default stays on free v1 | ✓ `versions/default-follows-active.test.ts` |
+| Cardless-trial paid draft: default follows (`isEligibleDefaultProduct`) | ✓ `versions/default-follows-active.test.ts` |
+| Explicit `auto_enable: true` on historical promote → `HistoricalPlanVersionCannotBeDefault` | ✓ `versions/default-follows-active.test.ts` |
+| Base promote re-points follow variant; no variant mint | ✓ `variants/pointer/pointer-on-base-promote.test.ts` |
+| Base promote leaves historical variant v1 on the old row | ✓ `variants/pointer/pointer-on-base-promote.test.ts` |
+| Promote leaves a pin at a historical non-active base | ✓ `variants/pointer/pointer-on-base-promote.test.ts` |
+| Child promote freezes uncustomized parent; propagate follows v2 | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
+| Customized parent is left on child promote | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
+| Parent promote (licenses omitted): child identity unchanged; v2 stays empty | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
+| Declared `licenses[]` on child promote re-links to newly active child | ✓ `licenses/pinned/uncustomized-freeze-on-child-promote.test.ts` |
+

--- a/server/tests/integration/catalog-v2/plans/licenses/pinned/uncustomized-freeze-on-child-promote.test.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/pinned/uncustomized-freeze-on-child-promote.test.ts
@@ -1,0 +1,269 @@
+/**
+ * catalogV2.update — child promote freezes uncustomized license definitions.
+ *
+ * Contract:
+ *   Uncustomized parent NOT in propagate → mint/pin a planLicense to child
+ *   v1 (customize overlay). Do not retarget to the newly active child.
+ *   Parent IN propagate → follow the newly active child (new reference).
+ *   Already-customized parent → leave (same row, same overlay, no retarget).
+ *   Parent promote (licenses omitted) → child identity unchanged;
+ *   v2 stays empty, v1 keeps the existing links.
+ *   Declared licenses[] on child promote is exclusive — re-link to the
+ *   newly active child, not an implicit freeze on the demoted row.
+ */
+
+import { expect, test } from "bun:test";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import {
+	expectLicenseLinkCorrect,
+	expectLicenseLinkMissing,
+} from "../utils/expectLicenseLinkCorrect.js";
+import {
+	getFullPlan,
+	messagesItem,
+	messagesOverride,
+	seedLinkedChildParent,
+	seedTwoParents,
+	withCatalogPlans,
+} from "../utils/seedLicensePlans.js";
+import { expectVersionIdentityCorrect } from "../../utils/expectVersionIdentity.js";
+
+const mintChildDraftV2 = async ({
+	autumn,
+	childId,
+}: {
+	autumn: Parameters<typeof seedLinkedChildParent>[0]["autumn"];
+	childId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [{ plan_id: childId, versioning: "new_version" }],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: child promote freezes uncustomized; propagate follows v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const frozenId = uniqueTestId("cv2_lic_pr_frz_p");
+		const followId = uniqueTestId("cv2_lic_pr_fol_p");
+		const childId = uniqueTestId("cv2_lic_pr_mix_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [frozenId, followId, childId],
+			run: async () => {
+				await seedTwoParents({
+					autumn: autumnV2_3,
+					childId,
+					parentIds: [frozenId, followId],
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await mintChildDraftV2({ autumn: autumnV2_3, childId });
+				const childV2 = await getFullPlan({
+					ctx,
+					planId: childId,
+					version: 2,
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							version_slug: "v2",
+							active: true,
+							items: [messagesItem(200)],
+							propagate: {
+								license_parents: [
+									{ plan_id: followId, versioning: "existing" },
+								],
+							},
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: frozenId,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					included: 2,
+					customized: true,
+					messagesAllowance: 10,
+					licenseInternalProductId: childV1.internal_id,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: followId,
+					licensePlanId: childId,
+					included: 2,
+					customized: false,
+					messagesAllowance: 200,
+					licenseInternalProductId: childV2.internal_id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: customized parent is left on child promote")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_pr_cust_p");
+		const childId = uniqueTestId("cv2_lic_pr_cust_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					customize: messagesOverride(500),
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				const before = await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					customized: true,
+					messagesAllowance: 500,
+					licenseInternalProductId: childV1.internal_id,
+				});
+
+				await mintChildDraftV2({ autumn: autumnV2_3, childId });
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: childId, version_slug: "v2", active: true }],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					licenseVersion: 1,
+					customized: true,
+					messagesAllowance: 500,
+					licenseInternalProductId: childV1.internal_id,
+					planLicenseId: before.planLicense.id,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: parent promote leaves child identity; omits licenses so v2 stays empty")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_pr_par_p");
+		const childId = uniqueTestId("cv2_lic_pr_par_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+				});
+				const childV1 = await getFullPlan({ ctx, planId: childId });
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: parentId, versioning: "new_version" }],
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [{ plan_id: parentId, version_slug: "v2", active: true }],
+				});
+
+				const childAfter = await getFullPlan({ ctx, planId: childId });
+				expect(childAfter.version).toBe(1);
+				expect(childAfter.internal_id).toBe(childV1.internal_id);
+
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: parentId,
+					version: 1,
+					active: false,
+				});
+				await expectVersionIdentityCorrect({
+					ctx,
+					planId: parentId,
+					version: 2,
+					active: true,
+				});
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 1,
+					licensePlanId: childId,
+					included: 2,
+					licenseInternalProductId: childV1.internal_id,
+				});
+				await expectLicenseLinkMissing({
+					ctx,
+					parentPlanId: parentId,
+					parentVersion: 2,
+					licensePlanId: childId,
+				});
+			},
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 plan-licenses: declared licenses[] on child promote re-links to v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const parentId = uniqueTestId("cv2_lic_pr_dec_p");
+		const childId = uniqueTestId("cv2_lic_pr_dec_c");
+		await withCatalogPlans({
+			ctx,
+			planIds: [parentId, childId],
+			run: async () => {
+				await seedLinkedChildParent({
+					autumn: autumnV2_3,
+					parentId,
+					childId,
+					customize: messagesOverride(500),
+				});
+				await mintChildDraftV2({ autumn: autumnV2_3, childId });
+				const childV2 = await getFullPlan({
+					ctx,
+					planId: childId,
+					version: 2,
+				});
+
+				await autumnV2_3.catalogV2.update({
+					plans: [
+						{
+							plan_id: childId,
+							version_slug: "v2",
+							active: true,
+							items: [messagesItem(200)],
+						},
+						{
+							plan_id: parentId,
+							licenses: [
+								{
+									license_plan_id: childId,
+									included: 2,
+									customize: messagesOverride(300),
+								},
+							],
+						},
+					],
+				});
+
+				await expectLicenseLinkCorrect({
+					ctx,
+					parentPlanId: parentId,
+					licensePlanId: childId,
+					customized: true,
+					messagesAllowance: 300,
+					licenseInternalProductId: childV2.internal_id,
+				});
+			},
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/licenses/utils/expectLicenseLinkCorrect.ts
+++ b/server/tests/integration/catalog-v2/plans/licenses/utils/expectLicenseLinkCorrect.ts
@@ -34,6 +34,7 @@ export const expectLicenseLinkCorrect = async ({
 	price,
 	overlayEntitlementCount,
 	licenseInternalProductId,
+	licenseVersion,
 	parentProductVersion,
 	omitFeatureIds,
 	planLicenseId,
@@ -42,6 +43,7 @@ export const expectLicenseLinkCorrect = async ({
 	parentPlanId: string;
 	licensePlanId: string;
 	parentVersion?: number;
+	licenseVersion?: number;
 	included?: number;
 	customized?: boolean;
 	prepaidOnly?: boolean;
@@ -59,6 +61,7 @@ export const expectLicenseLinkCorrect = async ({
 		parentPlanId,
 		parentVersion,
 		licensePlanId,
+		licenseVersion,
 	});
 
 	if (included !== undefined) {

--- a/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
+++ b/server/tests/integration/catalog-v2/plans/preview/utils/expectPlanPreview.ts
@@ -26,6 +26,7 @@ type ExpectedLicenseChange = Partial<
 type ExpectedSiblingVersion = {
 	version: number;
 	selected?: boolean;
+	active?: boolean;
 	hasCustomers?: boolean;
 	/** true = plan_change present; false/null = absent. */
 	hasPlanChange?: boolean;
@@ -208,6 +209,9 @@ const expectSiblingVersionsMatch = ({
 		).toBeDefined();
 		if (expectedSibling.selected !== undefined) {
 			expect(sibling?.selected).toBe(expectedSibling.selected);
+		}
+		if (expectedSibling.active !== undefined) {
+			expect(sibling?.active).toBe(expectedSibling.active);
 		}
 		if (expectedSibling.licenseAction !== undefined) {
 			expect(sibling?.license_action).toBe(expectedSibling.licenseAction);

--- a/server/tests/integration/catalog-v2/plans/utils/expectVersionIdentity.ts
+++ b/server/tests/integration/catalog-v2/plans/utils/expectVersionIdentity.ts
@@ -39,6 +39,27 @@ export const expectVersionIdentityCorrect = async ({
 	}
 };
 
+/** Exactly one row of this plan holds `active`. Returns that row. */
+export const expectExactlyOneActiveVersion = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}) => {
+	const versions = await ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: [planId],
+		returnAll: true,
+		skipCache: true,
+	});
+	const actives = versions.filter((product) => product.active);
+	expect(actives, `${planId}: unique_active_product`).toHaveLength(1);
+	return actives[0];
+};
+
 /** Flip the active pointer in DB (test-only — not a catalogV2 promote). */
 export const forceActiveVersion = async ({
 	ctx,

--- a/server/tests/integration/catalog-v2/plans/variants/pointer/pointer-on-base-promote.test.ts
+++ b/server/tests/integration/catalog-v2/plans/variants/pointer/pointer-on-base-promote.test.ts
@@ -1,0 +1,168 @@
+/**
+ * catalogV2.update — base promote re-points follow variants in place.
+ *
+ * Contract:
+ *   variant whose pointer == previous active base → base_internal_product_id
+ *   moves to the newly promoted base. No variant version is minted.
+ *   Historical variant versions stay on their existing base row.
+ *   Active variant pinned to a non-active historical base (not the old
+ *   pointer) is left. Draft mint without active must not repoint
+ *   (already covered in follower-mint-active).
+ */
+
+import { test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../../utils/uniqueTestId.js";
+import { deleteDbPlans, expectPlanVersionsCorrect } from "../../utils/expectCatalogPlans.js";
+import { forceActiveVersion } from "../../utils/expectVersionIdentity.js";
+import { messagesItem } from "../../licenses/utils/seedLicensePlans.js";
+import {
+	expectVariantPlanCorrect,
+	expectVariantPointerCorrect,
+} from "../utils/expectVariantPointer.js";
+import {
+	seedBaseWithVariant,
+	seedVariantNewVersion,
+} from "../utils/seedVariantPlans.js";
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: base promote re-points the follow variant, no mint")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_pr_fol");
+		const variantId = uniqueTestId("cv2_var_pr_fol_eu");
+		await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		try {
+			await seedBaseWithVariant({
+				autumn: autumnV2_3,
+				baseId,
+				variantId,
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: baseId,
+						versioning: "new_version",
+						items: [messagesItem(100)],
+					},
+				],
+			});
+			await expectVariantPointerCorrect({
+				ctx,
+				variantPlanId: variantId,
+				basePlanId: baseId,
+				baseVersion: 1,
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: baseId, version_slug: "v2", active: true }],
+			});
+
+			await expectPlanVersionsCorrect({
+				ctx,
+				planId: variantId,
+				versions: [1],
+			});
+			await expectVariantPointerCorrect({
+				ctx,
+				variantPlanId: variantId,
+				basePlanId: baseId,
+				baseVersion: 2,
+			});
+			await expectVariantPlanCorrect({
+				ctx,
+				variantPlanId: variantId,
+				allowances: { [TestFeature.Messages]: 200 },
+				featureIds: [TestFeature.Messages],
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: base promote leaves historical variant v1 on the old row")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_pr_hist");
+		const variantId = uniqueTestId("cv2_var_pr_hist_eu");
+		await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		try {
+			await seedBaseWithVariant({
+				autumn: autumnV2_3,
+				baseId,
+				variantId,
+			});
+			await seedVariantNewVersion({ autumn: autumnV2_3, variantId });
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: baseId, versioning: "new_version" }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: baseId, version_slug: "v2", active: true }],
+			});
+
+			await expectVariantPointerCorrect({
+				ctx,
+				variantPlanId: variantId,
+				variantVersion: 1,
+				basePlanId: baseId,
+				baseVersion: 1,
+			});
+			await expectVariantPointerCorrect({
+				ctx,
+				variantPlanId: variantId,
+				variantVersion: 2,
+				basePlanId: baseId,
+				baseVersion: 2,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 variants: promote leaves a pin at a historical non-active base")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const baseId = uniqueTestId("cv2_var_pr_pin");
+		const variantId = uniqueTestId("cv2_var_pr_pin_eu");
+		await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		try {
+			await seedBaseWithVariant({
+				autumn: autumnV2_3,
+				baseId,
+				variantId,
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: baseId, versioning: "new_version" }],
+			});
+			await forceActiveVersion({ ctx, planId: baseId, version: 2 });
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: baseId, versioning: "new_version" }],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: baseId, version_slug: "v3", active: true }],
+			});
+
+			await expectPlanVersionsCorrect({
+				ctx,
+				planId: variantId,
+				versions: [1],
+			});
+			await expectVariantPointerCorrect({
+				ctx,
+				variantPlanId: variantId,
+				basePlanId: baseId,
+				baseVersion: 1,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [baseId, variantId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/default-follows-active.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/default-follows-active.test.ts
@@ -5,6 +5,10 @@
  *   Promote existing draft (`version_slug` + `active: true`) → that row is
  *   active + is_default; the previous pointer loses both.
  *   Same for a custom slug (e.g. "summer"): pointer and default move together.
+ *   Paid draft: pointer moves; is_default stays on the free v1
+ *   (`handleDefaultFlagErrors` rejects default on a paid row — do not 400).
+ *   Cardless-trial paid draft: eligible, so default follows the promote.
+ *   Explicit `auto_enable: true` on a historical promote → 400.
  *
  * Draft-mint identity (omit `active` → v2 inactive, v1 keeps default) lives in
  * version-identity-mint.test.ts — asserted here only as the pre-promote state.
@@ -13,8 +17,14 @@
  */
 
 import { test } from "bun:test";
-import { ResetInterval } from "@autumn/shared";
+import {
+	BillingInterval,
+	ErrCode,
+	FreeTrialDuration,
+	ResetInterval,
+} from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 import { uniqueTestId } from "../../utils/uniqueTestId.js";
@@ -177,6 +187,163 @@ test.concurrent(
 				versionSlug: "summer",
 				active: true,
 				isDefault: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 defaults: promoting a paid draft moves pointer, default stays on free v1")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_def_paid");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultFreeV1({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						name: "Paid Draft",
+						create_in_stripe: false,
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [messagesItem(200)],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "v2", active: true }],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+				isDefault: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+				isDefault: false,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 defaults: promoting a cardless-trial draft takes default")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_def_ct");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Paid Trial V1",
+						auto_enable: true,
+						create_in_stripe: false,
+						price: { amount: 20, interval: BillingInterval.Month },
+						free_trial: {
+							duration_type: FreeTrialDuration.Day,
+							duration_length: 14,
+							card_required: false,
+						},
+						items: [messagesItem(100)],
+					},
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						name: "Paid Trial V2",
+						items: [messagesItem(200)],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "v2", active: true }],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+				isDefault: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+				isDefault: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 defaults: auto_enable on historical promote → HistoricalPlanVersionCannotBeDefault")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({
+			setup: [],
+			actions: [],
+		});
+		const planId = uniqueTestId("cv2_def_histp");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedDefaultFreeV1({ autumn: autumnV2_3, planId });
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						active: true,
+						name: "V2 Live",
+						items: [messagesItem(200)],
+					},
+				],
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.HistoricalPlanVersionCannotBeDefault,
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								version_slug: "v1",
+								active: true,
+								auto_enable: true,
+							},
+						],
+					}),
 			});
 		} finally {
 			await deleteDbPlans({ ctx, planIds: [planId] });

--- a/server/tests/integration/catalog-v2/plans/versions/promote-guards.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/promote-guards.test.ts
@@ -1,0 +1,185 @@
+/**
+ * catalogV2 promote — same-call pointer guards.
+ *
+ * Contract:
+ *   Two `active: true` entries for the same plan_id → 400
+ *   Two different plans both promoting in one call → both succeed
+ *   `versioning: "all_versions"` + `active: true` → 400 (unique_active)
+ */
+
+import { test } from "bun:test";
+import { ErrCode, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { expectVersionIdentityCorrect } from "../utils/expectVersionIdentity.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const seedV1ThenLiveV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "V1",
+				auto_enable: true,
+				items: [messagesItem(100)],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				active: true,
+				name: "V2",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+const seedV1AndDraftV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "V1",
+				items: [messagesItem(100)],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				name: "V2 Draft",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: two active:true on the same plan_id → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_2act");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "Cannot set active on two versions of the same plan",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{ plan_id: planId, version_slug: "v1", active: true },
+							{ plan_id: planId, version_slug: "v2", active: true },
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: two different plans promoting in one batch both succeed")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planA = uniqueTestId("cv2_prm_ba");
+		const planB = uniqueTestId("cv2_prm_bb");
+		await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		try {
+			await seedV1AndDraftV2({ autumn: autumnV2_3, planId: planA });
+			await seedV1AndDraftV2({ autumn: autumnV2_3, planId: planB });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planA, version_slug: "v2", active: true },
+					{ plan_id: planB, version_slug: "v2", active: true },
+				],
+			});
+
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: planA,
+				version: 1,
+				active: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: planA,
+				version: 2,
+				active: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: planB,
+				version: 1,
+				active: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: planB,
+				version: 2,
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planA, planB] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: all_versions + active:true → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_all");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "Cannot set active on all_versions",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [
+							{
+								plan_id: planId,
+								versioning: "all_versions",
+								active: true,
+							},
+						],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/promote-pointer.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/promote-pointer.test.ts
@@ -1,0 +1,252 @@
+/**
+ * catalogV2 promote — pointer flip, unique_active_product, active:false reject.
+ *
+ * Contract:
+ *   promote v1 while v2 is active → v1 takes the pointer; exactly one active
+ *   is_default does not jump onto a historical version (v1 < latest v2)
+ *   active:false on the current pointer with no successor → 400
+ *   active:false is allowed when another entry in the same call takes the pointer
+ *   promote + new_plan_id in one call → previously active row (old id) still demotes
+ *   numeric `version: 1` + `active: true` promotes the same as version_slug
+ */
+
+import { expect, test } from "bun:test";
+import { ErrCode, ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import {
+	expectExactlyOneActiveVersion,
+	expectVersionIdentityCorrect,
+} from "../utils/expectVersionIdentity.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const seedV1ThenLiveV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "V1",
+				auto_enable: true,
+				items: [messagesItem(100)],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				active: true,
+				name: "V2",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: v1 while v2 is active — one pointer, default stays on latest")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_back");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "v1", active: true }],
+			});
+
+			const active = await expectExactlyOneActiveVersion({ ctx, planId });
+			expect(active.version).toBe(1);
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: true,
+				isDefault: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: false,
+				isDefault: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: active:false on the pointer with no successor → 400")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_off");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: "Cannot set active to false",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						plans: [{ plan_id: planId, version_slug: "v2", active: false }],
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: taker renamed in the same call still demotes the old pointer")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_ren_a");
+		const renamedId = uniqueTestId("cv2_prm_ren_b");
+		await deleteDbPlans({ ctx, planIds: [planId, renamedId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "V1",
+						items: [messagesItem(100)],
+					},
+				],
+			});
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						versioning: "new_version",
+						name: "V2",
+						items: [messagesItem(200)],
+					},
+				],
+			});
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						version_slug: "v2",
+						new_plan_id: renamedId,
+						active: true,
+					},
+				],
+			});
+
+			const active = await expectExactlyOneActiveVersion({
+				ctx,
+				planId: renamedId,
+			});
+			expect(active.version).toBe(2);
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId: renamedId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+			});
+			// The row it replaces still carries the old plan id — demote it anyway.
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				active: false,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId, renamedId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: active:false is ok when another entry takes the pointer")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_swap");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{ plan_id: planId, version_slug: "v2", active: false },
+					{ plan_id: planId, version_slug: "v1", active: true },
+				],
+			});
+
+			await expectExactlyOneActiveVersion({ ctx, planId });
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				active: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				active: false,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: numeric version: 1 takes the pointer from live v2")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_num");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version: 1, active: true }],
+			});
+
+			const active = await expectExactlyOneActiveVersion({ ctx, planId });
+			expect(active.version).toBe(1);
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				active: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				active: false,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/versions/promote-preview.test.ts
+++ b/server/tests/integration/catalog-v2/plans/versions/promote-preview.test.ts
@@ -1,0 +1,246 @@
+/**
+ * catalogV2 promote — preview identity + no mint + idempotent.
+ *
+ * Contract:
+ *   preview: promoted row active:true; sibling (old pointer) active:false
+ *   preview back-promote: v1 active:true while v2 is live; sibling v2 inactive
+ *   promote does not mint — still exactly versions [1, 2]
+ *   active:true on the already-active row is a no-op (v1 draft case and live v2)
+ */
+
+import { test } from "bun:test";
+import { ResetInterval } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans, expectPlanVersionsCorrect } from "../utils/expectCatalogPlans.js";
+import { expectVersionIdentityCorrect } from "../utils/expectVersionIdentity.js";
+import {
+	expectPlanPreviewRowCorrect,
+	parsePlanPreview,
+} from "../preview/utils/expectPlanPreview.js";
+
+const messagesItem = (included: number) => ({
+	feature_id: TestFeature.Messages,
+	included,
+	reset: { interval: ResetInterval.Month },
+});
+
+const seedV1AndDraftV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "V1",
+				auto_enable: true,
+				items: [messagesItem(100)],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				name: "V2 Draft",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: preview shows v2 active and sibling v1 inactive")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_prev");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndDraftV2({ autumn: autumnV2_3, planId });
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, version_slug: "v2", active: true }],
+				}),
+			);
+
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					versionSlug: "v2",
+					active: true,
+					siblingVersions: [{ version: 1, active: false }],
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: does not mint a new version number")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_nomint");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndDraftV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "v2", active: true }],
+			});
+
+			await expectPlanVersionsCorrect({ ctx, planId, versions: [1, 2] });
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: active:true on the current pointer is a no-op")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_noop");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1AndDraftV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "v1", active: true }],
+			});
+
+			await expectPlanVersionsCorrect({ ctx, planId, versions: [1, 2] });
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: true,
+				isDefault: true,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: false,
+				isDefault: false,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+const seedV1ThenLiveV2 = async ({
+	autumn,
+	planId,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+}) => {
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				name: "V1",
+				auto_enable: true,
+				items: [messagesItem(100)],
+			},
+		],
+	});
+	await autumn.catalogV2.update({
+		plans: [
+			{
+				plan_id: planId,
+				versioning: "new_version",
+				active: true,
+				name: "V2",
+				items: [messagesItem(200)],
+			},
+		],
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: preview back-promote shows v1 active and sibling v2 inactive")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_bprev");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			const preview = parsePlanPreview(
+				await autumnV2_3.catalogV2.previewUpdate({
+					plans: [{ plan_id: planId, version_slug: "v1", active: true }],
+				}),
+			);
+
+			expectPlanPreviewRowCorrect({
+				preview,
+				expected: {
+					planId,
+					action: "update",
+					versionSlug: "v1",
+					active: true,
+					siblingVersions: [{ version: 2, active: false }],
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 promote: active:true on already-active v2 is a no-op")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_prm_noop2");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await seedV1ThenLiveV2({ autumn: autumnV2_3, planId });
+
+			await autumnV2_3.catalogV2.update({
+				plans: [{ plan_id: planId, version_slug: "v2", active: true }],
+			});
+
+			await expectPlanVersionsCorrect({ ctx, planId, versions: [1, 2] });
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 1,
+				versionSlug: "v1",
+				active: false,
+			});
+			await expectVersionIdentityCorrect({
+				ctx,
+				planId,
+				version: 2,
+				versionSlug: "v2",
+				active: true,
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
@@ -56,6 +56,17 @@ describe("productDetailsAreSame / diffProductDetails", () => {
 		});
 	});
 
+	test("active change diffs with previous value", () => {
+		const current = row({ active: false });
+		const next = row({ active: true });
+		expect(productDetailsAreSame({ product1: current, product2: next })).toBe(
+			false,
+		);
+		expect(diffProductDetails({ current, next })).toEqual({
+			active: false,
+		});
+	});
+
 	test("version_slug change diffs with previous value", () => {
 		const current = row({ version_slug: "v1" });
 		const next = row({ version_slug: "summer" });

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -50,6 +50,7 @@ export * from "./planV1Utils/licenses/diffLicensePlanCustomize";
 export * from "./pooledBalanceUtils/index";
 export * from "./productUtils/classifyProduct/classifyProductUtils";
 export * from "./productUtils/classifyProduct/hasMissingStripeResourcesForProduct";
+export * from "./productUtils/classifyProduct/isEligibleDefaultProduct";
 export * from "./productUtils/classifyProduct/isProductPaidAndRecurring";
 export * from "./productUtils/compareProduct/productDetailsAreSame";
 export * from "./productUtils/convertProduct/productKey";

--- a/shared/utils/productUtils/classifyProduct/isEligibleDefaultProduct.ts
+++ b/shared/utils/productUtils/classifyProduct/isEligibleDefaultProduct.ts
@@ -1,0 +1,22 @@
+import type { FullProduct } from "@models/productModels/productModels";
+import { isFreeProduct } from "./classifyProductUtils.js";
+
+/** Allowed to hold `is_default`: not a variant, not historical, free or cardless trial. */
+export const isEligibleDefaultProduct = ({
+	product,
+	latestExistingVersion,
+}: {
+	product: FullProduct;
+	latestExistingVersion?: number;
+}): boolean => {
+	if (product.base_internal_product_id) return false;
+	if (
+		latestExistingVersion !== undefined &&
+		product.version < latestExistingVersion
+	) {
+		return false;
+	}
+	const isFree = isFreeProduct({ prices: product.prices });
+	const isCardlessTrial = product.free_trial?.card_required === false;
+	return isFree || isCardlessTrial;
+};

--- a/shared/utils/productUtils/compareProduct/productDetailsAreSame.ts
+++ b/shared/utils/productUtils/compareProduct/productDetailsAreSame.ts
@@ -14,6 +14,7 @@ export const PRODUCT_DETAIL_KEYS = [
 	"is_add_on",
 	"is_default",
 	"archived",
+	"active",
 	"version_slug",
 	"config",
 	"metadata",
@@ -88,6 +89,7 @@ export const productDetailComparators: {
 	is_add_on: strictEqual(),
 	is_default: strictEqual(),
 	archived: strictEqual(),
+	active: strictEqual(),
 	version_slug: ({ left, right }) => (left ?? null) === (right ?? null),
 	config: ({ left, right }) =>
 		compareConfig({ newConfig: left, curConfig: right }),


### PR DESCRIPTION
Promote is pointer-only: demote the previous active row, follow default when eligible, and retarget variants and license parents without minting or inventing license links.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoting a version is now pointer-only. Setting active: true on an existing version moves the unique active pointer without minting; the previously active row auto-demotes, and default follows only when the promoted row is eligible.

- Enforces exactly one active per plan. Guards: two active: true for the same plan → 400; versioning: "all_versions" + active: true → 400; active: false without a same-call successor → 400.
- Planner expands one promotion into the target upsert plus an auto-demotion upsert; previews show sibling actives. Variants and licenses use previousActiveInternalId to decide retargets or pins.
- Variants that follow the active base retarget in place (no variant mint); historical variants remain pinned to their original base.
- License parents: uncustomized, non-propagated parents pin to the demoted child; propagated parents repoint to the new active child; customized parents are left; declared licenses override.
- Default auto-follows the pointer only when eligible (not a variant or historical; free or cardless-trial). Preserving an existing default is allowed; explicitly setting default on a historical version still 400.
- Executor proactively deactivates other active rows before activation to satisfy the non-deferrable unique-active constraint; product-details diffs/writes now include active.

- Client migration
  - Promote by sending active: true on an existing version (numeric version or version_slug).
  - Do not send active: false unless another entry in the same call takes the pointer.
  - Do not combine "all_versions" with active: true.

<sup>Written for commit 7c4cbef17466af14de3e3231a84057e98b162bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR changes promotion of an existing plan version into a pointer-only operation, with coordinated handling for defaults, variants, license parents, validation, previews, and persistence.
- **[API changes]** Accepts `active: true` to promote an existing version and validates conflicting or unsupported active-pointer inputs.
- **[Improvements]** Automatically demotes the previous active version and updates preview output to show the resulting sibling state.
- **[Improvements]** Retargets eligible defaults, variants, and license-parent relationships without minting another version.
- **[Bug fixes]** Persists active-state changes while proactively clearing the previous active row.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because concurrent promotions of different versions can still make one catalog update fail at the unique-active database constraint.

The active-pointer change remains split into separate deactivate and activate statements, so two requests promoting different versions of the same plan can interleave and collide when the second request activates its target.

**Files Needing Attention:** server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts; server/src/internal/products/repos/activateHighestRemainingProduct.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts | Persists the active flag and clears competing active rows, but the previously reported concurrent-promotion collision remains. |
| server/src/internal/products/repos/activateHighestRemainingProduct.ts | Adds scoped deactivation of other active versions as a separate statement, leaving the active-pointer transition vulnerable to concurrent promotions. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeUpsertProductPlan/computeUpsertProductPlan.ts | Produces the promoted target together with an automatically demoted sibling plan. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computePlanLicensesPlan/pinned/computePinnedPlanLicenses.ts | Updates license pinning behavior so promotion can preserve or retarget parent links without creating new child identities. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductActiveErrors.ts | Rejects invalid active-pointer combinations, including multiple successors and unsupported all-version activation. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Planner
    participant Executor
    participant DB
    Client->>Planner: Promote existing version
    Planner->>Planner: Build target and demotion plans
    Planner-->>Client: Preview pointer and related changes
    Client->>Executor: Apply update
    Executor->>DB: Deactivate other active versions
    Executor->>DB: Activate selected version
    Executor->>DB: Apply default, variant, and license updates
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(catalog): take the active pointer o..."](https://github.com/useautumn/autumn/commit/7c4cbef17466af14de3e3231a84057e98b162bf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56243858)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Database schema, relations, and migrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/database-schema-and-migrations.md)

<!-- /greptile_comment -->