### PR TITLE
feat: MotherDuck otel tracing + init hardening + deflation coalescing

### DIFF
--- a/server/src/external/motherduck/initMotherDuck.ts
+++ b/server/src/external/motherduck/initMotherDuck.ts
@@ -4,6 +4,8 @@ import {
 	drizzle,
 	isPool,
 } from "@duckdbfan/drizzle-duckdb";
+import { SpanKind } from "@opentelemetry/api";
+import { withActiveSpan } from "@/utils/otel/withActiveSpan.js";
 import { logger } from "../logtail/logtailUtils.js";
 import { registerMdPool, startMdPoolMonitor } from "./mdPoolMonitor.js";
 
@@ -82,6 +84,8 @@ export const isMotherDuckConfigured = (): boolean =>
 	Boolean(process.env.MOTHERDUCK_TOKEN);
 
 let resolverDbPromise: Promise<MotherDuckDb> | null = null;
+let resolverDbState: "uninitialized" | "initializing" | "ready" =
+	"uninitialized";
 
 /** Lazy pooled singleton on the read-only token: only processes that actually
  * serve balance sorts open MotherDuck connections. */
@@ -93,41 +97,64 @@ export const getMotherDuckResolverDb = (): Promise<MotherDuckDb> => {
 		);
 	}
 
-	if (!resolverDbPromise) {
-		const poolSize = poolSizeFromEnv();
-		const warning = computeMotherDuckPoolWarning({
-			poolSize,
-			fleetProcesses: Number(process.env.MOTHERDUCK_FLEET_PROCESSES ?? 20),
-		});
-		if (warning) logger.warn(warning);
+	const initialState = resolverDbState;
+	return withActiveSpan({
+		name: "motherduck.resolver.get",
+		attributes: {
+			"motherduck.resolver.initial_state": initialState,
+		},
+		fn: async (span) => {
+			if (!resolverDbPromise) {
+				const poolSize = poolSizeFromEnv();
+				const warning = computeMotherDuckPoolWarning({
+					poolSize,
+					fleetProcesses: Number(process.env.MOTHERDUCK_FLEET_PROCESSES ?? 20),
+				});
+				if (warning) logger.warn(warning);
 
-		resolverDbPromise = initMotherDuck({ token, poolSize })
-			.then((db) => {
-				if (isPool(db.$client)) {
-					registerMdPool({
-						pool: db.$client,
-						name: "md-resolver",
-						max: poolSize,
-					});
-					startMdPoolMonitor();
-				}
-				return db;
-			})
-			.catch((error) => {
-				// Failed init must not poison the singleton — next request retries.
-				resolverDbPromise = null;
-				throw error;
-			});
-	}
-	return resolverDbPromise;
+				resolverDbState = "initializing";
+				resolverDbPromise = withActiveSpan({
+					name: "motherduck.resolver.initialize",
+					attributes: {
+						"db.namespace": DEFAULT_DATABASE,
+						"motherduck.pool.max": poolSize,
+					},
+					fn: async (initializeSpan) => {
+						const db = await initMotherDuck({ token, poolSize });
+						const pooled = isPool(db.$client);
+						initializeSpan.setAttribute("motherduck.pool.enabled", pooled);
+						if (pooled) {
+							registerMdPool({
+								pool: db.$client,
+								name: "md-resolver",
+								max: poolSize,
+							});
+							startMdPoolMonitor();
+						}
+						resolverDbState = "ready";
+						return db;
+					},
+				}).catch((error) => {
+					resolverDbPromise = null;
+					resolverDbState = "uninitialized";
+					throw error;
+				});
+			}
+			const db = await resolverDbPromise;
+			span.setAttribute("motherduck.resolver.final_state", resolverDbState);
+			return db;
+		},
+	});
 };
 
 export const closeMotherDuckResolverDb = async (): Promise<void> => {
 	const pending = resolverDbPromise;
 	resolverDbPromise = null;
+	resolverDbState = "uninitialized";
 	if (!pending) return;
 	const db = await pending.catch(() => null);
 	await db?.close();
+	resolverDbState = "uninitialized";
 };
 
 /** One-shot RW session for the cache refresh cron: single connection,
@@ -163,19 +190,48 @@ export const runMdWithTimeout = async <T>({
 	timeoutMs?: number;
 	label: string;
 }): Promise<T> => {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	const timeout = new Promise<never>((_, reject) => {
-		timer = setTimeout(
-			() =>
-				reject(
-					new Error(`[motherduck] ${label} exceeded ${timeoutMs}ms timeout`),
-				),
-			timeoutMs,
-		);
+	return withActiveSpan({
+		name: "motherduck.query",
+		kind: SpanKind.CLIENT,
+		attributes: {
+			"db.system": "duckdb",
+			"db.namespace": DEFAULT_DATABASE,
+			"motherduck.query.label": label,
+			"motherduck.query.timeout_ms": timeoutMs,
+		},
+		fn: async (span) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const timeout = new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() =>
+						reject(
+							new Error(
+								`[motherduck] ${label} exceeded ${timeoutMs}ms timeout`,
+							),
+						),
+					timeoutMs,
+				);
+			});
+			try {
+				const result = await Promise.race([run(), timeout]);
+				const rows = Array.isArray(result)
+					? result
+					: result && typeof result === "object" && "rows" in result
+						? result.rows
+						: null;
+				if (Array.isArray(rows)) {
+					span.setAttribute("db.response.returned_rows", rows.length);
+				}
+				return result;
+			} catch (error) {
+				span.setAttribute(
+					"motherduck.query.timed_out",
+					error instanceof Error && error.message.includes("exceeded"),
+				);
+				throw error;
+			} finally {
+				clearTimeout(timer);
+			}
+		},
 	});
-	try {
-		return await Promise.race([run(), timeout]);
-	} finally {
-		clearTimeout(timer);
-	}
 };

--- a/server/src/external/motherduck/initMotherDuck.ts
+++ b/server/src/external/motherduck/initMotherDuck.ts
@@ -25,6 +25,9 @@ const CONNECTION_MAX_LIFETIME_MS = 10 * 60_000;
 const IDLE_TIMEOUT_MS = 60_000;
 
 export const MOTHERDUCK_QUERY_TIMEOUT_MS = 5_000;
+/** The MD extension handshake has no interrupt; a network blip once serialized
+ * every balance request behind a 100s init. Fail into the PG fallbacks instead. */
+const INIT_TIMEOUT_MS = 15_000;
 
 const poolSizeFromEnv = (): number => {
 	const parsed = Number(process.env.MOTHERDUCK_POOL_MAX);
@@ -87,6 +90,40 @@ let resolverDbPromise: Promise<MotherDuckDb> | null = null;
 let resolverDbState: "uninitialized" | "initializing" | "ready" =
 	"uninitialized";
 
+/** A timed-out init can't be interrupted — close its connection when it
+ * eventually lands so the retry's pool is the only one standing. */
+const raceInitTimeout = async ({
+	init,
+}: {
+	init: Promise<MotherDuckDb>;
+}): Promise<MotherDuckDb> => {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => {
+			init.then((db) => db.close()).catch(() => {});
+			reject(
+				new Error(
+					`[initMotherDuck] resolver init exceeded ${INIT_TIMEOUT_MS}ms`,
+				),
+			);
+		}, INIT_TIMEOUT_MS);
+	});
+	try {
+		return await Promise.race([init, timeout]);
+	} finally {
+		clearTimeout(timer);
+	}
+};
+
+/** Boot-time warm-up: pay the MD handshake before the first dashboard request
+ * instead of inside it. Fire-and-forget — failure just means lazy init later. */
+export const prewarmMotherDuckResolver = (): void => {
+	if (!isMotherDuckConfigured()) return;
+	getMotherDuckResolverDb().catch((error) => {
+		logger.warn(`[initMotherDuck] resolver pre-warm failed: ${error}`);
+	});
+};
+
 /** Lazy pooled singleton on the read-only token: only processes that actually
  * serve balance sorts open MotherDuck connections. */
 export const getMotherDuckResolverDb = (): Promise<MotherDuckDb> => {
@@ -120,7 +157,9 @@ export const getMotherDuckResolverDb = (): Promise<MotherDuckDb> => {
 						"motherduck.pool.max": poolSize,
 					},
 					fn: async (initializeSpan) => {
-						const db = await initMotherDuck({ token, poolSize });
+						const db = await raceInitTimeout({
+							init: initMotherDuck({ token, poolSize }),
+						});
 						const pooled = isPool(db.$client);
 						initializeSpan.setAttribute("motherduck.pool.enabled", pooled);
 						if (pooled) {

--- a/server/src/external/motherduck/mdPoolMonitor.ts
+++ b/server/src/external/motherduck/mdPoolMonitor.ts
@@ -1,4 +1,5 @@
 import type { DuckDBConnectionPool } from "@duckdbfan/drizzle-duckdb";
+import { SpanKind } from "@opentelemetry/api";
 import {
 	type AcquireStats,
 	computeUtilization,
@@ -7,6 +8,7 @@ import {
 	percentileOf,
 	reservoirInsert,
 } from "@/db/pgPoolMonitor.js";
+import { withActiveSpan } from "@/utils/otel/withActiveSpan.js";
 import { logger } from "../logtail/logtailUtils.js";
 
 type RegisteredMdPool = {
@@ -74,23 +76,45 @@ const timeAcquires = ({ entry }: { entry: RegisteredMdPool }): void => {
 	pool.acquire = (() => {
 		const startedAt = performance.now();
 		entry.waitingCount++;
-		return originalAcquire().then(
-			(connection) => {
-				entry.waitingCount--;
-				entry.busyCount++;
-				recordAcquire({ name, durationMs: performance.now() - startedAt });
-				return connection;
+		return withActiveSpan({
+			name: "motherduck.pool.acquire",
+			kind: SpanKind.CLIENT,
+			attributes: {
+				"motherduck.pool.name": name,
+				"motherduck.pool.max": entry.max,
+				"motherduck.pool.busy_before": entry.busyCount,
+				"motherduck.pool.waiting_before": entry.waitingCount - 1,
 			},
-			(error: Error) => {
-				entry.waitingCount--;
-				recordAcquire({
-					name,
-					durationMs: performance.now() - startedAt,
-					error,
-				});
-				throw error;
+			fn: async (span) => {
+				try {
+					const connection = await originalAcquire();
+					const durationMs = performance.now() - startedAt;
+					entry.waitingCount--;
+					entry.busyCount++;
+					recordAcquire({ name, durationMs });
+					span.setAttributes({
+						"motherduck.pool.acquire_ms": durationMs,
+						"motherduck.pool.busy_after": entry.busyCount,
+						"motherduck.pool.waiting_after": entry.waitingCount,
+					});
+					return connection;
+				} catch (error) {
+					const durationMs = performance.now() - startedAt;
+					entry.waitingCount--;
+					recordAcquire({
+						name,
+						durationMs,
+						error: error as Error,
+					});
+					span.setAttributes({
+						"motherduck.pool.acquire_ms": durationMs,
+						"motherduck.pool.busy_after": entry.busyCount,
+						"motherduck.pool.waiting_after": entry.waitingCount,
+					});
+					throw error;
+				}
 			},
-		);
+		});
 	}) as DuckDBConnectionPool["acquire"];
 
 	pool.release = ((connection) => {

--- a/server/src/init.ts
+++ b/server/src/init.ts
@@ -48,6 +48,7 @@ import "./internal/misc/asyncTrack/asyncTrackStore.js";
 // Side-effect: configures trigger.dev SDK to use TRIGGER_SERVER_SECRET_KEY.
 import "./trigger/configureTrigger.js";
 import { closeStripeSyncEngine } from "@autumn/stripe-sync";
+import { prewarmMotherDuckResolver } from "./external/motherduck/initMotherDuck.js";
 import { primeRedisMonitor } from "./external/redis/availabilityMonitor/redisAvailability.js";
 import {
 	primeRedisV2Monitor,
@@ -119,6 +120,9 @@ const init = async ({
 	// Observed immediately: awaits run before the bounded wait consumes it, and
 	// an early rejection would otherwise hit the fatal unhandledRejection exit.
 	void redisWarmup.catch(() => {});
+
+	// Pay the MotherDuck handshake at boot, not inside the first balance sort.
+	prewarmMotherDuckResolver();
 
 	await startAllEdgeConfigPolling({ logger });
 	await Promise.all([primeRedisMonitor(), primeRedisV2Monitor()]);

--- a/server/src/internal/customers/CusBatchService.ts
+++ b/server/src/internal/customers/CusBatchService.ts
@@ -26,6 +26,7 @@ import {
 import * as Sentry from "@sentry/bun";
 import { isMotherDuckConfigured } from "@/external/motherduck/initMotherDuck.js";
 import type { AutumnContext, RequestContext } from "@/honoUtils/HonoEnv.js";
+import { withActiveSpan } from "@/utils/otel/withActiveSpan.js";
 import {
 	getOrgCusProductLimit,
 	getOrgEntitiesLimit,
@@ -365,17 +366,38 @@ export class CusBatchService {
 		});
 
 		if (sortBy === "feature_balance") {
-			return await CusBatchService.getFeatureBalanceSortedPage({
-				ctx,
-				search,
-				filters,
-				sortFeatureId,
-				sortBasis,
-				cursor: featureBalanceCursor ?? null,
-				limit,
-				sortOrder,
-				cusProductLimit,
-				entitiesLimit,
+			return withActiveSpan({
+				name: "customer.dashboard.feature_balance",
+				attributes: {
+					"customer.balance_sort.feature_id": sortFeatureId ?? "missing",
+					"customer.balance_sort.basis": sortBasis ?? "remaining",
+					"customer.balance_sort.order": sortOrder ?? "desc",
+					"customer.balance_sort.limit": limit,
+					"customer.balance_sort.has_cursor": Boolean(featureBalanceCursor),
+					"customer.balance_sort.has_search": Boolean(search.trim()),
+					"customer.balance_sort.has_filters": Boolean(filters),
+				},
+				fn: async (span) => {
+					const result = await CusBatchService.getFeatureBalanceSortedPage({
+						ctx,
+						search,
+						filters,
+						sortFeatureId,
+						sortBasis,
+						cursor: featureBalanceCursor ?? null,
+						limit,
+						sortOrder,
+						cusProductLimit,
+						entitiesLimit,
+					});
+					span.setAttributes({
+						"customer.balance_sort.result_rows": result.fullCustomers.length,
+						"customer.balance_sort.has_next_cursor": Boolean(
+							result.next_cursor,
+						),
+					});
+					return result;
+				},
 			});
 		}
 
@@ -596,12 +618,23 @@ export class CusBatchService {
 			return { fullCustomers: [], next_cursor: null };
 		}
 
-		const fullCustomers = await CusBatchService.hydrateResolvedPage({
-			ctx,
-			internalIds,
-			cusProductLimit,
-			entitiesLimit,
-			balanceFeatureInternalIds: [feature.internal_id],
+		const fullCustomers = await withActiveSpan({
+			name: "customer.balance_filter.hydrate",
+			attributes: {
+				"customer.balance_filter.input_rows": internalIds.length,
+				"customer.balance_filter.feature_internal_id": feature.internal_id,
+			},
+			fn: async (span) => {
+				const result = await CusBatchService.hydrateResolvedPage({
+					ctx,
+					internalIds,
+					cusProductLimit,
+					entitiesLimit,
+					balanceFeatureInternalIds: [feature.internal_id],
+				});
+				span.setAttribute("customer.balance_filter.result_rows", result.length);
+				return result;
+			},
 		});
 
 		ctx.logger.info(
@@ -782,12 +815,23 @@ export class CusBatchService {
 		}
 
 		const internalIds = rows.map((row) => row.internalId);
-		const fullCustomers = await CusBatchService.hydrateResolvedPage({
-			ctx,
-			internalIds,
-			cusProductLimit,
-			entitiesLimit,
-			balanceFeatureInternalIds: [feature.internal_id],
+		const fullCustomers = await withActiveSpan({
+			name: "customer.balance_sort.hydrate",
+			attributes: {
+				"customer.balance_sort.input_rows": internalIds.length,
+				"customer.balance_sort.feature_internal_id": feature.internal_id,
+			},
+			fn: async (span) => {
+				const result = await CusBatchService.hydrateResolvedPage({
+					ctx,
+					internalIds,
+					cusProductLimit,
+					entitiesLimit,
+					balanceFeatureInternalIds: [feature.internal_id],
+				});
+				span.setAttribute("customer.balance_sort.result_rows", result.length);
+				return result;
+			},
 		});
 
 		ctx.logger.info(

--- a/server/src/internal/customers/resolveByFeatureBalanceSort.ts
+++ b/server/src/internal/customers/resolveByFeatureBalanceSort.ts
@@ -18,6 +18,7 @@ import {
 } from "@/external/motherduck/initMotherDuck.js";
 import { getMiscRedis } from "@/external/redis/initRedis.js";
 import { tryRedisOp } from "@/external/redis/utils/runRedisOp.js";
+import { withActiveSpan } from "@/utils/otel/withActiveSpan.js";
 import { buildSearchPredicates } from "./CusSearchService.js";
 
 /** `total` is the value of the REQUESTED basis (remaining/granted/usage) —
@@ -238,30 +239,53 @@ export const getDeflationExceptionRows = async ({
 	env: AppEnv;
 	internalFeatureId: string;
 	basis: FeatureBalanceSortBasis;
-}): Promise<FeatureBalanceSortRow[]> => {
-	const miscRedis = getMiscRedis();
-	const cacheKey = deflationSetCacheKey({ internalFeatureId, basis });
+}): Promise<FeatureBalanceSortRow[]> =>
+	withActiveSpan({
+		name: "customer.balance_sort.deflation",
+		attributes: {
+			"customer.balance_sort.feature_internal_id": internalFeatureId,
+			"customer.balance_sort.basis": basis,
+		},
+		fn: async (span) => {
+			const miscRedis = getMiscRedis();
+			const cacheKey = deflationSetCacheKey({ internalFeatureId, basis });
 
-	const cached = await tryRedisOp({
-		operation: () => miscRedis.get(cacheKey),
-		source: "balance-sort:deflation-set:get",
-		redisInstance: miscRedis,
-	});
-	if (cached) {
-		return (JSON.parse(cached) as [string, boolean, number][]).map(
-			([internalId, isUnlimited, total]) => ({
-				internalId,
-				isUnlimited,
-				total,
-			}),
-		);
-	}
+			const cached = await withActiveSpan({
+				name: "customer.balance_sort.deflation.cache_lookup",
+				fn: async (cacheSpan) => {
+					const result = await tryRedisOp({
+						operation: () => miscRedis.get(cacheKey),
+						source: "balance-sort:deflation-set:get",
+						redisInstance: miscRedis,
+					});
+					cacheSpan.setAttribute("cache.hit", Boolean(result));
+					return result;
+				},
+			});
+			if (cached) {
+				const rows = (JSON.parse(cached) as [string, boolean, number][]).map(
+					([internalId, isUnlimited, total]) => ({
+						internalId,
+						isUnlimited,
+						total,
+					}),
+				);
+				span.setAttributes({
+					"customer.balance_sort.cache_hit": true,
+					"customer.balance_sort.deflation_rows": rows.length,
+				});
+				return rows;
+			}
+			span.setAttribute("customer.balance_sort.cache_hit", false);
 
-	// Deflation sources = negative rows the lake counts but the live definition
-	// excludes: pooled contributions, and rows bound to non-active products
-	// (status-based — the lazily-backfilled `expired` flag misses churned rows).
-	const tStart = performance.now();
-	const idRows = await db.execute<{ internal_customer_id: string }>(sql`
+			// Deflation sources = negative rows the lake counts but the live definition
+			// excludes: pooled contributions, and rows bound to non-active products
+			// (status-based — the lazily-backfilled `expired` flag misses churned rows).
+			const tStart = performance.now();
+			const idRows = await withActiveSpan({
+				name: "customer.balance_sort.deflation.scan",
+				fn: async (scanSpan) => {
+					const result = await db.execute<{ internal_customer_id: string }>(sql`
 		SELECT DISTINCT ce.internal_customer_id
 		FROM customer_entitlements ce
 		LEFT JOIN customer_products cp ON cp.id = ce.customer_product_id
@@ -277,45 +301,83 @@ export const getDeflationExceptionRows = async ({
 		LIMIT ${DEFLATION_SET_CAP}
 		${planetScaleTag({ query: "balanceSortDeflationSet" })}
 	`);
-	if (idRows.length >= DEFLATION_SET_CAP) {
-		logger.warn(
-			`[balanceSort] deflation set hit cap (${DEFLATION_SET_CAP}) for feature ${internalFeatureId} — under-ranked customers beyond the cap can be missed`,
-		);
-	}
+					scanSpan.setAttribute(
+						"customer.balance_sort.candidate_rows",
+						result.length,
+					);
+					return result;
+				},
+			});
+			span.setAttribute(
+				"customer.balance_sort.deflation_candidate_rows",
+				idRows.length,
+			);
+			if (idRows.length >= DEFLATION_SET_CAP) {
+				logger.warn(
+					`[balanceSort] deflation set hit cap (${DEFLATION_SET_CAP}) for feature ${internalFeatureId} — under-ranked customers beyond the cap can be missed`,
+				);
+			}
 
-	// Exact values computed without search/filters: the set is feature-scoped
-	// and reused across requests; per-request predicates apply at merge time.
-	const rows =
-		idRows.length === 0
-			? []
-			: await verifyExactBalances({
-					db,
-					orgId,
-					env,
-					search: "",
-					filters: undefined,
-					internalFeatureId,
-					internalCustomerIds: idRows.map((row) => row.internal_customer_id),
-					basis,
-				});
+			// Exact values computed without search/filters: the set is feature-scoped
+			// and reused across requests; per-request predicates apply at merge time.
+			const rows = await withActiveSpan({
+				name: "customer.balance_sort.deflation.verify",
+				attributes: {
+					"customer.balance_sort.candidate_rows": idRows.length,
+				},
+				fn: async (verifySpan) => {
+					const result =
+						idRows.length === 0
+							? []
+							: await verifyExactBalances({
+									db,
+									orgId,
+									env,
+									search: "",
+									filters: undefined,
+									internalFeatureId,
+									internalCustomerIds: idRows.map(
+										(row) => row.internal_customer_id,
+									),
+									basis,
+								});
+					verifySpan.setAttribute(
+						"customer.balance_sort.verified_rows",
+						result.length,
+					);
+					return result;
+				},
+			});
 
-	logger.info(
-		`[balanceSort] deflation set for ${internalFeatureId}: ${rows.length} customers in ${(performance.now() - tStart).toFixed(0)}ms`,
-	);
+			logger.info(
+				`[balanceSort] deflation set for ${internalFeatureId}: ${rows.length} customers in ${(performance.now() - tStart).toFixed(0)}ms`,
+			);
 
-	await tryRedisOp({
-		operation: () =>
-			miscRedis.set(
-				cacheKey,
-				JSON.stringify(rows.map((r) => [r.internalId, r.isUnlimited, r.total])),
-				"EX",
-				DEFLATION_SET_TTL_SECONDS,
-			),
-		source: "balance-sort:deflation-set:set",
-		redisInstance: miscRedis,
+			await withActiveSpan({
+				name: "customer.balance_sort.deflation.cache_write",
+				attributes: {
+					"customer.balance_sort.deflation_rows": rows.length,
+					"cache.ttl_seconds": DEFLATION_SET_TTL_SECONDS,
+				},
+				fn: async () =>
+					await tryRedisOp({
+						operation: () =>
+							miscRedis.set(
+								cacheKey,
+								JSON.stringify(
+									rows.map((r) => [r.internalId, r.isUnlimited, r.total]),
+								),
+								"EX",
+								DEFLATION_SET_TTL_SECONDS,
+							),
+						source: "balance-sort:deflation-set:set",
+						redisInstance: miscRedis,
+					}),
+			});
+			span.setAttribute("customer.balance_sort.deflation_rows", rows.length);
+			return rows;
+		},
 	});
-	return rows;
-};
 
 /** Desc ranks unlimited first then largest totals; asc is the exact mirror. */
 const compareRows = (
@@ -424,117 +486,208 @@ export const resolveInternalIdsByFeatureBalanceSort = async ({
 	sortOrder?: SortOrder;
 	basis?: FeatureBalanceSortBasis;
 	remainingFilter?: BalanceThresholdFilter;
-}): Promise<{ rows: FeatureBalanceSortRow[]; hasMore: boolean }> => {
-	const md = await getMotherDuckResolverDb();
+}): Promise<{ rows: FeatureBalanceSortRow[]; hasMore: boolean }> =>
+	withActiveSpan({
+		name: "customer.balance_sort.resolve",
+		attributes: {
+			"customer.balance_sort.feature_internal_id": internalFeatureId,
+			"customer.balance_sort.basis": basis,
+			"customer.balance_sort.order": sortOrder,
+			"customer.balance_sort.limit": limit,
+			"customer.balance_sort.has_cursor": Boolean(cursor),
+			"customer.balance_sort.has_search": Boolean(search.trim()),
+			"customer.balance_sort.has_filters": Boolean(filters),
+			"customer.balance_sort.has_threshold": Boolean(remainingFilter),
+		},
+		fn: async (span) => {
+			const md = await getMotherDuckResolverDb();
 
-	const verifiedById = new Map<string, FeatureBalanceSortRow>();
+			const verifiedById = new Map<string, FeatureBalanceSortRow>();
+			let iterationCount = 0;
+			let nominationCount = 0;
+			let verifiedCount = 0;
 
-	// Deflation exceptions ride along from page one: their lake rank is wrong
-	// by construction, so only their (cached-exact) values can place them.
-	const exceptionRows = await getDeflationExceptionRows({
-		db,
-		orgId,
-		env,
-		internalFeatureId,
-		basis,
-	});
-	const exceptionIds = new Set(exceptionRows.map((row) => row.internalId));
+			// Deflation exceptions ride along from page one: their lake rank is wrong
+			// by construction, so only their (cached-exact) values can place them.
+			const exceptionRows = await getDeflationExceptionRows({
+				db,
+				orgId,
+				env,
+				internalFeatureId,
+				basis,
+			});
+			const exceptionIds = new Set(exceptionRows.map((row) => row.internalId));
 
-	let nominationAfter: NominationCursor | null = cursor
-		? { u: cursor.u, b: cursor.b, id: cursor.id }
-		: null;
-	let nominationsExhausted = false;
+			let nominationAfter: NominationCursor | null = cursor
+				? { u: cursor.u, b: cursor.b, id: cursor.id }
+				: null;
+			let nominationsExhausted = false;
 
-	for (let iteration = 0; iteration < MAX_TOPUP_ITERATIONS; iteration++) {
-		const nominationRows = (await runMdWithTimeout({
-			label: "balance-sort nomination",
-			run: () =>
-				md.execute(
-					nominationQuery({
-						internalFeatureId,
-						after: nominationAfter,
-						sortOrder,
-						basis,
-						remainingFilter,
-					}),
-				),
-		})) as unknown as {
-			internal_customer_id: string;
-			is_unlimited: boolean;
-			total: number | string;
-		}[];
+			for (let iteration = 0; iteration < MAX_TOPUP_ITERATIONS; iteration++) {
+				iterationCount = iteration + 1;
+				const nominationRows = await withActiveSpan({
+					name: "customer.balance_sort.nominate",
+					attributes: {
+						"customer.balance_sort.iteration": iteration,
+						"customer.balance_sort.has_nomination_cursor":
+							Boolean(nominationAfter),
+					},
+					fn: async (nominationSpan) => {
+						const result = (await runMdWithTimeout({
+							label: "balance-sort nomination",
+							run: () =>
+								md.execute(
+									nominationQuery({
+										internalFeatureId,
+										after: nominationAfter,
+										sortOrder,
+										basis,
+										remainingFilter,
+									}),
+								),
+						})) as unknown as {
+							internal_customer_id: string;
+							is_unlimited: boolean;
+							total: number | string;
+						}[];
+						nominationSpan.setAttribute(
+							"customer.balance_sort.nomination_rows",
+							result.length,
+						);
+						return result;
+					},
+				});
+				nominationCount += nominationRows.length;
 
-		if (nominationRows.length < NOMINATION_BATCH_SIZE) {
-			nominationsExhausted = true;
-		}
+				if (nominationRows.length < NOMINATION_BATCH_SIZE) {
+					nominationsExhausted = true;
+				}
 
-		const freshIds = nominationRows
-			.map((row) => row.internal_customer_id)
-			.filter((id) => !verifiedById.has(id) && !exceptionIds.has(id));
+				const freshIds = nominationRows
+					.map((row) => row.internal_customer_id)
+					.filter((id) => !verifiedById.has(id) && !exceptionIds.has(id));
 
-		const verified = await verifyExactBalances({
-			db,
-			orgId,
-			env,
-			search,
-			filters,
-			internalFeatureId,
-			internalCustomerIds: freshIds,
-			basis,
-			remainingFilter,
-		});
-		for (const row of verified) verifiedById.set(row.internalId, row);
+				const verified = await withActiveSpan({
+					name: "customer.balance_sort.verify",
+					attributes: {
+						"customer.balance_sort.iteration": iteration,
+						"customer.balance_sort.verify_source": "nomination",
+						"customer.balance_sort.candidate_rows": freshIds.length,
+					},
+					fn: async (verifySpan) => {
+						const result = await verifyExactBalances({
+							db,
+							orgId,
+							env,
+							search,
+							filters,
+							internalFeatureId,
+							internalCustomerIds: freshIds,
+							basis,
+							remainingFilter,
+						});
+						verifySpan.setAttribute(
+							"customer.balance_sort.verified_rows",
+							result.length,
+						);
+						return result;
+					},
+				});
+				verifiedCount += verified.length;
+				for (const row of verified) verifiedById.set(row.internalId, row);
 
-		if (iteration === 0) {
-			// Exceptions get per-request predicates applied via a verify pass too;
-			// cached values only pre-place them when no search/filters narrow the set.
-			const hasRequestPredicates = Boolean(
-				search.trim() ||
-					(filters && Object.values(filters).some((v) => v !== undefined)) ||
-					remainingFilter,
+				if (iteration === 0) {
+					// Exceptions get per-request predicates applied via a verify pass too;
+					// cached values only pre-place them when no search/filters narrow the set.
+					const hasRequestPredicates = Boolean(
+						search.trim() ||
+							(filters &&
+								Object.values(filters).some((v) => v !== undefined)) ||
+							remainingFilter,
+					);
+					const placedExceptions = hasRequestPredicates
+						? await withActiveSpan({
+								name: "customer.balance_sort.verify",
+								attributes: {
+									"customer.balance_sort.iteration": iteration,
+									"customer.balance_sort.verify_source": "deflation",
+									"customer.balance_sort.candidate_rows": exceptionRows.length,
+								},
+								fn: async (verifySpan) => {
+									const result = await verifyExactBalances({
+										db,
+										orgId,
+										env,
+										search,
+										filters,
+										internalFeatureId,
+										internalCustomerIds: exceptionRows.map(
+											(row) => row.internalId,
+										),
+										basis,
+										remainingFilter,
+									});
+									verifySpan.setAttribute(
+										"customer.balance_sort.verified_rows",
+										result.length,
+									);
+									return result;
+								},
+							})
+						: exceptionRows;
+					verifiedCount += placedExceptions.length;
+					for (const row of placedExceptions)
+						verifiedById.set(row.internalId, row);
+				}
+
+				const pageCandidates = [...verifiedById.values()]
+					.filter((row) => !cursor || isAfterCursor(row, cursor, sortOrder))
+					.sort((a, b) => compareRows(a, b, sortOrder));
+
+				if (pageCandidates.length > limit || nominationsExhausted) {
+					span.setAttributes({
+						"customer.balance_sort.iterations": iterationCount,
+						"customer.balance_sort.nomination_rows": nominationCount,
+						"customer.balance_sort.verified_rows": verifiedCount,
+						"customer.balance_sort.result_rows": Math.min(
+							pageCandidates.length,
+							limit,
+						),
+						"customer.balance_sort.nominations_exhausted": nominationsExhausted,
+					});
+					return {
+						rows: pageCandidates.slice(0, limit),
+						hasMore: pageCandidates.length > limit || !nominationsExhausted,
+					};
+				}
+
+				const lastNomination = nominationRows[nominationRows.length - 1];
+				nominationAfter = {
+					u: Boolean(lastNomination.is_unlimited),
+					b: Number(lastNomination.total),
+					id: lastNomination.internal_customer_id,
+				};
+			}
+
+			// Top-up budget exhausted with a page unfilled: heavy filter attrition.
+			// Return what verified; more may exist past the nomination horizon.
+			const pageCandidates = [...verifiedById.values()]
+				.filter((row) => !cursor || isAfterCursor(row, cursor, sortOrder))
+				.sort((a, b) => compareRows(a, b, sortOrder));
+			logger.warn(
+				`[balanceSort] top-up budget exhausted for feature ${internalFeatureId}: ${pageCandidates.length}/${limit} rows after ${MAX_TOPUP_ITERATIONS} batches`,
 			);
-			const placedExceptions = hasRequestPredicates
-				? await verifyExactBalances({
-						db,
-						orgId,
-						env,
-						search,
-						filters,
-						internalFeatureId,
-						internalCustomerIds: exceptionRows.map((r) => r.internalId),
-						basis,
-						remainingFilter,
-					})
-				: exceptionRows;
-			for (const row of placedExceptions) verifiedById.set(row.internalId, row);
-		}
-
-		const pageCandidates = [...verifiedById.values()]
-			.filter((row) => !cursor || isAfterCursor(row, cursor, sortOrder))
-			.sort((a, b) => compareRows(a, b, sortOrder));
-
-		if (pageCandidates.length > limit || nominationsExhausted) {
-			return {
-				rows: pageCandidates.slice(0, limit),
-				hasMore: pageCandidates.length > limit || !nominationsExhausted,
-			};
-		}
-
-		const lastNomination = nominationRows[nominationRows.length - 1];
-		nominationAfter = {
-			u: Boolean(lastNomination.is_unlimited),
-			b: Number(lastNomination.total),
-			id: lastNomination.internal_customer_id,
-		};
-	}
-
-	// Top-up budget exhausted with a page unfilled: heavy filter attrition.
-	// Return what verified; more may exist past the nomination horizon.
-	const pageCandidates = [...verifiedById.values()]
-		.filter((row) => !cursor || isAfterCursor(row, cursor, sortOrder))
-		.sort((a, b) => compareRows(a, b, sortOrder));
-	logger.warn(
-		`[balanceSort] top-up budget exhausted for feature ${internalFeatureId}: ${pageCandidates.length}/${limit} rows after ${MAX_TOPUP_ITERATIONS} batches`,
-	);
-	return { rows: pageCandidates.slice(0, limit), hasMore: true };
-};
+			span.setAttributes({
+				"customer.balance_sort.iterations": iterationCount,
+				"customer.balance_sort.nomination_rows": nominationCount,
+				"customer.balance_sort.verified_rows": verifiedCount,
+				"customer.balance_sort.result_rows": Math.min(
+					pageCandidates.length,
+					limit,
+				),
+				"customer.balance_sort.nominations_exhausted": nominationsExhausted,
+				"customer.balance_sort.topup_budget_exhausted": true,
+			});
+			return { rows: pageCandidates.slice(0, limit), hasMore: true };
+		},
+	});

--- a/server/src/internal/customers/resolveByFeatureBalanceSort.ts
+++ b/server/src/internal/customers/resolveByFeatureBalanceSort.ts
@@ -288,10 +288,44 @@ const verifyExactBalances = async ({
 	return mapped;
 };
 
+/** Search/full_customers/count fire together, so a cold cache otherwise runs
+ * N copies of the multi-second scan — concurrent callers share one compute. */
+const deflationInFlight = new Map<string, Promise<FeatureBalanceSortRow[]>>();
+
 /** Cached exact rows for the deflation-exception customers. Values are up to
  * TTL stale, but they only steer RANKING — displayed numbers come from
  * hydration. Recompute is a feature-index scan (~seconds on whale features). */
-export const getDeflationExceptionRows = async ({
+export const getDeflationExceptionRows = ({
+	db,
+	orgId,
+	env,
+	internalFeatureId,
+	basis,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	internalFeatureId: string;
+	basis: FeatureBalanceSortBasis;
+}): Promise<FeatureBalanceSortRow[]> => {
+	const key = deflationSetCacheKey({ internalFeatureId, basis });
+	const inFlight = deflationInFlight.get(key);
+	if (inFlight) return inFlight;
+
+	const compute = computeDeflationExceptionRows({
+		db,
+		orgId,
+		env,
+		internalFeatureId,
+		basis,
+	}).finally(() => {
+		deflationInFlight.delete(key);
+	});
+	deflationInFlight.set(key, compute);
+	return compute;
+};
+
+const computeDeflationExceptionRows = async ({
 	db,
 	orgId,
 	env,

--- a/server/src/utils/otel/withActiveSpan.ts
+++ b/server/src/utils/otel/withActiveSpan.ts
@@ -1,0 +1,39 @@
+import {
+	type Attributes,
+	type Span,
+	SpanKind,
+	SpanStatusCode,
+	trace,
+} from "@opentelemetry/api";
+
+const tracer = trace.getTracer("autumn.application");
+
+export const withActiveSpan = async <T>({
+	name,
+	attributes,
+	kind = SpanKind.INTERNAL,
+	fn,
+}: {
+	name: string;
+	attributes?: Attributes;
+	kind?: SpanKind;
+	fn: (span: Span) => Promise<T>;
+}): Promise<T> =>
+	tracer.startActiveSpan(name, { attributes, kind }, async (span) => {
+		try {
+			const result = await fn(span);
+			span.setStatus({ code: SpanStatusCode.OK });
+			return result;
+		} catch (error) {
+			span.recordException(
+				error instanceof Error ? error : new Error(String(error)),
+			);
+			span.setStatus({
+				code: SpanStatusCode.ERROR,
+				message: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
+		} finally {
+			span.end();
+		}
+	});


### PR DESCRIPTION
## What

Three related reliability/observability changes for the lake-backed balance sorts/filters:

**1. Otel tracing** (revives the unmerged `capy/balance-sort-tracing` work, rebased onto current dev): `withActiveSpan` helper + spans across the whole pipeline — `motherduck.resolver.get` / `.initialize`, `motherduck.pool.acquire`, `motherduck.query` (with returned-row counts), `customer.balance_sort.resolve/.nominate/.verify/.deflation` (incl. cache lookup/scan/write phases), and the CusBatchService dispatch/hydrate spans.

**2. Resolver init hardening:** the MotherDuck extension handshake has no interrupt and previously no timeout — a network blip serialized every balance request on a process behind a single ~100s init. Now: 15s init timeout (fails into the existing PG fallbacks; a late-landing connection is closed so the retry's pool is the only one standing) plus a fire-and-forget boot pre-warm so the handshake is paid at fork start, not inside the first dashboard request.

**3. Deflation coalescing:** search/full_customers/count fire together, and a cold deflation cache made each run its own multi-second scan. Concurrent callers now share one in-flight compute per feature+basis.

## Notes

- Merge of the tracing branch had one conflict (nomination loop had gained `orgId`/`env`/`createdAtRange` args on dev) — resolved keeping both.
- No schema, cache, or API changes; deploy-order free.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry tracing for the MotherDuck-backed balance sort pipeline, bounds resolver initialization, and coalesces deflation scans to reduce duplicate work. Previously: no spans, resolver init could hang ~100s and block requests, and each concurrent caller ran its own deflation scan; now: end-to-end spans with row counts, a 15s init timeout with boot pre-warm and late-connection close, and concurrent callers share one in-flight deflation compute. Side effect: a timed-out resolver init falls back to the existing Postgres path.

- Tracing: introduces `withActiveSpan` and instruments `motherduck.resolver.get/.initialize`, `motherduck.pool.acquire`, `motherduck.query` (with returned-row counts and timeout flag), `customer.balance_sort.resolve/.nominate/.verify/.deflation` (cache lookup/scan/verify/write), and CusBatchService dispatch/hydrate. Packages: `@opentelemetry/api`, `@duckdbfan/drizzle-duckdb`.
- Resolver init hardening: adds a 15s timeout and closes late-landing connections; pre-warms the resolver at process start when configured; tracks resolver state to avoid poisoning the singleton; unchanged schema/API.
- Deflation coalescing: shares one in-flight compute per feature+basis; cache TTL and keys unchanged; reduces multi-second duplicate scans when search/full_customers/count run together.

<sup>Written for commit e3d0dbeb9a6f066663c21f81278f4a472305f729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves reliability and observability for lake-backed customer balance sorting and filtering.
- **[Improvements]** Adds OpenTelemetry spans around MotherDuck initialization, pool acquisition, queries, balance resolution, verification, deflation scanning, and customer hydration.
- **[Bug fixes]** Bounds MotherDuck resolver initialization to 15 seconds, closes connections that finish after timing out, and prewarms the resolver during worker startup.
- **[Improvements]** Coalesces concurrent deflation-cache computations for the same globally unique feature and balance basis.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

The initialization timeout cleans up only its own late connection, tracing preserves the wrapped asynchronous results and errors, and deflation coalescing uses globally unique feature identifiers while retaining the existing cache scope.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/external/motherduck/initMotherDuck.ts | Adds traced resolver initialization, a bounded initialization race, late-connection cleanup, startup prewarming, and traced query execution. |
| server/src/external/motherduck/mdPoolMonitor.ts | Adds client spans and pool-state attributes around connection acquisition while preserving existing accounting. |
| server/src/init.ts | Starts the non-blocking MotherDuck resolver prewarm before the HTTP worker begins accepting traffic. |
| server/src/internal/customers/CusBatchService.ts | Adds tracing around feature-balance dispatch and resolved-page hydration without changing response behavior. |
| server/src/internal/customers/resolveByFeatureBalanceSort.ts | Adds pipeline spans and process-local coalescing for concurrent deflation computations keyed by globally unique feature ID and basis. |
| server/src/utils/otel/withActiveSpan.ts | Introduces a reusable async span helper that records failures, assigns status, and always closes spans. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Boot as HTTP worker startup
    participant Resolver as MotherDuck resolver
    participant MD as MotherDuck
    participant Request as Balance-sort request
    participant Redis as Deflation cache
    participant PG as PostgreSQL

    Boot->>Resolver: Fire-and-forget prewarm
    Resolver->>MD: Initialize pooled connection
    alt Initialization exceeds 15 seconds
        Resolver-->>Boot: Log failure
        MD-->>Resolver: Late connection
        Resolver->>MD: Close late connection
    else Initialization succeeds
        Resolver-->>Boot: Retain shared pool
    end

    Request->>Resolver: Resolve feature-balance page
    Resolver->>Redis: Read deflation exceptions
    alt Cache miss with concurrent callers
        Resolver->>Resolver: Share one in-flight computation
        Resolver->>PG: Scan and verify exception rows
        Resolver->>Redis: Cache verified rows
    end
    Resolver->>MD: Nominate balance candidates
    Resolver->>PG: Verify and rerank candidates
    Resolver-->>Request: Ordered customer IDs
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 bound MD resolver init, boot pr..."](https://github.com/useautumn/autumn/commit/e3d0dbeb9a6f066663c21f81278f4a472305f729) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56308568)</sub>

**Context used:**

- Knowledge Base — [Analytics stores and data exports](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/analytics-and-data-exports.md)
- Knowledge Base — [Backend service runtime](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/service-runtime.md)

<!-- /greptile_comment -->