### PR TITLE
Add invoice credit attribution lifecycle

### DIFF
--- a/scripts/dw/helpers/migration.ts
+++ b/scripts/dw/helpers/migration.ts
@@ -43,8 +43,9 @@ export function loadDbFunctions(branchName: string, databaseUrl: string): void {
 		"sql",
 	);
 	const sqlFiles = [
-		"deductFromRollovers.sql",
 		"deductFromMainBalance.sql",
+		"creditRateUtils.sql",
+		"deductFromRollovers.sql",
 		"unwindFromLockReceipt.sql",
 		"getTotalBalance.sql",
 		"deductFromAdditionalBalance.sql",

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/contextUtilsV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/contextUtilsV2.lua
@@ -163,7 +163,7 @@ end
 
 local function append_mutation_log(params)
   local context = params.context
-  table.insert(context.mutation_logs, {
+  local mutation_log = {
     target_type = params.target_type,
     customer_entitlement_id = params.customer_entitlement_id or cjson.null,
     rollover_id = params.rollover_id or cjson.null,
@@ -173,7 +173,13 @@ local function append_mutation_log(params)
     adjustment_delta = params.adjustment_delta or 0,
     usage_delta = params.usage_delta or 0,
     value_delta = params.value_delta or 0,
-  })
+  }
+
+  if not is_nil(params.usage_attribution_delta) then
+    mutation_log.usage_attribution_delta = params.usage_attribution_delta
+  end
+
+  table.insert(context.mutation_logs, mutation_log)
 end
 
 local function update_in_memory_customer_entitlement_mutation(params)
@@ -249,7 +255,10 @@ local function queue_customer_entitlement_mutation(params)
     adjustment_delta = params.alter_granted_balance and balance_delta or 0
   end
 
-  if balance_delta == 0 and adjustment_delta == 0 then
+  if balance_delta == 0
+      and adjustment_delta == 0
+      and is_nil(params.usage_attribution_delta)
+  then
     return
   end
 
@@ -269,6 +278,7 @@ local function queue_customer_entitlement_mutation(params)
     adjustment_delta = adjustment_delta,
     usage_delta = 0,
     value_delta = params.value_delta or 0,
+    usage_attribution_delta = params.usage_attribution_delta,
   })
 end
 
@@ -278,7 +288,10 @@ local function queue_rollover_mutation(params)
   local usage_delta = params.usage_delta or 0
   local rollover_id = params.rollover_id
 
-  if balance_delta == 0 and usage_delta == 0 then
+  if balance_delta == 0
+      and usage_delta == 0
+      and is_nil(params.usage_attribution_delta)
+  then
     return
   end
 
@@ -300,6 +313,7 @@ local function queue_rollover_mutation(params)
     adjustment_delta = 0,
     usage_delta = usage_delta,
     value_delta = params.value_delta or 0,
+    usage_attribution_delta = params.usage_attribution_delta,
   })
 end
 
@@ -314,6 +328,7 @@ local function queue_rollover_update(params)
     balance_delta = -deduct_amount,
     usage_delta = deduct_amount,
     value_delta = params.value_delta or 0,
+    usage_attribution_delta = params.usage_attribution_delta,
   })
 end
 

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/creditRateUtils.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/creditRateUtils.lua
@@ -3,6 +3,14 @@
 
 local CREDIT_RATE_EPSILON = 1e-10
 
+local function build_credit_rate_attribution_delta(params)
+  return {
+    units = params.units,
+    credits = params.credits,
+    rate_card = params.rate_card,
+  }
+end
+
 local function credit_rate_cost_at_usage(rate_card, usage)
   local bounded_usage = math.max(0, safe_number(usage))
   local feature_amount = safe_number(rate_card.feature_amount)

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/deductFromRolloversV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/deductFromRolloversV2.lua
@@ -16,6 +16,127 @@ local function calculate_rollover_change(balance, amount)
   return math.min(balance, amount)
 end
 
+-- Rate-card rollovers resolve units against the owner's current-cycle tier
+-- position; ordinary rollovers retain their fixed credit costs.
+local function calculate_rollover_rate_change(params)
+  local rollover_obj = params.rollover_obj
+  local rate_card = rollover_obj.rate_card
+  local requested_units = safe_number(params.requested_units)
+  local available_credits = math.max(0, safe_number(params.available_credits))
+
+  if is_nil(rate_card) then
+    local credit_cost = is_nil(rollover_obj.credit_cost)
+        and 1
+      or safe_number(rollover_obj.credit_cost)
+    if credit_cost == 0 then
+      return {
+        units = requested_units,
+        credits = 0,
+        rate_card = nil,
+      }
+    end
+
+    local credits = calculate_rollover_change(
+      available_credits,
+      requested_units * credit_cost
+    )
+    return {
+      units = credits / credit_cost,
+      credits = credits,
+      rate_card = nil,
+    }
+  end
+
+  local customer_entitlement_id = params.customer_entitlement_id
+  if is_nil(customer_entitlement_id)
+      or not params.context.customer_entitlements[customer_entitlement_id]
+  then
+    error('ROLLOVER_ATTRIBUTION_OWNER_MISSING')
+  end
+  local current_units = get_credit_rate_current_units(
+    params.context,
+    customer_entitlement_id,
+    rate_card
+  )
+  local requested_credits = math.max(
+    0,
+    credit_rate_cost_for_units(rate_card, current_units, requested_units)
+  )
+  local allowed_credits = math.min(available_credits, requested_credits)
+  local funded_units = credit_rate_units_for_credit_change({
+    rate_card = rate_card,
+    current_units = current_units,
+    requested_units = requested_units,
+    allowed_credit_change = allowed_credits,
+  })
+  local funded_credits = credit_rate_cost_for_units(
+    rate_card,
+    current_units,
+    funded_units
+  )
+
+  return {
+    units = funded_units,
+    credits = funded_credits,
+    rate_card = rate_card,
+  }
+end
+
+local function apply_rollover_rate_change(params)
+  local change = params.change
+  local rollover_obj = params.rollover_obj
+  local credit_cost = is_nil(rollover_obj.credit_cost)
+      and 1
+    or safe_number(rollover_obj.credit_cost)
+
+  if math.abs(change.units) <= CREDIT_RATE_EPSILON then
+    return 0
+  end
+
+  if not is_nil(change.rate_card) then
+    credit_cost = math.abs(change.units) > CREDIT_RATE_EPSILON
+        and change.credits / change.units
+      or 0
+  end
+
+  local usage_attribution_delta = nil
+  if not is_nil(change.rate_card) then
+    usage_attribution_delta = build_credit_rate_attribution_delta({
+      rate_card = change.rate_card,
+      units = change.units,
+      credits = change.credits,
+    })
+  end
+
+  queue_rollover_update({
+    context = params.context,
+    deduct_amount = change.credits,
+    rollover_id = rollover_obj.id,
+    entity_id = params.entity_id,
+    credit_cost = credit_cost,
+    value_delta = change.units,
+    usage_attribution_delta = usage_attribution_delta,
+  })
+
+  update_in_memory_rollover({
+    target = params.target,
+    entity_id = params.entity_id,
+    deduct_amount = change.credits,
+  })
+
+  if not is_nil(change.rate_card) then
+    apply_credit_rate_attribution_change({
+      context = params.context,
+      customer_entitlement_id = params.customer_entitlement_id,
+      rate_card = change.rate_card,
+      units = change.units,
+      credits = change.credits,
+    })
+  end
+
+  return change.units
+end
+
 --[[
   deduct_from_rollovers(params)
 
@@ -73,11 +194,10 @@ local function deduct_from_rollovers(params)
     if remaining <= 0 then break end
 
     local rollover_id = rollover_obj.id
-    local credit_cost = rollover_obj.credit_cost
-    if is_nil(credit_cost) then
-      credit_cost = 1
-    end
-    if credit_cost == 0 then
+    local credit_cost = is_nil(rollover_obj.credit_cost)
+        and 1
+      or safe_number(rollover_obj.credit_cost)
+    if is_nil(rollover_obj.rate_card) and credit_cost == 0 then
       -- Zero credit cost (e.g. -100% markup AI model): usage is free, leave rollovers untouched.
       logger.log("  Rollover %s credit_cost=0 - free deduction, skipping", rollover_id)
       remaining = 0
@@ -88,9 +208,6 @@ local function deduct_from_rollovers(params)
     if not rollover_data then
       logger.log("  Rollover %s not found in context", rollover_id)
     else
-      -- Convert remaining (feature units) to credits for this rollover
-      local remaining_credits = remaining * credit_cost
-
       -- ========================================================================
       -- CASE 1: Entity-scoped with specific target entity
       -- ========================================================================
@@ -99,29 +216,26 @@ local function deduct_from_rollovers(params)
         local entity_obj = entities[target_entity_id]
         local balance = entity_obj and safe_number(entity_obj.balance) or 0
 
-        local to_change = calculate_rollover_change(balance, remaining_credits)
+        local change = calculate_rollover_rate_change({
+          context = context,
+          rollover_obj = rollover_obj,
+          customer_entitlement_id = rollover_data.cus_ent_id,
+          requested_units = remaining,
+          available_credits = balance,
+        })
 
         logger.log("  Rollover %s entity %s: balance=%s, credit_cost=%s, to_change=%s",
-          rollover_id, target_entity_id, balance, credit_cost, to_change)
+          rollover_id, target_entity_id, balance, credit_cost, change.credits)
 
-        if to_change > 0 then
-          queue_rollover_update({
+        if math.abs(change.units) > CREDIT_RATE_EPSILON then
+          local features = apply_rollover_rate_change({
             context = context,
-            deduct_amount = to_change,
-            rollover_id = rollover_id,
-            entity_id = target_entity_id,
-            credit_cost = credit_cost,
-            value_delta = to_change / credit_cost,
-          })
-
-          update_in_memory_rollover({
+            rollover_obj = rollover_obj,
+            customer_entitlement_id = rollover_data.cus_ent_id,
             target = entities,
             entity_id = target_entity_id,
-            deduct_amount = to_change,
+            change = change,
           })
-
-          -- Convert credits deducted back to features
-          local features = to_change / credit_cost
           deducted = deducted + features
           remaining = remaining - features
         end
@@ -136,34 +250,29 @@ local function deduct_from_rollovers(params)
         for _, entity_key in ipairs(entity_keys) do
           if remaining <= 0 then break end
 
-          -- Recalculate remaining_credits (remaining may have changed)
-          remaining_credits = remaining * credit_cost
-
           local entity_obj = entities[entity_key]
           local balance = entity_obj and safe_number(entity_obj.balance) or 0
 
-          local to_change = calculate_rollover_change(balance, remaining_credits)
+          local change = calculate_rollover_rate_change({
+            context = context,
+            rollover_obj = rollover_obj,
+            customer_entitlement_id = rollover_data.cus_ent_id,
+            requested_units = remaining,
+            available_credits = balance,
+          })
 
           logger.log("  Rollover %s entity %s: balance=%s, credit_cost=%s, to_change=%s",
-            rollover_id, entity_key, balance, credit_cost, to_change)
+            rollover_id, entity_key, balance, credit_cost, change.credits)
 
-          if to_change > 0 then
-            queue_rollover_update({
+          if math.abs(change.units) > CREDIT_RATE_EPSILON then
+            local features = apply_rollover_rate_change({
               context = context,
-              deduct_amount = to_change,
-              rollover_id = rollover_id,
-              entity_id = entity_key,
-              credit_cost = credit_cost,
-              value_delta = to_change / credit_cost,
-            })
-
-            update_in_memory_rollover({
+              rollover_obj = rollover_obj,
+              customer_entitlement_id = rollover_data.cus_ent_id,
               target = entities,
               entity_id = entity_key,
-              deduct_amount = to_change,
+              change = change,
             })
-
-            local features = to_change / credit_cost
             deducted = deducted + features
             remaining = remaining - features
           end
@@ -175,28 +284,26 @@ local function deduct_from_rollovers(params)
       else
         local balance = safe_number(rollover_data.balance)
 
-        local to_change = calculate_rollover_change(balance, remaining_credits)
+        local change = calculate_rollover_rate_change({
+          context = context,
+          rollover_obj = rollover_obj,
+          customer_entitlement_id = rollover_data.cus_ent_id,
+          requested_units = remaining,
+          available_credits = balance,
+        })
 
         logger.log("  Rollover %s top-level: balance=%s, credit_cost=%s, to_change=%s",
-          rollover_id, balance, credit_cost, to_change)
+          rollover_id, balance, credit_cost, change.credits)
 
-        if to_change > 0 then
-          queue_rollover_update({
+        if math.abs(change.units) > CREDIT_RATE_EPSILON then
+          local features = apply_rollover_rate_change({
             context = context,
-            deduct_amount = to_change,
-            rollover_id = rollover_id,
-            entity_id = nil,
-            credit_cost = credit_cost,
-            value_delta = to_change / credit_cost,
-          })
-
-          update_in_memory_rollover({
+            rollover_obj = rollover_obj,
+            customer_entitlement_id = rollover_data.cus_ent_id,
             target = rollover_data,
             entity_id = nil,
-            deduct_amount = to_change,
+            change = change,
           })
-
-          local features = to_change / credit_cost
           deducted = deducted + features
           remaining = remaining - features
         end

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/lock/unwindLockV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/lock/unwindLockV2.lua
@@ -39,6 +39,58 @@ local function calculate_unwind_iteration_value(params)
   return math.min(item_value_magnitude, remaining_unwind_value)
 end
 
+-- Rate-card releases reprice the source's current marginal tail so attribution
+-- credits remain equal to its cumulative cost.
+local function calculate_rate_card_unwind_change(params)
+  local item = params.item or {}
+  local attribution_delta = item.usage_attribution_delta
+  if is_nil(attribution_delta) or is_nil(attribution_delta.rate_card) then
+    return nil
+  end
+
+  if not params.context.customer_entitlements[params.customer_entitlement_id] then
+    return nil
+  end
+
+  local original_units = safe_number(attribution_delta.units)
+  local original_magnitude = math.abs(original_units)
+  if original_magnitude <= CREDIT_RATE_EPSILON then
+    return nil
+  end
+
+  local unwind_magnitude = math.min(
+    original_magnitude,
+    safe_number(params.unwind_iteration_value)
+  )
+  local direction = original_units >= 0 and 1 or -1
+  local current_units = math.max(
+    0,
+    get_credit_rate_current_units(
+      params.context,
+      params.customer_entitlement_id,
+      attribution_delta.rate_card
+    )
+  )
+  local attribution_unwind_magnitude = direction > 0
+      and math.min(unwind_magnitude, current_units)
+    or unwind_magnitude
+  local inverse_units = -direction * attribution_unwind_magnitude
+  local restored_units = math.max(0, current_units + inverse_units)
+  local inverse_credits = credit_rate_cost_at_usage(
+    attribution_delta.rate_card,
+    restored_units
+  ) - credit_rate_cost_at_usage(
+    attribution_delta.rate_card,
+    current_units
+  )
+
+  return build_credit_rate_attribution_delta({
+    rate_card = attribution_delta.rate_card,
+    units = inverse_units,
+    credits = inverse_credits,
+  })
+end
+
 -- ============================================================================
 -- STEP 1: Calculate the current signed lock value from receipt items
 -- ============================================================================
@@ -144,7 +196,18 @@ local function unwind_lock_item_iteration(params)
     item = item,
   })
 
-  -- Calculate the amount of credits to unwind
+  local customer_entitlement_id = normalize_lock_item_id(
+    item.customer_entitlement_id
+  )
+  local rate_card_unwind_change = calculate_rate_card_unwind_change({
+    context = context,
+    customer_entitlement_id = customer_entitlement_id,
+    item = item,
+    unwind_iteration_value = unwind_iteration_value,
+  })
+
+  -- Legacy receipts use their fixed credit_cost. New rate-card receipts use
+  -- exact marginal credits from the stored source-unit segment.
   local credits_to_unwind =
     unwind_iteration_value * safe_number(item.credit_cost or 1)
   local inverse_balance_delta = -signs.balance_sign * credits_to_unwind
@@ -155,11 +218,20 @@ local function unwind_lock_item_iteration(params)
       and (-signs.usage_sign * credits_to_unwind)
     or 0 --[[ default to 0 if usage_delta is not set ]]
   local inverse_value_delta = -signs.value_sign * unwind_iteration_value
+  local unwind_credit_cost = safe_number(item.credit_cost or 1)
+  if not is_nil(rate_card_unwind_change) then
+    inverse_balance_delta = -rate_card_unwind_change.credits
+    inverse_usage_delta = safe_number(item.usage_delta) ~= 0
+        and rate_card_unwind_change.credits
+      or 0
+    inverse_value_delta = rate_card_unwind_change.units
+    unwind_credit_cost = math.abs(rate_card_unwind_change.units) > CREDIT_RATE_EPSILON
+        and rate_card_unwind_change.credits / rate_card_unwind_change.units
+      or 0
+  end
   local entity_id = normalize_lock_item_id(item.entity_id)
 
   if item.target_type == 'customer_entitlement' then
-    local customer_entitlement_id =
-      normalize_lock_item_id(item.customer_entitlement_id)
     local ent_data = context.customer_entitlements[customer_entitlement_id]
     if not ent_data then
       -- Entitlement no longer exists (e.g. product upgraded mid-flight).
@@ -177,10 +249,11 @@ local function unwind_lock_item_iteration(params)
       context = context,
       customer_entitlement_id = customer_entitlement_id,
       entity_id = entity_id,
-      credit_cost = safe_number(item.credit_cost or 1),
+      credit_cost = unwind_credit_cost,
       balance_delta = inverse_balance_delta,
       adjustment_delta = inverse_adjustment_delta,
       value_delta = inverse_value_delta,
+      usage_attribution_delta = rate_card_unwind_change,
     })
 
     update_in_memory_customer_entitlement_mutation({
@@ -189,6 +262,16 @@ local function unwind_lock_item_iteration(params)
       balance_delta = inverse_balance_delta,
       adjustment_delta = inverse_adjustment_delta,
     })
+
+    if not is_nil(rate_card_unwind_change) then
+      apply_credit_rate_attribution_change({
+        context = context,
+        customer_entitlement_id = customer_entitlement_id,
+        rate_card = rate_card_unwind_change.rate_card,
+        units = rate_card_unwind_change.units,
+        credits = rate_card_unwind_change.credits,
+      })
+    end
 
     return {
       applied = true,
@@ -212,14 +295,27 @@ local function unwind_lock_item_iteration(params)
       }
     end
 
+    if not is_nil(item.usage_attribution_delta)
+        and not is_nil(item.usage_attribution_delta.rate_card)
+        and not context.customer_entitlements[customer_entitlement_id]
+    then
+      return {
+        applied = false,
+        unwind_iteration_value = 0,
+        remaining_unwind_value = remaining_unwind_value,
+        error = 'LOCK_ATTRIBUTION_OWNER_MISSING',
+      }
+    end
+
     queue_rollover_mutation({
       context = context,
       rollover_id = rollover_id,
       entity_id = entity_id,
-      credit_cost = safe_number(item.credit_cost or 1),
+      credit_cost = unwind_credit_cost,
       balance_delta = inverse_balance_delta,
       usage_delta = inverse_usage_delta,
       value_delta = inverse_value_delta,
+      usage_attribution_delta = rate_card_unwind_change,
     })
 
     update_in_memory_rollover_mutation({
@@ -228,6 +324,16 @@ local function unwind_lock_item_iteration(params)
       balance_delta = inverse_balance_delta,
       usage_delta = inverse_usage_delta,
     })
+
+    if not is_nil(rate_card_unwind_change) then
+      apply_credit_rate_attribution_change({
+        context = context,
+        customer_entitlement_id = customer_entitlement_id,
+        rate_card = rate_card_unwind_change.rate_card,
+        units = rate_card_unwind_change.units,
+        credits = rate_card_unwind_change.credits,
+      })
+    end
 
     return {
       applied = true,

--- a/server/src/_luaScriptsV2/fullSubjectDeduction/runDeductionOnContextV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/runDeductionOnContextV2.lua
@@ -190,17 +190,36 @@ local function process_deduction_pass(params)
               adjustment_delta = 0,
               usage_delta = 0,
               value_delta = deducted_units,
+              usage_attribution_delta = build_credit_rate_attribution_delta({
+                rate_card = rate_card,
+                units = deducted_units,
+                credits = deducted,
+              }),
             })
           else
+            local log_units_before = current_rate_units
+            local remaining_log_units = deducted_units
             for log_index = mutation_log_start + 1, #context.mutation_logs do
               local mutation_log = context.mutation_logs[log_index]
               if mutation_log.customer_entitlement_id == ent_id then
                 local log_credit_change = -safe_number(mutation_log.balance_delta)
-                local log_units = deducted_units * log_credit_change / deducted
+                local log_units = credit_rate_units_for_credit_change({
+                  rate_card = rate_card,
+                  current_units = log_units_before,
+                  requested_units = remaining_log_units,
+                  allowed_credit_change = log_credit_change,
+                })
                 mutation_log.value_delta = log_units
                 mutation_log.credit_cost = math.abs(log_units) > CREDIT_RATE_EPSILON
                     and log_credit_change / log_units
                   or 0
+                mutation_log.usage_attribution_delta = build_credit_rate_attribution_delta({
+                  rate_card = rate_card,
+                  units = log_units,
+                  credits = log_credit_change,
+                })
+                log_units_before = log_units_before + log_units
+                remaining_log_units = remaining_log_units - log_units
               end
             end
           end
@@ -563,6 +582,27 @@ local function run_deduction_on_context(params)
       update.adjustment = ent_data.adjustment or 0
       update.additional_balance = 0
       update.usage_attribution = ent_data.subject_balance.usage_attribution or {}
+    end
+  end
+
+  -- Rollover-only rate changes need a zero-deduction entitlement update so
+  -- TypeScript receives the changed attribution.
+  for _, ent_id in ipairs(context.pending_writes or {}) do
+    if is_nil(updates[ent_id]) then
+      local ent_data = context.customer_entitlements[ent_id]
+      if ent_data then
+        updates[ent_id] = {
+          balance = ent_data.has_entity_scope and 0 or ent_data.balance,
+          additional_balance = safe_number(
+            ent_data.subject_balance.additional_balance
+          ),
+          adjustment = ent_data.adjustment or 0,
+          entities = ent_data.entities or {},
+          usage_attribution = ent_data.subject_balance.usage_attribution or {},
+          deducted = 0,
+          additional_deducted = 0,
+        }
+      end
     end
   end
 

--- a/server/src/db/initializeDatabaseFunctions.ts
+++ b/server/src/db/initializeDatabaseFunctions.ts
@@ -21,9 +21,9 @@ export const initializeDatabaseFunctions = async () => {
 		// 2. Main functions (depend on helpers)
 		const sqlFiles = [
 			// Helper functions
-			"deductFromRollovers.sql",
 			"deductFromMainBalance.sql",
 			"creditRateUtils.sql",
+			"deductFromRollovers.sql",
 			"unwindFromLockReceipt.sql",
 			"getTotalBalance.sql",
 			"deductFromAdditionalBalance.sql",

--- a/server/src/internal/balances/batchReset/execute/executeResetMutations.ts
+++ b/server/src/internal/balances/batchReset/execute/executeResetMutations.ts
@@ -41,6 +41,10 @@ const updateCustomerEntitlements = async ({
 			),
 			adjustment = reset_update.adjustment,
 			entities = COALESCE(reset_update.entities, customer_entitlement.entities),
+			usage_attribution = COALESCE(
+				NULLIF(reset_update.usage_attribution, 'null'::jsonb),
+				'{}'::jsonb
+			),
 			next_reset_at = reset_update.next_reset_at,
 			cache_version = COALESCE(customer_entitlement.cache_version, 0) + 1
 		FROM jsonb_to_recordset(${JSON.stringify(updates)}::jsonb) AS reset_update(
@@ -50,6 +54,7 @@ const updateCustomerEntitlements = async ({
 			additional_balance numeric,
 			adjustment numeric,
 			entities jsonb,
+			usage_attribution jsonb,
 			next_reset_at numeric
 		)
 		WHERE customer_entitlement.id = reset_update.id

--- a/server/src/internal/balances/utils/deduction/computeCreditCosts.ts
+++ b/server/src/internal/balances/utils/deduction/computeCreditCosts.ts
@@ -47,32 +47,22 @@ export const computeCreditCosts = ({
 			continue;
 		}
 
+		let rateCard: CreditRateCard | undefined;
 		try {
-			const rateCard = !deduction.tokens
+			rateCard = !deduction.tokens
 				? getCreditRateCard({
 						sourceFeature: deduction.feature,
 						creditSystem: ce.entitlement.feature,
 					})
 				: undefined;
 			if (
-				rateCard?.tier_behavior === "graduated" &&
+				rateCard &&
 				(ce.unlimited ||
 					ce.entitlement.allowance_type === AllowanceType.Unlimited)
 			) {
 				throw new RecaseError({
 					message:
-						"Graduated credit rate cards with unlimited credit balances are not supported yet",
-					code: ErrCode.InvalidRequest,
-					statusCode: 400,
-				});
-			}
-			if (
-				rateCard?.tier_behavior === "graduated" &&
-				(ce.rollovers?.length ?? 0) > 0
-			) {
-				throw new RecaseError({
-					message:
-						"Graduated credit rate cards with rollover balances are not supported yet",
+						"Credit rate cards with unlimited credit balances are not supported yet",
 					code: ErrCode.InvalidRequest,
 					statusCode: 400,
 				});
@@ -83,10 +73,10 @@ export const computeCreditCosts = ({
 					(entityBalance) =>
 						Math.abs(entityBalance.additional_balance ?? 0) > 0,
 				);
-			if (rateCard?.tier_behavior === "graduated" && hasAdditionalBalance) {
+			if (rateCard && hasAdditionalBalance) {
 				throw new RecaseError({
 					message:
-						"Graduated credit rate cards with additional balances are not supported yet",
+						"Credit rate cards with additional balances are not supported yet",
 					code: ErrCode.InvalidRequest,
 					statusCode: 400,
 				});
@@ -103,6 +93,7 @@ export const computeCreditCosts = ({
 		} catch (error) {
 			// A configured rate that cannot be evaluated must fail closed.
 			if (
+				rateCard ||
 				creditSystemContainsFeature({
 					creditSystem: ce.entitlement.feature,
 					meteredFeatureId: deduction.feature.id,

--- a/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
+++ b/server/src/internal/balances/utils/deduction/prepareFeatureDeduction.ts
@@ -1,7 +1,6 @@
 import {
 	AllowanceType,
 	cusEntToStartingBalance,
-	ErrCode,
 	type FullCusEntWithFullCusProduct,
 	type FullCustomer,
 	fullCustomerToCustomerEntitlements,
@@ -14,7 +13,6 @@ import {
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
-	RecaseError,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { buildLockReceiptKey } from "@/internal/balances/utils/lock/buildLockReceiptKey.js";
@@ -148,19 +146,6 @@ export const prepareFeatureDeduction = ({
 			};
 		});
 
-	if (
-		lock?.enabled &&
-		customerEntitlementDeductions.some(
-			(entry) => entry.rate_card?.tier_behavior === "graduated",
-		)
-	) {
-		throw new RecaseError({
-			message: "Graduated credit rate cards do not support balance locks yet",
-			code: ErrCode.InvalidRequest,
-			statusCode: 400,
-		});
-	}
-
 	// The deduction sort only prefers unlimited within a tier (entity level and
 	// credit systems sort first/last regardless), but the sink contract is that
 	// an unlimited entitlement absorbs everything and finite siblings stay
@@ -180,10 +165,11 @@ export const prepareFeatureDeduction = ({
 	// Collect and sort rollovers by expires_at (oldest first), including credit_cost from parent entitlement
 	const sortedRollovers = cusEnts
 		.flatMap((ce) => {
-			const { creditCost } = getCreditCostForEnt(ce.id);
+			const { creditCost, rateCard } = getCreditCostForEnt(ce.id);
 			return (ce.rollovers || []).map((r) => ({
 				...r,
 				credit_cost: creditCost,
+				...(rateCard ? { rate_card: rateCard } : {}),
 			}));
 		})
 		.sort((a, b) => {
@@ -227,6 +213,7 @@ export const prepareFeatureDeduction = ({
 		rollovers: sortedRollovers.map((r) => ({
 			id: r.id,
 			credit_cost: r.credit_cost,
+			...(r.rate_card ? { rate_card: r.rate_card } : {}),
 		})),
 		lock: preparedLock,
 	};

--- a/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
+++ b/server/src/internal/balances/utils/deductionV2/prepareFeatureDeductionV2.ts
@@ -1,7 +1,6 @@
 import {
 	AllowanceType,
 	cusEntToStartingBalance,
-	ErrCode,
 	type FullCusEntWithFullCusProduct,
 	type FullSubject,
 	fullSubjectToCustomerEntitlements,
@@ -15,7 +14,6 @@ import {
 	isFreeCustomerEntitlement,
 	notNullish,
 	orgToInStatuses,
-	RecaseError,
 	usageLimitFilterMatchesProperties,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -199,19 +197,6 @@ export const prepareFeatureDeductionV2 = ({
 			};
 		});
 
-	if (
-		lock?.enabled &&
-		customerEntitlementDeductions.some(
-			(entry) => entry.rate_card?.tier_behavior === "graduated",
-		)
-	) {
-		throw new RecaseError({
-			message: "Graduated credit rate cards do not support balance locks yet",
-			code: ErrCode.InvalidRequest,
-			statusCode: 400,
-		});
-	}
-
 	// The deduction sort only prefers unlimited within a tier (entity level and
 	// credit systems sort first/last regardless), but the sink contract is that
 	// an unlimited entitlement absorbs everything and finite siblings stay
@@ -229,10 +214,13 @@ export const prepareFeatureDeductionV2 = ({
 	}
 
 	const rolloverArrays = customerEntitlements.map((customerEntitlement) => {
-		const { creditCost } = getCreditCostForEnt(customerEntitlement.id);
+		const { creditCost, rateCard } = getCreditCostForEnt(
+			customerEntitlement.id,
+		);
 		return (customerEntitlement.rollovers || []).map((rollover) => ({
 			...rollover,
 			credit_cost: creditCost,
+			...(rateCard ? { rate_card: rateCard } : {}),
 		}));
 	});
 
@@ -286,6 +274,7 @@ export const prepareFeatureDeductionV2 = ({
 		rollovers: sortedRollovers.map((rollover) => ({
 			id: rollover.id,
 			credit_cost: rollover.credit_cost,
+			...(rollover.rate_card ? { rate_card: rollover.rate_card } : {}),
 		})),
 		lock: preparedLock,
 	};

--- a/server/src/internal/balances/utils/sql/client.ts
+++ b/server/src/internal/balances/utils/sql/client.ts
@@ -1,4 +1,4 @@
-import type { EntityBalance, Rollover } from "@autumn/shared";
+import type { EntityBalance, Rollover, UsageAttribution } from "@autumn/shared";
 import { sql } from "drizzle-orm";
 import { planetScaleTag } from "@/db/dbUtils.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -9,6 +9,7 @@ export type ResetCusEntParam = {
 	additional_balance: number | null;
 	adjustment: number;
 	entities: Record<string, EntityBalance> | null;
+	usage_attribution: UsageAttribution;
 	next_reset_at: number;
 	rollover_insert: Pick<
 		Rollover,
@@ -21,6 +22,7 @@ export type AppliedCusEntReset = {
 	additional_balance: number;
 	adjustment: number;
 	entities: Record<string, EntityBalance> | null;
+	usage_attribution: UsageAttribution;
 	next_reset_at: number;
 	cache_version: number;
 	rollover: Pick<

--- a/server/src/internal/balances/utils/sql/creditRateUtils.sql
+++ b/server/src/internal/balances/utils/sql/creditRateUtils.sql
@@ -1,5 +1,23 @@
 DROP FUNCTION IF EXISTS credit_rate_cost_at_usage(jsonb, numeric);
 
+DROP FUNCTION IF EXISTS build_credit_rate_attribution_delta(jsonb, numeric, numeric);
+
+CREATE FUNCTION build_credit_rate_attribution_delta(
+  rate_card jsonb,
+  units numeric,
+  credits numeric
+)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT jsonb_build_object(
+    'units', units,
+    'credits', credits,
+    'rate_card', rate_card
+  );
+$$;
+
 CREATE FUNCTION credit_rate_cost_at_usage(rate_card jsonb, usage numeric)
 RETURNS numeric
 LANGUAGE plpgsql
@@ -229,47 +247,184 @@ BEGIN
 END;
 $$;
 
-DROP FUNCTION IF EXISTS reprice_credit_rate_mutation_logs(jsonb, text, numeric, numeric);
+DROP FUNCTION IF EXISTS credit_rate_unwind_attribution_delta(jsonb, jsonb, numeric);
+
+CREATE FUNCTION credit_rate_unwind_attribution_delta(
+  attribution_delta jsonb,
+  current_usage_attribution jsonb,
+  unwind_value numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  epsilon numeric := 0.0000000001;
+  rate_card jsonb := attribution_delta->'rate_card';
+  original_units numeric := COALESCE((attribution_delta->>'units')::numeric, 0);
+  original_magnitude numeric := ABS(original_units);
+  unwind_magnitude numeric;
+  attribution_unwind_magnitude numeric;
+  direction integer;
+  current_units numeric;
+  restored_units numeric;
+  inverse_units numeric;
+  inverse_credits numeric;
+BEGIN
+  IF attribution_delta IS NULL
+    OR jsonb_typeof(attribution_delta) != 'object'
+    OR rate_card IS NULL
+    OR jsonb_typeof(rate_card) != 'object'
+    OR original_magnitude <= epsilon
+  THEN
+    RETURN NULL;
+  END IF;
+
+  unwind_magnitude := LEAST(original_magnitude, GREATEST(0, unwind_value));
+  direction := CASE WHEN original_units >= 0 THEN 1 ELSE -1 END;
+  current_units := GREATEST(
+    0,
+    credit_rate_current_units(current_usage_attribution, rate_card)
+  );
+  attribution_unwind_magnitude := CASE
+    WHEN direction > 0 THEN LEAST(unwind_magnitude, current_units)
+    ELSE unwind_magnitude
+  END;
+  inverse_units := -direction * attribution_unwind_magnitude;
+  restored_units := GREATEST(0, current_units + inverse_units);
+  inverse_credits := credit_rate_cost_at_usage(rate_card, restored_units)
+    - credit_rate_cost_at_usage(rate_card, current_units);
+
+  RETURN build_credit_rate_attribution_delta(
+    rate_card,
+    inverse_units,
+    inverse_credits
+  );
+END;
+$$;
+
+DROP FUNCTION IF EXISTS credit_rate_rollover_change(jsonb, jsonb, numeric, numeric);
+
+CREATE FUNCTION credit_rate_rollover_change(
+  usage_attribution jsonb,
+  rate_card jsonb,
+  requested_units numeric,
+  available_credits numeric
+)
+RETURNS TABLE (
+  funded_units numeric,
+  funded_credits numeric,
+  new_usage_attribution jsonb,
+  usage_attribution_delta jsonb
+)
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  current_units numeric := credit_rate_current_units(
+    usage_attribution,
+    rate_card
+  );
+  requested_credits numeric;
+  allowed_credits numeric;
+BEGIN
+  requested_credits := GREATEST(
+    0,
+    credit_rate_cost_at_usage(
+      rate_card,
+      GREATEST(0, current_units + requested_units)
+    ) - credit_rate_cost_at_usage(rate_card, current_units)
+  );
+  allowed_credits := LEAST(
+    GREATEST(0, available_credits),
+    requested_credits
+  );
+  funded_units := credit_rate_units_for_credit_change(
+    rate_card,
+    current_units,
+    requested_units,
+    allowed_credits
+  );
+  funded_credits := credit_rate_cost_at_usage(
+    rate_card,
+    current_units + funded_units
+  ) - credit_rate_cost_at_usage(rate_card, current_units);
+  new_usage_attribution := apply_credit_rate_attribution(
+    usage_attribution,
+    rate_card,
+    funded_units,
+    funded_credits
+  );
+  usage_attribution_delta := build_credit_rate_attribution_delta(
+    rate_card,
+    funded_units,
+    funded_credits
+  );
+
+  RETURN NEXT;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS reprice_credit_rate_mutation_logs(jsonb, text, numeric, numeric, jsonb, numeric);
 
 CREATE FUNCTION reprice_credit_rate_mutation_logs(
   mutation_logs jsonb,
   customer_entitlement_id text,
   deducted_credits numeric,
-  deducted_units numeric
+  deducted_units numeric,
+  rate_card jsonb,
+  current_units numeric
 )
 RETURNS jsonb
-LANGUAGE sql
+LANGUAGE plpgsql
 IMMUTABLE
 AS $$
-  SELECT COALESCE(
-    jsonb_agg(
-      CASE
-        WHEN log_item->>'customer_entitlement_id' = customer_entitlement_id
-          AND deducted_credits != 0
-        THEN jsonb_set(
-          jsonb_set(
-            log_item,
-            '{value_delta}',
-            to_jsonb(
-              deducted_units
-                * (-(log_item->>'balance_delta')::numeric)
-                / deducted_credits
-            )
-          ),
-          '{credit_cost}',
-          to_jsonb(
-            CASE
-              WHEN deducted_units = 0 THEN 0
-              ELSE deducted_credits / deducted_units
-            END
-          )
+DECLARE
+  epsilon numeric := 0.0000000001;
+  result jsonb := '[]'::jsonb;
+  log_item jsonb;
+  log_credit_change numeric;
+  log_units numeric;
+  log_units_before numeric := current_units;
+  remaining_log_units numeric := deducted_units;
+BEGIN
+  FOR log_item IN
+    SELECT value FROM jsonb_array_elements(COALESCE(mutation_logs, '[]'::jsonb))
+  LOOP
+    IF log_item->>'customer_entitlement_id' = customer_entitlement_id
+      AND ABS(deducted_credits) > epsilon
+    THEN
+      log_credit_change := -COALESCE(
+        (log_item->>'balance_delta')::numeric,
+        0
+      );
+      log_units := credit_rate_units_for_credit_change(
+        rate_card,
+        log_units_before,
+        remaining_log_units,
+        log_credit_change
+      );
+      log_item := log_item || jsonb_build_object(
+        'value_delta', log_units,
+        'credit_cost', CASE
+          WHEN ABS(log_units) <= epsilon THEN 0
+          ELSE log_credit_change / log_units
+        END,
+        'usage_attribution_delta', build_credit_rate_attribution_delta(
+          rate_card,
+          log_units,
+          log_credit_change
         )
-        ELSE log_item
-      END
-    ),
-    '[]'::jsonb
-  )
-  FROM jsonb_array_elements(COALESCE(mutation_logs, '[]'::jsonb)) log_item;
+      );
+      log_units_before := log_units_before + log_units;
+      remaining_log_units := remaining_log_units - log_units;
+    END IF;
+
+    result := result || jsonb_build_array(log_item);
+  END LOOP;
+
+  RETURN result;
+END;
 $$;
 
 DROP FUNCTION IF EXISTS deduct_from_credit_rate_main_balance(jsonb);
@@ -379,14 +534,21 @@ BEGIN
         'balance_delta', 0,
         'adjustment_delta', 0,
         'usage_delta', 0,
-        'value_delta', deducted_units
+        'value_delta', deducted_units,
+        'usage_attribution_delta', build_credit_rate_attribution_delta(
+          rate_card,
+          deducted_units,
+          deducted
+        )
       ));
     ELSE
       mutation_logs := reprice_credit_rate_mutation_logs(
         mutation_logs,
         customer_entitlement_id,
         deducted,
-        deducted_units
+        deducted_units,
+        rate_card,
+        current_units
       );
     END IF;
   END IF;

--- a/server/src/internal/balances/utils/sql/deductFromRollovers.sql
+++ b/server/src/internal/balances/utils/sql/deductFromRollovers.sql
@@ -1,30 +1,40 @@
--- Helper: Deduct from rollovers before deducting from main entitlements
--- Supports new 'rollovers' array with credit_cost, falls back to 'rollover_ids' (credit_cost=1)
--- Returns: total_deducted in FEATURE units (not credit units) so caller can subtract directly from remaining_amount
+-- Rate-card rollovers rate against their owner's current-cycle attribution;
+-- deduct_from_cus_ents already holds both row locks.
 DROP FUNCTION IF EXISTS deduct_from_rollovers(jsonb);
 
 CREATE FUNCTION deduct_from_rollovers(params jsonb)
-RETURNS TABLE(total_deducted numeric, mutation_logs jsonb)
+RETURNS TABLE(
+  total_deducted numeric,
+  mutation_logs jsonb
+)
 LANGUAGE plpgsql
 AS $$
 DECLARE
-  -- Extract parameters from JSONB
+  epsilon numeric := 0.0000000001;
   rollovers_arr jsonb;
   rollover_ids text[];
   amount_to_deduct numeric := (params->>'amount_to_deduct')::numeric;
   target_entity_id text := NULLIF(params->>'target_entity_id', '');
-  has_entity_scope boolean := COALESCE((params->>'has_entity_scope')::boolean, false);
-  
-  -- Other variables
+  has_entity_scope boolean := COALESCE(
+    (params->>'has_entity_scope')::boolean,
+    false
+  );
+
   remaining_amount numeric := amount_to_deduct;
   rollover_obj jsonb;
   rollover_id text;
+  customer_entitlement_id text;
+  rate_card jsonb;
   credit_cost numeric;
+  effective_credit_cost numeric;
   current_balance numeric;
   current_usage numeric;
   current_entities jsonb;
-  current_cus_ent_id text;
-  
+  current_customer_entitlement_id text;
+  current_usage_attribution jsonb;
+  new_usage_attribution jsonb;
+  usage_attribution_delta jsonb;
+
   entity_key text;
   entity_balance numeric;
   entity_usage numeric;
@@ -36,170 +46,325 @@ DECLARE
   rollover_total_deducted_features numeric := 0;
   mutation_logs_json jsonb := '[]'::jsonb;
 BEGIN
-  -- Normalize input: if rollovers array provided use it, otherwise convert rollover_ids to same format
-  IF params->'rollovers' IS NOT NULL AND jsonb_typeof(params->'rollovers') = 'array' AND jsonb_array_length(params->'rollovers') > 0 THEN
+  IF params->'rollovers' IS NOT NULL
+    AND jsonb_typeof(params->'rollovers') = 'array'
+    AND jsonb_array_length(params->'rollovers') > 0
+  THEN
     rollovers_arr := params->'rollovers';
-  ELSIF params->'rollover_ids' IS NOT NULL AND jsonb_typeof(params->'rollover_ids') = 'array' THEN
-    -- Convert rollover_ids string array to rollovers object array with credit_cost = 1
-    rollover_ids := ARRAY(SELECT jsonb_array_elements_text(params->'rollover_ids'));
+  ELSIF params->'rollover_ids' IS NOT NULL
+    AND jsonb_typeof(params->'rollover_ids') = 'array'
+  THEN
+    rollover_ids := ARRAY(
+      SELECT jsonb_array_elements_text(params->'rollover_ids')
+    );
     SELECT jsonb_agg(jsonb_build_object('id', id, 'credit_cost', 1))
     INTO rollovers_arr
     FROM unnest(rollover_ids) AS id;
   ELSE
-    -- No rollovers to process
     RETURN QUERY SELECT 0::numeric, '[]'::jsonb;
     RETURN;
   END IF;
-  
-  -- Early return if no amount
+
   IF remaining_amount <= 0 THEN
     RETURN QUERY SELECT 0::numeric, '[]'::jsonb;
     RETURN;
   END IF;
 
-  -- Loop through rollovers array (each element has id and credit_cost)
   FOR rollover_obj IN SELECT * FROM jsonb_array_elements(rollovers_arr)
   LOOP
     EXIT WHEN remaining_amount <= 0;
-    
+
     rollover_id := rollover_obj->>'id';
+    rate_card := rollover_obj->'rate_card';
     credit_cost := COALESCE((rollover_obj->>'credit_cost')::numeric, 1);
-    
-    -- Lock and fetch rollover data
-    SELECT r.balance, COALESCE(r.usage, 0), r.entities, r.cus_ent_id
-    INTO current_balance, current_usage, current_entities, current_cus_ent_id
+
+    SELECT
+      r.balance,
+      COALESCE(r.usage, 0),
+      COALESCE(r.entities, '{}'::jsonb),
+      r.cus_ent_id
+    INTO
+      current_balance,
+      current_usage,
+      current_entities,
+      current_customer_entitlement_id
     FROM rollovers r
     WHERE r.id = rollover_id
     FOR UPDATE;
-    
-    -- Handle entity-scoped rollovers (specific entity)
+
+    IF NOT FOUND THEN
+      CONTINUE;
+    END IF;
+
+    customer_entitlement_id := current_customer_entitlement_id;
+
+    IF rate_card IS NOT NULL THEN
+      SELECT COALESCE(ce.usage_attribution, '{}'::jsonb)
+      INTO current_usage_attribution
+      FROM customer_entitlements ce
+      WHERE ce.id = customer_entitlement_id
+      FOR UPDATE;
+
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'ROLLOVER_ATTRIBUTION_OWNER_MISSING';
+      END IF;
+    END IF;
+
     IF has_entity_scope AND target_entity_id IS NOT NULL THEN
-      entity_balance := COALESCE((current_entities->target_entity_id->>'balance')::numeric, 0);
-      entity_usage := COALESCE((current_entities->target_entity_id->>'usage')::numeric, 0);
-      
-      -- Calculate: credits needed = remaining_amount * credit_cost
-      -- Actual deduction = min(available_balance, credits_needed)
-      credit_deduct_amount := LEAST(entity_balance, remaining_amount * credit_cost);
-      
-      IF credit_deduct_amount > 0 THEN
+      entity_balance := COALESCE(
+        (current_entities->target_entity_id->>'balance')::numeric,
+        0
+      );
+      entity_usage := COALESCE(
+        (current_entities->target_entity_id->>'usage')::numeric,
+        0
+      );
+
+      IF rate_card IS NOT NULL THEN
+        SELECT *
+        INTO
+          feature_deduct_amount,
+          credit_deduct_amount,
+          new_usage_attribution,
+          usage_attribution_delta
+        FROM credit_rate_rollover_change(
+          current_usage_attribution,
+          rate_card,
+          remaining_amount,
+          entity_balance
+        );
+      ELSE
+        credit_deduct_amount := LEAST(
+          entity_balance,
+          remaining_amount * credit_cost
+        );
+        feature_deduct_amount := CASE
+          WHEN credit_deduct_amount > 0 THEN credit_deduct_amount / credit_cost
+          ELSE 0
+        END;
+        new_usage_attribution := NULL;
+        usage_attribution_delta := NULL;
+      END IF;
+
+      IF ABS(feature_deduct_amount) > epsilon THEN
         new_balance := entity_balance - credit_deduct_amount;
         new_usage := entity_usage + credit_deduct_amount;
-        
         new_entities := jsonb_set(
-          current_entities,
-          ARRAY[target_entity_id, 'balance'],
-          to_jsonb(new_balance)
-        );
-        new_entities := jsonb_set(
-          new_entities,
+          jsonb_set(
+            current_entities,
+            ARRAY[target_entity_id, 'balance'],
+            to_jsonb(new_balance),
+            true
+          ),
           ARRAY[target_entity_id, 'usage'],
-          to_jsonb(new_usage)
+          to_jsonb(new_usage),
+          true
         );
-        
-        UPDATE rollovers r
-        SET entities = new_entities
-        WHERE r.id = rollover_id;
-        
-        feature_deduct_amount := credit_deduct_amount / credit_cost;
+        UPDATE rollovers SET entities = new_entities WHERE id = rollover_id;
+        current_entities := new_entities;
+
+        IF rate_card IS NOT NULL THEN
+          UPDATE customer_entitlements
+          SET usage_attribution = new_usage_attribution
+          WHERE id = customer_entitlement_id;
+          current_usage_attribution := new_usage_attribution;
+        END IF;
+
+        effective_credit_cost := CASE
+          WHEN ABS(feature_deduct_amount) <= epsilon THEN 0
+          ELSE credit_deduct_amount / feature_deduct_amount
+        END;
         mutation_logs_json := mutation_logs_json || jsonb_build_array(
           jsonb_build_object(
             'target_type', 'rollover',
-            'customer_entitlement_id', current_cus_ent_id,
+            'customer_entitlement_id', customer_entitlement_id,
             'rollover_id', rollover_id,
             'entity_id', target_entity_id,
-            'credit_cost', credit_cost,
+            'credit_cost', effective_credit_cost,
             'balance_delta', -credit_deduct_amount,
             'adjustment_delta', 0,
             'usage_delta', credit_deduct_amount,
             'value_delta', feature_deduct_amount
-          )
+          ) || CASE
+            WHEN usage_attribution_delta IS NULL THEN '{}'::jsonb
+            ELSE jsonb_build_object(
+              'usage_attribution_delta', usage_attribution_delta
+            )
+          END
         );
         remaining_amount := remaining_amount - feature_deduct_amount;
-        rollover_total_deducted_features := rollover_total_deducted_features + feature_deduct_amount;
+        rollover_total_deducted_features :=
+          rollover_total_deducted_features + feature_deduct_amount;
       END IF;
-      
-    -- Handle entity-scoped rollovers (deduct from all entities)
-    ELSIF has_entity_scope AND target_entity_id IS NULL THEN
+
+    ELSIF has_entity_scope THEN
       new_entities := current_entities;
-      
+
       FOR entity_key IN SELECT jsonb_object_keys(current_entities) ORDER BY 1
       LOOP
         EXIT WHEN remaining_amount <= 0;
-        
-        entity_balance := COALESCE((new_entities->entity_key->>'balance')::numeric, 0);
-        entity_usage := COALESCE((new_entities->entity_key->>'usage')::numeric, 0);
-        
-        credit_deduct_amount := LEAST(entity_balance, remaining_amount * credit_cost);
-        
-        IF credit_deduct_amount > 0 THEN
+
+        entity_balance := COALESCE(
+          (new_entities->entity_key->>'balance')::numeric,
+          0
+        );
+        entity_usage := COALESCE(
+          (new_entities->entity_key->>'usage')::numeric,
+          0
+        );
+
+        IF rate_card IS NOT NULL THEN
+          SELECT *
+          INTO
+            feature_deduct_amount,
+            credit_deduct_amount,
+            new_usage_attribution,
+            usage_attribution_delta
+          FROM credit_rate_rollover_change(
+            current_usage_attribution,
+            rate_card,
+            remaining_amount,
+            entity_balance
+          );
+        ELSE
+          credit_deduct_amount := LEAST(
+            entity_balance,
+            remaining_amount * credit_cost
+          );
+          feature_deduct_amount := CASE
+            WHEN credit_deduct_amount > 0 THEN credit_deduct_amount / credit_cost
+            ELSE 0
+          END;
+          new_usage_attribution := NULL;
+          usage_attribution_delta := NULL;
+        END IF;
+
+        IF ABS(feature_deduct_amount) > epsilon THEN
           new_balance := entity_balance - credit_deduct_amount;
           new_usage := entity_usage + credit_deduct_amount;
-          
           new_entities := jsonb_set(
-            new_entities,
-            ARRAY[entity_key, 'balance'],
-            to_jsonb(new_balance)
-          );
-          new_entities := jsonb_set(
-            new_entities,
+            jsonb_set(
+              new_entities,
+              ARRAY[entity_key, 'balance'],
+              to_jsonb(new_balance),
+              true
+            ),
             ARRAY[entity_key, 'usage'],
-            to_jsonb(new_usage)
+            to_jsonb(new_usage),
+            true
           );
-          
-          feature_deduct_amount := credit_deduct_amount / credit_cost;
+
+          IF rate_card IS NOT NULL THEN
+            UPDATE customer_entitlements
+            SET usage_attribution = new_usage_attribution
+            WHERE id = customer_entitlement_id;
+            current_usage_attribution := new_usage_attribution;
+          END IF;
+
+          effective_credit_cost := CASE
+            WHEN ABS(feature_deduct_amount) <= epsilon THEN 0
+            ELSE credit_deduct_amount / feature_deduct_amount
+          END;
           mutation_logs_json := mutation_logs_json || jsonb_build_array(
             jsonb_build_object(
               'target_type', 'rollover',
-              'customer_entitlement_id', current_cus_ent_id,
+              'customer_entitlement_id', customer_entitlement_id,
               'rollover_id', rollover_id,
               'entity_id', entity_key,
-              'credit_cost', credit_cost,
+              'credit_cost', effective_credit_cost,
               'balance_delta', -credit_deduct_amount,
               'adjustment_delta', 0,
               'usage_delta', credit_deduct_amount,
               'value_delta', feature_deduct_amount
-            )
+            ) || CASE
+              WHEN usage_attribution_delta IS NULL THEN '{}'::jsonb
+              ELSE jsonb_build_object(
+                'usage_attribution_delta', usage_attribution_delta
+              )
+            END
           );
           remaining_amount := remaining_amount - feature_deduct_amount;
-          rollover_total_deducted_features := rollover_total_deducted_features + feature_deduct_amount;
+          rollover_total_deducted_features :=
+            rollover_total_deducted_features + feature_deduct_amount;
         END IF;
       END LOOP;
-      
+
       IF new_entities IS DISTINCT FROM current_entities THEN
-        UPDATE rollovers r
-        SET entities = new_entities
-        WHERE r.id = rollover_id;
+        UPDATE rollovers SET entities = new_entities WHERE id = rollover_id;
       END IF;
-      
-    -- Handle regular balance rollovers
+
     ELSE
-      credit_deduct_amount := LEAST(current_balance, remaining_amount * credit_cost);
-      
-      IF credit_deduct_amount > 0 THEN
-        UPDATE rollovers r
-        SET balance = balance - credit_deduct_amount, usage = usage + credit_deduct_amount
-        WHERE r.id = rollover_id;
-        
-        feature_deduct_amount := credit_deduct_amount / credit_cost;
+      IF rate_card IS NOT NULL THEN
+        SELECT *
+        INTO
+          feature_deduct_amount,
+          credit_deduct_amount,
+          new_usage_attribution,
+          usage_attribution_delta
+        FROM credit_rate_rollover_change(
+          current_usage_attribution,
+          rate_card,
+          remaining_amount,
+          current_balance
+        );
+      ELSE
+        credit_deduct_amount := LEAST(
+          current_balance,
+          remaining_amount * credit_cost
+        );
+        feature_deduct_amount := CASE
+          WHEN credit_deduct_amount > 0 THEN credit_deduct_amount / credit_cost
+          ELSE 0
+        END;
+        new_usage_attribution := NULL;
+        usage_attribution_delta := NULL;
+      END IF;
+
+      IF ABS(feature_deduct_amount) > epsilon THEN
+        UPDATE rollovers
+        SET
+          balance = balance - credit_deduct_amount,
+          usage = COALESCE(usage, 0) + credit_deduct_amount
+        WHERE id = rollover_id;
+
+        IF rate_card IS NOT NULL THEN
+          UPDATE customer_entitlements
+          SET usage_attribution = new_usage_attribution
+          WHERE id = customer_entitlement_id;
+          current_usage_attribution := new_usage_attribution;
+        END IF;
+
+        effective_credit_cost := CASE
+          WHEN ABS(feature_deduct_amount) <= epsilon THEN 0
+          ELSE credit_deduct_amount / feature_deduct_amount
+        END;
         mutation_logs_json := mutation_logs_json || jsonb_build_array(
           jsonb_build_object(
             'target_type', 'rollover',
-            'customer_entitlement_id', current_cus_ent_id,
+            'customer_entitlement_id', customer_entitlement_id,
             'rollover_id', rollover_id,
             'entity_id', NULL,
-            'credit_cost', credit_cost,
+            'credit_cost', effective_credit_cost,
             'balance_delta', -credit_deduct_amount,
             'adjustment_delta', 0,
             'usage_delta', credit_deduct_amount,
             'value_delta', feature_deduct_amount
-          )
+          ) || CASE
+            WHEN usage_attribution_delta IS NULL THEN '{}'::jsonb
+            ELSE jsonb_build_object(
+              'usage_attribution_delta', usage_attribution_delta
+            )
+          END
         );
         remaining_amount := remaining_amount - feature_deduct_amount;
-        rollover_total_deducted_features := rollover_total_deducted_features + feature_deduct_amount;
+        rollover_total_deducted_features :=
+          rollover_total_deducted_features + feature_deduct_amount;
       END IF;
     END IF;
   END LOOP;
-  
-  RETURN QUERY SELECT rollover_total_deducted_features, mutation_logs_json;
+
+  RETURN QUERY SELECT
+    rollover_total_deducted_features,
+    mutation_logs_json;
 END;
 $$;

--- a/server/src/internal/balances/utils/sql/performDeduction.sql
+++ b/server/src/internal/balances/utils/sql/performDeduction.sql
@@ -66,6 +66,8 @@ DECLARE
 
   remaining_amount numeric;
   rollover_deducted numeric := 0;
+  attribution_entitlement_id text;
+  attribution_value jsonb;
   ent_obj jsonb;
   -- Entitlement properties
   ent_id text;
@@ -204,7 +206,7 @@ BEGIN
     has_entity_scope := (ent_obj->>'entity_feature_id') IS NOT NULL;
 
     IF rate_card IS NOT NULL THEN
-      RAISE EXCEPTION 'UNSUPPORTED_GRADUATED_CREDIT_RATE_CARD_UNLIMITED';
+      RAISE EXCEPTION 'UNSUPPORTED_CREDIT_RATE_CARD_UNLIMITED';
     END IF;
 
     SELECT
@@ -350,7 +352,7 @@ BEGIN
     -- untouched (reset windows are TS-suppressed).
     IF is_unlimited THEN
       IF rate_card IS NOT NULL THEN
-        RAISE EXCEPTION 'UNSUPPORTED_GRADUATED_CREDIT_RATE_CARD_UNLIMITED';
+        RAISE EXCEPTION 'UNSUPPORTED_CREDIT_RATE_CARD_UNLIMITED';
       END IF;
 
       -- Fetch current state (rows already locked in STEP 0)
@@ -442,6 +444,51 @@ BEGIN
         'has_entity_scope', has_entity_scope
       ));
       mutation_logs_json := mutation_logs_json || COALESCE(step_mutation_logs, '[]'::jsonb);
+
+      FOR attribution_entitlement_id IN
+        SELECT DISTINCT mutation_log->>'customer_entitlement_id'
+        FROM jsonb_array_elements(
+          COALESCE(step_mutation_logs, '[]'::jsonb)
+        ) AS mutation_log
+        WHERE mutation_log ? 'usage_attribution_delta'
+          AND NULLIF(mutation_log->>'customer_entitlement_id', '') IS NOT NULL
+      LOOP
+        SELECT
+          ce.balance,
+          COALESCE(ce.additional_balance, 0),
+          COALESCE(ce.adjustment, 0),
+          COALESCE(ce.entities, '{}'::jsonb),
+          COALESCE(ce.usage_attribution, '{}'::jsonb)
+        INTO
+          current_balance,
+          current_additional_balance,
+          current_adjustment,
+          current_entities,
+          attribution_value
+        FROM customer_entitlements ce
+        WHERE ce.id = attribution_entitlement_id;
+
+        updates_json := jsonb_set(
+          updates_json,
+          ARRAY[attribution_entitlement_id],
+          jsonb_build_object(
+            'balance', current_balance,
+            'additional_balance', current_additional_balance,
+            'adjustment', current_adjustment,
+            'entities', current_entities,
+            'usage_attribution', attribution_value,
+            'deducted', COALESCE(
+              (updates_json->attribution_entitlement_id->>'deducted')::numeric,
+              0
+            ),
+            'additional_deducted', COALESCE(
+              (updates_json->attribution_entitlement_id->>'additional_deducted')::numeric,
+              0
+            )
+          ),
+          true
+        );
+      END LOOP;
       -- rollover_deducted is returned in feature units, so can subtract directly
       remaining_amount := remaining_amount - rollover_deducted;
     END IF;
@@ -466,13 +513,18 @@ BEGIN
       ABS(current_additional_balance) > 0.0000000001
       OR EXISTS (
         SELECT 1
-        FROM jsonb_each(current_entities) entity_entry
+        FROM jsonb_each(
+          CASE
+            WHEN jsonb_typeof(current_entities) = 'object' THEN current_entities
+            ELSE '{}'::jsonb
+          END
+        ) entity_entry
         WHERE ABS(
           COALESCE((entity_entry.value->>'additional_balance')::numeric, 0)
         ) > 0.0000000001
       )
     ) THEN
-      RAISE EXCEPTION 'UNSUPPORTED_GRADUATED_CREDIT_RATE_CARD_ADDITIONAL_BALANCE';
+      RAISE EXCEPTION 'UNSUPPORTED_CREDIT_RATE_CARD_ADDITIONAL_BALANCE';
     END IF;
 
     -- STEP 2: Deduct from additional_balance (customer-level and entity-level) [TODO: add max balance here?]

--- a/server/src/internal/balances/utils/sql/resetCusEnts.sql
+++ b/server/src/internal/balances/utils/sql/resetCusEnts.sql
@@ -9,6 +9,7 @@
 --     - additional_balance: numeric (null if entity-scoped)
 --     - adjustment: numeric
 --     - entities: jsonb (null if non-entity)
+--     - usage_attribution: jsonb (cleared to {} for the new cycle)
 --     - next_reset_at: bigint (new next_reset_at value)
 --     - rollover_insert: jsonb object or null, with fields:
 --         id, cus_ent_id, balance, usage, expires_at, entities
@@ -21,6 +22,7 @@
 --         "additional_balance": number,
 --         "adjustment": number,
 --         "entities": jsonb,
+--         "usage_attribution": jsonb,
 --         "next_reset_at": number,
 --         "rollover": jsonb or null
 --       }
@@ -43,6 +45,7 @@ DECLARE
   new_additional_balance numeric;
   new_adjustment numeric;
   new_entities jsonb;
+  new_usage_attribution jsonb;
   new_next_reset_at bigint;
   rollover_obj jsonb;
 
@@ -63,6 +66,11 @@ BEGIN
     new_additional_balance := (reset_obj->>'additional_balance')::numeric;
     new_adjustment := (reset_obj->>'adjustment')::numeric;
     new_entities := reset_obj->'entities';
+    new_usage_attribution := CASE
+      WHEN jsonb_typeof(reset_obj->'usage_attribution') = 'object'
+        THEN reset_obj->'usage_attribution'
+      ELSE '{}'::jsonb
+    END;
     new_next_reset_at := (reset_obj->>'next_reset_at')::bigint;
     rollover_obj := reset_obj->'rollover_insert';
 
@@ -91,9 +99,11 @@ BEGIN
       additional_balance = COALESCE(new_additional_balance, ce.additional_balance),
       adjustment = COALESCE(new_adjustment, ce.adjustment),
       entities = COALESCE(new_entities, ce.entities),
+      usage_attribution = new_usage_attribution,
       next_reset_at = new_next_reset_at
     WHERE ce.id = ent_id
     RETURNING ce.balance, ce.additional_balance, ce.adjustment, ce.entities,
+              ce.usage_attribution,
               ce.next_reset_at, ce.cache_version
     INTO updated_row;
 
@@ -119,6 +129,7 @@ BEGIN
         'additional_balance', updated_row.additional_balance,
         'adjustment', updated_row.adjustment,
         'entities', updated_row.entities,
+        'usage_attribution', updated_row.usage_attribution,
         'next_reset_at', updated_row.next_reset_at,
         'rollover', CASE
           WHEN rollover_obj IS NOT NULL AND rollover_obj != 'null'::jsonb THEN rollover_obj

--- a/server/src/internal/balances/utils/sql/unwindFromLockReceipt.sql
+++ b/server/src/internal/balances/utils/sql/unwindFromLockReceipt.sql
@@ -26,6 +26,10 @@ DECLARE
   rollover_id text;
   entity_id text;
   credit_cost numeric;
+  usage_attribution_delta jsonb;
+  current_usage_attribution jsonb;
+  rate_card_unwind_change jsonb;
+  unwind_credit_cost numeric;
 
   item_value_delta numeric;
   item_value_magnitude numeric;
@@ -41,6 +45,7 @@ DECLARE
   updated_additional_balance numeric;
   updated_adjustment numeric;
   updated_entities jsonb;
+  updated_usage_attribution jsonb;
 
   rows_affected integer;
 
@@ -81,6 +86,7 @@ BEGIN
     rollover_id := NULLIF(item->>'rollover_id', '');
     entity_id := NULLIF(item->>'entity_id', '');
     credit_cost := COALESCE((item->>'credit_cost')::numeric, 1);
+    usage_attribution_delta := item->'usage_attribution_delta';
 
     item_value_delta := COALESCE((item->>'value_delta')::numeric, 0);
     item_value_magnitude := ABS(item_value_delta);
@@ -113,6 +119,38 @@ BEGIN
       ELSE 0
     END;
 
+    current_usage_attribution := NULL;
+    IF usage_attribution_delta IS NOT NULL
+      AND jsonb_typeof(usage_attribution_delta) = 'object'
+      AND customer_entitlement_id IS NOT NULL
+    THEN
+      SELECT COALESCE(ce.usage_attribution, '{}'::jsonb)
+      INTO current_usage_attribution
+      FROM customer_entitlements ce
+      WHERE ce.id = customer_entitlement_id;
+    END IF;
+
+    rate_card_unwind_change := credit_rate_unwind_attribution_delta(
+      usage_attribution_delta,
+      current_usage_attribution,
+      unwind_iteration_value
+    );
+    unwind_credit_cost := credit_cost;
+    IF rate_card_unwind_change IS NOT NULL THEN
+      inverse_balance_delta := -(rate_card_unwind_change->>'credits')::numeric;
+      inverse_usage_delta := CASE
+        WHEN COALESCE((item->>'usage_delta')::numeric, 0) != 0
+          THEN (rate_card_unwind_change->>'credits')::numeric
+        ELSE 0
+      END;
+      inverse_value_delta := (rate_card_unwind_change->>'units')::numeric;
+      unwind_credit_cost := CASE
+        WHEN ABS(inverse_value_delta) <= 0.0000000001 THEN 0
+        ELSE (rate_card_unwind_change->>'credits')::numeric
+          / inverse_value_delta
+      END;
+    END IF;
+
     IF item_target_type = 'customer_entitlement' THEN
       IF customer_entitlement_id IS NULL THEN
         RAISE EXCEPTION 'LOCK_CUSTOMER_ENTITLEMENT_ID_MISSING';
@@ -134,17 +172,29 @@ BEGIN
         UPDATE customer_entitlements ce
         SET
           balance = ce.balance + inverse_balance_delta,
-          adjustment = COALESCE(ce.adjustment, 0) + inverse_adjustment_delta
+          adjustment = COALESCE(ce.adjustment, 0) + inverse_adjustment_delta,
+          usage_attribution = CASE
+            WHEN rate_card_unwind_change IS NULL THEN ce.usage_attribution
+            ELSE apply_credit_rate_attribution(
+              COALESCE(ce.usage_attribution, '{}'::jsonb),
+              rate_card_unwind_change->'rate_card',
+              (rate_card_unwind_change->>'units')::numeric,
+              (rate_card_unwind_change->>'credits')::numeric
+            )
+          END
         WHERE ce.id = customer_entitlement_id
         RETURNING
           ce.balance,
           COALESCE(ce.additional_balance, 0),
           COALESCE(ce.adjustment, 0),
-          COALESCE(ce.entities, '{}'::jsonb)
-        INTO updated_balance, updated_additional_balance, updated_adjustment, updated_entities;
+          COALESCE(ce.entities, '{}'::jsonb),
+          COALESCE(ce.usage_attribution, '{}'::jsonb)
+        INTO updated_balance, updated_additional_balance, updated_adjustment,
+          updated_entities, updated_usage_attribution;
       ELSE
         UPDATE customer_entitlements ce
-        SET entities = jsonb_set(
+        SET
+          entities = jsonb_set(
           jsonb_set(
             COALESCE(ce.entities, '{}'::jsonb),
             ARRAY[entity_id, 'balance'],
@@ -154,14 +204,25 @@ BEGIN
           ARRAY[entity_id, 'adjustment'],
           to_jsonb(COALESCE((COALESCE(ce.entities, '{}'::jsonb)->entity_id->>'adjustment')::numeric, 0) + inverse_adjustment_delta),
           true
-        )
+          ),
+          usage_attribution = CASE
+            WHEN rate_card_unwind_change IS NULL THEN ce.usage_attribution
+            ELSE apply_credit_rate_attribution(
+              COALESCE(ce.usage_attribution, '{}'::jsonb),
+              rate_card_unwind_change->'rate_card',
+              (rate_card_unwind_change->>'units')::numeric,
+              (rate_card_unwind_change->>'credits')::numeric
+            )
+          END
         WHERE ce.id = customer_entitlement_id
         RETURNING
           ce.balance,
           COALESCE(ce.additional_balance, 0),
           COALESCE(ce.adjustment, 0),
-          COALESCE(ce.entities, '{}'::jsonb)
-        INTO updated_balance, updated_additional_balance, updated_adjustment, updated_entities;
+          COALESCE(ce.entities, '{}'::jsonb),
+          COALESCE(ce.usage_attribution, '{}'::jsonb)
+        INTO updated_balance, updated_additional_balance, updated_adjustment,
+          updated_entities, updated_usage_attribution;
       END IF;
 
       -- Entitlement no longer exists (e.g. product upgraded mid-flight).
@@ -181,6 +242,7 @@ BEGIN
           'additional_balance', updated_additional_balance,
           'adjustment', updated_adjustment,
           'entities', updated_entities,
+          'usage_attribution', updated_usage_attribution,
           'deducted', COALESCE((updates_json->customer_entitlement_id->>'deducted')::numeric, 0) + inverse_value_delta,
           'additional_deducted', COALESCE((updates_json->customer_entitlement_id->>'additional_deducted')::numeric, 0)
         ),
@@ -222,6 +284,51 @@ BEGIN
         CONTINUE;
       END IF;
 
+      IF rate_card_unwind_change IS NOT NULL THEN
+        updated_balance := NULL;
+        UPDATE customer_entitlements ce
+        SET usage_attribution = apply_credit_rate_attribution(
+          COALESCE(ce.usage_attribution, '{}'::jsonb),
+          rate_card_unwind_change->'rate_card',
+          (rate_card_unwind_change->>'units')::numeric,
+          (rate_card_unwind_change->>'credits')::numeric
+        )
+        WHERE ce.id = customer_entitlement_id
+        RETURNING
+          ce.balance,
+          COALESCE(ce.additional_balance, 0),
+          COALESCE(ce.adjustment, 0),
+          COALESCE(ce.entities, '{}'::jsonb),
+          COALESCE(ce.usage_attribution, '{}'::jsonb)
+        INTO updated_balance, updated_additional_balance, updated_adjustment,
+          updated_entities, updated_usage_attribution;
+
+        IF updated_balance IS NULL THEN
+          RAISE EXCEPTION 'LOCK_ATTRIBUTION_OWNER_MISSING';
+        END IF;
+
+        updates_json := jsonb_set(
+          updates_json,
+          ARRAY[customer_entitlement_id],
+          jsonb_build_object(
+            'balance', updated_balance,
+            'additional_balance', updated_additional_balance,
+            'adjustment', updated_adjustment,
+            'entities', updated_entities,
+            'usage_attribution', updated_usage_attribution,
+            'deducted', COALESCE(
+              (updates_json->customer_entitlement_id->>'deducted')::numeric,
+              0
+            ) + inverse_value_delta,
+            'additional_deducted', COALESCE(
+              (updates_json->customer_entitlement_id->>'additional_deducted')::numeric,
+              0
+            )
+          ),
+          true
+        );
+      END IF;
+
       modified_rollover_ids_array := array_append(modified_rollover_ids_array, rollover_id);
     ELSE
       RAISE EXCEPTION 'INVALID_LOCK_ITEM_TARGET_TYPE|targetType:%', item_target_type;
@@ -233,12 +340,17 @@ BEGIN
         'customer_entitlement_id', customer_entitlement_id,
         'rollover_id', rollover_id,
         'entity_id', entity_id,
-        'credit_cost', credit_cost,
+        'credit_cost', unwind_credit_cost,
         'balance_delta', inverse_balance_delta,
         'adjustment_delta', inverse_adjustment_delta,
         'usage_delta', inverse_usage_delta,
         'value_delta', inverse_value_delta
-      )
+      ) || CASE
+        WHEN rate_card_unwind_change IS NULL THEN '{}'::jsonb
+        ELSE jsonb_build_object(
+          'usage_attribution_delta', rate_card_unwind_change
+        )
+      END
     );
 
     remaining_value := remaining_value - unwind_iteration_value;

--- a/server/src/internal/balances/utils/types/deductionTypes.ts
+++ b/server/src/internal/balances/utils/types/deductionTypes.ts
@@ -45,6 +45,7 @@ export type CustomerEntitlementDeduction = {
 export type RolloverDeduction = {
 	id: string;
 	credit_cost: number;
+	rate_card?: CreditRateCard;
 };
 
 /** Prepared input for executing a feature deduction */

--- a/server/src/internal/balances/utils/types/mutationLogItem.ts
+++ b/server/src/internal/balances/utils/types/mutationLogItem.ts
@@ -1,3 +1,11 @@
+import type { CreditRateCard } from "@/internal/features/creditSystemUtils.js";
+
+export type UsageAttributionDelta = {
+	units: number;
+	credits: number;
+	rate_card: CreditRateCard;
+};
+
 export interface MutationLogItem {
 	target_type: "customer_entitlement" | "rollover";
 	customer_entitlement_id: string | null;
@@ -8,4 +16,5 @@ export interface MutationLogItem {
 	adjustment_delta: number;
 	usage_delta: number;
 	value_delta: number;
+	usage_attribution_delta?: UsageAttributionDelta;
 }

--- a/server/src/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.ts
@@ -70,6 +70,13 @@ export const applyExistingUsages = ({
 			cusProducts: [customerProduct],
 			internalFeatureIds: [internalFeatureId],
 		});
+		const attributionOwnerId = existingUsage.usageAttribution
+			? (cusEnts.find(
+					(customerEntitlement) =>
+						customerEntitlement.entitlement.feature.config?.invoice_credit ===
+						true,
+				)?.id ?? cusEnts[0]?.id)
+			: undefined;
 
 		// 1. Deduct entity usages
 		for (const [entityId, entityUsage] of Object.entries(
@@ -100,6 +107,11 @@ export const applyExistingUsages = ({
 				original.balance = newCusEnt.balance;
 				original.entities = newCusEnt.entities;
 				original.adjustment = newCusEnt.adjustment;
+				if (newCusEnt.id === attributionOwnerId) {
+					original.usage_attribution = structuredClone(
+						existingUsage.usageAttribution ?? {},
+					);
+				}
 
 				ctx.logger.debug(`Deduction for feature ${newCusEnt.feature_id}:`, {
 					balance: newCusEnt.balance,

--- a/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
@@ -28,13 +28,7 @@ export const cusProductToExistingUsages = ({
 
 	const cusEnts = cusProduct.customer_entitlements;
 
-	const existingUsages: Record<
-		string,
-		{
-			usage: number;
-			entityUsages: Record<string, number>;
-		}
-	> = {};
+	const existingUsages: ExistingUsages = {};
 
 	for (const cusEnt of cusEnts) {
 		if (isBooleanCusEnt({ cusEnt })) continue;
@@ -70,6 +64,29 @@ export const cusProductToExistingUsages = ({
 		}
 
 		const currentExistingUsage = existingUsages[internalFeatureId];
+
+		if (
+			carryConsumableFeature &&
+			Object.keys(cusEnt.usage_attribution ?? {}).length > 0
+		) {
+			const mergedUsageAttribution =
+				currentExistingUsage.usageAttribution ?? {};
+			for (const [sourceInternalFeatureId, attribution] of Object.entries(
+				cusEnt.usage_attribution ?? {},
+			)) {
+				const currentAttribution =
+					mergedUsageAttribution[sourceInternalFeatureId];
+				mergedUsageAttribution[sourceInternalFeatureId] = {
+					units: new Decimal(currentAttribution?.units ?? 0)
+						.add(attribution.units)
+						.toNumber(),
+					credits: new Decimal(currentAttribution?.credits ?? 0)
+						.add(attribution.credits)
+						.toNumber(),
+				};
+			}
+			currentExistingUsage.usageAttribution = mergedUsageAttribution;
+		}
 
 		// 1. If it's entity scoped
 		if (isEntityScopedCusEnt(cusEnt)) {

--- a/server/src/internal/billing/v2/utils/initFullCustomerProduct/reapplyExistingUsagesToCustomerProduct.ts
+++ b/server/src/internal/billing/v2/utils/initFullCustomerProduct/reapplyExistingUsagesToCustomerProduct.ts
@@ -22,7 +22,6 @@ export const reapplyExistingUsagesToCustomerProduct = async ({
 	fromCustomerProduct?: FullCusProduct;
 	customerProduct: FullCusProduct;
 }) => {
-	const { db } = ctx;
 	const { valid } = cp(customerProduct).main().recurring();
 	if (!valid) return;
 
@@ -62,6 +61,7 @@ export const reapplyExistingUsagesToCustomerProduct = async ({
 
 		cusEnt.balance = balance;
 		cusEnt.entities = entities;
+		cusEnt.usage_attribution = {};
 	}
 
 	applyExistingUsages({
@@ -78,6 +78,7 @@ export const reapplyExistingUsagesToCustomerProduct = async ({
 			updates: {
 				balance: cusEnt.balance ?? 0,
 				entities: cusEnt.entities,
+				usage_attribution: cusEnt.usage_attribution ?? {},
 			},
 		});
 	}

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/applyResetResults.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/applyResetResults.ts
@@ -88,6 +88,7 @@ export const applyResetResults = async ({
 			original.additional_balance = updates.additional_balance;
 		original.adjustment = updates.adjustment;
 		if (updates.entities !== null) original.entities = updates.entities;
+		original.usage_attribution = updates.usage_attribution;
 		original.next_reset_at = updates.next_reset_at;
 
 		if (!result.rolloverInsert) continue;

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/processReset.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/processReset.ts
@@ -7,6 +7,7 @@ import {
 	isUnlimitedEntitlement,
 	orgPersistFreeOverage,
 	type Rollover,
+	type UsageAttribution,
 } from "@autumn/shared";
 import { logger } from "better-auth";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
@@ -20,6 +21,7 @@ export type ResetUpdates = {
 	additional_balance: number | null;
 	adjustment: number;
 	entities: Record<string, EntityBalance> | null;
+	usage_attribution: UsageAttribution;
 	next_reset_at: number;
 };
 
@@ -119,6 +121,7 @@ export const processReset = async ({
 					additional_balance: null,
 					adjustment: 0,
 					entities: resetBalanceUpdate.entities,
+					usage_attribution: resetBalanceUpdate.usage_attribution,
 					next_reset_at: nextResetAt,
 				}
 			: {
@@ -126,6 +129,7 @@ export const processReset = async ({
 					additional_balance: resetBalanceUpdate.additional_balance,
 					adjustment: 0,
 					entities: null,
+					usage_attribution: resetBalanceUpdate.usage_attribution,
 					next_reset_at: nextResetAt,
 				};
 

--- a/server/src/internal/customers/actions/resetCustomerEntitlements/processResetResultToResetCusEntParam.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlements/processResetResultToResetCusEntParam.ts
@@ -16,6 +16,7 @@ export const processResetResultToResetCusEntParam = ({
 		additional_balance: updates.additional_balance,
 		adjustment: updates.adjustment,
 		entities: updates.entities,
+		usage_attribution: updates.usage_attribution,
 		next_reset_at: updates.next_reset_at,
 		rollover_insert: result.rolloverInsert?.rows[0] ?? null,
 	};

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/applyResetResultsToFullSubject.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/applyResetResultsToFullSubject.ts
@@ -76,6 +76,7 @@ export const applyResetResultsToFullSubject = async ({
 			original.additional_balance = updates.additional_balance;
 		original.adjustment = updates.adjustment;
 		if (updates.entities !== null) original.entities = updates.entities;
+		original.usage_attribution = updates.usage_attribution;
 		original.next_reset_at = updates.next_reset_at;
 
 		if (!result.rolloverInsert) continue;
@@ -126,6 +127,7 @@ export const applyResetResultsToNormalized = ({
 			subjectBalance.additional_balance = updates.additional_balance;
 		subjectBalance.adjustment = updates.adjustment;
 		if (updates.entities !== null) subjectBalance.entities = updates.entities;
+		subjectBalance.usage_attribution = updates.usage_attribution;
 		subjectBalance.next_reset_at = updates.next_reset_at;
 		if (result.pooledGranted !== undefined && subjectBalance.pooled_balance) {
 			subjectBalance.pooled_balance.granted = result.pooledGranted;

--- a/server/src/internal/customers/actions/resetCustomerEntitlementsV2/resetSubjectCache.ts
+++ b/server/src/internal/customers/actions/resetCustomerEntitlementsV2/resetSubjectCache.ts
@@ -1,3 +1,4 @@
+import type { UsageAttribution } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import type { ResetCusEntParam } from "@/internal/balances/utils/sql/client.js";
 import { buildSharedFullSubjectBalanceKey } from "@/internal/customers/cache/fullSubject/builders/buildSharedFullSubjectBalanceKey.js";
@@ -11,6 +12,7 @@ interface SubjectBalanceUpdate {
 	additional_balance: number | null;
 	adjustment: number | null;
 	entities: Record<string, unknown> | null;
+	usage_attribution: UsageAttribution;
 	next_reset_at: number | null;
 	expected_next_reset_at: number | null;
 	pooled_granted: number | null;
@@ -63,6 +65,7 @@ export const resetSubjectCache = async ({
 				additional_balance: reset.additional_balance,
 				adjustment: reset.adjustment,
 				entities: reset.entities,
+				usage_attribution: reset.usage_attribution,
 				next_reset_at: reset.next_reset_at,
 				expected_next_reset_at: oldNextResetAts[reset.cus_ent_id] ?? null,
 				pooled_granted: pooledGrantedByCusEntId?.[reset.cus_ent_id] ?? null,

--- a/server/src/internal/customers/cusProducts/cusEnts/groupByUtils.ts
+++ b/server/src/internal/customers/cusProducts/cusEnts/groupByUtils.ts
@@ -1,10 +1,15 @@
-import type { EntityBalance, FullCustomerEntitlement } from "@autumn/shared";
+import type {
+	EntityBalance,
+	FullCustomerEntitlement,
+	UsageAttribution,
+} from "@autumn/shared";
 import { Decimal } from "decimal.js";
 import { notNullish } from "@/utils/genUtils.js";
 
-export type ResetBalancesUpdate =
+export type ResetBalancesUpdate = (
 	| { entities: Record<string, EntityBalance> }
-	| { balance: number; additional_balance: number; adjustment: number };
+	| { balance: number; additional_balance: number; adjustment: number }
+) & { usage_attribution: UsageAttribution };
 
 /** Returns the overage amount to deduct: max(0, -balance). */
 const computeOverageDeduction = ({ balance }: { balance: number }): Decimal => {
@@ -42,7 +47,7 @@ export const getResetBalancesUpdate = ({
 			newEntities[entityId].balance = entityResetBalance;
 			newEntities[entityId].adjustment = 0;
 		}
-		return { entities: newEntities };
+		return { entities: newEntities, usage_attribution: {} };
 	}
 
 	let resetBalance = newBalance;
@@ -57,5 +62,6 @@ export const getResetBalancesUpdate = ({
 		balance: resetBalance,
 		additional_balance: 0,
 		adjustment: 0,
+		usage_attribution: {},
 	};
 };

--- a/server/src/internal/features/creditSystemUtils.ts
+++ b/server/src/internal/features/creditSystemUtils.ts
@@ -192,28 +192,44 @@ export const getCreditRateCard = ({
 	sourceFeature: Feature;
 	creditSystem: Feature;
 }): CreditRateCard | undefined => {
-	if (
-		creditSystem.type !== FeatureType.CreditSystem ||
-		sourceFeature.id === creditSystem.id
-	) {
+	if (creditSystem.type !== FeatureType.CreditSystem) {
 		return undefined;
+	}
+
+	if (sourceFeature.id === creditSystem.id) {
+		return creditSystem.config.invoice_credit
+			? {
+					source_internal_feature_id: sourceFeature.internal_id,
+					feature_amount: 1,
+					credit_amount: 1,
+				}
+			: undefined;
 	}
 
 	const schemaItem = getCreditSchemaItem({
 		featureId: sourceFeature.id,
 		creditSystem,
 	});
-	if (!schemaItem || schemaItem.tier_behavior !== "graduated") return undefined;
+	if (!schemaItem) return undefined;
 
 	const base = {
 		source_internal_feature_id: sourceFeature.internal_id,
 		feature_amount: schemaItem.feature_amount ?? 1,
 	};
-	return {
-		...base,
-		tier_behavior: "graduated",
-		tiers: schemaItem.tiers,
-	};
+	if (schemaItem.tier_behavior === "graduated") {
+		return {
+			...base,
+			tier_behavior: "graduated",
+			tiers: schemaItem.tiers,
+		};
+	}
+
+	return creditSystem.config.invoice_credit
+		? {
+				...base,
+				credit_amount: schemaItem.credit_amount,
+			}
+		: undefined;
 };
 
 const creditSystemContainsFeature = ({

--- a/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
+++ b/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { type ApiCustomer, RolloverExpiryDurationType } from "@autumn/shared";
+import {
+	type ApiCustomer,
+	type ApiCustomerV5,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
 import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
 import { TestFeature } from "@tests/setup/v2Features.js";
 import { expireCusEntForReset } from "@tests/utils/cusProductUtils/resetTestUtils.js";
@@ -8,6 +12,8 @@ import { products } from "@tests/utils/fixtures/products.js";
 import { timeout } from "@tests/utils/genUtils";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { executePostgresDeductionV2 } from "@/internal/balances/utils/deductionV2/executePostgresDeductionV2.js";
+import { getOrSetCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrSetCachedFullSubject.js";
 
 // ─────────────────────────────────────────────────────────────────
 // Lazy reset with rollovers (DB path) — GET /customers skip_cache
@@ -147,3 +153,157 @@ test.concurrent(`${chalk.yellowBright("lazy reset rollover (cache): caps rollove
 	expect(cusEntAfter).toBeDefined();
 	expect(cusEntAfter!.next_reset_at).toBeGreaterThan(Date.now());
 });
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-credit cached reset: clears prior attribution and rates new-cycle rollover usage from zero")}`,
+	async () => {
+		const tieredCreditsItem = items.free({
+			featureId: TestFeature.TieredCredits,
+			includedUsage: 1_000,
+			rolloverConfig: {
+				max: 1_000,
+				length: 1,
+				duration: RolloverExpiryDurationType.Month,
+			},
+		});
+		const product = products.base({
+			id: "invoice-credit-reset-rollover",
+			items: [tieredCreditsItem],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "invoice-credit-reset-rollover",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.billing.attach({ productId: product.id })],
+		});
+		const sourceInternalFeatureId = ctx.features.find(
+			(feature) => feature.id === TestFeature.TieredAction,
+		)?.internal_id;
+		expect(sourceInternalFeatureId).toBeDefined();
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 5_000,
+		});
+		await timeout(2_000);
+		const beforeReset = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.TieredCredits,
+		});
+		expect(beforeReset?.usage_attribution?.[sourceInternalFeatureId!]).toEqual({
+			units: 5_000,
+			credits: 50,
+		});
+
+		await expireCusEntForReset({
+			ctx,
+			customerId,
+			featureId: TestFeature.TieredCredits,
+		});
+		const afterReset =
+			await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		expect(afterReset.balances[TestFeature.TieredCredits].remaining).toBe(
+			1_950,
+		);
+		const resetCustomerEntitlement = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.TieredCredits,
+		});
+		expect(resetCustomerEntitlement?.usage_attribution).toEqual({});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 100,
+		});
+		await timeout(2_000);
+		const afterRolloverSpend = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.TieredCredits,
+		});
+		expect(
+			afterRolloverSpend?.usage_attribution?.[sourceInternalFeatureId!],
+		).toEqual({
+			units: 100,
+			credits: 1,
+		});
+		expect(afterRolloverSpend?.rollovers[0]?.balance).toBe(949);
+	},
+	{ timeout: 120_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-credit rollover: Postgres fallback advances new-cycle attribution atomically")}`,
+	async () => {
+		const tieredCreditsItem = items.free({
+			featureId: TestFeature.TieredCredits,
+			includedUsage: 1_000,
+			rolloverConfig: {
+				max: 1_000,
+				length: 1,
+				duration: RolloverExpiryDurationType.Month,
+			},
+		});
+		const product = products.base({
+			id: "invoice-credit-postgres-rollover",
+			items: [tieredCreditsItem],
+		});
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "invoice-credit-postgres-rollover",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.billing.attach({ productId: product.id })],
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 5_000,
+		});
+		await timeout(2_000);
+		await expireCusEntForReset({
+			ctx,
+			customerId,
+			featureId: TestFeature.TieredCredits,
+		});
+		await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+
+		const fullSubject = await getOrSetCachedFullSubject({
+			ctx,
+			customerId,
+			source: "invoice-credit-postgres-rollover-test",
+		});
+		const sourceFeature = ctx.features.find(
+			(feature) => feature.id === TestFeature.TieredAction,
+		);
+		expect(sourceFeature).toBeDefined();
+		await executePostgresDeductionV2({
+			ctx,
+			fullSubject,
+			customerId,
+			deductions: [{ feature: sourceFeature!, deduction: 100 }],
+		});
+
+		const customerEntitlement = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.TieredCredits,
+		});
+		expect(
+			customerEntitlement?.usage_attribution?.[sourceFeature!.internal_id],
+		).toEqual({ units: 100, credits: 1 });
+		expect(customerEntitlement?.rollovers[0]?.balance).toBe(949);
+	},
+	{ timeout: 120_000 },
+);

--- a/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
@@ -69,7 +69,7 @@ const getPersistedCreditEntitlement = async ({
 	return rows[0];
 };
 
-test(
+test.concurrent(
 	`${chalk.yellowBright("graduated-credit-rating: Redis handles checks, concurrent boundary crossing, and refunds")}`,
 	async () => {
 		const customerId = "graduated-credit-rating-redis";
@@ -143,22 +143,82 @@ test(
 			credits: 99.5,
 		});
 
+		// Reserve across the first tier boundary, then finalize below the
+		// reservation. Only the final 100 source units (0.8 credits) unwind.
+		await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			required_balance: 200,
+			lock: {
+				enabled: true,
+				lock_id: `${customerId}-partial`,
+			},
+		});
+		await autumnV2_3.balances.finalize({
+			lock_id: `${customerId}-partial`,
+			action: "confirm",
+			override_value: 100,
+		});
+		const afterPartialFinalize =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
 		expect(
-			autumnV2_3.check({
-				customer_id: customerId,
-				feature_id: TestFeature.TieredAction,
-				required_balance: 100,
-				lock: {
-					enabled: true,
-					lock_id: "graduated-credit-rating-lock",
-				},
-			}),
-		).rejects.toThrow(/graduated credit.*lock/i);
+			afterPartialFinalize.features[TestFeature.TieredCredits].balance,
+		).toBeCloseTo(899.6, 10);
+
+		// Finalizing above the reservation keeps the reserve and rates the extra
+		// units from the already-advanced tier position.
+		await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			required_balance: 50,
+			lock: {
+				enabled: true,
+				lock_id: `${customerId}-higher`,
+			},
+		});
+		await autumnV2_3.balances.finalize({
+			lock_id: `${customerId}-higher`,
+			action: "confirm",
+			override_value: 100,
+		});
+
+		// A release is a full unwind of both the balance and attribution entry.
+		await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			required_balance: 100,
+			lock: {
+				enabled: true,
+				lock_id: `${customerId}-release`,
+			},
+		});
+		await autumnV2_3.balances.finalize({
+			lock_id: `${customerId}-release`,
+			action: "release",
+		});
+
+		const afterLockLifecycle =
+			await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(
+			afterLockLifecycle.features[TestFeature.TieredCredits].balance,
+		).toBeCloseTo(898.8, 10);
+
+		await timeout(3_000);
+		const afterLockPersisted = await getPersistedCreditEntitlement({
+			ctx,
+			internalCustomerId: customer.internal_id,
+		});
+		expect(
+			afterLockPersisted?.usageAttribution[sourceInternalFeatureId!],
+		).toEqual({
+			units: 10_150,
+			credits: 101.2,
+		});
 	},
 	{ timeout: 120_000 },
 );
 
-test(
+test.concurrent(
 	`${chalk.yellowBright("graduated-credit-rating: only usage spilling past the source allowance enters the card")}`,
 	async () => {
 		const customerId = "graduated-credit-rating-spill";
@@ -204,12 +264,78 @@ test(
 	{ timeout: 120_000 },
 );
 
-test(
+test.concurrent(
+	`${chalk.yellowBright("graduated-credit-rating: releasing a lock reprices from the current tier position")}`,
+	async () => {
+		const customerId = "graduated-credit-rating-lock-current-position";
+		const product = makeCreditProduct({
+			id: "graduated-credit-lock-current-position",
+		});
+		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.attach({ productId: product.id })],
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 9_900,
+		});
+		await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			required_balance: 50,
+			lock: {
+				enabled: true,
+				lock_id: `${customerId}-release`,
+			},
+		});
+
+		// Releasing the earlier 50 units removes the current marginal tail (0.4
+		// credits), leaving cost(10,000), rather than its original 0.5-credit cost.
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 100,
+		});
+		await autumnV2_3.balances.finalize({
+			lock_id: `${customerId}-release`,
+			action: "release",
+		});
+
+		const response = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(response.features[TestFeature.TieredCredits].balance).toBeCloseTo(
+			900,
+			10,
+		);
+
+		await timeout(3_000);
+		const persisted = await getPersistedCreditEntitlement({
+			ctx,
+			internalCustomerId: customer.internal_id,
+		});
+		const sourceInternalFeatureId = ctx.features.find(
+			(feature) => feature.id === TestFeature.TieredAction,
+		)?.internal_id;
+		expect(sourceInternalFeatureId).toBeDefined();
+		expect(persisted?.usageAttribution[sourceInternalFeatureId!]).toEqual({
+			units: 10_000,
+			credits: 100,
+		});
+	},
+	{ timeout: 120_000 },
+);
+
+test.concurrent(
 	`${chalk.yellowBright("graduated-credit-rating: Postgres fallback matches marginal rating")}`,
 	async () => {
 		const customerId = "graduated-credit-rating-postgres";
 		const product = makeCreditProduct({ id: "graduated-credit-postgres" });
-		const { customer, ctx } = await initScenario({
+		const { autumnV2_3, customer, ctx } = await initScenario({
 			customerId,
 			setup: [
 				s.customer({ testClock: false }),
@@ -263,6 +389,39 @@ test(
 				cached.value.balances[0]?.usage_attribution?.[sourceInternalFeatureId],
 			).toEqual({ units: 10_050, credits: 100.4 });
 		}
+
+		const lockId = `${customerId}-postgres-release`;
+		await executePostgresDeductionV2({
+			ctx,
+			fullSubject,
+			customerId,
+			deductions: [
+				{
+					feature: feature!,
+					deduction: 50,
+					lock: { enabled: true, lock_id: lockId },
+				},
+			],
+		});
+		await executePostgresDeductionV2({
+			ctx,
+			fullSubject,
+			customerId,
+			deductions: [{ feature: feature!, deduction: 100 }],
+		});
+		await autumnV2_3.balances.finalize(
+			{ lock_id: lockId, action: "release" },
+			{ skipCache: true },
+		);
+
+		const afterPostgresRelease = await getPersistedCreditEntitlement({
+			ctx,
+			internalCustomerId: customer.internal_id,
+		});
+		expect(afterPostgresRelease?.balance).toBeCloseTo(898.8, 10);
+		expect(
+			afterPostgresRelease?.usageAttribution[sourceInternalFeatureId],
+		).toEqual({ units: 10_150, credits: 101.2 });
 	},
 	{ timeout: 120_000 },
 );

--- a/server/tests/integration/balances/track/basic/track-invoice-credit-attribution.test.ts
+++ b/server/tests/integration/balances/track/basic/track-invoice-credit-attribution.test.ts
@@ -1,0 +1,88 @@
+/** One aggregate entry is kept per stable source ID; direct pool tracks are
+ * attributed 1:1, and refunds change only their source entry. */
+
+import { expect, test } from "bun:test";
+import { customerEntitlements } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { timeout } from "@tests/utils/genUtils.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { and, eq } from "drizzle-orm";
+
+test.concurrent(
+	"invoice-credit attribution aggregates multiple sources and isolated refunds",
+	async () => {
+		const customerId = "invoice-credit-flat-attribution";
+		const product = products.base({
+			id: "invoice-credit-flat-attribution",
+			items: [
+				items.free({
+					featureId: TestFeature.InvoiceCredits,
+					includedUsage: 1_000,
+				}),
+			],
+		});
+		const { autumnV2_3, customer, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.billing.attach({ productId: product.id })],
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 100,
+		});
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action2,
+			value: 100,
+		});
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.InvoiceCredits,
+			value: 10,
+		});
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: -50,
+		});
+
+		await timeout(3_000);
+		const [persisted] = await ctx.db
+			.select({
+				balance: customerEntitlements.balance,
+				usageAttribution: customerEntitlements.usage_attribution,
+			})
+			.from(customerEntitlements)
+			.where(
+				and(
+					eq(customerEntitlements.internal_customer_id, customer.internal_id),
+					eq(customerEntitlements.feature_id, TestFeature.InvoiceCredits),
+				),
+			)
+			.limit(1);
+
+		const internalId = (featureId: TestFeature) =>
+			ctx.features.find((feature) => feature.id === featureId)?.internal_id;
+		const action1InternalId = internalId(TestFeature.Action1);
+		const action2InternalId = internalId(TestFeature.Action2);
+		const invoiceCreditsInternalId = internalId(TestFeature.InvoiceCredits);
+		expect(action1InternalId).toBeDefined();
+		expect(action2InternalId).toBeDefined();
+		expect(invoiceCreditsInternalId).toBeDefined();
+
+		expect(persisted?.balance).toBeCloseTo(920, 10);
+		expect(persisted?.usageAttribution).toEqual({
+			[action1InternalId!]: { units: 50, credits: 10 },
+			[action2InternalId!]: { units: 100, credits: 60 },
+			[invoiceCreditsInternalId!]: { units: 10, credits: 10 },
+		});
+	},
+	{ timeout: 120_000 },
+);

--- a/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-basic.test.ts
+++ b/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-basic.test.ts
@@ -10,8 +10,9 @@
  *   on a plan transition (no clamping to zero)
  */
 
-import { test } from "bun:test";
+import { expect, test } from "bun:test";
 import type { ApiCustomerV3 } from "@autumn/shared";
+import { findCustomerEntitlement } from "@tests/balances/utils/findCustomerEntitlement.js";
 import { expectCustomerFeatureCorrect } from "@tests/integration/billing/utils/expectCustomerFeatureCorrect";
 import { TestFeature } from "@tests/setup/v2Features";
 import { items } from "@tests/utils/fixtures/items";
@@ -77,6 +78,64 @@ test.concurrent(
 			usage: 40,
 		});
 	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("carry-over-usage invoice credit: tier position follows the carried balance usage")}`,
+	async () => {
+		const oldCredits = items.free({
+			featureId: TestFeature.InvoiceCredits,
+			includedUsage: 1_000,
+		});
+		const newCredits = items.free({
+			featureId: TestFeature.InvoiceCredits,
+			includedUsage: 2_000,
+		});
+		const oldPlan = products.pro({
+			id: "invoice-credit-carry-old",
+			items: [oldCredits],
+		});
+		const newPlan = products.premium({
+			id: "invoice-credit-carry-new",
+			items: [newCredits],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "carry-over-usage-invoice-credit",
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [oldPlan, newPlan] }),
+			],
+			actions: [s.attach({ productId: oldPlan.id, timeout: 4_000 })],
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.Action1,
+			value: 100,
+		});
+		await new Promise((resolve) => setTimeout(resolve, 2_000));
+		await autumnV2_3.billing.attach({
+			customer_id: customerId,
+			plan_id: newPlan.id,
+			carry_over_usages: { enabled: true },
+		});
+
+		const customerEntitlement = await findCustomerEntitlement({
+			ctx,
+			customerId,
+			featureId: TestFeature.InvoiceCredits,
+		});
+		const sourceInternalFeatureId = ctx.features.find(
+			(feature) => feature.id === TestFeature.Action1,
+		)?.internal_id;
+		expect(sourceInternalFeatureId).toBeDefined();
+		expect(customerEntitlement?.balance).toBeCloseTo(1_980, 10);
+		expect(
+			customerEntitlement?.usage_attribution?.[sourceInternalFeatureId!],
+		).toEqual({ units: 100, credits: 20 });
+	},
+	{ timeout: 120_000 },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/server/tests/setup/v2Features.ts
+++ b/server/tests/setup/v2Features.ts
@@ -28,6 +28,7 @@ export enum TestFeature {
 	Credits2 = "credits2", // credit system
 	TieredAction = "tiered_action",
 	TieredCredits = "tiered_credits",
+	InvoiceCredits = "invoice_credits",
 
 	Credits3 = "credits3", // credit system (overlaps with credits on action1)
 
@@ -163,6 +164,39 @@ export const getFeatures = ({ orgId }: { orgId: string }) => ({
 						{ to: 50_000, credit_amount: 0.8 },
 						{ to: "inf" as const, credit_amount: 0.5 },
 					],
+				},
+			],
+		},
+	},
+	[TestFeature.InvoiceCredits]: {
+		...constructCreditSystem({
+			featureId: TestFeature.InvoiceCredits,
+			orgId,
+			env: AppEnv.Sandbox,
+			schema: [
+				{
+					metered_feature_id: TestFeature.Action1,
+					credit_cost: 0.2,
+				},
+				{
+					metered_feature_id: TestFeature.Action2,
+					credit_cost: 0.6,
+				},
+			],
+		}),
+		config: {
+			usage_type: FeatureUsageType.Single,
+			invoice_credit: true,
+			schema: [
+				{
+					metered_feature_id: TestFeature.Action1,
+					feature_amount: 1,
+					credit_amount: 0.2,
+				},
+				{
+					metered_feature_id: TestFeature.Action2,
+					feature_amount: 1,
+					credit_amount: 0.6,
 				},
 			],
 		},

--- a/server/tests/unit/balances/compute-credit-costs.test.ts
+++ b/server/tests/unit/balances/compute-credit-costs.test.ts
@@ -124,22 +124,25 @@ describe("computeCreditCosts", () => {
 		});
 	});
 
-	test("rejects graduated cards backed by an unlimited credit entitlement", () => {
-		const deduction: FeatureDeduction = { feature: messages, deduction: 10 };
-		const unlimitedEntitlement = {
-			...makeCusEnt("ce_graduated", graduatedCredits),
-			unlimited: true,
-		} as FullCusEntWithFullCusProduct;
+	test.concurrent(
+		"rejects rate cards backed by an unlimited credit entitlement",
+		() => {
+			const deduction: FeatureDeduction = { feature: messages, deduction: 10 };
+			const unlimitedEntitlement = {
+				...makeCusEnt("ce_graduated", graduatedCredits),
+				unlimited: true,
+			} as FullCusEntWithFullCusProduct;
 
-		expect(() =>
-			computeCreditCosts({
-				cusEnts: [unlimitedEntitlement],
-				deduction,
-			}),
-		).toThrow(/graduated credit rate cards.*unlimited/i);
-	});
+			expect(() =>
+				computeCreditCosts({
+					cusEnts: [unlimitedEntitlement],
+					deduction,
+				}),
+			).toThrow(/credit rate cards.*unlimited/i);
+		},
+	);
 
-	test("rejects graduated cards backed by additional balances", () => {
+	test.concurrent("rejects rate cards backed by additional balances", () => {
 		const deduction: FeatureDeduction = { feature: messages, deduction: 10 };
 		const customerAdditionalBalance = {
 			...makeCusEnt("ce_customer_additional", graduatedCredits),
@@ -166,7 +169,28 @@ describe("computeCreditCosts", () => {
 					cusEnts: [customerEntitlement],
 					deduction,
 				}),
-			).toThrow(/graduated credit rate cards.*additional balances/i);
+			).toThrow(/credit rate cards.*additional balances/i);
 		}
 	});
+
+	test.concurrent(
+		"rejects direct invoice-credit tracks backed by additional balance",
+		() => {
+			const deduction: FeatureDeduction = {
+				feature: currentInvoiceCredits,
+				deduction: 10,
+			};
+			const customerEntitlement = {
+				...makeCusEnt("ce_invoice_credits", currentInvoiceCredits),
+				additional_balance: 1,
+			} as FullCusEntWithFullCusProduct;
+
+			expect(() =>
+				computeCreditCosts({
+					cusEnts: [customerEntitlement],
+					deduction,
+				}),
+			).toThrow(/credit rate cards.*additional balances/i);
+		},
+	);
 });

--- a/server/tests/unit/billing/existing-usages/credit-rate-card-attribution-carry.test.ts
+++ b/server/tests/unit/billing/existing-usages/credit-rate-card-attribution-carry.test.ts
@@ -1,0 +1,242 @@
+/** Carry-over moves balance usage with its complete per-source tier position. */
+
+import { describe, expect, test } from "bun:test";
+import {
+	type ExistingUsages,
+	FeatureType,
+	type FullCustomerEntitlement,
+	type UsageAttribution,
+} from "@autumn/shared";
+import { contexts } from "@tests/utils/fixtures/db/contexts.js";
+import { customerEntitlements } from "@tests/utils/fixtures/db/customerEntitlements.js";
+import { customerProducts } from "@tests/utils/fixtures/db/customerProducts.js";
+import { applyExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.js";
+import { cusProductToExistingUsages } from "@/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.js";
+
+const CREDIT_FEATURE_ID = "invoice_credits";
+const CREDIT_INTERNAL_FEATURE_ID = "internal_invoice_credits";
+const SOURCE_A_ID = "feature_a";
+const SOURCE_A_INTERNAL_ID = "internal_feature_a";
+const SOURCE_B_ID = "feature_b";
+const SOURCE_B_INTERNAL_ID = "internal_feature_b";
+
+const usageAttribution = {
+	[SOURCE_A_INTERNAL_ID]: { units: 30_000, credits: 260 },
+	[SOURCE_B_INTERNAL_ID]: { units: 5_000, credits: 500 },
+};
+
+const makeRateCardEntitlement = ({
+	balance,
+	attribution = usageAttribution,
+	invoiceCredit = true,
+}: {
+	balance: number;
+	attribution?: UsageAttribution;
+	invoiceCredit?: boolean;
+}): FullCustomerEntitlement => {
+	const customerEntitlement = customerEntitlements.create({
+		featureId: CREDIT_FEATURE_ID,
+		internalFeatureId: CREDIT_INTERNAL_FEATURE_ID,
+		featureName: "Invoice credits",
+		featureType: FeatureType.CreditSystem,
+		featureConfig: {
+			invoice_credit: invoiceCredit,
+			schema: invoiceCredit
+				? []
+				: [SOURCE_A_ID, SOURCE_B_ID].map((meteredFeatureId) => ({
+						metered_feature_id: meteredFeatureId,
+						feature_amount: 100,
+						tier_behavior: "graduated" as const,
+						tiers: [{ to: "inf" as const, credit_amount: 1 }],
+					})),
+		},
+		allowance: 1_000,
+		balance,
+	});
+	customerEntitlement.usage_attribution = structuredClone(attribution);
+	return customerEntitlement;
+};
+
+describe("credit-rate usage attribution carry-over", () => {
+	test.concurrent("carry all preserves the complete attribution object", () => {
+		const customerProduct = customerProducts.create({
+			customerEntitlements: [makeRateCardEntitlement({ balance: 240 })],
+		});
+
+		const existingUsages = cusProductToExistingUsages({
+			cusProduct: customerProduct,
+			carryAllConsumableFeatures: true,
+		});
+
+		expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
+			usage: 760,
+			entityUsages: {},
+			usageAttribution,
+		});
+	});
+
+	test.concurrent(
+		"feature_ids carries attribution when the credit feature is selected",
+		() => {
+			const customerProduct = customerProducts.create({
+				customerEntitlements: [makeRateCardEntitlement({ balance: 240 })],
+			});
+
+			const existingUsages = cusProductToExistingUsages({
+				cusProduct: customerProduct,
+				consumableFeatureIdsToCarry: [CREDIT_FEATURE_ID],
+			});
+
+			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
+				usage: 760,
+				entityUsages: {},
+				usageAttribution,
+			});
+		},
+	);
+
+	test.concurrent(
+		"carry all preserves tier position when invoice rendering is disabled",
+		() => {
+			const customerProduct = customerProducts.create({
+				customerEntitlements: [
+					makeRateCardEntitlement({
+						balance: 240,
+						invoiceCredit: false,
+					}),
+				],
+			});
+
+			const existingUsages = cusProductToExistingUsages({
+				cusProduct: customerProduct,
+				carryAllConsumableFeatures: true,
+			});
+
+			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
+				usage: 760,
+				entityUsages: {},
+				usageAttribution,
+			});
+		},
+	);
+
+	test.concurrent(
+		"sums duplicate source entries from multiple credit entitlements",
+		() => {
+			const customerProduct = customerProducts.create({
+				customerEntitlements: [
+					makeRateCardEntitlement({
+						balance: 988,
+						attribution: {
+							[SOURCE_A_INTERNAL_ID]: { units: 1_000, credits: 10 },
+							[SOURCE_B_INTERNAL_ID]: { units: 20, credits: 2 },
+						},
+					}),
+					makeRateCardEntitlement({
+						balance: 992,
+						attribution: {
+							[SOURCE_A_INTERNAL_ID]: { units: 500, credits: 5 },
+							[SOURCE_B_INTERNAL_ID]: { units: 30, credits: 3 },
+						},
+					}),
+				],
+			});
+
+			const existingUsages = cusProductToExistingUsages({
+				cusProduct: customerProduct,
+				carryAllConsumableFeatures: true,
+			});
+
+			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
+				usage: 20,
+				entityUsages: {},
+				usageAttribution: {
+					[SOURCE_A_INTERNAL_ID]: { units: 1_500, credits: 15 },
+					[SOURCE_B_INTERNAL_ID]: { units: 50, credits: 5 },
+				},
+			});
+		},
+	);
+
+	test.concurrent(
+		"rollover-funded attribution does not deduct the main allowance twice",
+		() => {
+			const customerProduct = customerProducts.create({
+				customerEntitlements: [
+					makeRateCardEntitlement({
+						balance: 1_000,
+						attribution: {
+							[SOURCE_A_INTERNAL_ID]: { units: 5_000, credits: 50 },
+						},
+					}),
+				],
+			});
+
+			const existingUsages = cusProductToExistingUsages({
+				cusProduct: customerProduct,
+				carryAllConsumableFeatures: true,
+			});
+
+			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
+				usage: 0,
+				entityUsages: {},
+				usageAttribution: {
+					[SOURCE_A_INTERNAL_ID]: { units: 5_000, credits: 50 },
+				},
+			});
+
+			const targetCustomerEntitlement = makeRateCardEntitlement({
+				balance: 1_000,
+			});
+			targetCustomerEntitlement.usage_attribution = {};
+			const targetCustomerProduct = customerProducts.create({
+				customerEntitlements: [targetCustomerEntitlement],
+			});
+			applyExistingUsages({
+				ctx: contexts.create({}),
+				customerProduct: targetCustomerProduct,
+				existingUsages,
+				entities: [],
+			});
+
+			expect(targetCustomerEntitlement.balance).toBe(1_000);
+			expect(targetCustomerEntitlement.usage_attribution).toEqual({
+				[SOURCE_A_INTERNAL_ID]: { units: 5_000, credits: 50 },
+			});
+		},
+	);
+
+	test.concurrent(
+		"applying carried usage installs the matching attribution on the target",
+		() => {
+			const targetCustomerEntitlement = makeRateCardEntitlement({
+				balance: 1_000,
+			});
+			targetCustomerEntitlement.usage_attribution = {};
+			const customerProduct = customerProducts.create({
+				customerEntitlements: [targetCustomerEntitlement],
+			});
+			const existingUsages: ExistingUsages = {
+				[CREDIT_INTERNAL_FEATURE_ID]: {
+					usage: 260,
+					entityUsages: {},
+					usageAttribution: {
+						[SOURCE_A_INTERNAL_ID]: usageAttribution[SOURCE_A_INTERNAL_ID],
+					},
+				},
+			};
+
+			applyExistingUsages({
+				ctx: contexts.create({}),
+				customerProduct,
+				existingUsages,
+				entities: [],
+			});
+
+			expect(targetCustomerEntitlement.balance).toBe(740);
+			expect(targetCustomerEntitlement.usage_attribution).toEqual({
+				[SOURCE_A_INTERNAL_ID]: usageAttribution[SOURCE_A_INTERNAL_ID],
+			});
+		},
+	);
+});

--- a/server/tests/unit/customers/get-reset-balances-update.test.ts
+++ b/server/tests/unit/customers/get-reset-balances-update.test.ts
@@ -1,0 +1,66 @@
+/** A cycle reset clears prior attribution in the same typed intent as the
+ * balance refill. */
+
+import { describe, expect, test } from "bun:test";
+import type { FullCustomerEntitlement } from "@autumn/shared";
+import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils.js";
+
+const makeCustomerEntitlement = ({
+	entityFeatureId,
+}: {
+	entityFeatureId?: string;
+}) =>
+	({
+		balance: 40,
+		additional_balance: 0,
+		adjustment: 0,
+		entities: entityFeatureId
+			? {
+					entity_1: {
+						balance: 40,
+						adjustment: 0,
+					},
+				}
+			: {},
+		usage_attribution: {
+			feature_a_internal: {
+				units: 60,
+				credits: 60,
+			},
+		},
+		entitlement: {
+			allowance: 100,
+			entity_feature_id: entityFeatureId ?? null,
+		},
+	}) as unknown as FullCustomerEntitlement;
+
+describe("getResetBalancesUpdate", () => {
+	test.concurrent("clears attribution on a top-level balance reset", () => {
+		const update = getResetBalancesUpdate({
+			cusEnt: makeCustomerEntitlement({}),
+		});
+
+		expect(update).toMatchObject({
+			balance: 100,
+			additional_balance: 0,
+			adjustment: 0,
+			usage_attribution: {},
+		});
+	});
+
+	test.concurrent("clears attribution on an entity balance reset", () => {
+		const update = getResetBalancesUpdate({
+			cusEnt: makeCustomerEntitlement({ entityFeatureId: "workspace" }),
+		});
+
+		expect(update).toMatchObject({
+			usage_attribution: {},
+			entities: {
+				entity_1: {
+					balance: 100,
+					adjustment: 0,
+				},
+			},
+		});
+	});
+});

--- a/server/tests/unit/features/get-credit-cost.test.ts
+++ b/server/tests/unit/features/get-credit-cost.test.ts
@@ -18,7 +18,7 @@ await mockModuleWithRestore(
 const { getModelCreditCost, getModelCreditCostBreakdown } = await import(
 	"@/internal/features/aiCreditSystemUtils.js"
 );
-const { getCreditCost } = await import(
+const { getCreditCost, getCreditRateCard } = await import(
 	"@/internal/features/creditSystemUtils.js"
 );
 
@@ -64,6 +64,85 @@ const graduatedCreditFeature: Feature = {
 	},
 	model_markups: null,
 };
+
+const sourceFeature: Feature = {
+	...aiCreditFeature,
+	internal_id: "fe_messages",
+	id: "messages",
+	name: "Messages",
+	type: FeatureType.Metered,
+	config: {
+		usage_type: FeatureUsageType.Single,
+	},
+	model_markups: null,
+};
+
+const flatInvoiceCreditFeature: Feature = {
+	...graduatedCreditFeature,
+	config: {
+		usage_type: FeatureUsageType.Single,
+		invoice_credit: true,
+		schema: [
+			{
+				metered_feature_id: sourceFeature.id,
+				feature_amount: 100,
+				credit_amount: 2,
+			},
+		],
+	},
+};
+
+describe("getCreditRateCard — invoice attribution descriptors", () => {
+	test.concurrent(
+		"returns a flat descriptor for source usage on invoice credits",
+		() => {
+			expect(
+				getCreditRateCard({
+					sourceFeature,
+					creditSystem: flatInvoiceCreditFeature,
+				}),
+			).toEqual({
+				source_internal_feature_id: sourceFeature.internal_id,
+				feature_amount: 100,
+				credit_amount: 2,
+			});
+		},
+	);
+
+	test.concurrent(
+		"attributes direct invoice-credit tracks to the credit feature at 1:1",
+		() => {
+			expect(
+				getCreditRateCard({
+					sourceFeature: flatInvoiceCreditFeature,
+					creditSystem: flatInvoiceCreditFeature,
+				}),
+			).toEqual({
+				source_internal_feature_id: flatInvoiceCreditFeature.internal_id,
+				feature_amount: 1,
+				credit_amount: 1,
+			});
+		},
+	);
+
+	test.concurrent(
+		"does not add attribution state to ordinary flat credit systems",
+		() => {
+			expect(
+				getCreditRateCard({
+					sourceFeature,
+					creditSystem: {
+						...flatInvoiceCreditFeature,
+						config: {
+							...flatInvoiceCreditFeature.config,
+							invoice_credit: false,
+						},
+					},
+				}),
+			).toBeUndefined();
+		},
+	);
+});
 
 describe("getCreditCost — graduated rate cards", () => {
 	test("charges the marginal cost when usage crosses one tier", () => {

--- a/server/tests/utils/fixtures/items.ts
+++ b/server/tests/utils/fixtures/items.ts
@@ -53,15 +53,18 @@ const free = ({
 	featureId,
 	includedUsage = 100,
 	entityFeatureId,
+	rolloverConfig,
 }: {
 	featureId: string;
 	includedUsage?: number;
 	entityFeatureId?: string;
+	rolloverConfig?: RolloverConfig;
 }): LimitedItem =>
 	constructFeatureItem({
 		featureId,
 		includedUsage,
 		entityFeatureId,
+		rolloverConfig,
 	}) as LimitedItem;
 
 /**

--- a/shared/models/billingModels/customerProduct/existingUsages.ts
+++ b/shared/models/billingModels/customerProduct/existingUsages.ts
@@ -1,10 +1,12 @@
 import { z } from "zod/v4";
+import { UsageAttributionSchema } from "../../cusProductModels/cusEntModels/cusEntModels.js";
 
 export const ExistingUsagesSchema = z.record(
 	z.string(),
 	z.object({
 		usage: z.number(),
 		entityUsages: z.record(z.string(), z.number()),
+		usageAttribution: UsageAttributionSchema.optional(),
 	}),
 );
 


### PR DESCRIPTION
## Cubic summary

Keeps each invoice-credit entitlement's per-feature usage attribution in sync with its balance through tracks, locks, refunds, resets, rollovers, and plan carry-over.

Stack: #2867 -> #2897 -> #2938 -> this PR.

## What changed

- Carries `{ units, credits }` attribution through both Redis/Lua and Postgres deductions.
- Attributes direct credit tracks 1:1 and keeps one aggregate per stable source feature ID.
- Unwinds attribution during lock confirmation/release and negative usage.
- Clears attribution on reset while rating new-cycle rollover spend from zero.
- Preserves attribution across `carry_over_usages` without double-deducting rollover-funded usage.
- Loads the SQL credit-rate helpers before the rollover and deduction functions that depend on them.

## Scope

This is step 4 of the enterprise credit rate-card stack. It adds the attribution lifecycle needed for a later itemized invoice breakdown.

It does not add pooled/direct-balance mutation guards or Stripe invoice rendering; those remain follow-up PRs.

## Testing

- 34 focused unit tests.
- 35 integration tests covering flat and graduated attribution, Redis and Postgres parity, locks, refunds, resets, rollovers, carry-over, and existing credit-system regressions.
- `cd server && bun run ts`
- Commit hooks: `knip` and server typecheck.
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps per-source invoice-credit usage attribution synchronized with balances across deductions, locks, refunds, resets, rollovers, and plan carry-over to enable itemized invoice breakdowns. Behavior changes: lock confirm/release reprices and unwinds at the current marginal rate-card attribution (fixes under-restoration), resets clear `usage_attribution`, and rate cards are now supported with rollovers and locks (still disallowed with unlimited credit entitlements).

- Attributes `{units, credits, rate_card}` per stable source feature in Redis/Lua and Postgres; direct pool tracks are 1:1 and mutation logs may include `usage_attribution_delta`.
- Rollover-funded usage rates against the owner’s current-cycle tier position and avoids double-charging; carry-over restores full per-source attribution on the target entitlement.
- SQL: adds attribution helpers and repricing for rollovers and lock unwind; ensures `creditRateUtils.sql` loads before dependent functions; unlimited-credit + rate-card requests return an error.

Bolded rollout and migration
- Re-run the DB function loader so `creditRateUtils.sql` installs before `deductFromRollovers.sql` and `unwindFromLockReceipt.sql`.
- Ensure services tolerate `MutationLogItem.usage_attribution_delta` and `usage_attribution` on entitlement resets/updates.
- Do not back rate cards with unlimited credit entitlements; this remains unsupported and will error.

<sup>Written for commit 194dbccd3c675134b2b2a51e9b794238ea4fb6ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Keeps invoice-credit usage attribution synchronized across deductions, rollovers, resets, locks, refunds, and plan carry-over.

- **[Improvements]** Carries per-feature units, credits, and rate-card attribution through Redis/Lua and PostgreSQL balance mutations.
- **[Bug fixes]** Clears or preserves attribution as appropriate during resets, rollovers, refunds, and carried usage.
- **[API changes]** Extends internal reset, existing-usage, and mutation-log data shapes with usage-attribution fields.
- **[Improvements]** Loads shared credit-rate SQL helpers before dependent rollover and lock-unwind functions.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because rate-card lock release can still leave a customer's credit balance below the amount it should restore.

A positive lock receipt can be fully consumed after a negative usage adjustment even though restoration is capped to the smaller live attribution, so the previously reported balance-under-restoration failure remains.

**Files Needing Attention:** server/src/_luaScriptsV2/fullSubjectDeduction/lock/unwindLockV2.lua

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/_luaScriptsV2/fullSubjectDeduction/lock/unwindLockV2.lua | Adds marginal rate-card repricing during lock unwind, but the previously reported partial-restoration defect remains outstanding. |
| server/src/internal/balances/utils/sql/creditRateUtils.sql | Adds reusable attribution, rollover-rating, mutation-log repricing, and lock-unwind helpers. |
| server/src/internal/balances/utils/sql/deductFromRollovers.sql | Rates rollover-funded usage against current entitlement attribution and persists coordinated rollover and attribution mutations. |
| server/src/_luaScriptsV2/fullSubjectDeduction/deductFromRolloversV2.lua | Adds Redis/Lua rollover attribution and marginal rate-card deduction behavior. |
| server/src/internal/balances/batchReset/execute/executeResetMutations.ts | Persists reset-produced usage attribution alongside balances, entities, and reset timing. |
| server/src/internal/billing/v2/utils/handleExistingUsages/applyExistingUsages.ts | Extends existing-usage carry-over processing to preserve invoice-credit attribution. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Track[Track usage] --> Deduct[Deduct credits]
  Deduct --> Attribute[Record source units and credits]
  Attribute --> Lock[Lock lifecycle]
  Attribute --> Reset[Reset or rollover]
  Attribute --> Carry[Plan carry-over]
  Lock --> Unwind[Confirm or release]
  Unwind --> Attribute
  Reset --> NewCycle[New-cycle attribution]
  Carry --> Target[Target entitlement attribution]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Add invoice credit attribution lifecycle"](https://github.com/useautumn/autumn/commit/50e088e54804414f71a0f0e1d0efaf23cfdb5fbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56274870)</sub>

<!-- /greptile_comment -->