### PR TITLE
feat(dashboard): surface plan versions, promotion, and mint slugs

### DIFF
--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -134,22 +134,29 @@ function SelectLabel({
 function SelectItem({
 	className,
 	children,
+	indicator = true,
 	...props
-}: SelectPrimitive.Item.Props) {
+}: SelectPrimitive.Item.Props & {
+	/** Opt out when the row already reads as selected without a checkmark. */
+	indicator?: boolean;
+}) {
 	return (
 		<SelectPrimitive.Item
 			data-slot="select-item"
 			className={cn(
-				"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-highlighted:**:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				"data-highlighted:bg-accent data-highlighted:text-accent-foreground data-highlighted:**:text-accent-foreground focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pl-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				indicator ? "pr-8" : "pr-1.5",
 				className,
 			)}
 			{...props}
 		>
-			<span className="pointer-events-none absolute right-2 flex items-center justify-center">
-				<SelectPrimitive.ItemIndicator>
-					<CheckIcon className="size-4" />
-				</SelectPrimitive.ItemIndicator>
-			</span>
+			{indicator ? (
+				<span className="pointer-events-none absolute right-2 flex items-center justify-center">
+					<SelectPrimitive.ItemIndicator>
+						<CheckIcon className="size-4" />
+					</SelectPrimitive.ItemIndicator>
+				</span>
+			) : null}
 			<SelectPrimitive.ItemText className="flex items-center gap-2">
 				{children}
 			</SelectPrimitive.ItemText>

--- a/vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx
+++ b/vite/src/components/v2/inline-custom-plan-editor/PlanEditorContext.tsx
@@ -23,6 +23,7 @@ import { useFeaturesQuery } from "@/hooks/queries/useFeaturesQuery";
 import { useProductStore } from "@/hooks/stores/useProductStore";
 import { useSheetStore } from "@/hooks/stores/useSheetStore";
 import { getItemId } from "@/utils/product/productItemUtils";
+import { versionSlugRenamed } from "@/views/products/plan/utils/versionSlug";
 
 type SetProduct = (
 	product: FrontendProduct | ((prev: FrontendProduct) => FrontendProduct),
@@ -244,6 +245,7 @@ export function usePlanSheet(sheetType: string | null): PlanSheetState {
 
 	const hasChanges = useMemo(() => {
 		if (!initialProduct) return false;
+		if (versionSlugRenamed({ product, previous: initialProduct })) return true;
 
 		const {
 			itemsSame,

--- a/vite/src/hooks/queries/useProductVersionsQuery.tsx
+++ b/vite/src/hooks/queries/useProductVersionsQuery.tsx
@@ -1,0 +1,47 @@
+import type { ProductV2 } from "@autumn/shared";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+const EMPTY_VERSIONS: ProductV2[] = [];
+
+/**
+ * All version rows for one productId. Not on the plan page's primary query —
+ * enable after the page is interactive (typically on dropdown open).
+ */
+export const useProductVersionsQuery = ({
+	productId,
+	enabled = false,
+}: {
+	productId: string | undefined;
+	enabled?: boolean;
+}) => {
+	const axiosInstance = useAxiosInstance();
+	const queryClient = useQueryClient();
+	const buildKey = useQueryKeyFactory();
+
+	const { data, isLoading, error, refetch } = useQuery<ProductV2[]>({
+		queryKey: buildKey(["product_versions", productId]),
+		queryFn: async () => {
+			const { data } = await axiosInstance.get<{ products: ProductV2[] }>(
+				"/products/products",
+				{
+					params: { all_versions: true, product_id: productId },
+				},
+			);
+			return data.products;
+		},
+		enabled: enabled && !!productId,
+	});
+
+	const invalidate = () =>
+		queryClient.invalidateQueries({ queryKey: ["product_versions"] });
+
+	return {
+		versions: data ?? EMPTY_VERSIONS,
+		isLoading,
+		error,
+		refetch,
+		invalidate,
+	};
+};

--- a/vite/src/hooks/queries/useProductsQuery.tsx
+++ b/vite/src/hooks/queries/useProductsQuery.tsx
@@ -60,6 +60,7 @@ export const useProductsQuery = ({
 		await Promise.all([
 			queryClient.invalidateQueries({ queryKey: ["products"] }),
 			queryClient.invalidateQueries({ queryKey: ["product_counts"] }),
+			queryClient.invalidateQueries({ queryKey: ["product_versions"] }),
 		]);
 	};
 

--- a/vite/src/hooks/stores/useProductStore.ts
+++ b/vite/src/hooks/stores/useProductStore.ts
@@ -18,6 +18,7 @@ import { itemToFeature } from "@/utils/product/productItemUtils/convertItem";
 import { getVersionCounts } from "@/utils/productUtils";
 import { useVariantLinkVisibility } from "@/views/products/plan/hooks/useVariantLinkVisibility";
 import { DEFAULT_PRODUCT } from "@/views/products/plan/utils/defaultProduct";
+import { versionSlugRenamed } from "@/views/products/plan/utils/versionSlug";
 import { useSheetStore } from "./useSheetStore";
 
 interface ProductState {
@@ -87,6 +88,7 @@ export const useHasChanges = () => {
 			!comparison.configSame ||
 			!comparison.billingControlsSame ||
 			!comparison.metadataSame ||
+			versionSlugRenamed({ product, previous: baseProduct }) ||
 			selectedBasePlanId !== basePlanId;
 
 		return hasChanges;
@@ -127,6 +129,7 @@ export const useHasContentChanges = () => {
 
 	return useMemo(() => {
 		if (!baseProduct) return false;
+		if (versionSlugRenamed({ product, previous: baseProduct })) return true;
 		return !productsAreSame({
 			newProductV2: product,
 			curProductV2: baseProduct,

--- a/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
+++ b/vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts
@@ -10,6 +10,7 @@ import type {
 	UpdateCatalogPlanParamsInput,
 } from "@autumn/shared";
 import { alignTierCurrencyShapes } from "../utils/currencyUtils";
+import { versionSlugRenamed } from "../utils/versionSlug";
 import { frontendProductToApiPlanV1 } from "../versioning/buildMigrationDraft";
 
 const omitStripePriceId = <T extends object>(
@@ -48,11 +49,50 @@ const planItemsToCatalogParams = (
 const pinsVersion = (versioning: CatalogPlanVersioningStrategy | undefined) =>
 	versioning == null || versioning === "existing";
 
+/** The two things `new_version_slug` can mean on one save. Never both at once. */
+export type NewVersionSlugSource =
+	/** Rename the row this save targets — derived from the edited product. */
+	| { source: "renamed_row" }
+	/** Name the row a `new_version` save mints. Blank falls back to a slug edit. */
+	| { source: "minted_row"; slug?: string };
+
+const renamedRowSlug = ({
+	baseProduct,
+	editedProduct,
+}: {
+	baseProduct?: FrontendProduct | null;
+	editedProduct: FrontendProduct;
+}): string | undefined =>
+	versionSlugRenamed({ product: editedProduct, previous: baseProduct })
+		? editedProduct.version_slug?.trim()
+		: undefined;
+
+/** `all_versions` names no single row, so it never carries a slug. */
+const resolveNewVersionSlug = ({
+	newVersionSlug,
+	baseProduct,
+	editedProduct,
+	versioning,
+}: {
+	newVersionSlug: NewVersionSlugSource;
+	baseProduct?: FrontendProduct | null;
+	editedProduct: FrontendProduct;
+	versioning?: CatalogPlanVersioningStrategy;
+}): string | undefined => {
+	if (versioning === "all_versions") return undefined;
+	const renamed = renamedRowSlug({ baseProduct, editedProduct });
+	if (newVersionSlug.source === "minted_row") {
+		return newVersionSlug.slug?.trim() || renamed;
+	}
+	return renamed;
+};
+
 export const buildUpdateCatalogPlanParams = ({
 	baseProduct,
 	editedProduct,
 	features,
 	versioning,
+	newVersionSlug = { source: "renamed_row" },
 	propagate,
 	licenses,
 	migration,
@@ -62,6 +102,7 @@ export const buildUpdateCatalogPlanParams = ({
 	editedProduct: FrontendProduct;
 	features: Feature[];
 	versioning?: CatalogPlanVersioningStrategy;
+	newVersionSlug?: NewVersionSlugSource;
 	propagate?: CatalogPropagateParams;
 	licenses?: PlanLicenseParams[];
 	migration?: MigrationParamsInput;
@@ -73,6 +114,12 @@ export const buildUpdateCatalogPlanParams = ({
 		baseProduct && editedProduct.id !== baseProduct.id
 			? editedProduct.id
 			: undefined;
+	const resolvedVersionSlug = resolveNewVersionSlug({
+		newVersionSlug,
+		baseProduct,
+		editedProduct,
+		versioning,
+	});
 	const plan = frontendProductToApiPlanV1(
 		{
 			...editedProduct,
@@ -86,6 +133,7 @@ export const buildUpdateCatalogPlanParams = ({
 	return {
 		plan_id: source.id,
 		...(newPlanId ? { new_plan_id: newPlanId } : {}),
+		...(resolvedVersionSlug ? { new_version_slug: resolvedVersionSlug } : {}),
 		...(pinsVersion(versioning) && baseProduct?.version
 			? { version: baseProduct.version }
 			: {}),

--- a/vite/src/views/products/plan/catalog/catalogPlanPreview.ts
+++ b/vite/src/views/products/plan/catalog/catalogPlanPreview.ts
@@ -74,7 +74,14 @@ export const catalogPreviewHasPlanIdChange = ({
 	preview,
 }: {
 	preview: CatalogPlanUpdatePreview | undefined;
-}): boolean => typeof preview?.plan_change?.previous_attributes?.id === "string";
+}): boolean =>
+	typeof preview?.plan_change?.previous_attributes?.id === "string";
+
+export const catalogPreviewHasPromotion = ({
+	preview,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+}): boolean => Boolean(preview?.promotion_details);
 
 export const catalogPreviewPlanIdChange = ({
 	preview,
@@ -90,14 +97,35 @@ export const catalogPreviewPlanIdChange = ({
 	return { from, to: nextPlanId };
 };
 
+/** The server reports a slug rename on the row identity, not in previous_attributes. */
+export const catalogPreviewVersionSlugChange = ({
+	preview,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+}): { from: string; to: string } | undefined => {
+	const to = preview?.new_version_slug;
+	if (!to || !preview?.version_slug) return undefined;
+	return { from: preview.version_slug, to };
+};
+
+export const catalogPreviewHasVersionSlugChange = ({
+	preview,
+}: {
+	preview: CatalogPlanUpdatePreview | undefined;
+}): boolean => catalogPreviewVersionSlugChange({ preview }) !== undefined;
+
 export const catalogPreviewOpensDialog = ({
 	preview,
 }: {
 	preview: CatalogPlanUpdatePreview | undefined;
 }): boolean => {
+	if (catalogPreviewHasPromotion({ preview })) return true;
 	if (catalogPreviewHasAliasReplacement({ preview })) return true;
 	if (isCatalogMetadataOnly({ preview })) {
-		return catalogPreviewHasPlanIdChange({ preview });
+		return (
+			catalogPreviewHasPlanIdChange({ preview }) ||
+			catalogPreviewHasVersionSlugChange({ preview })
+		);
 	}
 	return (
 		previewOpensStrategyStep({ preview }) ||
@@ -118,7 +146,9 @@ export const isConfirmOnlyPlanChangeDialog = ({
 	showLicenseParentScope: boolean;
 }): boolean =>
 	(catalogPreviewHasAliasReplacement({ preview }) ||
-		catalogPreviewHasPlanIdChange({ preview })) &&
+		catalogPreviewHasPlanIdChange({ preview }) ||
+		catalogPreviewHasVersionSlugChange({ preview }) ||
+		catalogPreviewHasPromotion({ preview })) &&
 	!showVersionStrategy &&
 	!showVariantScope &&
 	!showLicenseParentScope;
@@ -184,6 +214,45 @@ export const buildCatalogPropagate = ({
 	};
 };
 
+/** A variant or license-parent lane entry, as far as mint detection cares. */
+type FollowerVersioningPreview = {
+	versioning?: { resolved: CatalogPlanVersioningStrategy };
+	state: { has_customers: boolean };
+};
+
+/** This follower gets a new row: the server resolved one, or the base mint cascades. */
+export const followerMintsNewVersion = ({
+	follower,
+	baseMintsNewVersion,
+}: {
+	follower: FollowerVersioningPreview;
+	baseMintsNewVersion: boolean;
+}): boolean => {
+	if (follower.versioning?.resolved === "new_version") return true;
+	return (
+		follower.versioning === undefined &&
+		baseMintsNewVersion &&
+		follower.state.has_customers
+	);
+};
+
+/**
+ * Would following this base mint give the variant its own new row? The variant lane
+ * always reports `versioning`, and the discover preview sends no propagate, so its
+ * `resolved` reads `existing` even when the save would mint. Mirrors the server's
+ * gate: the base mints and this variant's active row has versionable customers.
+ */
+export const variantFollowMintsNewVersion = ({
+	variant,
+	baseMintsNewVersion,
+}: {
+	variant: FollowerVersioningPreview;
+	baseMintsNewVersion: boolean;
+}): boolean => {
+	if (variant.versioning?.resolved === "new_version") return true;
+	return baseMintsNewVersion && variant.state.has_customers;
+};
+
 export const getLicenseParentVersionKey = ({
 	plan_id,
 	version,
@@ -222,6 +291,12 @@ export type PropagationTarget = {
 	name: string;
 	detail: string;
 	conflicts: CatalogConflictPreview[];
+	/** This target gets its own new row, so the save can name it. */
+	mintsNewVersion: boolean;
+	/** The version that row lands at — max+1, not active+1. */
+	mintVersion: number;
+	/** Display slugs this plan's versions already hold. */
+	takenSlugs: string[];
 } & CatalogPlanChangeDiff;
 
 export const emptyCatalogPlanChangeDiff = (): CatalogPlanChangeDiff => ({
@@ -330,50 +405,40 @@ export const applyLicenseParentScopedDiffs = ({
 		}),
 	}));
 
-const toPropagationTarget = ({
-	id,
-	name,
-	detail,
-	conflicts,
-	planChange,
-}: {
-	id: string;
-	name: string;
-	detail: string;
-	conflicts?: CatalogConflictPreview[];
-	planChange?: PlanChangeV0 | null;
-}): PropagationTarget => ({
-	id,
-	name,
-	detail,
-	conflicts: conflicts ?? [],
-	...planChangeToTargetDiff({ planChange }),
-});
-
 export const toVariantPropagationTargets = ({
 	variants,
 	namesByPlanId,
 	includeHistoricalVersions = false,
+	baseMintsNewVersion = false,
 }: {
 	variants: CatalogVariantPreview[] | undefined;
 	namesByPlanId: Record<string, string>;
 	includeHistoricalVersions?: boolean;
+	baseMintsNewVersion?: boolean;
 }): PropagationTarget[] =>
-	(variants ?? []).map((variant) =>
-		toPropagationTarget({
+	(variants ?? []).map((variant) => {
+		const versions = variantVersions({ variant });
+		return {
 			id: variant.plan_id,
 			name: namesByPlanId[variant.plan_id] ?? variant.plan_id,
 			detail: variant.plan_id,
 			conflicts: dedupeBy(
-				(includeHistoricalVersions
-					? variantVersions({ variant })
-					: [variant]
-				).flatMap((entry) => entry.conflicts ?? []),
+				(includeHistoricalVersions ? versions : [variant]).flatMap(
+					(entry) => entry.conflicts ?? [],
+				),
 				(conflict) => JSON.stringify(conflict),
 			),
-			planChange: variant.plan_change,
-		}),
-	);
+			mintsNewVersion: variantFollowMintsNewVersion({
+				variant,
+				baseMintsNewVersion,
+			}),
+			mintVersion:
+				Math.max(...versions.map((entry) => entry.version), variant.version) +
+				1,
+			takenSlugs: versions.map((entry) => entry.version_slug).filter(Boolean),
+			...planChangeToTargetDiff({ planChange: variant.plan_change }),
+		};
+	});
 
 /** One parent plan and every version of it that offers the edited child. */
 export type LicenseParentTarget = {
@@ -526,11 +591,10 @@ const buildLicenseParentMigrateTargets = ({
 		const selected = changed.length > 0 ? changed : selectedByScope;
 		if (selected.length === 0) continue;
 
-		const mints =
-			parent.versioning?.resolved === "new_version" ||
-			(parent.versioning === undefined &&
-				isNewVersion &&
-				parent.state.has_customers);
+		const mints = followerMintsNewVersion({
+			follower: parent,
+			baseMintsNewVersion: isNewVersion,
+		});
 		const rows = mints
 			? [
 					migrateRowFromPlanChange({
@@ -622,11 +686,10 @@ export const buildCatalogMigrateTargets = ({
 			(entry) => entry.plan_id === variantId,
 		);
 		if (!variant) continue;
-		const createsNewVersion =
-			variant.versioning?.resolved === "new_version" ||
-			(variant.versioning === undefined &&
-				isNewVersion &&
-				variant.state.has_customers);
+		const createsNewVersion = followerMintsNewVersion({
+			follower: variant,
+			baseMintsNewVersion: isNewVersion,
+		});
 		const affectedVersions = variantVersions({ variant }).filter(
 			(entry) => entry.variant_action !== "unchanged",
 		);

--- a/vite/src/views/products/plan/catalog/resolvePlanChangePreview.ts
+++ b/vite/src/views/products/plan/catalog/resolvePlanChangePreview.ts
@@ -115,10 +115,17 @@ export const resolvePlanChangePreview = ({
 		showAllOption,
 	});
 
+	const strategy = strategyForCatalogPreview({
+		choice: effectiveVersionChoice,
+		options: versioningOptions,
+		isLatest,
+	});
+
 	const variantTargets = toVariantPropagationTargets({
 		variants: preview?.variants,
 		namesByPlanId,
 		includeHistoricalVersions: effectiveVersionChoice === "all",
+		baseMintsNewVersion: strategy === "new_version",
 	});
 	const defaultVariantIds = getDefaultPropagationTargetIds({
 		targets: variantTargets,
@@ -152,11 +159,7 @@ export const resolvePlanChangePreview = ({
 		showAllOption,
 		showUpdateOption,
 		effectiveVersionChoice,
-		strategy: strategyForCatalogPreview({
-			choice: effectiveVersionChoice,
-			options: versioningOptions,
-			isLatest,
-		}),
+		strategy,
 		variantTargets,
 		defaultVariantIds,
 		selectedVariantIds,

--- a/vite/src/views/products/plan/catalog/usePlanChangeCatalogPreview.ts
+++ b/vite/src/views/products/plan/catalog/usePlanChangeCatalogPreview.ts
@@ -6,6 +6,10 @@ import type {
 } from "@autumn/shared";
 import { usePreviewUpdateCatalog } from "@/hooks/queries/catalog/usePreviewUpdateCatalog";
 import {
+	type MintSlugSelection,
+	propagateWithMintSlugs,
+} from "../versioning/mintTargetSlugs";
+import {
 	buildCatalogUpdatePlans,
 	tryBuildUpdateCatalogPlanParams,
 } from "./buildUpdateCatalogPlanParams";
@@ -132,13 +136,30 @@ export const usePlanChangeCatalogPreview = ({
 			})
 		: [];
 
-	const buildSaveParams = ({ migrate }: { migrate: boolean }) =>
-		buildCatalogUpdatePlans({
+	/** Typed slugs are save-only — sending them to preview would surface collisions early. */
+	const buildSaveParams = ({
+		migrate,
+		slugSelection,
+	}: {
+		migrate: boolean;
+		slugSelection: MintSlugSelection;
+	}) => {
+		const mints = model.strategy === "new_version";
+		const slug = mints ? slugSelection.base.trim() || undefined : undefined;
+		return buildCatalogUpdatePlans({
 			baseProduct,
 			editedProduct: product,
 			features,
 			versioning: model.strategy,
-			propagate: model.propagate,
+			newVersionSlug: mints
+				? { source: "minted_row", slug }
+				: { source: "renamed_row" },
+			propagate: mints
+				? propagateWithMintSlugs({
+						propagate: model.propagate,
+						selection: slugSelection,
+					})
+				: model.propagate,
 			licenses,
 			migration:
 				migrate && migrateNeeded && model.strategy !== "new_version"
@@ -146,6 +167,7 @@ export const usePlanChangeCatalogPreview = ({
 					: undefined,
 			persistedBasePlanId,
 		});
+	};
 
 	return {
 		...model,

--- a/vite/src/views/products/plan/components/DeletePlanDialog.tsx
+++ b/vite/src/views/products/plan/components/DeletePlanDialog.tsx
@@ -15,16 +15,12 @@ import {
 } from "@autumn/ui";
 import { useProductStore } from "@/hooks/stores/useProductStore";
 import {
+	allVersionsScopeLabel,
+	DELETE_PLAN_SCOPE_LABELS,
+	DELETE_THIS_VERSION_WARNING,
 	type DeletePlanScope,
-	useDeletePlanDialog,
-} from "./useDeletePlanDialog";
-
-// Base UI projects the trigger label from the Root's `items` map — without it
-// the trigger renders the raw scope value.
-const SCOPE_LABELS: Record<DeletePlanScope, string> = {
-	latest: "Latest version",
-	all: "All versions",
-};
+} from "./deletePlanScope";
+import { useDeletePlanDialog } from "./useDeletePlanDialog";
 
 export const DeletePlanDialog = ({
 	propProduct,
@@ -48,10 +44,12 @@ export const DeletePlanDialog = ({
 		isPending,
 		previewError,
 		reasons,
+		removeThisVersion,
 		scope,
 		setScope,
 		titleAction,
 		willArchive,
+		willArchiveAll,
 		handleConfirm,
 		handleOpenChange,
 	} = useDeletePlanDialog({
@@ -63,6 +61,11 @@ export const DeletePlanDialog = ({
 	});
 
 	if (isLoading && !archived) return null;
+
+	const scopeLabels: Record<DeletePlanScope, string> = {
+		...DELETE_PLAN_SCOPE_LABELS,
+		all: allVersionsScopeLabel({ willArchiveAll }),
+	};
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
@@ -90,8 +93,9 @@ export const DeletePlanDialog = ({
 								))}
 							{!archived && !previewError && reasons.length === 0 && (
 								<p>
-									Are you sure you want to delete this plan? This action cannot
-									be undone.
+									{removeThisVersion
+										? DELETE_THIS_VERSION_WARNING
+										: "Are you sure you want to delete this plan? This action cannot be undone."}
 								</p>
 							)}
 						</div>
@@ -102,15 +106,15 @@ export const DeletePlanDialog = ({
 					<Select
 						value={scope}
 						onValueChange={(value) =>
-							setScope(value === "all" ? "all" : "latest")
+							setScope(value === "all" ? "all" : "version")
 						}
-						items={SCOPE_LABELS}
+						items={scopeLabels}
 					>
 						<SelectTrigger className="w-6/12">
 							<SelectValue placeholder="Select a version" />
 						</SelectTrigger>
 						<SelectContent>
-							{Object.entries(SCOPE_LABELS).map(([value, label]) => (
+							{Object.entries(scopeLabels).map(([value, label]) => (
 								<SelectItem key={value} value={value}>
 									{label}
 								</SelectItem>

--- a/vite/src/views/products/plan/components/EditPlanHeader.tsx
+++ b/vite/src/views/products/plan/components/EditPlanHeader.tsx
@@ -8,16 +8,11 @@ import {
 	SelectSeparator,
 	SelectTrigger,
 	SelectValue,
-	SmallSpinner,
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@autumn/ui";
-import {
-	ArrowsClockwiseIcon,
-	TriangleIcon,
-	UserIcon,
-} from "@phosphor-icons/react";
+import { TriangleIcon, UserIcon } from "@phosphor-icons/react";
 import { PlusIcon } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { useMemo, useState } from "react";
@@ -39,10 +34,7 @@ import { pushPage } from "@/utils/genUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery.tsx";
 import { useCusProductQuery } from "@/views/customers/customer/product/hooks/useCusProductQuery.tsx";
 import { useProductCountsQuery } from "../../product/hooks/queries/useProductCountsQuery";
-import {
-	useProductQuery,
-	useProductQueryState,
-} from "../../product/hooks/useProductQuery";
+import { useProductQuery } from "../../product/hooks/useProductQuery";
 import { useCreateVariant } from "../hooks/useCreateVariant";
 import {
 	MigrateCustomersDialog,
@@ -51,17 +43,18 @@ import {
 import { CreateVariantButton } from "./CreateVariantButton";
 import { CreateVariantDialog } from "./CreateVariantDialog";
 import { PlanToolbar } from "./PlanToolbar.tsx";
+import { PlanVersionSelect } from "./PlanVersionSelect";
+import { PromoteToActiveButton } from "./PromoteToActiveButton";
 import { BackToPlanButton } from "./plan-licenses/BackToPlanButton";
-
-const MIGRATE_CUSTOMERS = "__migrate_customers__";
+import { VersionSlugBadge } from "./VersionSlugBadge";
+import { versionLabel } from "./versionLabel";
 
 export const EditPlanHeader = () => {
-	const { numVersions, versionCounts, isLoading } = useProductQuery();
+	const { numVersions, versionCounts } = useProductQuery();
 	const product = useProductStore((s) => s.product);
 	const { counts } = useProductCountsQuery(
 		product.version ? { version: product.version } : {},
 	);
-	const { queryStates, setQueryStates } = useProductQueryState();
 	const navigate = useNavigate();
 	const isCusPlanEditor = useIsCusPlanEditor();
 	const flags = useAutumnFlags();
@@ -70,7 +63,6 @@ export const EditPlanHeader = () => {
 	const env = useEnv();
 	const currency = org?.default_currency ?? "USD";
 	const [migrateDialogOpen, setMigrateDialogOpen] = useState(false);
-	const showAllVariants = useVariantViewStore((s) => s.showAllVariants);
 
 	const pastVersionsWithCustomers = useMemo(() => {
 		if (!numVersions || numVersions <= 1) return [];
@@ -107,27 +99,7 @@ export const EditPlanHeader = () => {
 		!!vercelAllowedIds?.length &&
 		vercelAllowedIds.includes(product.id);
 
-	const versionOptions = Array.from(
-		{ length: numVersions },
-		(_, i) => numVersions - i,
-	);
-	const currentVersion = queryStates.version || product.version;
-
 	const canMigrate = pastVersionsWithCustomers.length > 0 && !isCusPlanEditor;
-
-	const handleVersionChange = (version: string) => {
-		if (version === MIGRATE_CUSTOMERS) {
-			setMigrateDialogOpen(true);
-			return;
-		}
-		const versionNumber = parseInt(version, 10);
-		if (versionNumber === numVersions && !isCusPlanEditor) {
-			// Remove version param for latest version
-			setQueryStates({ version: null });
-		} else {
-			setQueryStates({ version: versionNumber });
-		}
-	};
 
 	const getProductAdminHover = () => {
 		return [
@@ -196,9 +168,6 @@ export const EditPlanHeader = () => {
 								{product.name}
 							</span>
 						</AdminHover>
-						<span className="text-sm text-tertiary-foreground">
-							v{product.version}
-						</span>
 					</div>
 				</div>
 				<div className="flex flex-row justify-between items-center">
@@ -212,6 +181,12 @@ export const EditPlanHeader = () => {
 								innerClassName="max-w-30 text-tiny-id truncate"
 							/>
 						)}
+						<VersionSlugBadge
+							slug={versionLabel({
+								versionSlug: product.version_slug,
+								version: product.version,
+							})}
+						/>
 						<AdminHover
 							texts={[
 								{ key: "active", value: counts?.active?.toString() || "0" },
@@ -260,75 +235,14 @@ export const EditPlanHeader = () => {
 					</div>
 
 					<div className="flex flex-row gap-2 items-center">
+						{/* Left of the selectors so showing it never shifts them. */}
+						<PromoteToActiveButton />
 						<VariantSelect />
-						{numVersions && numVersions > 1 && (
-							<Select
-								value={currentVersion.toString()}
-								onValueChange={handleVersionChange}
-								disabled={showAllVariants}
-								items={{
-									...Object.fromEntries(
-										versionOptions.map((version) => [
-											version.toString(),
-											`Version ${version}`,
-										]),
-									),
-									...(canMigrate
-										? { [MIGRATE_CUSTOMERS]: "Migrate customers" }
-										: {}),
-								}}
-							>
-								{showAllVariants ? (
-									<Tooltip>
-										<TooltipTrigger render={<span />}>
-											<SelectTrigger className="w-fit min-w-28 !h-6" size="sm">
-												<SelectValue placeholder="Version" />
-											</SelectTrigger>
-										</TooltipTrigger>
-										<TooltipContent>
-											Latest versions of all plans are shown
-										</TooltipContent>
-									</Tooltip>
-								) : (
-									<SelectTrigger className="w-fit min-w-28 !h-6" size="sm">
-										<SelectValue placeholder="Version" />
-									</SelectTrigger>
-								)}
-								<SelectContent>
-									{versionOptions.map((version) => {
-										const count = versionCounts[version]?.active || 0;
-										const hasLoaded = Object.keys(versionCounts).length > 0;
-										return (
-											<SelectItem key={version} value={version.toString()}>
-												<div className="flex items-center justify-between w-full gap-3">
-													<span>Version {version}</span>
-													{hasLoaded ? (
-														<IconBadge variant="muted" icon={<UserIcon />}>
-															{count}
-														</IconBadge>
-													) : (
-														<SmallSpinner
-															size={10}
-															className="text-tertiary-foreground"
-														/>
-													)}
-												</div>
-											</SelectItem>
-										);
-									})}
-									{canMigrate && (
-										<>
-											<SelectSeparator />
-											<SelectItem value={MIGRATE_CUSTOMERS}>
-												<div className="flex items-center gap-2">
-													<ArrowsClockwiseIcon />
-													<span>Migrate customers</span>
-												</div>
-											</SelectItem>
-										</>
-									)}
-								</SelectContent>
-							</Select>
+						{product.id && (
+							<PlanVersionSelect
+								canMigrate={canMigrate}
+								onMigrateCustomers={() => setMigrateDialogOpen(true)}
+							/>
 						)}
 						{!isCusPlanEditor && (
 							<>

--- a/vite/src/views/products/plan/components/PlanVersionOption.tsx
+++ b/vite/src/views/products/plan/components/PlanVersionOption.tsx
@@ -1,0 +1,63 @@
+import {
+	IconBadge,
+	SmallSpinner,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@autumn/ui";
+import { UserIcon } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+
+export const ActiveVersionDot = ({ active }: { active: boolean }) => {
+	if (!active) {
+		return <span className="size-1.5 shrink-0 rounded-full bg-transparent" />;
+	}
+
+	return (
+		<Tooltip>
+			<TooltipTrigger render={<span className="flex shrink-0" />}>
+				<span className="size-1.5 rounded-full bg-green-500">
+					<span className="sr-only">Active version</span>
+				</span>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-64">
+				This version is active. Attaching this plan by ID uses it by default.
+			</TooltipContent>
+		</Tooltip>
+	);
+};
+
+export const PlanVersionOption = ({
+	label,
+	active,
+	selected,
+	count,
+	countLoaded,
+}: {
+	label: string;
+	active: boolean;
+	selected: boolean;
+	count: number;
+	countLoaded: boolean;
+}) => (
+	<div className="flex w-full items-center justify-between gap-4">
+		<span className="flex min-w-0 items-center gap-2">
+			<ActiveVersionDot active={active} />
+			<span
+				className={cn(
+					"truncate",
+					selected ? "text-foreground font-medium" : "text-muted-foreground",
+				)}
+			>
+				{label}
+			</span>
+		</span>
+		{countLoaded ? (
+			<IconBadge className="shrink-0" variant="muted" icon={<UserIcon />}>
+				{count}
+			</IconBadge>
+		) : (
+			<SmallSpinner size={10} className="shrink-0 text-tertiary-foreground" />
+		)}
+	</div>
+);

--- a/vite/src/views/products/plan/components/PlanVersionSelect.tsx
+++ b/vite/src/views/products/plan/components/PlanVersionSelect.tsx
@@ -1,0 +1,160 @@
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectSeparator,
+	SelectTrigger,
+	SmallSpinner,
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@autumn/ui";
+import { ArrowsClockwiseIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { useProductVersionsQuery } from "@/hooks/queries/useProductVersionsQuery";
+import {
+	useIsCusPlanEditor,
+	useProductStore,
+} from "@/hooks/stores/useProductStore";
+import { useVariantViewStore } from "@/hooks/stores/useVariantViewStore";
+import { cn } from "@/lib/utils";
+import {
+	useProductQuery,
+	useProductQueryState,
+} from "../../product/hooks/useProductQuery";
+import { ActiveVersionDot, PlanVersionOption } from "./PlanVersionOption";
+import { versionLabel } from "./versionLabel";
+
+const MIGRATE_CUSTOMERS = "__migrate_customers__";
+
+export const PlanVersionSelect = ({
+	canMigrate,
+	onMigrateCustomers,
+}: {
+	canMigrate: boolean;
+	onMigrateCustomers: () => void;
+}) => {
+	const product = useProductStore((s) => s.product);
+	const { versionCounts } = useProductQuery();
+	const { queryStates, setQueryStates } = useProductQueryState();
+	const isCusPlanEditor = useIsCusPlanEditor();
+	const showAllVariants = useVariantViewStore((s) => s.showAllVariants);
+	const [open, setOpen] = useState(false);
+	const { versions, isLoading } = useProductVersionsQuery({
+		productId: product.id,
+		enabled: open,
+	});
+
+	const currentVersion = queryStates.version || product.version;
+	const rows = versions.length > 0 ? versions : [product];
+	const sortedRows = [...rows].sort((left, right) => {
+		if (Boolean(left.active) !== Boolean(right.active)) {
+			return left.active ? -1 : 1;
+		}
+		return (right.version ?? 0) - (left.version ?? 0);
+	});
+
+	const handleVersionChange = (version: string) => {
+		if (version === MIGRATE_CUSTOMERS) {
+			onMigrateCustomers();
+			return;
+		}
+		const versionNumber = Number.parseInt(version, 10);
+		const selected = sortedRows.find((row) => row.version === versionNumber);
+		// Pin unless we know the row is active; a missing flag must not read as active.
+		if (Boolean(selected?.active) && !isCusPlanEditor) {
+			setQueryStates({ version: null });
+			return;
+		}
+		setQueryStates({ version: versionNumber });
+	};
+
+	const currentRow =
+		sortedRows.find((row) => row.version === currentVersion) ?? product;
+
+	const items = {
+		...Object.fromEntries(
+			sortedRows.map((row) => [
+				String(row.version),
+				versionLabel({ versionSlug: row.version_slug, version: row.version }),
+			]),
+		),
+		...(canMigrate ? { [MIGRATE_CUSTOMERS]: "Migrate customers" } : {}),
+	};
+
+	const triggerContent = (
+		<SelectTrigger className="w-32 !h-6" size="sm">
+			<span className="flex min-w-0 items-center gap-1.5">
+				{currentRow.active ? <ActiveVersionDot active /> : null}
+				<span className="truncate">
+					{versionLabel({
+						versionSlug: currentRow.version_slug,
+						version: currentRow.version,
+					})}
+				</span>
+			</span>
+		</SelectTrigger>
+	);
+
+	return (
+		<Select
+			value={String(currentVersion)}
+			onValueChange={handleVersionChange}
+			onOpenChange={setOpen}
+			disabled={showAllVariants}
+			items={items}
+		>
+			{showAllVariants ? (
+				<Tooltip>
+					<TooltipTrigger render={<span />}>{triggerContent}</TooltipTrigger>
+					<TooltipContent>
+						Latest versions of all plans are shown
+					</TooltipContent>
+				</Tooltip>
+			) : (
+				triggerContent
+			)}
+			<SelectContent className="min-w-40 max-w-64">
+				{isLoading && versions.length === 0 ? (
+					<div className="flex items-center justify-center py-2">
+						<SmallSpinner size={10} className="text-tertiary-foreground" />
+					</div>
+				) : (
+					sortedRows.map((row) => {
+						const selected = row.version === currentVersion;
+						return (
+							<SelectItem
+								key={row.version}
+								value={String(row.version)}
+								indicator={false}
+								className={cn("*:last:w-full", selected && "bg-accent/70")}
+							>
+								<PlanVersionOption
+									label={versionLabel({
+										versionSlug: row.version_slug,
+										version: row.version,
+									})}
+									active={Boolean(row.active)}
+									selected={selected}
+									count={versionCounts[row.version]?.active || 0}
+									countLoaded={Object.keys(versionCounts).length > 0}
+								/>
+							</SelectItem>
+						);
+					})
+				)}
+				{canMigrate && (
+					<>
+						<SelectSeparator />
+						<SelectItem value={MIGRATE_CUSTOMERS} indicator={false}>
+							<div className="flex items-center gap-2">
+								<ArrowsClockwiseIcon />
+								<span>Migrate customers</span>
+							</div>
+						</SelectItem>
+					</>
+				)}
+			</SelectContent>
+		</Select>
+	);
+};

--- a/vite/src/views/products/plan/components/PromoteToActiveButton.tsx
+++ b/vite/src/views/products/plan/components/PromoteToActiveButton.tsx
@@ -1,0 +1,35 @@
+import { IconButton } from "@autumn/ui";
+import { ArrowUpFromLine } from "lucide-react";
+import { usePromotePlanVersion } from "../hooks/usePromotePlanVersion";
+import PlanChangeDialog from "../versioning/PlanChangeDialog";
+
+export const PromoteToActiveButton = () => {
+	const promote = usePromotePlanVersion();
+
+	if (!promote.canPromote) return null;
+
+	return (
+		<>
+			<IconButton
+				onClick={promote.startPromote}
+				aria-label="Promote to active"
+				variant="secondary"
+				iconOrientation="left"
+				icon={<ArrowUpFromLine />}
+				size="mini"
+				disabled={promote.isPreviewing}
+			>
+				Promote to active
+			</IconButton>
+			{promote.confirm && (
+				<PlanChangeDialog
+					createConfirm={promote.confirm}
+					open
+					setOpen={(nextOpen) => {
+						if (!nextOpen) promote.setConfirm(null);
+					}}
+				/>
+			)}
+		</>
+	);
+};

--- a/vite/src/views/products/plan/components/VersionSlugBadge.tsx
+++ b/vite/src/views/products/plan/components/VersionSlugBadge.tsx
@@ -1,0 +1,14 @@
+import { IconBadge, Tooltip, TooltipContent, TooltipTrigger } from "@autumn/ui";
+import { StackIcon } from "@phosphor-icons/react";
+
+/** Slugs are free text and can outgrow the header, so the tooltip carries the full value. */
+export const VersionSlugBadge = ({ slug }: { slug: string }) => (
+	<Tooltip>
+		<TooltipTrigger>
+			<IconBadge variant="muted" icon={<StackIcon />}>
+				<span className="max-w-30 text-tiny-id truncate">{slug}</span>
+			</IconBadge>
+		</TooltipTrigger>
+		<TooltipContent>Version {slug}</TooltipContent>
+	</Tooltip>
+);

--- a/vite/src/views/products/plan/components/deletePlanScope.ts
+++ b/vite/src/views/products/plan/components/deletePlanScope.ts
@@ -1,0 +1,57 @@
+export type DeletePlanScope = "version" | "all";
+
+export const DELETE_THIS_VERSION_WARNING =
+	"Are you sure you want to delete this version? This action cannot be undone.";
+
+export const DELETE_PLAN_SCOPE_LABELS: Record<DeletePlanScope, string> = {
+	version: "Delete this version",
+	all: "All versions",
+};
+
+export const allVersionsScopeLabel = ({
+	willArchiveAll,
+}: {
+	willArchiveAll: boolean;
+}) => (willArchiveAll ? "Archive all versions" : "All versions");
+
+export const canDeleteThisVersion = ({
+	hasPreview,
+	previewFailed,
+	willArchive,
+}: {
+	hasPreview: boolean;
+	previewFailed: boolean;
+	willArchive: boolean;
+}) => hasPreview && !previewFailed && !willArchive;
+
+export const hasMultiplePlanVersions = ({
+	viewedVersion,
+	listedVersion,
+	numVersions,
+}: {
+	viewedVersion: number;
+	listedVersion: number | undefined;
+	numVersions: number;
+}) =>
+	numVersions > 1 ||
+	viewedVersion > 1 ||
+	(listedVersion != null &&
+		(listedVersion > 1 || listedVersion !== viewedVersion));
+
+export const canChooseDeleteScope = ({
+	thisVersionDeletable,
+	hasMultipleVersions,
+	willArchiveAll,
+}: {
+	thisVersionDeletable: boolean;
+	hasMultipleVersions: boolean;
+	willArchiveAll: boolean;
+}) => thisVersionDeletable && (hasMultipleVersions || willArchiveAll);
+
+export const shouldRemoveThisVersion = ({
+	thisVersionDeletable,
+	scope,
+}: {
+	thisVersionDeletable: boolean;
+	scope: DeletePlanScope;
+}) => thisVersionDeletable && scope === "version";

--- a/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/MoreSettingsSection.tsx
@@ -21,6 +21,7 @@ import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditor
 import { useVariantLinkVisibility } from "../../hooks/useVariantLinkVisibility";
 import { MetadataEditor } from "./MetadataEditor";
 import { PlanBillingControlsSection } from "./PlanBillingControlsSection";
+import { VersionSlugField } from "./VersionSlugField";
 
 const NO_BASE_PLAN = "__none__";
 
@@ -37,6 +38,8 @@ export const MoreSettingsSection = () => {
 	} = useVariantLinkVisibility(product);
 
 	const hasGroup = notNullish(product.group);
+	// A version row only exists once the plan is saved; creating one always mints v1.
+	const isExistingVersion = !isCustomPlan && Boolean(product.internal_id);
 	// The linked base can be archived or a variant, so it stays selectable.
 	const visibleBasePlanOptions =
 		basePlan && !basePlanOptions.some((p) => p.id === basePlan.id)
@@ -72,6 +75,8 @@ export const MoreSettingsSection = () => {
 				titleClassName="text-tertiary-foreground"
 			>
 				<div className="space-y-5">
+					{isExistingVersion && <VersionSlugField />}
+
 					<ConfigRow
 						title="Group"
 						description="Assign the plan to a subscription tier group."

--- a/vite/src/views/products/plan/components/edit-plan-details/VersionSlugField.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-details/VersionSlugField.tsx
@@ -1,0 +1,34 @@
+import { Input } from "@autumn/ui";
+import { ConfigRow } from "@/components/forms/shared/ConfigRow";
+import { useProduct } from "@/components/v2/inline-custom-plan-editor/PlanEditorContext";
+import { versionSlugError } from "../../utils/versionSlug";
+import { defaultVersionSlug } from "../versionLabel";
+
+export const VersionSlugField = () => {
+	const { product, setProduct } = useProduct();
+	const fallbackSlug = defaultVersionSlug({ version: product.version });
+	// Only an unset slug falls back; a cleared one stays empty so it can be retyped.
+	const slug = product.version_slug ?? fallbackSlug;
+	const error = versionSlugError({ slug });
+
+	return (
+		<ConfigRow
+			title="Version slug"
+			description="Names this version in the API and dashboard. Other versions keep theirs."
+		>
+			<Input
+				aria-invalid={!!error}
+				onChange={(event) =>
+					setProduct({ ...product, version_slug: event.target.value })
+				}
+				placeholder={fallbackSlug}
+				value={slug}
+			/>
+			{error && (
+				<p className="mt-1 text-xs text-destructive" role="alert">
+					{error}
+				</p>
+			)}
+		</ConfigRow>
+	);
+};

--- a/vite/src/views/products/plan/components/useDeletePlanDialog.ts
+++ b/vite/src/views/products/plan/components/useDeletePlanDialog.ts
@@ -1,4 +1,4 @@
-import type { ProductV2 } from "@autumn/shared";
+import type { PreviewUpdateCatalogResponse, ProductV2 } from "@autumn/shared";
 import { useQuery } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
 import { useState } from "react";
@@ -6,11 +6,17 @@ import { toast } from "sonner";
 import { useQueryKeyFactory } from "@/hooks/common/useQueryKeyFactory";
 import { useUpdateCatalogMutation } from "@/hooks/queries/catalog/useUpdateCatalogMutation";
 import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import { useProductQuery } from "@/views/products/product/hooks/useProductQuery";
 import { CatalogV2Service } from "@/services/CatalogV2Service";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr } from "@/utils/genUtils";
-
-export type DeletePlanScope = "latest" | "all";
+import {
+	canChooseDeleteScope,
+	canDeleteThisVersion,
+	type DeletePlanScope,
+	hasMultiplePlanVersions,
+	shouldRemoveThisVersion,
+} from "./deletePlanScope";
 
 const titleActionFor = ({
 	archived,
@@ -36,6 +42,14 @@ const confirmErrorFallback = ({
 	return "Error deleting plan";
 };
 
+const planPreviewEntry = ({
+	preview,
+	planId,
+}: {
+	preview: PreviewUpdateCatalogResponse | undefined;
+	planId: string;
+}) => preview?.plans.find((candidate) => candidate.plan_id === planId);
+
 export const useDeletePlanDialog = ({
 	product,
 	open,
@@ -52,41 +66,72 @@ export const useDeletePlanDialog = ({
 	const axiosInstance = useAxiosInstance();
 	const buildKey = useQueryKeyFactory();
 	const { products } = useProductsQuery();
+	const { numVersions } = useProductQuery();
 	const { mutateAsync: updateCatalog, isPending } = useUpdateCatalogMutation();
-	const [scope, setScope] = useState<DeletePlanScope>("latest");
+	const [scope, setScope] = useState<DeletePlanScope>("version");
 
 	const archived = product.archived ?? false;
-	const latestVersion =
-		products.find((candidate) => candidate.id === product.id)?.version ??
-		product.version;
-	// Only the latest version can be removed on its own, so a historical version
-	// offers whole-plan removal instead of a scope choice.
-	const canChooseScope = latestVersion > 1 && product.version === latestVersion;
-	const removeAllVersions = !canChooseScope || scope === "all";
+	const previewEnabled = (open || dropdownOpen) && !archived;
+	const listedVersion = products.find(
+		(candidate) => candidate.id === product.id,
+	)?.version;
+	const hasMultipleVersions = hasMultiplePlanVersions({
+		viewedVersion: product.version,
+		listedVersion,
+		numVersions,
+	});
 
-	const {
-		data: preview,
-		error: previewQueryError,
-		isLoading,
-		refetch: refetchPreview,
-	} = useQuery({
+	const thisVersionQuery = useQuery({
 		queryKey: buildKey([
 			"catalogV2PlanDeletePreview",
 			product.id,
-			removeAllVersions ? "all" : product.version,
+			product.version,
 		]),
 		queryFn: () =>
 			CatalogV2Service.previewUpdate(axiosInstance, {
-				remove_plans: removeAllVersions
-					? [{ plan_id: product.id }]
-					: [{ plan_id: product.id, version: product.version }],
+				remove_plans: [{ plan_id: product.id, version: product.version }],
 			}),
-		enabled: (open || dropdownOpen) && !archived,
+		enabled: previewEnabled,
 	});
 
-	const entry = preview?.plans.find(
-		(candidate) => candidate.plan_id === product.id,
-	);
+	const allVersionsQuery = useQuery({
+		queryKey: buildKey(["catalogV2PlanDeletePreview", product.id, "all"]),
+		queryFn: () =>
+			CatalogV2Service.previewUpdate(axiosInstance, {
+				remove_plans: [{ plan_id: product.id }],
+			}),
+		enabled: previewEnabled,
+	});
+
+	const thisVersionEntry = planPreviewEntry({
+		preview: thisVersionQuery.data,
+		planId: product.id,
+	});
+	const allVersionsEntry = planPreviewEntry({
+		preview: allVersionsQuery.data,
+		planId: product.id,
+	});
+
+	const thisVersionDeletable = canDeleteThisVersion({
+		hasPreview: thisVersionEntry != null,
+		previewFailed: Boolean(thisVersionQuery.error),
+		willArchive: thisVersionEntry?.state.will_archive ?? true,
+	});
+	const willArchiveAll = allVersionsEntry?.state.will_archive ?? false;
+	const canChooseScope = canChooseDeleteScope({
+		thisVersionDeletable,
+		hasMultipleVersions,
+		willArchiveAll,
+	});
+	const removeThisVersion = shouldRemoveThisVersion({
+		thisVersionDeletable,
+		scope,
+	});
+
+	const entry = removeThisVersion ? thisVersionEntry : allVersionsEntry;
+	const previewQueryError = removeThisVersion
+		? thisVersionQuery.error
+		: allVersionsQuery.error;
 	const willArchive = entry?.state.will_archive ?? false;
 	const reasons = entry?.state.reasons ?? [];
 	const previewError = previewQueryError
@@ -96,12 +141,14 @@ export const useDeletePlanDialog = ({
 		archived,
 		willArchive,
 	});
+	const isLoading = thisVersionQuery.isLoading || allVersionsQuery.isLoading;
 
 	const handleOpenChange = (nextOpen: boolean) => {
 		setOpen(nextOpen);
 		if (!nextOpen) return;
-		setScope("latest");
-		void refetchPreview();
+		setScope("version");
+		void thisVersionQuery.refetch();
+		void allVersionsQuery.refetch();
 	};
 
 	const handleConfirm = async () => {
@@ -120,9 +167,9 @@ export const useDeletePlanDialog = ({
 				toast.success(`${product.name} unarchived successfully`);
 			} else {
 				await updateCatalog({
-					remove_plans: removeAllVersions
-						? [{ plan_id: product.id }]
-						: [{ plan_id: product.id, version: product.version }],
+					remove_plans: removeThisVersion
+						? [{ plan_id: product.id, version: product.version }]
+						: [{ plan_id: product.id }],
 				});
 				if (willArchive) {
 					toast.success(`${product.name} archived successfully`);
@@ -152,10 +199,12 @@ export const useDeletePlanDialog = ({
 		isPending,
 		previewError,
 		reasons,
+		removeThisVersion,
 		scope,
 		setScope,
 		titleAction,
 		willArchive,
+		willArchiveAll,
 		handleConfirm,
 		handleOpenChange,
 	};

--- a/vite/src/views/products/plan/components/versionLabel.ts
+++ b/vite/src/views/products/plan/components/versionLabel.ts
@@ -1,0 +1,12 @@
+/** The slug the server stamps on a version row that has none of its own. */
+export const defaultVersionSlug = ({ version }: { version: number }) =>
+	`v${version}`;
+
+/** A version row's display slug, falling back to the server default. */
+export const versionLabel = ({
+	versionSlug,
+	version,
+}: {
+	versionSlug?: string | null;
+	version: number;
+}) => versionSlug || defaultVersionSlug({ version });

--- a/vite/src/views/products/plan/hooks/usePromotePlanVersion.ts
+++ b/vite/src/views/products/plan/hooks/usePromotePlanVersion.ts
@@ -1,0 +1,97 @@
+import type {
+	FrontendProduct,
+	UpdateCatalogPlanParamsInput,
+} from "@autumn/shared";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useFetchPreviewUpdateCatalog } from "@/hooks/queries/catalog/usePreviewUpdateCatalog";
+import { useProductsQuery } from "@/hooks/queries/useProductsQuery";
+import {
+	useIsCusPlanEditor,
+	useProductStore,
+} from "@/hooks/stores/useProductStore";
+import { getBackendErr } from "@/utils/genUtils";
+import {
+	useProductQuery,
+	useProductQueryState,
+} from "../../product/hooks/useProductQuery";
+import type { PlanChangeCreateConfirm } from "../versioning/PlanChangeDialog";
+
+export const buildPromoteCatalogPlanParams = ({
+	product,
+}: {
+	product: Pick<FrontendProduct, "id" | "version" | "version_slug">;
+}): UpdateCatalogPlanParamsInput => {
+	const versionSlug = product.version_slug;
+	if (versionSlug) {
+		return {
+			plan_id: product.id,
+			version_slug: versionSlug,
+			active: true,
+		};
+	}
+
+	return {
+		plan_id: product.id,
+		version: product.version,
+		active: true,
+	};
+};
+
+export const usePromotePlanVersion = () => {
+	const product = useProductStore((s) => s.product);
+	const isCusPlanEditor = useIsCusPlanEditor();
+	const fetchPreviewUpdateCatalog = useFetchPreviewUpdateCatalog();
+	const { setQueryStates } = useProductQueryState();
+	const { invalidate: invalidateProduct } = useProductQuery();
+	const { invalidate: invalidateProducts } = useProductsQuery();
+	const [confirm, setConfirm] = useState<PlanChangeCreateConfirm | null>(null);
+
+	const isAlreadyActive = Boolean(product.active);
+	const canPromote = !isAlreadyActive && !isCusPlanEditor;
+
+	const afterPromoted = async () => {
+		await setQueryStates({ version: null });
+		await Promise.all([invalidateProduct(), invalidateProducts()]);
+	};
+
+	const previewPromote = useMutation({
+		mutationFn: async () => {
+			const plans = [buildPromoteCatalogPlanParams({ product })];
+			const preview = await fetchPreviewUpdateCatalog({ plans });
+			return { plans, preview };
+		},
+		onSuccess: ({ plans, preview }) => {
+			const planPreview = preview.plans[0];
+			if (!planPreview?.promotion_details) {
+				toast.error("This version is already the active plan");
+				return;
+			}
+
+			setConfirm({
+				preview: planPreview,
+				plans,
+				title: "Promote to active",
+				successText: "Version promoted",
+				errorText: "Failed to promote version",
+				confirmLabel: "Promote to active",
+				onSaved: afterPromoted,
+			});
+		},
+		onError: (error) => {
+			toast.error(getBackendErr(error, "Failed to preview promotion"));
+		},
+	});
+
+	return {
+		canPromote,
+		isPreviewing: previewPromote.isPending,
+		confirm,
+		setConfirm,
+		startPromote: () => {
+			if (!canPromote) return;
+			previewPromote.mutate();
+		},
+	};
+};

--- a/vite/src/views/products/plan/utils/defaultProduct.ts
+++ b/vite/src/views/products/plan/utils/defaultProduct.ts
@@ -16,6 +16,8 @@ export const DEFAULT_PRODUCT: FrontendProduct = {
 	is_add_on: false,
 	is_default: false,
 	version: 1,
+	version_slug: "v1",
+	active: true,
 	group: null,
 	env: AppEnv.Sandbox,
 	internal_id: "",

--- a/vite/src/views/products/plan/utils/versionSlug.ts
+++ b/vite/src/views/products/plan/utils/versionSlug.ts
@@ -1,0 +1,45 @@
+import { type FrontendProduct, idRegex } from "@autumn/shared";
+import { versionLabel } from "../components/versionLabel";
+
+type VersionedProduct = Pick<FrontendProduct, "version" | "version_slug">;
+
+/** productsAreSame ignores version_slug, so plan-change detection has to ask separately. */
+export const versionSlugRenamed = ({
+	product,
+	previous,
+}: {
+	product: VersionedProduct;
+	previous?: VersionedProduct | null;
+}): boolean => {
+	if (!previous) return false;
+	const next = product.version_slug?.trim();
+	// Blank is an unfinished edit, not a rename — the server requires a nonempty slug.
+	if (!next) return false;
+	return (
+		next !==
+		versionLabel({
+			versionSlug: previous.version_slug,
+			version: previous.version,
+		})
+	);
+};
+
+/** Mirrors the server's `nonempty().regex(idRegex)`. Collisions stay a server error. */
+export const versionSlugError = ({ slug }: { slug: string }): string | null => {
+	if (slug.trim().length === 0) return "Enter a version slug.";
+	if (!idRegex.test(slug)) {
+		return "Use letters, numbers, dashes or underscores only.";
+	}
+	return null;
+};
+
+/** Naming a minted row is optional — blank lets the server stamp `v{n}`. */
+export const mintVersionSlugError = ({
+	slug,
+}: {
+	slug: string;
+}): string | null => {
+	const trimmed = slug.trim();
+	if (trimmed.length === 0) return null;
+	return versionSlugError({ slug: trimmed });
+};

--- a/vite/src/views/products/plan/versioning/MintVersionSlugInput.tsx
+++ b/vite/src/views/products/plan/versioning/MintVersionSlugInput.tsx
@@ -1,0 +1,41 @@
+import { Input } from "@autumn/ui";
+import { mintVersionSlugError } from "../utils/versionSlug";
+import { PlanChangeFieldLabel } from "./PlanChangeFieldLabel";
+
+/** Names the row this save mints. Optional — blank keeps the server default. */
+export function MintVersionSlugInput({
+	defaultSlug,
+	value,
+	onChange,
+}: {
+	defaultSlug: string;
+	value: string;
+	onChange: (value: string) => void;
+}) {
+	const error = mintVersionSlugError({ slug: value });
+
+	return (
+		<div className="flex flex-col gap-2 text-sm">
+			<div className="flex flex-col gap-0.5">
+				<PlanChangeFieldLabel>Version slug</PlanChangeFieldLabel>
+				<span className="text-tertiary-foreground text-xs">
+					Optional name for the new version. Leave blank to use{" "}
+					<span className="font-mono text-foreground">{defaultSlug}</span>.
+				</span>
+			</div>
+			<Input
+				aria-invalid={!!error}
+				className="w-full"
+				onChange={(event) => onChange(event.target.value)}
+				placeholder={defaultSlug}
+				type="text"
+				value={value}
+			/>
+			{error && (
+				<p className="text-xs text-destructive" role="alert">
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeDialog.tsx
@@ -43,7 +43,6 @@ import { useMeasuredHeight } from "@/hooks/useMeasuredHeight";
 import { CatalogV2Service } from "@/services/CatalogV2Service";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getBackendErr, navigateTo } from "@/utils/genUtils";
-import { useVariantLinkVisibility } from "../hooks/useVariantLinkVisibility";
 import {
 	useProductQuery,
 	useProductQueryState,
@@ -53,6 +52,7 @@ import {
 	type CatalogVersionChoice,
 	catalogPreviewAliasReplacements,
 	catalogPreviewPlanIdChange,
+	catalogPreviewVersionSlugChange,
 	isConfirmOnlyPlanChangeDialog,
 } from "../catalog/catalogPlanPreview";
 import { usePlanChangeCatalogPreview } from "../catalog/usePlanChangeCatalogPreview";
@@ -60,14 +60,31 @@ import {
 	commitLicenseChanges,
 	getLicenseUpdatePayload,
 } from "../components/plan-licenses/useLicenseSaveRegistry";
-import { PlanIdChangeNotice } from "./PlanIdChangeNotice";
+import { defaultVersionSlug } from "../components/versionLabel";
+import { useVariantLinkVisibility } from "../hooks/useVariantLinkVisibility";
+import { mintVersionSlugError } from "../utils/versionSlug";
 import { LicenseChangeList } from "./LicenseChangeList";
 import { LicenseParentTargetsStep } from "./LicenseParentTargetsStep";
 import { MigrateTargetsStep } from "./MigrateTargetsStep";
-import { PlanSettingsChanges } from "./PlanSettingsChanges";
+import { MintVersionSlugInput } from "./MintVersionSlugInput";
+import {
+	emptyMintSlugSelection,
+	type MintSlugSelection,
+	mintTargetSlugConflicts,
+	withMintSlugOverride,
+} from "./mintTargetSlugs";
+import { PlanChangeFieldLabel } from "./PlanChangeFieldLabel";
+import { PlanIdChangeNotice } from "./PlanIdChangeNotice";
+import {
+	PlanSettingsChanges,
+	previousAttributesToSettingChanges,
+} from "./PlanSettingsChanges";
+import { PromoteReviewSection } from "./PromoteReviewSection";
 import { getPlanPriceChange } from "./planMigrationDiff";
 import { Stepper, type StepperStep } from "./Stepper";
+import { savedVersionPin } from "./savedVersionPin";
 import { VariantTargetsStep } from "./VariantTargetsStep";
+import { VersionSlugChangeNotice } from "./VersionSlugChangeNotice";
 
 type StepKey =
 	| "review"
@@ -97,6 +114,26 @@ const buildPlanChangeSteps = ({
 		: []),
 	{ key: "migrate", label: "Review", icon: SealCheckIcon },
 ];
+
+/** A slug problem blocks the step that shows it, so Next never hides its own cause. */
+const stepBlocksPlanChangeAdvance = ({
+	step,
+	confirmed,
+	baseSlugInvalid,
+	hasSlugConflicts,
+}: {
+	step: StepKey;
+	confirmed: boolean;
+	baseSlugInvalid: boolean;
+	hasSlugConflicts: boolean;
+}): boolean => {
+	if (step === "strategy") return baseSlugInvalid;
+	if (step === "variant_scope") return hasSlugConflicts;
+	if (step === "migrate") {
+		return !confirmed || baseSlugInvalid || hasSlugConflicts;
+	}
+	return false;
+};
 
 const planChangePrimaryText = ({
 	isFinalStep,
@@ -130,19 +167,29 @@ const planChangePrimaryText = ({
 const planChangeDescription = ({
 	aliasOnly,
 	planIdChangeOnly,
+	versionSlugChangeOnly,
+	promotionOnly,
 	step,
 	migrateNeeded,
 }: {
 	aliasOnly: boolean;
 	planIdChangeOnly: boolean;
+	versionSlugChangeOnly: boolean;
+	promotionOnly: boolean;
 	step: StepKey;
 	migrateNeeded: boolean;
 }) => {
 	if (planIdChangeOnly) {
 		return "Confirm you want to change this plan's ID.";
 	}
+	if (versionSlugChangeOnly) {
+		return "Confirm you want to rename this version's slug.";
+	}
 	if (aliasOnly) {
 		return "This plan ID is currently an alias of another plan.";
+	}
+	if (promotionOnly) {
+		return "Confirm which version this plan resolves to by default.";
 	}
 	if (step === "review") return "Review what's changing before you save.";
 	if (step === "strategy") return "Choose how this applies across versions.";
@@ -180,12 +227,6 @@ const planChangeSaveSuccessText = ({
 	return "Plan updated";
 };
 
-function FieldLabel({ children }: { children: React.ReactNode }) {
-	return (
-		<span className="text-[13px] font-medium text-foreground">{children}</span>
-	);
-}
-
 function ConfirmInput({
 	productId,
 	value,
@@ -221,6 +262,10 @@ export type PlanChangeCreateConfirm = {
 	preview: CatalogPlanUpdatePreview;
 	plans: UpdateCatalogPlanParamsInput[];
 	onSaved?: (result: UpdateCatalogResponse) => void | Promise<void>;
+	title?: string;
+	successText?: string;
+	errorText?: string;
+	confirmLabel?: string;
 };
 
 export default function PlanChangeDialog({
@@ -239,8 +284,7 @@ export default function PlanChangeDialog({
 	const setBaseProduct = useProductStore((s) => s.setBaseProduct);
 	const { basePlanId: persistedBasePlanId } = useVariantLinkVisibility(product);
 	const { features = [] } = useFeaturesQuery();
-	const catalogLicenses =
-		useOptionalProductContext()?.catalogLicenses ?? [];
+	const catalogLicenses = useOptionalProductContext()?.catalogLicenses ?? [];
 	const {
 		refetch,
 		invalidate: invalidateProduct,
@@ -258,6 +302,9 @@ export default function PlanChangeDialog({
 		useState<CatalogVersionChoice>("new");
 	const [includeCustom, setIncludeCustom] = useState(false);
 	const [confirmText, setConfirmText] = useState("");
+	const [slugSelection, setSlugSelection] = useState<MintSlugSelection>(
+		emptyMintSlugSelection,
+	);
 	const [isLoading, setIsLoading] = useState(false);
 	const [variantSelection, setVariantSelection] = useState<string[] | null>(
 		null,
@@ -282,7 +329,9 @@ export default function PlanChangeDialog({
 	const { data: variants = [] } = usePlanVariants(product.id, editorOpen);
 	const namesByPlanId = {
 		...Object.fromEntries(products.map((entry) => [entry.id, entry.name])),
-		...Object.fromEntries(variants.map((variant) => [variant.id, variant.name])),
+		...Object.fromEntries(
+			variants.map((variant) => [variant.id, variant.name]),
+		),
 	};
 
 	const {
@@ -298,6 +347,7 @@ export default function PlanChangeDialog({
 		selectedVariantIds,
 		showVersionStrategy,
 		showVariantScope,
+		effectiveVariantIds,
 		licenseParentTargets,
 		selectedLicenseParentKeys,
 		showLicenseParentScope,
@@ -336,6 +386,33 @@ export default function PlanChangeDialog({
 				preview: planPreview,
 				nextPlanId: product.id,
 			});
+	// On a mint the typed slug names the new row, so only an in-place save renames.
+	const versionSlugRename =
+		createConfirm || strategy === "new_version"
+			? undefined
+			: catalogPreviewVersionSlugChange({ preview: planPreview });
+	const mintsNewVersion = strategy === "new_version";
+	const mintedVersionDefaultSlug = defaultVersionSlug({
+		version: preview?.versioning?.new_version ?? product.version + 1,
+	});
+	const baseSlugInvalid =
+		mintsNewVersion && !!mintVersionSlugError({ slug: slugSelection.base });
+	const slugConflicts = mintsNewVersion
+		? mintTargetSlugConflicts({
+				targets: variantTargets,
+				selectedIds: effectiveVariantIds,
+				selection: slugSelection,
+			})
+		: [];
+	const mintSlugsBlocked = baseSlugInvalid || slugConflicts.length > 0;
+	const stepBlocksAdvance = createConfirm
+		? false
+		: stepBlocksPlanChangeAdvance({
+				step,
+				confirmed,
+				baseSlugInvalid,
+				hasSlugConflicts: slugConflicts.length > 0,
+			});
 	const confirmOnlyDialog =
 		!!createConfirm ||
 		isConfirmOnlyPlanChangeDialog({
@@ -360,12 +437,13 @@ export default function PlanChangeDialog({
 		setVersionChoice(isLatest ? "new" : "update");
 		setIncludeCustom(false);
 		setConfirmText("");
+		setSlugSelection(emptyMintSlugSelection());
 		setVariantSelection(null);
 		setLicenseParentSelection(null);
 	};
 
-	const syncToLatestVersion = async () => {
-		await setQueryStates({ version: null });
+	const syncToSavedVersion = async (version: number | null) => {
+		await setQueryStates({ version });
 		await refetch();
 		await Promise.all([invalidateProduct(), invalidateProducts()]);
 	};
@@ -388,7 +466,7 @@ export default function PlanChangeDialog({
 				const result = await CatalogV2Service.update(axiosInstance, {
 					plans: createConfirm.plans,
 				});
-				toast.success("Plan created");
+				toast.success(createConfirm.successText ?? "Plan created");
 				closeDialog();
 				await createConfirm.onSaved?.(result);
 				return;
@@ -397,7 +475,7 @@ export default function PlanChangeDialog({
 			const willMigrate =
 				migrateNeeded && migrate && strategy !== "new_version";
 			const result = await CatalogV2Service.update(axiosInstance, {
-				plans: buildSaveParams({ migrate }),
+				plans: buildSaveParams({ migrate, slugSelection }),
 			});
 			if (licenses) {
 				commitLicenseChanges();
@@ -411,10 +489,16 @@ export default function PlanChangeDialog({
 			void invalidateProducts();
 			closeDialog();
 			const renamed = Boolean(baseProduct && product.id !== baseProduct.id);
+			const versionPin = savedVersionPin({
+				plans: result.plans,
+				planId: product.id,
+			});
 			if (renamed) {
-				navigateTo(`/products/${product.id}`, navigate);
+				const versionQuery =
+					versionPin === null ? "" : `?version=${versionPin}`;
+				navigateTo(`/products/${product.id}${versionQuery}`, navigate);
 			} else if (effectiveVersionChoice === "new") {
-				void syncToLatestVersion();
+				void syncToSavedVersion(versionPin);
 			} else {
 				void refetch();
 			}
@@ -433,7 +517,9 @@ export default function PlanChangeDialog({
 			toast.error(
 				getBackendErr(
 					error,
-					createConfirm ? "Failed to create plan" : "Failed to save plan",
+					createConfirm
+						? (createConfirm.errorText ?? "Failed to create plan")
+						: "Failed to save plan",
 				),
 			);
 		} finally {
@@ -459,20 +545,39 @@ export default function PlanChangeDialog({
 		if (!nextOpen) resetState();
 	};
 
-	const primaryText = planChangePrimaryText({
-		isFinalStep,
-		migrateNeeded,
-		isMetadataOnly,
-		showVersionStrategy,
-		effectiveVersionChoice,
-		versionChoiceOnlyAffectsParents,
-		isLatest,
-	});
+	const primaryText =
+		createConfirm?.confirmLabel && isFinalStep
+			? createConfirm.confirmLabel
+			: planChangePrimaryText({
+					isFinalStep,
+					migrateNeeded,
+					isMetadataOnly,
+					showVersionStrategy,
+					effectiveVersionChoice,
+					versionChoiceOnlyAffectsParents,
+					isLatest,
+				});
 
-	const title = createConfirm ? "Create plan" : "Save plan changes";
+	const title =
+		createConfirm?.title ??
+		(createConfirm ? "Create plan" : "Save plan changes");
+	const hasPromotion = Boolean(planPreview?.promotion_details);
+	const hasAliasReplacements = aliasReplacements.length > 0;
+	const isPromotionOnlyConfirm =
+		confirmOnlyDialog &&
+		hasPromotion &&
+		!planIdChange &&
+		!versionSlugRename &&
+		!hasAliasReplacements;
+	const confirmOnlySettings = previousAttributesToSettingChanges(
+		planPreview?.plan_change?.previous_attributes,
+	);
 	const description = planChangeDescription({
-		aliasOnly: confirmOnlyDialog && aliasReplacements.length > 0,
+		aliasOnly: confirmOnlyDialog && hasAliasReplacements,
 		planIdChangeOnly: confirmOnlyDialog && !!planIdChange,
+		versionSlugChangeOnly:
+			confirmOnlyDialog && !!versionSlugRename && !planIdChange,
+		promotionOnly: isPromotionOnlyConfirm,
 		step,
 		migrateNeeded,
 	});
@@ -514,17 +619,30 @@ export default function PlanChangeDialog({
 								className="text-sm flex flex-col gap-4"
 							>
 								{step === "review" && confirmOnlyDialog && (
-									<PlanIdChangeNotice
-										from={planIdChange?.from}
-										to={planIdChange?.to}
-										namesByPlanId={namesByPlanId}
-										replacements={aliasReplacements}
-									/>
+									<>
+										<PlanIdChangeNotice
+											from={planIdChange?.from}
+											to={planIdChange?.to}
+											namesByPlanId={namesByPlanId}
+											replacements={aliasReplacements}
+										/>
+										<VersionSlugChangeNotice
+											from={versionSlugRename?.from}
+											to={versionSlugRename?.to}
+										/>
+										<PromoteReviewSection preview={planPreview} />
+										{confirmOnlySettings.length > 0 && (
+											<div className="rounded-lg bg-secondary/40 px-3 py-2.5">
+												<PlanSettingsChanges changes={confirmOnlySettings} />
+											</div>
+										)}
+									</>
 								)}
 
 								{step === "review" && !confirmOnlyDialog && (
 									<div className="flex flex-col gap-2.5">
-										<FieldLabel>Preview changes</FieldLabel>
+										<PromoteReviewSection preview={planPreview} />
+										<PlanChangeFieldLabel>Preview changes</PlanChangeFieldLabel>
 										<div className="rounded-lg bg-secondary/40 px-3 py-2.5 flex flex-col gap-2">
 											{priceChange && (
 												<PlanPriceHeader
@@ -553,16 +671,24 @@ export default function PlanChangeDialog({
 								{step === "variant_scope" && (
 									<div className="flex flex-col gap-2.5">
 										<div className="flex flex-col gap-0.5">
-											<FieldLabel>Apply to variants</FieldLabel>
+											<PlanChangeFieldLabel>
+												Apply to variants
+											</PlanChangeFieldLabel>
 											<span className="text-tertiary-foreground text-xs">
 												Select which variants receive this change. Unselected
 												variants stay as they are.
 											</span>
+											{slugConflicts.length > 0 && (
+												<span className="text-amber-600 text-xs dark:text-amber-500">
+													Rename the highlighted version slugs to continue.
+												</span>
+											)}
 										</div>
 										<VariantTargetsStep
 											features={features}
 											targets={variantTargets}
 											selectedIds={selectedVariantIds}
+											slugSelection={slugSelection}
 											onToggle={(id) =>
 												setVariantSelection((current) => {
 													const selected = current ?? defaultVariantIds;
@@ -571,6 +697,15 @@ export default function PlanChangeDialog({
 														: [...selected, id];
 												})
 											}
+											onSlugChange={({ planId, slug }) =>
+												setSlugSelection((current) =>
+													withMintSlugOverride({
+														selection: current,
+														planId,
+														slug,
+													}),
+												)
+											}
 										/>
 									</div>
 								)}
@@ -578,7 +713,9 @@ export default function PlanChangeDialog({
 								{step === "license_scope" && (
 									<div className="flex flex-col gap-2.5">
 										<div className="flex flex-col gap-0.5">
-											<FieldLabel>Apply to parent plans</FieldLabel>
+											<PlanChangeFieldLabel>
+												Apply to parent plans
+											</PlanChangeFieldLabel>
 											<span className="text-tertiary-foreground text-xs">
 												Pick which parents receive this update, and how far
 												back. Unselected versions keep their current effective
@@ -596,7 +733,9 @@ export default function PlanChangeDialog({
 
 								{step === "strategy" && (
 									<div className="flex flex-col gap-2.5">
-										<FieldLabel>How should this apply?</FieldLabel>
+										<PlanChangeFieldLabel>
+											How should this apply?
+										</PlanChangeFieldLabel>
 										<RadioGroup
 											value={effectiveVersionChoice}
 											onValueChange={(val) =>
@@ -647,6 +786,15 @@ export default function PlanChangeDialog({
 												/>
 											)}
 										</RadioGroup>
+										{mintsNewVersion && (
+											<MintVersionSlugInput
+												defaultSlug={mintedVersionDefaultSlug}
+												onChange={(base) =>
+													setSlugSelection((current) => ({ ...current, base }))
+												}
+												value={slugSelection.base}
+											/>
+										)}
 									</div>
 								)}
 
@@ -658,9 +806,16 @@ export default function PlanChangeDialog({
 											namesByPlanId={namesByPlanId}
 											replacements={aliasReplacements}
 										/>
+										<VersionSlugChangeNotice
+											from={versionSlugRename?.from}
+											to={versionSlugRename?.to}
+										/>
+										<PromoteReviewSection preview={planPreview} />
 										<div className="flex flex-col gap-2.5">
 											<div className="flex flex-col gap-0.5">
-												<FieldLabel>Review &amp; confirm</FieldLabel>
+												<PlanChangeFieldLabel>
+													Review &amp; confirm
+												</PlanChangeFieldLabel>
 												<span className="text-tertiary-foreground text-xs">
 													{migrateSubtitle}
 												</span>
@@ -751,7 +906,7 @@ export default function PlanChangeDialog({
 				</div>
 
 				{step === "migrate" && (
-					<div className="px-4 pt-3 pb-2">
+					<div className="flex flex-col gap-3 px-4 pt-3 pb-2">
 						<ConfirmInput
 							productId={product.id}
 							value={confirmText}
@@ -773,7 +928,7 @@ export default function PlanChangeDialog({
 						<ShortcutButton
 							variant="secondary"
 							onClick={() => applyChanges({ migrate: false })}
-							disabled={isLoading || !confirmed}
+							disabled={isLoading || !confirmed || mintSlugsBlocked}
 						>
 							Skip
 						</ShortcutButton>
@@ -783,7 +938,7 @@ export default function PlanChangeDialog({
 						metaShortcut="enter"
 						onClick={advance}
 						isLoading={isLoading}
-						disabled={isLoading || (step === "migrate" && !confirmed)}
+						disabled={isLoading || stepBlocksAdvance}
 						className="flex-1 justify-center"
 					>
 						{primaryText}

--- a/vite/src/views/products/plan/versioning/PlanChangeFieldLabel.tsx
+++ b/vite/src/views/products/plan/versioning/PlanChangeFieldLabel.tsx
@@ -1,0 +1,10 @@
+/** Section label inside a PlanChangeDialog step. */
+export function PlanChangeFieldLabel({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return (
+		<span className="text-[13px] font-medium text-foreground">{children}</span>
+	);
+}

--- a/vite/src/views/products/plan/versioning/PromoteReviewSection.tsx
+++ b/vite/src/views/products/plan/versioning/PromoteReviewSection.tsx
@@ -1,0 +1,24 @@
+const VersionSlug = ({ slug }: { slug: string }) => (
+	<span className="font-mono font-medium text-foreground">{slug}</span>
+);
+
+export function PromoteReviewSection({
+	preview,
+}: {
+	preview?: {
+		version_slug: string;
+		promotion_details?: { previous_active_version_slug: string };
+	};
+}) {
+	const details = preview?.promotion_details;
+	if (!preview || !details) return null;
+
+	return (
+		<div className="rounded-lg bg-secondary/40 px-3 py-2.5 text-sm text-muted-foreground">
+			<VersionSlug slug={preview.version_slug} /> becomes the active version of
+			this plan. Attaching by plan ID will use it instead of{" "}
+			<VersionSlug slug={details.previous_active_version_slug} />. Existing
+			customers stay on their current version.
+		</div>
+	);
+}

--- a/vite/src/views/products/plan/versioning/TargetVersionSlugControl.tsx
+++ b/vite/src/views/products/plan/versioning/TargetVersionSlugControl.tsx
@@ -1,0 +1,73 @@
+import { Input, Popover, PopoverContent, PopoverTrigger } from "@autumn/ui";
+import { WarningIcon } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
+import { defaultVersionSlug } from "../components/versionLabel";
+import { mintTargetSlugError } from "./mintTargetSlugs";
+
+/**
+ * Names the row a propagation target mints. Sits in the row's trailing slot so the
+ * chip reads as this target's resulting version, with editing one click away.
+ */
+export function TargetVersionSlugControl({
+	slug,
+	mintVersion,
+	takenSlugs,
+	onChange,
+}: {
+	slug: string;
+	mintVersion: number;
+	takenSlugs: string[];
+	onChange: (slug: string) => void;
+}) {
+	const fallbackSlug = defaultVersionSlug({ version: mintVersion });
+	const error = mintTargetSlugError({ slug, takenSlugs });
+	const trimmed = slug.trim();
+
+	return (
+		<Popover>
+			<PopoverTrigger
+				className={cn(
+					"flex h-6 shrink-0 cursor-pointer items-center gap-1 rounded-lg px-2 font-mono text-xs transition-colors",
+					error
+						? "text-amber-600 hover:bg-amber-500/10 dark:text-amber-500"
+						: "text-tertiary-foreground hover:bg-secondary hover:text-foreground",
+				)}
+			>
+				{error && <WarningIcon size={11} weight="fill" />}
+				{trimmed || fallbackSlug}
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				className="flex w-64 flex-col gap-2 rounded-lg border-none bg-interactive-secondary p-3 shadow-md ring-1 ring-foreground/10"
+				side="right"
+			>
+				<div className="flex flex-col gap-0.5">
+					<span className="font-medium text-foreground text-xs">
+						Version slug
+					</span>
+					<span className="text-tertiary-foreground text-xs">
+						Names this plan's new v{mintVersion}. Blank uses{" "}
+						<span className="font-mono text-foreground">{fallbackSlug}</span>.
+					</span>
+				</div>
+				<Input
+					aria-invalid={!!error}
+					autoFocus
+					className="w-full"
+					onChange={(event) => onChange(event.target.value)}
+					placeholder={fallbackSlug}
+					type="text"
+					value={slug}
+				/>
+				{error && (
+					<p
+						className="text-amber-600 text-xs dark:text-amber-500"
+						role="alert"
+					>
+						{error}
+					</p>
+				)}
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/vite/src/views/products/plan/versioning/VariantTargetsStep.tsx
+++ b/vite/src/views/products/plan/versioning/VariantTargetsStep.tsx
@@ -1,22 +1,28 @@
 import type { Feature } from "@autumn/shared";
 import type { PropagationTarget } from "../catalog/catalogPlanPreview";
+import { effectiveMintSlug, type MintSlugSelection } from "./mintTargetSlugs";
 import { PropagationConflictWarning } from "./PropagationConflictWarning";
 import { PropagationTargetRow } from "./PropagationTargetRow";
+import { TargetVersionSlugControl } from "./TargetVersionSlugControl";
 
 /**
  * Variants follow the base plan's own versioning strategy, so they get a plain
- * follow/don't-follow checkbox with no version scope of their own.
+ * follow/don't-follow checkbox — plus a slug for the row a follow mints.
  */
 export function VariantTargetsStep({
 	features,
 	targets,
 	selectedIds,
+	slugSelection,
 	onToggle,
+	onSlugChange,
 }: {
 	features?: Feature[];
 	targets: PropagationTarget[];
 	selectedIds: string[];
+	slugSelection: MintSlugSelection;
 	onToggle: (id: string) => void;
+	onSlugChange: (args: { planId: string; slug: string }) => void;
 }) {
 	if (targets.length === 0) return null;
 
@@ -26,18 +32,36 @@ export function VariantTargetsStep({
 				hasConflicts={targets.some((target) => target.conflicts.length > 0)}
 			/>
 			<div className="flex flex-col gap-2">
-				{targets.map((target) => (
-					<PropagationTargetRow
-						checked={selectedIds.includes(target.id)}
-						conflicts={target.conflicts}
-						detail={target.detail}
-						diff={target}
-						features={features}
-						key={target.id}
-						name={target.name}
-						onToggle={() => onToggle(target.id)}
-					/>
-				))}
+				{targets.map((target) => {
+					const selected = selectedIds.includes(target.id);
+					return (
+						<PropagationTargetRow
+							checked={selected}
+							conflicts={target.conflicts}
+							detail={target.detail}
+							diff={target}
+							features={features}
+							key={target.id}
+							name={target.name}
+							onToggle={() => onToggle(target.id)}
+							trailing={
+								selected && target.mintsNewVersion ? (
+									<TargetVersionSlugControl
+										mintVersion={target.mintVersion}
+										onChange={(slug) =>
+											onSlugChange({ planId: target.id, slug })
+										}
+										slug={effectiveMintSlug({
+											selection: slugSelection,
+											planId: target.id,
+										})}
+										takenSlugs={target.takenSlugs}
+									/>
+								) : undefined
+							}
+						/>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/vite/src/views/products/plan/versioning/VersionSlugChangeNotice.tsx
+++ b/vite/src/views/products/plan/versioning/VersionSlugChangeNotice.tsx
@@ -1,0 +1,21 @@
+const VersionSlug = ({ slug }: { slug: string }) => (
+	<span className="font-mono font-medium text-foreground">{slug}</span>
+);
+
+export const VersionSlugChangeNotice = ({
+	from,
+	to,
+}: {
+	from?: string;
+	to?: string;
+}) => {
+	if (from === undefined || to === undefined) return null;
+
+	return (
+		<div className="rounded-lg bg-secondary/40 px-3 py-2.5 text-sm text-muted-foreground">
+			You're renaming this version's slug from <VersionSlug slug={from} /> to{" "}
+			<VersionSlug slug={to} />. Calls targeting <VersionSlug slug={from} />{" "}
+			will stop resolving; other versions of this plan are unaffected.
+		</div>
+	);
+};

--- a/vite/src/views/products/plan/versioning/mintTargetSlugs.ts
+++ b/vite/src/views/products/plan/versioning/mintTargetSlugs.ts
@@ -1,0 +1,103 @@
+import type { CatalogPropagateParams } from "@autumn/shared";
+import type { PropagationTarget } from "../catalog/catalogPlanPreview";
+import { mintVersionSlugError } from "../utils/versionSlug";
+
+/**
+ * What every row this save mints gets named. Targets reuse `base` until overridden,
+ * so "same slug as the plan" needs no control of its own.
+ */
+export type MintSlugSelection = {
+	base: string;
+	overrides: Record<string, string>;
+};
+
+export const emptyMintSlugSelection = (): MintSlugSelection => ({
+	base: "",
+	overrides: {},
+});
+
+export const effectiveMintSlug = ({
+	selection,
+	planId,
+}: {
+	selection: MintSlugSelection;
+	planId: string;
+}): string => selection.overrides[planId] ?? selection.base;
+
+export const withMintSlugOverride = ({
+	selection,
+	planId,
+	slug,
+}: {
+	selection: MintSlugSelection;
+	planId: string;
+	slug: string;
+}): MintSlugSelection => ({
+	...selection,
+	overrides: { ...selection.overrides, [planId]: slug },
+});
+
+/**
+ * Preview slugs collapse a null slug to `v{n}`, so a match here can flag a name the
+ * server would allow. Blocking is the kinder read: two rows showing `v2` is worse.
+ */
+export const mintTargetSlugError = ({
+	slug,
+	takenSlugs,
+}: {
+	slug: string;
+	takenSlugs: string[];
+}): string | null => {
+	const formatError = mintVersionSlugError({ slug });
+	if (formatError) return formatError;
+
+	const trimmed = slug.trim();
+	if (trimmed.length === 0) return null;
+	if (!takenSlugs.includes(trimmed)) return null;
+	return `Another version of this plan already uses ${trimmed}.`;
+};
+
+/**
+ * Selected minting targets whose slug the save would reject. Scoped to the selection
+ * so a blocked step always renders the row that blocks it.
+ */
+export const mintTargetSlugConflicts = ({
+	targets,
+	selectedIds,
+	selection,
+}: {
+	targets: PropagationTarget[];
+	selectedIds: string[];
+	selection: MintSlugSelection;
+}): PropagationTarget[] =>
+	targets.filter(
+		(target) =>
+			selectedIds.includes(target.id) &&
+			target.mintsNewVersion &&
+			mintTargetSlugError({
+				slug: effectiveMintSlug({ selection, planId: target.id }),
+				takenSlugs: target.takenSlugs,
+			}) !== null,
+	);
+
+/** Save-only: naming targets in preview would surface collisions before they're editable. */
+export const propagateWithMintSlugs = ({
+	propagate,
+	selection,
+}: {
+	propagate: CatalogPropagateParams | undefined;
+	selection: MintSlugSelection;
+}): CatalogPropagateParams | undefined => {
+	if (!propagate?.variants) return propagate;
+
+	return {
+		...propagate,
+		variants: propagate.variants.map((target) => {
+			const slug = effectiveMintSlug({
+				selection,
+				planId: target.plan_id,
+			}).trim();
+			return slug ? { ...target, new_version_slug: slug } : target;
+		}),
+	};
+};

--- a/vite/src/views/products/plan/versioning/savedVersionPin.ts
+++ b/vite/src/views/products/plan/versioning/savedVersionPin.ts
@@ -1,0 +1,17 @@
+import type { ApiPlanV1 } from "@autumn/shared";
+
+/**
+ * Which `?version` the editor should land on after a save. A minted row is not
+ * active unless it was promoted, so an unpinned URL would resolve to the old row.
+ */
+export const savedVersionPin = ({
+	plans,
+	planId,
+}: {
+	plans: ApiPlanV1[];
+	planId: string;
+}): number | null => {
+	const saved = plans.find((plan) => plan.id === planId);
+	if (!saved || saved.active) return null;
+	return saved.version;
+};

--- a/vite/src/views/products/product/hooks/useProductQuery.tsx
+++ b/vite/src/views/products/product/hooks/useProductQuery.tsx
@@ -87,6 +87,7 @@ export const useProductQuery = () => {
 		await queryClient.invalidateQueries({ queryKey: ["product"] });
 		await Promise.all([
 			queryClient.invalidateQueries({ queryKey: ["product_counts"] }),
+			queryClient.invalidateQueries({ queryKey: ["product_versions"] }),
 			queryClient.invalidateQueries({ queryKey: ["migrations"] }),
 		]);
 	};

--- a/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
+++ b/vite/tests/views/products/plan/catalog/build-update-catalog-plan-params.test.ts
@@ -139,6 +139,87 @@ describe("buildUpdateCatalogPlanParams", () => {
 		expect(params.new_plan_id).toBe("pro_plus");
 	});
 
+	test("renaming the version slug sends new_version_slug", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: { ...editedProduct, version_slug: "beta" },
+			features,
+		});
+		expect(params.version).toBe(3);
+		expect(params.new_version_slug).toBe("beta");
+	});
+
+	test("retyping the implicit v{n} slug is not a rename", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: { ...editedProduct, version_slug: "v3" },
+			features,
+		});
+		expect(params.new_version_slug).toBeUndefined();
+	});
+
+	test("a blank version slug is an unfinished edit, not a rename", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct: { ...baseProduct, version_slug: "beta" },
+			editedProduct: { ...editedProduct, version_slug: "  " },
+			features,
+		});
+		expect(params.new_version_slug).toBeUndefined();
+	});
+
+	test("a mint sends the slug typed for its new row", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct,
+			features,
+			versioning: "new_version",
+			newVersionSlug: { source: "minted_row", slug: "  summer  " },
+		});
+		expect(params.versioning).toBe("new_version");
+		expect(params.new_version_slug).toBe("summer");
+	});
+
+	test("a mint with no typed slug omits new_version_slug so the server stamps v{n}", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct,
+			features,
+			versioning: "new_version",
+			newVersionSlug: { source: "minted_row" },
+		});
+		expect(params.new_version_slug).toBeUndefined();
+	});
+
+	test("a mint with a blank typed slug falls back to a slug edit on the plan", () => {
+		const params = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: { ...editedProduct, version_slug: "beta" },
+			features,
+			versioning: "new_version",
+			newVersionSlug: { source: "minted_row", slug: "" },
+		});
+		expect(params.new_version_slug).toBe("beta");
+	});
+
+	test("all_versions never sends new_version_slug — one slug can't name every row", () => {
+		const renamed = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct: { ...editedProduct, version_slug: "beta" },
+			features,
+			versioning: "all_versions",
+		});
+		expect(renamed.new_version_slug).toBeUndefined();
+
+		const minted = buildUpdateCatalogPlanParams({
+			baseProduct,
+			editedProduct,
+			features,
+			versioning: "all_versions",
+			newVersionSlug: { source: "minted_row", slug: "summer" },
+		});
+		expect(minted.new_version_slug).toBeUndefined();
+	});
+
 	test("new_version and all_versions omit the version pin", () => {
 		const minted = buildUpdateCatalogPlanParams({
 			baseProduct,

--- a/vite/tests/views/products/plan/catalog/catalog-plan-preview.test.ts
+++ b/vite/tests/views/products/plan/catalog/catalog-plan-preview.test.ts
@@ -10,12 +10,15 @@ import {
 	buildSelectedLicenseParentPropagate,
 	catalogPreviewAliasReplacements,
 	catalogPreviewHasPlanIdChange,
+	catalogPreviewHasPromotion,
+	catalogPreviewHasVersionSlugChange,
 	catalogPreviewOpensDialog,
 	catalogPreviewPlanIdChange,
+	catalogPreviewVersionSlugChange,
 	emptyCatalogPlanChangeDiff,
-	isConfirmOnlyPlanChangeDialog,
 	hasCatalogMigrationTargets,
 	isCatalogMetadataOnly,
+	isConfirmOnlyPlanChangeDialog,
 	planChangeToTargetDiff,
 	previewOpensStrategyStep,
 	strategyForCatalogPreview,
@@ -245,6 +248,69 @@ describe("catalog plan preview helpers", () => {
 		).toBe(true);
 	});
 
+	test("a version slug rename opens a confirm-only Review on its own", () => {
+		const renamed = planPreview({
+			version_slug: "v1",
+			new_version_slug: "beta",
+		});
+		expect(catalogPreviewVersionSlugChange({ preview: renamed })).toEqual({
+			from: "v1",
+			to: "beta",
+		});
+		expect(catalogPreviewHasVersionSlugChange({ preview: renamed })).toBe(true);
+		expect(catalogPreviewOpensDialog({ preview: renamed })).toBe(true);
+		expect(
+			isConfirmOnlyPlanChangeDialog({
+				preview: renamed,
+				showVersionStrategy: false,
+				showVariantScope: false,
+				showLicenseParentScope: false,
+			}),
+		).toBe(true);
+
+		const unchanged = planPreview({ version_slug: "v1" });
+		expect(
+			catalogPreviewVersionSlugChange({ preview: unchanged }),
+		).toBeUndefined();
+		expect(catalogPreviewOpensDialog({ preview: unchanged })).toBe(false);
+	});
+
+	test("promotion_details presence opens a confirm-only Review", () => {
+		const promotePreview = planPreview({
+			promotion_details: { previous_active_version_slug: "v1" },
+		});
+		expect(catalogPreviewHasPromotion({ preview: planPreview() })).toBe(false);
+		expect(catalogPreviewHasPromotion({ preview: promotePreview })).toBe(true);
+		expect(catalogPreviewOpensDialog({ preview: promotePreview })).toBe(true);
+		expect(
+			isConfirmOnlyPlanChangeDialog({
+				preview: promotePreview,
+				showVersionStrategy: false,
+				showVariantScope: false,
+				showLicenseParentScope: false,
+			}),
+		).toBe(true);
+		expect(
+			isConfirmOnlyPlanChangeDialog({
+				preview: promotePreview,
+				showVersionStrategy: true,
+				showVariantScope: false,
+				showLicenseParentScope: false,
+			}),
+		).toBe(false);
+		expect(
+			catalogPreviewOpensDialog({
+				preview: planPreview({
+					promotion_details: { previous_active_version_slug: "v1" },
+					plan_change: {
+						item_changes: [],
+						previous_attributes: { name: "Pro" },
+					},
+				}),
+			}),
+		).toBe(true);
+	});
+
 	test("isCatalogMetadataOnly is true when customize and licenses are absent", () => {
 		expect(isCatalogMetadataOnly({ preview: planPreview() })).toBe(true);
 		expect(
@@ -298,6 +364,55 @@ describe("catalog plan preview helpers", () => {
 		).toBe(true);
 	});
 
+	test("a variant with customers mints on the discover preview, which reports resolved: existing", () => {
+		const [withCustomers, withoutCustomers] = toVariantPropagationTargets({
+			variants: [
+				{
+					plan_id: "pro_eu",
+					version: 1,
+					version_slug: "v1",
+					state: { has_customers: true, will_archive: false },
+					// The discover preview sends no propagate, so no mint is resolved yet.
+					versioning: {
+						current_version: 1,
+						new_version: null,
+						resolved: "existing",
+						options: [],
+					},
+					sibling_versions: [
+						{
+							plan_id: "pro_eu",
+							version: 2,
+							version_slug: "add-dashboard",
+							state: { has_customers: false, will_archive: false },
+						},
+					],
+				},
+				{
+					plan_id: "pro_uk",
+					version: 1,
+					version_slug: "v1",
+					state: { has_customers: false, will_archive: false },
+					versioning: {
+						current_version: 1,
+						new_version: null,
+						resolved: "existing",
+						options: [],
+					},
+				},
+			],
+			namesByPlanId: {},
+			baseMintsNewVersion: true,
+		} as Parameters<typeof toVariantPropagationTargets>[0]);
+
+		// Active v1 with customers, max v2 → the mint lands at v3, not active+1.
+		expect(withCustomers.mintsNewVersion).toBe(true);
+		expect(withCustomers.mintVersion).toBe(3);
+		expect(withCustomers.takenSlugs).toEqual(["add-dashboard", "v1"]);
+		// No customers means the base edit lands in place, so there is nothing to name.
+		expect(withoutCustomers.mintsNewVersion).toBe(false);
+	});
+
 	test("maps variants and license parents onto propagate targets", () => {
 		expect(
 			toVariantPropagationTargets({
@@ -305,6 +420,7 @@ describe("catalog plan preview helpers", () => {
 					{
 						plan_id: "pro_eu",
 						version: 1,
+						version_slug: "v1",
 						state: { has_customers: false, will_archive: false },
 						conflicts: [],
 						plan_change: { item_changes: [] },
@@ -318,6 +434,9 @@ describe("catalog plan preview helpers", () => {
 				name: "Pro EU",
 				detail: "pro_eu",
 				conflicts: [],
+				mintsNewVersion: false,
+				mintVersion: 2,
+				takenSlugs: ["v1"],
 				...emptyCatalogPlanChangeDiff(),
 			},
 		]);

--- a/vite/tests/views/products/plan/delete-plan-scope.test.ts
+++ b/vite/tests/views/products/plan/delete-plan-scope.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import {
+	allVersionsScopeLabel,
+	canChooseDeleteScope,
+	canDeleteThisVersion,
+	DELETE_PLAN_SCOPE_LABELS,
+	hasMultiplePlanVersions,
+	shouldRemoveThisVersion,
+} from "@/views/products/plan/components/deletePlanScope";
+
+describe("delete plan scope", () => {
+	test("this version is deletable only when preview says it will not archive", () => {
+		expect(
+			canDeleteThisVersion({
+				hasPreview: true,
+				previewFailed: false,
+				willArchive: false,
+			}),
+		).toBe(true);
+		expect(
+			canDeleteThisVersion({
+				hasPreview: true,
+				previewFailed: false,
+				willArchive: true,
+			}),
+		).toBe(false);
+		expect(
+			canDeleteThisVersion({
+				hasPreview: false,
+				previewFailed: false,
+				willArchive: false,
+			}),
+		).toBe(false);
+		expect(
+			canDeleteThisVersion({
+				hasPreview: true,
+				previewFailed: true,
+				willArchive: false,
+			}),
+		).toBe(false);
+	});
+
+	test("an empty draft still counts as multiple versions when the list row is active v1", () => {
+		expect(
+			hasMultiplePlanVersions({
+				viewedVersion: 2,
+				listedVersion: 1,
+				numVersions: 1,
+			}),
+		).toBe(true);
+		expect(
+			hasMultiplePlanVersions({
+				viewedVersion: 1,
+				listedVersion: 1,
+				numVersions: 1,
+			}),
+		).toBe(false);
+	});
+
+	test("scope choice is offered when this version can be deleted and archive-all differs", () => {
+		expect(
+			canChooseDeleteScope({
+				thisVersionDeletable: true,
+				hasMultipleVersions: false,
+				willArchiveAll: true,
+			}),
+		).toBe(true);
+		expect(
+			canChooseDeleteScope({
+				thisVersionDeletable: true,
+				hasMultipleVersions: true,
+				willArchiveAll: false,
+			}),
+		).toBe(true);
+		expect(
+			canChooseDeleteScope({
+				thisVersionDeletable: false,
+				hasMultipleVersions: true,
+				willArchiveAll: true,
+			}),
+		).toBe(false);
+		expect(
+			canChooseDeleteScope({
+				thisVersionDeletable: true,
+				hasMultipleVersions: false,
+				willArchiveAll: false,
+			}),
+		).toBe(false);
+	});
+
+	test("a deletable version is removed on its own even if the selector is hidden", () => {
+		expect(
+			shouldRemoveThisVersion({
+				thisVersionDeletable: true,
+				scope: "version",
+			}),
+		).toBe(true);
+		expect(
+			shouldRemoveThisVersion({
+				thisVersionDeletable: false,
+				scope: "version",
+			}),
+		).toBe(false);
+		expect(
+			shouldRemoveThisVersion({
+				thisVersionDeletable: true,
+				scope: "all",
+			}),
+		).toBe(false);
+	});
+
+	test("labels distinguish delete this version from archive all", () => {
+		expect(DELETE_PLAN_SCOPE_LABELS.version).toBe("Delete this version");
+		expect(allVersionsScopeLabel({ willArchiveAll: true })).toBe(
+			"Archive all versions",
+		);
+		expect(allVersionsScopeLabel({ willArchiveAll: false })).toBe(
+			"All versions",
+		);
+	});
+});

--- a/vite/tests/views/products/plan/hooks/use-promote-plan-version.test.ts
+++ b/vite/tests/views/products/plan/hooks/use-promote-plan-version.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { buildPromoteCatalogPlanParams } from "@/views/products/plan/hooks/usePromotePlanVersion";
+
+describe("buildPromoteCatalogPlanParams", () => {
+	test("targets the row by version_slug when present", () => {
+		expect(
+			buildPromoteCatalogPlanParams({
+				product: { id: "pro", version: 2, version_slug: "v2" },
+			}),
+		).toEqual({
+			plan_id: "pro",
+			version_slug: "v2",
+			active: true,
+		});
+	});
+
+	test("falls back to version when the slug is missing", () => {
+		expect(
+			buildPromoteCatalogPlanParams({
+				product: { id: "pro", version: 2, version_slug: null },
+			}),
+		).toEqual({
+			plan_id: "pro",
+			version: 2,
+			active: true,
+		});
+	});
+});

--- a/vite/tests/views/products/plan/utils/version-slug.test.ts
+++ b/vite/tests/views/products/plan/utils/version-slug.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+	mintVersionSlugError,
+	versionSlugError,
+	versionSlugRenamed,
+} from "@/views/products/plan/utils/versionSlug";
+
+describe("versionSlugError", () => {
+	test("mirrors the server's nonempty + idRegex contract", () => {
+		expect(versionSlugError({ slug: "beta_2" })).toBeNull();
+		expect(versionSlugError({ slug: "v1" })).toBeNull();
+		expect(versionSlugError({ slug: "" })).toBe("Enter a version slug.");
+		expect(versionSlugError({ slug: "   " })).toBe("Enter a version slug.");
+		expect(versionSlugError({ slug: "beta 2" })).toBe(
+			"Use letters, numbers, dashes or underscores only.",
+		);
+	});
+});
+
+describe("mintVersionSlugError", () => {
+	test("blank is valid — the server stamps v{n}", () => {
+		expect(mintVersionSlugError({ slug: "" })).toBeNull();
+		expect(mintVersionSlugError({ slug: "  " })).toBeNull();
+	});
+
+	test("a typed slug still has to satisfy idRegex", () => {
+		expect(mintVersionSlugError({ slug: "summer_25" })).toBeNull();
+		expect(mintVersionSlugError({ slug: "summer 25" })).toBe(
+			"Use letters, numbers, dashes or underscores only.",
+		);
+	});
+});
+
+describe("versionSlugRenamed", () => {
+	const previous = { version: 3, version_slug: null };
+
+	test("typing over the implicit v{n} label is not a rename", () => {
+		expect(
+			versionSlugRenamed({
+				product: { version: 3, version_slug: "v3" },
+				previous,
+			}),
+		).toBe(false);
+	});
+
+	test("a different slug renames the row", () => {
+		expect(
+			versionSlugRenamed({
+				product: { version: 3, version_slug: "beta" },
+				previous,
+			}),
+		).toBe(true);
+	});
+
+	test("creating a plan has nothing to rename", () => {
+		expect(
+			versionSlugRenamed({ product: { version: 1, version_slug: "beta" } }),
+		).toBe(false);
+	});
+});

--- a/vite/tests/views/products/plan/versioning/mint-target-slugs.test.ts
+++ b/vite/tests/views/products/plan/versioning/mint-target-slugs.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import type { PropagationTarget } from "@/views/products/plan/catalog/catalogPlanPreview";
+import { emptyCatalogPlanChangeDiff } from "@/views/products/plan/catalog/catalogPlanPreview";
+import {
+	effectiveMintSlug,
+	mintTargetSlugConflicts,
+	mintTargetSlugError,
+	propagateWithMintSlugs,
+	withMintSlugOverride,
+} from "@/views/products/plan/versioning/mintTargetSlugs";
+
+const target = (
+	overrides: Partial<PropagationTarget> & { id: string },
+): PropagationTarget => ({
+	name: overrides.id,
+	detail: overrides.id,
+	conflicts: [],
+	mintsNewVersion: true,
+	mintVersion: 3,
+	takenSlugs: [],
+	...emptyCatalogPlanChangeDiff(),
+	...overrides,
+});
+
+describe("mint target slugs", () => {
+	test("targets reuse the base slug until overridden", () => {
+		const selection = { base: "add-dashboard", overrides: {} };
+		expect(effectiveMintSlug({ selection, planId: "pro_eu" })).toBe(
+			"add-dashboard",
+		);
+
+		const overridden = withMintSlugOverride({
+			selection,
+			planId: "pro_eu",
+			slug: "add-dashboard-eu",
+		});
+		expect(effectiveMintSlug({ selection: overridden, planId: "pro_eu" })).toBe(
+			"add-dashboard-eu",
+		);
+		expect(effectiveMintSlug({ selection: overridden, planId: "pro_uk" })).toBe(
+			"add-dashboard",
+		);
+	});
+
+	test("an override to blank falls back to the server default, not the base", () => {
+		const selection = withMintSlugOverride({
+			selection: { base: "add-dashboard", overrides: {} },
+			planId: "pro_eu",
+			slug: "",
+		});
+		expect(effectiveMintSlug({ selection, planId: "pro_eu" })).toBe("");
+	});
+
+	test("flags a slug another version of that plan already holds", () => {
+		expect(
+			mintTargetSlugError({ slug: "add-dashboard", takenSlugs: ["v1", "v2"] }),
+		).toBeNull();
+		expect(
+			mintTargetSlugError({
+				slug: "add-dashboard",
+				takenSlugs: ["v1", "add-dashboard"],
+			}),
+		).toBe("Another version of this plan already uses add-dashboard.");
+		expect(mintTargetSlugError({ slug: "", takenSlugs: ["v1"] })).toBeNull();
+		expect(
+			mintTargetSlugError({ slug: "not a slug", takenSlugs: [] }),
+		).not.toBeNull();
+	});
+
+	test("only selected minting targets can conflict", () => {
+		const targets = [
+			target({ id: "pro_eu", takenSlugs: ["v1", "add-dashboard"] }),
+			target({ id: "pro_uk", takenSlugs: ["v1"] }),
+			target({
+				id: "legacy",
+				mintsNewVersion: false,
+				takenSlugs: ["add-dashboard"],
+			}),
+		];
+		const selectedIds = ["pro_eu", "pro_uk", "legacy"];
+		const selection = { base: "add-dashboard", overrides: {} };
+
+		expect(
+			mintTargetSlugConflicts({ targets, selectedIds, selection }).map(
+				(entry) => entry.id,
+			),
+		).toEqual(["pro_eu"]);
+
+		// Unselected targets are never propagated to, so they cannot block the save.
+		expect(
+			mintTargetSlugConflicts({
+				targets,
+				selectedIds: ["pro_uk"],
+				selection,
+			}),
+		).toEqual([]);
+
+		expect(
+			mintTargetSlugConflicts({
+				targets,
+				selectedIds,
+				selection: {
+					base: "add-dashboard",
+					overrides: { pro_eu: "add-dashboard-eu" },
+				},
+			}),
+		).toEqual([]);
+	});
+
+	test("stamps the effective slug onto every variant target, trimmed", () => {
+		expect(
+			propagateWithMintSlugs({
+				propagate: {
+					variants: [{ plan_id: "pro_eu" }, { plan_id: "pro_uk" }],
+					license_parents: [{ plan_id: "team", version: 2 }],
+				},
+				selection: {
+					base: " add-dashboard ",
+					overrides: { pro_uk: "add-dashboard-uk" },
+				},
+			}),
+		).toEqual({
+			variants: [
+				{ plan_id: "pro_eu", new_version_slug: "add-dashboard" },
+				{ plan_id: "pro_uk", new_version_slug: "add-dashboard-uk" },
+			],
+			license_parents: [{ plan_id: "team", version: 2 }],
+		});
+	});
+
+	test("a blank selection leaves targets unnamed so the server stamps v{n}", () => {
+		expect(
+			propagateWithMintSlugs({
+				propagate: { variants: [{ plan_id: "pro_eu" }] },
+				selection: { base: "", overrides: {} },
+			}),
+		).toEqual({ variants: [{ plan_id: "pro_eu" }] });
+		expect(
+			propagateWithMintSlugs({
+				propagate: undefined,
+				selection: { base: "add-dashboard", overrides: {} },
+			}),
+		).toBeUndefined();
+	});
+});


### PR DESCRIPTION
The plan page can now move between versions and name them. A fixed-width
version select lists every version with its slug and marks the active one,
"Promote to active" takes the pointer without editing content, and the
version slug is editable under More settings.

The plan change dialog asks for the new version's slug on the Versions
step, then lets each selected variant that will mint override it from a
chip on its row. Sibling slugs come back in the preview, so a collision
shows up before saving rather than as a server error, and Continue stays
blocked while one is unresolved. Saving pins the newly minted version so
the page lands on the row that was just created.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface plan versions, promotion, and version slugs on the plan page to make version navigation explicit and prevent slug conflicts before saving. Previously you couldn’t rename a version slug, promote without editing, or name minted rows; now you can do all three with in-dialog validation and previews.

- New version selector: loads all versions on demand (`useProductVersionsQuery`), shows an active marker and customer counts, supports “Migrate customers,” and the header shows a slug badge.
- Promote to active: a new button previews promotion and opens a confirm-only dialog; promotion targets a row by `version_slug` when present; on success clears any `?version` pin and invalidates `product`, `products`, and `product_versions` queries.
- Version slug editing: existing versions get a “Version slug” field (validated against `idRegex`). `buildUpdateCatalogPlanParams` now sets `new_version_slug` for slug renames or for minted rows; metadata-only slug renames open a confirm-only Review.
- Minting slugs: in “Versions,” collect an optional base slug; in “Variants,” minting targets get an inline slug chip with per-target overrides and sibling-slug conflict warnings. Continue is blocked until format/collision issues are resolved. `propagateWithMintSlugs` stamps `new_version_slug` per variant; after save, the editor pins to the newly minted version when not active.
- Delete plan scope: can delete just this version when preview confirms it won’t archive; scope values now “version” | “all,” with clearer labels and warnings. Both “version” and “all” previews are fetched to decide scope availability and copy.
- Shared plumbing: `SelectItem` supports `indicator={false}` for custom-selected rows; the default product now has `version_slug: "v1"` and `active: true`; invalidations include `product_versions`.

Migration/rollout
- Update any call sites expecting `DeletePlanScope`: values are now “version” | “all” and exported from `deletePlanScope.ts`.
- Backend must already accept `new_version_slug` on plan updates (including per-variant in propagate). No data migrations required.

<sup>Written for commit f599765ec4cf74a1fc54e6006309c9dfc1c3c8f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The dashboard now exposes plan-version navigation, promotion, slug editing, per-variant mint naming, and version-aware deletion.
- **[Improvements]** Adds a version selector, active-version promotion, slug badges, and editable version slugs.
- **[API changes] [Improvements]** Sends `new_version_slug` for renamed or newly minted base and variant rows and refreshes version queries after writes.
- **[Improvements]** Adds version-scoped deletion and pins the editor to a newly created version after saving.
- **[Bug fixes]** Adds pre-save slug collision handling for minted variants, although the equivalent base-plan collision remains unhandled.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until duplicate base-version slugs are caught before Apply rather than failing at the server after the review flow.

Variant slugs are checked against existing sibling rows, but the base slug receives only format validation and is absent from preview, allowing a duplicate value to reach the save request and be rejected.

**Files Needing Attention:** vite/src/views/products/plan/versioning/PlanChangeDialog.tsx, vite/src/views/products/plan/catalog/usePlanChangeCatalogPreview.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/versioning/PlanChangeDialog.tsx | Coordinates the expanded versioning workflow, but fails to check the base plan's minted slug against existing sibling slugs. |
| vite/src/views/products/plan/catalog/usePlanChangeCatalogPreview.ts | Builds discovery and scoped previews, then adds selected mint slugs only to the final save parameters. |
| vite/src/views/products/plan/catalog/buildUpdateCatalogPlanParams.ts | Adds correctly scoped `new_version_slug` construction for row renames and newly minted versions. |
| vite/src/views/products/plan/catalog/catalogPlanPreview.ts | Extends preview interpretation with promotions, slug changes, mint detection, sibling slugs, and target-version calculations. |
| vite/src/views/products/plan/components/useDeletePlanDialog.ts | Keeps version/all removal preview parameters aligned with the eventual delete request. |
| vite/src/views/products/plan/hooks/usePromotePlanVersion.ts | Previews and applies the same active-version promotion request, then reloads the active row. |
| vite/src/hooks/queries/useProductVersionsQuery.tsx | Adds an on-demand query for all rows belonging to one plan identity. |
| packages/ui/src/components/ui/select.tsx | Adds an option to suppress the standard selected-item indicator when a custom row already communicates selection. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Edit plan] --> B[Preview content and version scope]
  B --> C{Version action}
  C -->|Existing| D[Update selected version]
  C -->|New version| E[Choose base and variant slugs]
  C -->|All versions| F[Update every version]
  E --> G[Apply catalog update]
  G --> H[Pin newly minted version]
  D --> I[Refresh plan queries]
  F --> I
  H --> I
  J[Historical version] --> K[Promote to active]
  K --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/products/plan/versioning/PlanChangeDialog.tsx:398-405
**Base slug collisions bypass validation**

When a user gives a new base-plan version the same slug as an existing version, `baseSlugInvalid` checks only the slug format while collision validation covers only variants. The dialog therefore allows the user to continue, but Apply sends the duplicate slug and the server rejects the save.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(dashboard): surface plan versions, ..."](https://github.com/useautumn/autumn/commit/f599765ec4cf74a1fc54e6006309c9dfc1c3c8f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56243902)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Operational web applications and UI primitives](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/operational-web-applications.md)

<!-- /greptile_comment -->