### PR TITLE
feat: support named sandboxes in MCP OAuth

### DIFF
--- a/packages/auth/src/oauth/autumnOAuth.ts
+++ b/packages/auth/src/oauth/autumnOAuth.ts
@@ -3,8 +3,8 @@ import {
 	OAUTH_PROTOCOL_SCOPES,
 } from "@autumn/shared/utils/auth/autumnOAuthScopes";
 import {
-	getOAuthProtocolScopes as getSharedOAuthProtocolScopes,
 	getRequestedOAuthResourceScopes,
+	getOAuthProtocolScopes as getSharedOAuthProtocolScopes,
 	isOAuthProtocolScope,
 } from "@autumn/shared/utils/auth/oauthScopeUtils";
 
@@ -22,7 +22,19 @@ export const getDefaultOAuthScopes = (requestedScopes?: string[] | null) => {
 	return [...new Set([...resourceScopes, ...OAUTH_PROTOCOL_SCOPES])];
 };
 
-export const getOAuthResourceScopes = <T extends string>(scopes: readonly T[]) =>
-	scopes.filter((scope) => !isOAuthProtocolScope(scope));
+export const getOAuthResourceScopes = <T extends string>(
+	scopes: readonly T[],
+) => scopes.filter((scope) => !isOAuthProtocolScope(scope));
 
 export const getOAuthProtocolScopes = getSharedOAuthProtocolScopes;
+
+export const getOAuthConsentOrgId = ({
+	metadata,
+	referenceId,
+}: {
+	metadata: Record<string, unknown> | null;
+	referenceId: string;
+}) =>
+	typeof metadata?.sandboxOrgId === "string" && metadata.sandboxOrgId
+		? metadata.sandboxOrgId
+		: referenceId;

--- a/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
+++ b/server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts
@@ -1,4 +1,4 @@
-import { AppEnv, RecaseError } from "@autumn/shared";
+import { AppEnv, organizations, RecaseError } from "@autumn/shared";
 import {
 	asNonEmptyString,
 	type OAuthRequestFields,
@@ -6,6 +6,7 @@ import {
 	rebuildOAuthRequest,
 } from "@autumn/shared/utils/auth/oauthRequestBody";
 import { splitOAuthScopeString } from "@autumn/shared/utils/auth/oauthScopeUtils";
+import { and, eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { type DrizzleCli, db } from "@/db/initDrizzle.js";
 import { auth } from "@/utils/auth.js";
@@ -195,6 +196,30 @@ export const handleOAuthConsentWithEnv = async (c: Context) => {
 		});
 	}
 
+	const requestedSandboxOrgId = asNonEmptyString(fields.sandbox_org_id);
+	let sandboxOrgId: string | null = null;
+	if (requestedSandboxOrgId) {
+		const [sandbox] = await db
+			.select({ id: organizations.id })
+			.from(organizations)
+			.where(
+				and(
+					eq(organizations.id, requestedSandboxOrgId),
+					eq(organizations.created_by, principal.orgId),
+					eq(organizations.is_sandbox, true),
+				),
+			)
+			.limit(1);
+		if (!sandbox || env !== AppEnv.Sandbox) {
+			return jsonOAuthError({
+				code: "invalid_request",
+				description: "Select a sandbox owned by the active organization.",
+				status: 400,
+			});
+		}
+		sandboxOrgId = sandbox.id;
+	}
+
 	let narrowed: { grantedScopes: string[]; request: Request };
 	try {
 		narrowed = await narrowConsentScopes({
@@ -229,6 +254,7 @@ export const handleOAuthConsentWithEnv = async (c: Context) => {
 		userId: principal.userId,
 		referenceId: principal.orgId,
 		env,
+		sandboxOrgId,
 		redirectUri: getRedirectUriFromFields(fields),
 		scopes: narrowed.grantedScopes,
 	});

--- a/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
+++ b/server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts
@@ -1,5 +1,8 @@
 import { prefixOAuthToken } from "@autumn/auth";
-import { returnsOAuthAccessTokenForClientId } from "@autumn/auth/oauth";
+import {
+	getOAuthConsentOrgId,
+	returnsOAuthAccessTokenForClientId,
+} from "@autumn/auth/oauth";
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { asNonEmptyString } from "@autumn/shared/utils/auth/oauthRequestBody";
 import type { Context } from "hono";
@@ -10,6 +13,7 @@ import {
 	storeOAuthRefreshReplay,
 } from "@/external/redis/actions/oauthRefreshReplay/oauthRefreshReplay.js";
 import { auth } from "@/utils/auth.js";
+import { oauthConsentRepo } from "../repos/index.js";
 import { isMcpOAuthClient } from "./mcpOAuthScopes.js";
 import {
 	getExternalOAuthApiKeyForToken,
@@ -88,6 +92,16 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 			tokenRecord,
 		});
 		const consentedTokenRecord = { ...tokenRecord, oauthConsentId };
+		const consentMetadata = oauthConsentId
+			? await oauthConsentRepo.getMetadataById({
+					db,
+					consentId: oauthConsentId,
+				})
+			: null;
+		const grantReferenceId = getOAuthConsentOrgId({
+			metadata: consentMetadata,
+			referenceId: tokenRecord.referenceId,
+		});
 
 		// The minted token names the authoritative client: a confidential client
 		// authenticates over the header, so setup saw no client_id to classify.
@@ -113,6 +127,7 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 			accessTokenId: tokenRecord.id,
 			db,
 			oauthConsentId,
+			referenceId: grantReferenceId,
 			refreshTokenId: tokenRecord.refreshId,
 			resource: tokenRequest.resource,
 			scopes: issuedScopes,
@@ -146,7 +161,11 @@ export const handleOAuthTokenWithApiKey = async (c: Context) => {
 		// 7. Everyone else exchanges the token for a scoped api key
 		const apiKeyResult = await getExternalOAuthApiKeyForToken({
 			db,
-			tokenRecord: { ...consentedTokenRecord, scopes: issuedScopes },
+			tokenRecord: {
+				...consentedTokenRecord,
+				referenceId: grantReferenceId,
+				scopes: issuedScopes,
+			},
 			requestedScopes: requestedResourceScopes,
 		});
 		if (!apiKeyResult) return response;

--- a/server/src/internal/auth/oauth/oauthConsentApiKey.ts
+++ b/server/src/internal/auth/oauth/oauthConsentApiKey.ts
@@ -111,7 +111,6 @@ export const rotateOAuthConsentApiKey = async ({
 			consentId: consent.id,
 			clientId: tokenRecord.clientId,
 			redirectUri: consent.redirectUri,
-			orgId: tokenRecord.referenceId,
 			userId: tokenRecord.userId,
 			env,
 		});

--- a/server/src/internal/auth/oauth/token/persistOAuthTokenGrant.ts
+++ b/server/src/internal/auth/oauth/token/persistOAuthTokenGrant.ts
@@ -9,6 +9,7 @@ export const persistOAuthTokenGrant = async ({
 	accessTokenId,
 	db,
 	oauthConsentId,
+	referenceId,
 	refreshTokenId,
 	resource,
 	scopes,
@@ -16,6 +17,7 @@ export const persistOAuthTokenGrant = async ({
 	accessTokenId?: string | null;
 	db: DrizzleCli;
 	oauthConsentId: string | null;
+	referenceId?: string;
 	refreshTokenId?: string | null;
 	resource: string | null;
 	scopes: string[];
@@ -28,6 +30,7 @@ export const persistOAuthTokenGrant = async ({
 				db: tx,
 				id: accessTokenId,
 				oauthConsentId,
+				referenceId,
 				resource,
 				scopes,
 			});

--- a/server/src/internal/auth/repos/oauthAccessTokenRepo.ts
+++ b/server/src/internal/auth/repos/oauthAccessTokenRepo.ts
@@ -22,17 +22,30 @@ const deleteOAuthAccessTokensByClientAndReference = async ({
 			),
 		);
 
+const deleteOAuthAccessTokensByConsentId = async ({
+	db,
+	consentId,
+}: {
+	db: DrizzleCli;
+	consentId: string;
+}) =>
+	db
+		.delete(oauthAccessToken)
+		.where(eq(oauthAccessToken.oauthConsentId, consentId));
+
 /** Null consent/resource leave the stored value alone; a grant is never blanked. */
 const updateOAuthAccessTokenGrant = async ({
 	db,
 	id,
 	oauthConsentId,
+	referenceId,
 	resource,
 	scopes,
 }: {
 	db: Pick<DrizzleCli, "update">;
 	id: string;
 	oauthConsentId: string | null;
+	referenceId?: string;
 	resource: string | null;
 	scopes: string[];
 }) =>
@@ -41,11 +54,13 @@ const updateOAuthAccessTokenGrant = async ({
 		.set({
 			scopes,
 			...(oauthConsentId ? { oauthConsentId } : {}),
+			...(referenceId ? { referenceId } : {}),
 			...(resource ? { resource } : {}),
 		})
 		.where(eq(oauthAccessToken.id, id));
 
 export const oauthAccessTokenRepo = {
 	deleteByClientAndReference: deleteOAuthAccessTokensByClientAndReference,
+	deleteByConsentId: deleteOAuthAccessTokensByConsentId,
 	updateGrant: updateOAuthAccessTokenGrant,
 };

--- a/server/src/internal/auth/repos/oauthApiKeyRepo.ts
+++ b/server/src/internal/auth/repos/oauthApiKeyRepo.ts
@@ -20,7 +20,6 @@ export const isOAuthConsentLinkedApiKey = ({
 	consentId,
 	clientId,
 	redirectUri,
-	orgId,
 	userId,
 	env,
 }: {
@@ -28,12 +27,10 @@ export const isOAuthConsentLinkedApiKey = ({
 	consentId: string;
 	clientId: string;
 	redirectUri: string | null;
-	orgId: string;
 	userId: string;
 	env: AppEnv;
 }) => {
 	if (
-		apiKey.orgId !== orgId ||
 		apiKey.userId !== userId ||
 		apiKey.env !== env ||
 		!isRecord(apiKey.meta)
@@ -56,7 +53,6 @@ export const deleteOAuthConsentLinkedApiKey = async ({
 	consentId,
 	clientId,
 	redirectUri,
-	orgId,
 	userId,
 	env,
 }: {
@@ -65,7 +61,6 @@ export const deleteOAuthConsentLinkedApiKey = async ({
 	consentId: string;
 	clientId: string;
 	redirectUri: string | null;
-	orgId: string;
 	userId: string;
 	env: AppEnv;
 }) => {
@@ -90,7 +85,6 @@ export const deleteOAuthConsentLinkedApiKey = async ({
 			consentId,
 			clientId,
 			redirectUri,
-			orgId,
 			userId,
 			env,
 		})

--- a/server/src/internal/auth/repos/oauthConsentRepo.ts
+++ b/server/src/internal/auth/repos/oauthConsentRepo.ts
@@ -156,6 +156,7 @@ export const updateOAuthConsentEnv = async ({
 	userId,
 	referenceId,
 	env,
+	sandboxOrgId,
 	redirectUri,
 	scopes,
 }: {
@@ -164,6 +165,7 @@ export const updateOAuthConsentEnv = async ({
 	userId: string;
 	referenceId: string;
 	env: AppEnv;
+	sandboxOrgId: string | null;
 	redirectUri: string | null;
 	scopes?: string[];
 }) =>
@@ -171,6 +173,9 @@ export const updateOAuthConsentEnv = async ({
 		.update(oauthConsent)
 		.set({
 			env,
+			metadata: sandboxOrgId
+				? sql`COALESCE(${oauthConsent.metadata}, '{}'::jsonb) || jsonb_build_object('sandboxOrgId', ${sandboxOrgId}::text)`
+				: sql`COALESCE(${oauthConsent.metadata}, '{}'::jsonb) - 'sandboxOrgId'`,
 			redirectUri,
 			...(scopes ? { scopes } : {}),
 			updatedAt: new Date(),

--- a/server/src/internal/misc/consent/handlers/handleRevokeConsent.ts
+++ b/server/src/internal/misc/consent/handlers/handleRevokeConsent.ts
@@ -9,18 +9,7 @@ import {
 	oauthRefreshTokenRepo,
 } from "@/internal/auth/repos/index.js";
 
-/**
- * Revoke an OAuth consent and delete all linked resources:
- * - API keys (with meta.oauth_consent_id matching)
- * - Access tokens (matching clientId + referenceId)
- * - Refresh tokens (matching clientId + referenceId)
- * - The consent itself
- *
- * DELETE /consents/:consent_id
- * Auth: Session (from internalRouter middleware)
- *
- * Returns: { deleted_api_keys: ["am_sk_test_...", ...] }
- */
+/** Only the consent owner may revoke it and its linked credentials. */
 export const handleRevokeConsent = createRoute({
 	scopes: [Scopes.Organisation.Write],
 	params: z.object({
@@ -77,12 +66,13 @@ export const handleRevokeConsent = createRoute({
 			}
 		}
 
-		// 4. Delete access tokens for this client + org
+		// Delete legacy main-org tokens and sandbox-bound consent tokens.
 		await oauthAccessTokenRepo.deleteByClientAndReference({
 			db,
 			clientId,
 			referenceId,
 		});
+		await oauthAccessTokenRepo.deleteByConsentId({ db, consentId: consent_id });
 
 		// 5. Delete refresh tokens for this client + org
 		await oauthRefreshTokenRepo.deleteByClientAndReference({

--- a/server/tests/integration/auth/mcp-oauth-end-to-end.test.ts
+++ b/server/tests/integration/auth/mcp-oauth-end-to-end.test.ts
@@ -5,12 +5,15 @@ import {
 	DEFAULT_OAUTH_RESOURCE_SCOPES,
 	oauthAccessToken,
 	oauthClient,
+	oauthConsent,
+	oauthRefreshToken,
 } from "@autumn/shared";
 import { hashOAuthToken } from "@autumn/shared/utils/auth/oauthAccessTokens";
 import defaultCtx from "@tests/utils/testInitUtils/createTestContext.js";
 import {
 	createDashboardSession,
 	type DashboardSession,
+	dashboardFetch,
 } from "@tests/utils/testInitUtils/dashboardSession.js";
 import { eq } from "drizzle-orm";
 import { initDrizzle } from "@/db/initDrizzle.js";
@@ -130,11 +133,13 @@ const sessionHeaders = ({
 const authorizeWithConsent = async ({
 	clientId,
 	resource,
+	sandboxOrgId,
 	scopes,
 	session,
 }: {
 	clientId: string;
 	resource: string;
+	sandboxOrgId?: string;
 	scopes: string[];
 	session: DashboardSession;
 }) => {
@@ -181,6 +186,7 @@ const authorizeWithConsent = async ({
 		body: JSON.stringify({
 			accept: true,
 			env: "sandbox",
+			...(sandboxOrgId ? { sandbox_org_id: sandboxOrgId } : {}),
 			oauth_query: oauthQuery,
 			scope: new URLSearchParams(oauthQuery).get("scope") ?? undefined,
 		}),
@@ -226,6 +232,31 @@ const exchangeCode = async ({
 	};
 };
 
+const exchangeRefreshToken = async ({
+	clientId,
+	refreshToken,
+	resource,
+}: {
+	clientId: string;
+	refreshToken: string;
+	resource: string;
+}) => {
+	const response = await fetch(`${baseUrl}/api/auth/oauth2/token`, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			client_id: clientId,
+			grant_type: "refresh_token",
+			refresh_token: refreshToken,
+			resource,
+		}),
+	});
+	return {
+		body: (await response.json()) as Record<string, unknown>,
+		status: response.status,
+	};
+};
+
 const getCallbackCode = (consentBody: Record<string, unknown>) => {
 	const redirect = consentBody.url ?? consentBody.redirect_uri;
 	if (typeof redirect !== "string") {
@@ -242,17 +273,20 @@ const getCallbackCode = (consentBody: Record<string, unknown>) => {
 const grantTokenForResource = async ({
 	clientId,
 	resource,
+	sandboxOrgId,
 	scopes,
 	session,
 }: {
 	clientId: string;
 	resource: string;
+	sandboxOrgId?: string;
 	scopes: string[];
 	session: DashboardSession;
 }) => {
 	const consent = await authorizeWithConsent({
 		clientId,
 		resource,
+		sandboxOrgId,
 		scopes,
 		session,
 	});
@@ -270,6 +304,7 @@ const grantTokenForResource = async ({
 test("MCP OAuth end to end: challenge, discovery, DCR, consent, token, tool call", async () => {
 	const session = await createDashboardSession(defaultCtx);
 	let clientId: string | null = null;
+	let sandboxId: string | null = null;
 
 	try {
 		// 1. Unauthenticated challenge
@@ -325,14 +360,56 @@ test("MCP OAuth end to end: challenge, discovery, DCR, consent, token, tool call
 		expect(registration.status).toBe(201);
 		expect(typeof registration.body.client_id).toBe("string");
 		clientId = registration.body.client_id as string;
+		const sandbox = await dashboardFetch<{ id: string }>(
+			defaultCtx,
+			session,
+			"/v1/sandboxes.create",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-client-type": "dashboard",
+				},
+				body: JSON.stringify({
+					name: `MCP OAuth E2E ${randomBytes(4).toString("hex")}`,
+				}),
+			},
+		);
+		expect(sandbox.status).toBe(200);
+		sandboxId = sandbox.data.id;
 
 		// 4-5. Authorize, consent, token exchange bound to the MCP resource.
 		// The client asks for exactly what discovery advertised — the server adds
 		// offline_access for MCP clients, so the grant is still renewable.
 		const requestedScopes = [...challengeScopes];
+		const sandboxList = await dashboardFetch<{ list: { id: string }[] }>(
+			defaultCtx,
+			session,
+			"/v1/sandboxes.list",
+			{
+				method: "POST",
+				headers: { "x-client-type": "dashboard" },
+			},
+		);
+		expect(sandboxList.status).toBe(200);
+		expect(sandboxList.data.list).toContainEqual(
+			expect.objectContaining({ id: sandboxId }),
+		);
+
+		const invalidSandbox = await authorizeWithConsent({
+			clientId,
+			resource: mcpUrl,
+			sandboxOrgId: defaultCtx.org.id,
+			scopes: requestedScopes,
+			session,
+		});
+		expect(invalidSandbox.consentStatus).toBe(400);
+		expect(invalidSandbox.consentBody.error).toBe("invalid_request");
+
 		const granted = await grantTokenForResource({
 			clientId,
 			resource: mcpUrl,
+			sandboxOrgId: sandboxId,
 			scopes: requestedScopes,
 			session,
 		});
@@ -352,6 +429,13 @@ test("MCP OAuth end to end: challenge, discovery, DCR, consent, token, tool call
 			),
 		});
 		expect(tokenRow?.resource).toBe(mcpUrl);
+		expect(tokenRow?.referenceId).toBe(sandboxId);
+		const consent = tokenRow?.oauthConsentId
+			? await db.query.oauthConsent.findFirst({
+					where: eq(oauthConsent.id, tokenRow.oauthConsentId),
+				})
+			: null;
+		expect(consent?.metadata).toMatchObject({ sandboxOrgId: sandboxId });
 
 		// 6. Real MCP traffic
 		const initialize = await postMcp({
@@ -399,7 +483,11 @@ test("MCP OAuth end to end: challenge, discovery, DCR, consent, token, tool call
 		};
 		expect(toolResult?.isError).toBeFalsy();
 		expect(Array.isArray(toolResult?.content)).toBe(true);
-		expect(toolResult?.content?.[0]?.text).toContain(defaultCtx.org.id);
+		const currentOrganization = JSON.parse(
+			toolResult?.content?.[0]?.text ?? "{}",
+		) as { id?: string };
+		expect(currentOrganization.id).toBe(sandboxId);
+		expect(currentOrganization.id).not.toBe(defaultCtx.org.id);
 
 		// 7. Audience negative: an MCP client asking for the API root is refused at
 		// the token endpoint, so no grant can be stamped for an audience /mcp
@@ -408,15 +496,73 @@ test("MCP OAuth end to end: challenge, discovery, DCR, consent, token, tool call
 		const foreign = await grantTokenForResource({
 			clientId,
 			resource: apiRoot,
+			sandboxOrgId: sandboxId,
 			scopes: requestedScopes,
 			session,
 		});
 		expect(foreign.token.status).toBe(400);
 		expect(foreign.token.body.error).toBe("invalid_target");
 		expect(foreign.token.body.access_token).toBeUndefined();
+
+		const refreshToken = granted.token.body.refresh_token as string;
+		const refreshed = await exchangeRefreshToken({
+			clientId,
+			refreshToken,
+			resource: mcpUrl,
+		});
+		expect(refreshed.status).toBe(200);
+		const refreshedAccessToken = refreshed.body.access_token as string;
+		const refreshedTokenRow = await db.query.oauthAccessToken.findFirst({
+			where: eq(
+				oauthAccessToken.token,
+				hashOAuthToken(stripOAuthTokenPrefix({ token: refreshedAccessToken })),
+			),
+		});
+		expect(refreshedTokenRow?.referenceId).toBe(sandboxId);
+
+		const organization = await fetch(`${baseUrl}/v1/organization`, {
+			headers: { Authorization: `Bearer ${refreshedAccessToken}` },
+		});
+		expect(organization.status).toBe(200);
+		expect(await organization.json()).toMatchObject({ id: sandboxId });
+
+		const consentId = refreshedTokenRow?.oauthConsentId;
+		if (!consentId) throw new Error("Refreshed token missing consent");
+		const revoked = await dashboardFetch(
+			defaultCtx,
+			session,
+			`/consents/${consentId}`,
+			{ method: "DELETE" },
+		);
+		expect(revoked.status).toBe(200);
+		expect(
+			await db.query.oauthAccessToken.findFirst({
+				where: eq(oauthAccessToken.oauthConsentId, consentId),
+			}),
+		).toBeUndefined();
+		expect(
+			await db.query.oauthRefreshToken.findFirst({
+				where: eq(oauthRefreshToken.oauthConsentId, consentId),
+			}),
+		).toBeUndefined();
+		expect(
+			await fetch(`${baseUrl}/v1/organization`, {
+				headers: { Authorization: `Bearer ${refreshedAccessToken}` },
+			}),
+		).toHaveProperty("status", 401);
 	} finally {
 		if (clientId) {
 			await db.delete(oauthClient).where(eq(oauthClient.clientId, clientId));
+		}
+		if (sandboxId) {
+			await dashboardFetch(defaultCtx, session, "/v1/sandboxes.delete", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"x-client-type": "dashboard",
+				},
+				body: JSON.stringify({ id: sandboxId }),
+			});
 		}
 		await session.cleanup();
 	}

--- a/server/tests/unit/auth/oauth/oauth-consent-env.test.ts
+++ b/server/tests/unit/auth/oauth/oauth-consent-env.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { SUMMER_OAUTH_CLIENT_ID } from "@autumn/auth/oauth";
+import {
+	getOAuthConsentOrgId,
+	SUMMER_OAUTH_CLIENT_ID,
+} from "@autumn/auth/oauth";
 import { AppEnv } from "@autumn/shared";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import { resolveOAuthConsentEnv } from "@/internal/auth/oauth/handleOAuthConsentWithEnv.js";
@@ -83,5 +86,22 @@ describe("resolveOAuthConsentEnv", () => {
 			env: null,
 			envRequired: false,
 		});
+	});
+});
+
+describe("getOAuthConsentOrgId", () => {
+	test("uses a consent's named sandbox", () => {
+		expect(
+			getOAuthConsentOrgId({
+				metadata: { sandboxOrgId: "sandbox_org" },
+				referenceId: "main_org",
+			}),
+		).toBe("sandbox_org");
+	});
+
+	test("falls back to the consent's main organization", () => {
+		expect(
+			getOAuthConsentOrgId({ metadata: {}, referenceId: "main_org" }),
+		).toBe("main_org");
 	});
 });

--- a/server/tests/unit/auth/oauth/oauth-token-grant.test.ts
+++ b/server/tests/unit/auth/oauth/oauth-token-grant.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import { persistOAuthTokenGrant } from "@/internal/auth/oauth/token/persistOAuthTokenGrant.js";
+
+describe("persistOAuthTokenGrant", () => {
+	test("binds only the access token to a named sandbox", async () => {
+		const updates: Record<string, unknown>[] = [];
+		const tx = {
+			update: () => ({
+				set: (values: Record<string, unknown>) => {
+					updates.push(values);
+					return { where: async () => undefined };
+				},
+			}),
+		};
+		const db = {
+			transaction: async (run: (db: typeof tx) => Promise<void>) => run(tx),
+		} as unknown as DrizzleCli;
+
+		await persistOAuthTokenGrant({
+			accessTokenId: "access_token",
+			db,
+			oauthConsentId: "consent",
+			referenceId: "sandbox_org",
+			refreshTokenId: "refresh_token",
+			resource: "https://api.example.com/mcp",
+			scopes: ["customers:read"],
+		});
+
+		expect(updates).toHaveLength(2);
+		expect(updates[0]?.referenceId).toBe("sandbox_org");
+		expect(updates[1]?.referenceId).toBeUndefined();
+	});
+});

--- a/server/tests/unit/auth/oauthApiKeyRepo.test.ts
+++ b/server/tests/unit/auth/oauthApiKeyRepo.test.ts
@@ -27,7 +27,6 @@ const matchesConsent = (apiKey: GuardApiKey) =>
 		consentId: "consent_123",
 		clientId: "oauth_client_2abcDEF",
 		redirectUri: "cursor://anysphere.cursor-retrieval/callback",
-		orgId: "org_123",
 		userId: "user_123",
 		env: AppEnv.Sandbox,
 	});
@@ -65,15 +64,17 @@ describe("isOAuthConsentLinkedApiKey", () => {
 				consentId: "consent_123",
 				clientId: "oauth_client_2abcDEF",
 				redirectUri: "cursor://oauth/other-callback",
-				orgId: "org_123",
 				userId: "user_123",
 				env: AppEnv.Sandbox,
 			}),
 		).toBe(false);
 	});
 
-	test("rejects an OAuth key with different ownership or env", () => {
-		expect(matchesConsent({ ...baseApiKey, orgId: "org_other" })).toBe(false);
+	test("allows a key from the consent's previous environment target", () => {
+		expect(matchesConsent({ ...baseApiKey, orgId: "org_other" })).toBe(true);
+	});
+
+	test("rejects an OAuth key with different user ownership or env", () => {
 		expect(matchesConsent({ ...baseApiKey, userId: "user_other" })).toBe(false);
 		expect(matchesConsent({ ...baseApiKey, env: AppEnv.Live })).toBe(false);
 	});

--- a/vite/src/views/auth/Consent.tsx
+++ b/vite/src/views/auth/Consent.tsx
@@ -21,6 +21,7 @@ import { useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { CustomToaster } from "@/components/general/CustomToaster";
 import { ScopeSelector } from "@/components/v2/scope-selector";
+import { useSandboxesQuery } from "@/hooks/queries/useSandboxesQuery";
 import {
 	authClient,
 	useListOrganizations,
@@ -183,7 +184,9 @@ export const Consent = () => {
 	const [scopeOverride, setScopeOverride] = useState<ScopeString[] | null>(
 		null,
 	);
-	const [envOverride, setEnvOverride] = useState<AppEnv | null>(null);
+	const [environmentOverride, setEnvironmentOverride] = useState<string | null>(
+		null,
+	);
 
 	const clientId = searchParams.get("client_id");
 	const redirectUri = searchParams.get("redirect_uri");
@@ -196,10 +199,15 @@ export const Consent = () => {
 		(session as SessionWithScopes | null | undefined)?.scopes ?? [];
 	const clientInfoQuery = useQuery({
 		queryKey: ["oauth-client-info", clientId, redirectUri],
-		queryFn: () => fetchOAuthClientInfo({ clientId: clientId!, redirectUri }),
+		queryFn: () =>
+			fetchOAuthClientInfo({ clientId: clientId ?? "", redirectUri }),
 		enabled: !!clientId,
 	});
 	const clientInfo = clientInfoQuery.data ?? null;
+	const currentOrg = activeOrganization || orgs?.[0];
+	const { sandboxes } = useSandboxesQuery({
+		enabled: !!currentOrg && clientInfo?.is_atmn === false,
+	});
 	const defaultScopes = getGrantableOAuthScopes({
 		requestedScopes,
 		sessionScopes,
@@ -208,11 +216,17 @@ export const Consent = () => {
 		getSelectableOAuthResourceScopes(requestedScopes),
 	);
 	const selectedScopes = scopeOverride ?? defaultScopes;
-	const selectedEnv = envOverride ?? clientInfo?.default_env ?? initialEnv;
+	const selectedEnvironment =
+		environmentOverride ?? clientInfo?.default_env ?? initialEnv;
+	const selectedEnv =
+		selectedEnvironment === AppEnv.Live ? AppEnv.Live : AppEnv.Sandbox;
+	const selectedSandboxOrgId =
+		selectedEnvironment === AppEnv.Live ||
+		selectedEnvironment === AppEnv.Sandbox
+			? undefined
+			: selectedEnvironment;
 	const isLoading = !!clientId && clientInfoQuery.isLoading;
 	const canAuthorize = selectedScopes.length > 0;
-
-	const currentOrg = activeOrganization || orgs?.[0];
 
 	const handleStopImpersonating = async () => {
 		setIsEndingImpersonation(true);
@@ -266,10 +280,12 @@ export const Consent = () => {
 				client_id: clientId,
 				redirect_uri: redirectUri,
 				env: clientInfo.is_atmn ? undefined : selectedEnv,
+				sandbox_org_id: clientInfo.is_atmn ? undefined : selectedSandboxOrgId,
 			} as Parameters<typeof authClient.oauth2.consent>[0] & {
 				client_id: string | null;
 				redirect_uri: string | null;
 				env?: AppEnv;
+				sandbox_org_id?: string;
 			});
 
 			if (error) {
@@ -489,12 +505,8 @@ export const Consent = () => {
 									Environment
 								</span>
 								<Select
-									value={selectedEnv}
-									onValueChange={(value) => setEnvOverride(value as AppEnv)}
-									items={{
-										[AppEnv.Sandbox]: "Sandbox",
-										[AppEnv.Live]: "Production",
-									}}
+									value={selectedEnvironment}
+									onValueChange={setEnvironmentOverride}
 								>
 									<SelectTrigger className="w-[200px]">
 										<SelectValue />
@@ -502,6 +514,11 @@ export const Consent = () => {
 									<SelectContent>
 										<SelectItem value={AppEnv.Sandbox}>Sandbox</SelectItem>
 										<SelectItem value={AppEnv.Live}>Production</SelectItem>
+										{sandboxes.map((sandbox) => (
+											<SelectItem key={sandbox.id} value={sandbox.id}>
+												{sandbox.name}
+											</SelectItem>
+										))}
 									</SelectContent>
 								</Select>
 							</div>


### PR DESCRIPTION
## Summary
- show named sandboxes in the OAuth consent environment picker
- validate sandbox ownership and bind issued OAuth credentials to the selected sandbox
- preserve named-sandbox binding across refresh and revoke all consent-bound credentials

## Verification
- `NODE_TLS_REJECT_UNAUTHORIZED=0 … mcp-oauth-end-to-end.test.ts` (59 assertions)
- focused OAuth unit tests (15 passing)
- `bun -F @autumn/server ts`, `bun -F @autumn/vite ts`, `bun -F @autumn/auth ts`
- Biome and diff checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports selecting named sandboxes in MCP OAuth consent and binds issued credentials to the selected sandbox. Previously, tokens were bound to the main organization; now, access tokens use the sandbox org when chosen, and this binding is preserved on refresh and revocation.

- Consent: Validates sandbox ownership under the active org and Sandbox env, then stores `sandboxOrgId` in consent metadata. Non-sandbox or foreign sandbox selection returns 400.
- Token grants: Derive the grant reference from consent metadata via `getOAuthConsentOrgId`. Persist the sandbox `referenceId` on access tokens; refresh tokens are not re-bound. API key issuance uses the sandbox reference for scoping.
- Revocation: Deletes legacy main-org tokens (client+reference) and all consent-bound tokens via consent ID. OAuth consent-linked API key matching no longer checks `orgId`; it still requires user ownership and env.
- UI (`vite`): Environment picker shows named sandboxes for non-`@autumn` clients, and submits `sandbox_org_id` with consent.
- Tests: Adds end-to-end coverage for sandbox binding, refresh preservation, and revocation; unit tests for consent env resolution and grant persistence.

<sup>Written for commit 0279e5ef31d49f43d244936d1acb8f081bdd6a00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds named-sandbox selection to MCP OAuth and propagates the selected sandbox through token issuance, refresh, and revocation.

- **[Improvements, API changes]** Adds named sandboxes to the OAuth consent environment picker and validates that the selected sandbox belongs to the active organization.
- **[Improvements]** Binds issued access tokens and generated API keys to the selected sandbox.
- **[Bug fixes]** Deletes sandbox-bound access tokens by consent ID during revocation and adds end-to-end coverage for refresh and revocation.
</details>


<h3>Confidence Score: 3/5</h3>

This PR should not merge until refresh credentials remain bound to their originally selected sandbox instead of following later consent changes.

Re-authorizing the same client for a second sandbox overwrites shared consent metadata, and an older refresh token subsequently reads that new value and receives access to the second sandbox.

**Files Needing Attention:** server/src/internal/auth/repos/oauthConsentRepo.ts, server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts

<details open><summary><h3>Security Review</h3></summary>

A refresh token can change sandbox access after the same user authorizes the client for another sandbox. The selected sandbox is read from mutable consent metadata rather than an immutable property of the original refresh grant.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/auth/repos/oauthConsentRepo.ts | Stores the selected sandbox on consent metadata, but updates all consents sharing the client, user, and main organization, allowing existing refresh grants to be retargeted. |
| server/src/internal/auth/oauth/handleOAuthTokenWithApiKey.ts | Resolves newly issued and refreshed access-token organization bindings from the consent's current sandbox metadata. |
| server/src/internal/auth/oauth/handleOAuthConsentWithEnv.ts | Validates sandbox ownership and records the selected sandbox after successful consent. |
| server/src/internal/misc/consent/handlers/handleRevokeConsent.ts | Adds consent-scoped access-token deletion so sandbox-bound access tokens are revoked. |
| vite/src/views/auth/Consent.tsx | Adds named sandboxes to the environment picker and submits the selected sandbox identifier. |
| server/tests/integration/auth/mcp-oauth-end-to-end.test.ts | Covers initial named-sandbox issuance, one refresh, and revocation, but does not exercise re-consenting to a different sandbox before refreshing an older grant. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor User
  participant Client as OAuth Client
  participant Consent as Consent Endpoint
  participant DB as OAuth Storage
  participant Token as Token Endpoint
  User->>Consent: Authorize client for sandbox A
  Consent->>DB: "Store sandboxOrgId=A on shared consent"
  Token->>DB: Link refresh token A to consent
  User->>Consent: Authorize same client for sandbox B
  Consent->>DB: "Replace shared metadata with sandboxOrgId=B"
  Client->>Token: Refresh using token A
  Token->>DB: Read current consent metadata
  DB-->>Token: "sandboxOrgId=B"
  Token-->>Client: Access token bound to sandbox B
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/auth/repos/oauthConsentRepo.ts:176-178
**Refresh grants follow mutable sandbox binding**

When a user authorizes the same OAuth client for sandbox A and later for sandbox B, this update replaces the sandbox on the shared consent record. Refreshing the older grant then reads sandbox B from that consent and issues an access token for the wrong sandbox.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: support named sandboxes in MCP OAu..."](https://github.com/useautumn/autumn/commit/0279e5ef31d49f43d244936d1acb8f081bdd6a00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56279422)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->