### PR TITLE
fix(billing): pass deletedCustomerProducts when computing cancel default

### DIFF
--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts
@@ -18,7 +18,6 @@ import { computeCancelUpdates } from "./computeCancelUpdates";
 import { computeCustomerProductToDelete } from "./computeCustomerProductToDelete";
 import { computeDefaultCustomerProduct } from "./computeDefaultCustomerProduct";
 import { computeEndOfCycleMs } from "./computeEndOfCycleMs";
-
 const computeScheduledAddOnsToDelete = ({
 	billingContext,
 }: {
@@ -221,7 +220,11 @@ export const computeCancelPlan = ({
 	// Step 2: Build cancel updates for customer product
 	const cancelUpdates = computeCancelUpdates({ billingContext, endOfCycleMs });
 
-	// Step 3: Create default product (if applicable)
+	// Step 3: Find existing scheduled products to delete
+	const productToDelete = computeCustomerProductToDelete({ billingContext });
+	const productsToDelete = computeScheduledAddOnsToDelete({ billingContext });
+
+	// Step 4: Create default product (if applicable)
 	// Skip when cancelling a revert trial — the previous plan will be restored instead.
 	const isRevertTrialCancel =
 		billingContext.customerProduct.on_trial_end === "revert";
@@ -231,15 +234,15 @@ export const computeCancelPlan = ({
 				ctx,
 				billingContext,
 				endOfCycleMs,
+				deletedCustomerProducts: [
+					...(productToDelete ? [productToDelete] : []),
+					...productsToDelete,
+				],
 			});
 
 	ctx.logger.debug(
 		`[computeCancelPlan] default customer product: ${defaultCustomerProduct?.product.name}`,
 	);
-
-	// Step 4: Find existing scheduled product to delete
-	const productToDelete = computeCustomerProductToDelete({ billingContext });
-	const productsToDelete = computeScheduledAddOnsToDelete({ billingContext });
 
 	// Step 5: Compute prorated refund line items for immediate cancellation
 	const cancelLineItems = computeCancelLineItems({ ctx, billingContext });

--- a/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
+++ b/server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts
@@ -11,17 +11,24 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { initFullCustomerProduct } from "@/internal/billing/v2/utils/initFullCustomerProduct/initFullCustomerProduct";
 
 const hasOtherEffectivePaidMainProduct = ({
-	billingContext,
+	customerProduct,
+	customerProducts,
+	deletedCustomerProducts = [],
 	effectiveAt,
 }: {
-	billingContext: UpdateSubscriptionBillingContext;
+	customerProduct: FullCusProduct;
+	customerProducts: FullCusProduct[];
+	deletedCustomerProducts?: FullCusProduct[];
 	effectiveAt: number;
 }) => {
-	const { customerProduct, fullCustomer } = billingContext;
 	const internalEntityId = customerProduct.internal_entity_id ?? undefined;
+	const deletedCustomerProductIds = new Set(
+		deletedCustomerProducts.map((deletedCustomerProduct) => deletedCustomerProduct.id),
+	);
 
-	return fullCustomer.customer_products.some((candidate) => {
+	return customerProducts.some((candidate) => {
 		if (candidate.id === customerProduct.id) return false;
+		if (deletedCustomerProductIds.has(candidate.id)) return false;
 
 		const inScope = cp(candidate)
 			.hasRelevantStatus()
@@ -51,10 +58,12 @@ export const computeDefaultCustomerProduct = ({
 	ctx,
 	billingContext,
 	endOfCycleMs,
+	deletedCustomerProducts = [],
 }: {
 	ctx: AutumnContext;
 	billingContext: UpdateSubscriptionBillingContext;
 	endOfCycleMs: number;
+	deletedCustomerProducts?: FullCusProduct[];
 }): FullCusProduct | undefined => {
 	const {
 		cancelAction,
@@ -81,7 +90,9 @@ export const computeDefaultCustomerProduct = ({
 
 	if (
 		hasOtherEffectivePaidMainProduct({
-			billingContext,
+			customerProduct,
+			customerProducts: fullCustomer.customer_products,
+			deletedCustomerProducts,
 			effectiveAt: startsAt,
 		})
 	) {


### PR DESCRIPTION
## Summary

When cancelling at end of cycle with a scheduled downgrade (e.g. Pro → lower tier), `hasOtherEffectivePaidMainProduct` still saw the scheduled product on `fullCustomer.customer_products` and incorrectly blocked attaching the free default.

This passes the same-write deletes (`productToDelete` and scheduled add-ons) into `computeDefaultCustomerProduct` via `deletedCustomerProducts` so those products are excluded from the effective-paid check.

## Test plan

- [x] `cancel-end-of-cycle` integration suite: 6/6 pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cancel-at-end-of-cycle with a scheduled downgrade by excluding same-write deletions from the “other effective paid product” check. Previously the check still saw the scheduled product and blocked attaching the free default; now it correctly attaches the default when appropriate.

- Passes `deletedCustomerProducts` (the main productToDelete and scheduled add-ons) to `computeDefaultCustomerProduct` and filters them in `hasOtherEffectivePaidMainProduct`.
- Reorders cancel computation to collect scheduled deletions before default creation.
- No API or schema changes; no migration required.

<sup>Written for commit 4294ccf1ee3d143bf448a6e6aa72afba518fb5fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes default-product selection when cancellation also removes a scheduled replacement product.

- **Bug fixes:** Pass customer products being deleted by the same cancellation plan into the effective-paid-product check, preventing a deleted scheduled downgrade from blocking the free default.
- **Improvements:** Refactor the effective-paid check to accept its customer-product inputs explicitly.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or quality issues identified.

The default-product calculation now evaluates the customer state that will remain after the same billing plan’s unconditional deletions, while preserving existing scope, status, timing, and paid-main-product checks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeCancelPlan.ts | Computes planned customer-product deletions before default selection and passes the same deletion set into that calculation. |
| server/src/internal/billing/v2/actions/updateSubscription/compute/cancel/computeDefaultCustomerProduct.ts | Excludes products scheduled for deletion from the check for another effective paid main product. |

<sub>Reviews (1): Last reviewed commit: ["fix(billing): pass deletedCustomerProduc..."](https://github.com/useautumn/autumn/commit/4294ccf1ee3d143bf448a6e6aa72afba518fb5fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56284088)</sub>

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->