### PR TITLE
fix: plan diff item filters match priced items like the engine

### DIFF
--- a/server/tests/unit/shared/applyDiff.test.ts
+++ b/server/tests/unit/shared/applyDiff.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
-	AppEnv,
 	type ApiPlanLicenseV1,
 	type ApiPlanV1,
+	AppEnv,
 	BillingInterval,
 	BillingMethod,
 	type DiffedCustomizePlanV1,
@@ -162,4 +162,85 @@ test("applyCustomizeToPlan drops licenses listed in remove_licenses", () => {
 	});
 
 	expect(applied.licenses).toEqual([]);
+});
+
+describe("removeItems filter parity with the engine", () => {
+	const emailsPricedPlan = () =>
+		makePlan({
+			items: [
+				{
+					feature_id: "emails",
+					included: 0,
+					unlimited: false,
+					reset: null,
+					price: {
+						amount: 0.9,
+						billing_units: 1000,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.UsageBased,
+						max_purchase: null,
+					},
+				},
+			],
+		});
+
+	// Incident repro (resend, 24 Aug): the Slack card removed the plan's priced
+	// emails item by feature_id and added a custom one. The engine matched and
+	// attached fine; this translator kept both items, so the dashboard preview
+	// failed with "same feature, same reset interval".
+	test("a feature_id-only filter removes a priced item, like the engine", () => {
+		const diff = {
+			remove_items: [{ feature_id: "emails" }],
+			add_items: [
+				{
+					feature_id: "emails",
+					included: 5_000_000,
+					price: {
+						amount: 0.35,
+						billing_units: 1000,
+						interval: BillingInterval.Month,
+						billing_method: BillingMethod.UsageBased,
+					},
+				},
+			],
+		} as DiffedCustomizePlanV1;
+
+		const items = applyDiff({ base: emailsPricedPlan(), diff }).items;
+
+		expect(items).toHaveLength(1);
+		expect(items[0].included).toBe(5_000_000);
+		expect(items[0].price?.amount).toBe(0.35);
+	});
+
+	test("a billing_method filter still only matches that method", () => {
+		const diff = {
+			remove_items: [
+				{ feature_id: "emails", billing_method: BillingMethod.Prepaid },
+			],
+		} as DiffedCustomizePlanV1;
+
+		const items = applyDiff({ base: emailsPricedPlan(), diff }).items;
+
+		expect(items).toHaveLength(1);
+		expect(items[0].price?.amount).toBe(0.9);
+	});
+
+	test("a feature_id-only filter still removes an unpriced item", () => {
+		const base = makePlan({
+			items: [
+				{
+					feature_id: "emails",
+					included: 1000,
+					unlimited: false,
+					reset: null,
+					price: null,
+				},
+			],
+		});
+		const diff = {
+			remove_items: [{ feature_id: "emails" }],
+		} as DiffedCustomizePlanV1;
+
+		expect(applyDiff({ base, diff }).items).toHaveLength(0);
+	});
 });

--- a/shared/utils/planV1Utils/diff/applyDiff.ts
+++ b/shared/utils/planV1Utils/diff/applyDiff.ts
@@ -36,9 +36,12 @@ const itemMatchesFilter = (
 ): boolean => {
 	if (filter.feature_id !== undefined && item.feature_id !== filter.feature_id)
 		return false;
-	if (filter.billing_method !== undefined) {
-		if (item.price?.billing_method !== filter.billing_method) return false;
-	} else if (item.price?.billing_method !== undefined) {
+	// Omitted billing_method is a wildcard — same rule as the engine's
+	// matchesPlanItemFilter, so a feature_id-only filter matches priced items.
+	if (
+		filter.billing_method !== undefined &&
+		item.price?.billing_method !== filter.billing_method
+	) {
 		return false;
 	}
 	if (filter.interval !== undefined) {
@@ -228,10 +231,7 @@ const applyLicenses = ({
 		(diff.remove_licenses ?? []).map((entry) => entry.license_plan_id),
 	);
 	const pending = new Map(
-		(diff.upsert_licenses ?? []).map((entry) => [
-			entry.license_plan_id,
-			entry,
-		]),
+		(diff.upsert_licenses ?? []).map((entry) => [entry.license_plan_id, entry]),
 	);
 
 	const next: ApiPlanLicenseV1[] = [];


### PR DESCRIPTION
## Bug

The \"View in dashboard\" flow can turn a working Slack-approved billing request into a broken one. `billingParamsV1ToV0`'s `applyDiff` only matched a priced item when the remove filter also spelled out `billing_method` — the billing engine's `matchesPlanItemFilter` treats every omitted filter field as a wildcard.

So a customize that removed a plan's priced item by `feature_id` alone (e.g. drop the built-in emails item at \$0.90/1k, add a custom one at 5M included + \$0.35/1k) attached fine through the engine, but the translated dashboard request silently kept **both** emails items, and the dashboard preview errored:

> You're trying to add the same feature (emails), with the same reset interval.

Real occurrence: resend org, customer `5954ff1c-5f69-4b96-b80f-fc380ddeac92`, 24 Aug 14:33 UTC.

## Fix

One rule change in `shared/utils/planV1Utils/diff/applyDiff.ts`: omitted `billing_method` is a wildcard, matching the engine's semantics. Filters that do specify `billing_method` still match only that method. The diff composer (`diffPlanV1`) already emits `billing_method` on filters it generates for priced items, so generated diffs never depended on the old strictness — only externally-authored filters (agent cards) hit it. The shared `itemMatchesFilter` also serves `applyPlanItemParamsDiff`, so both diff paths align.

## Tests

Three unit cases in `server/tests/unit/shared/applyDiff.test.ts` (red before, green after):
- incident repro: `feature_id`-only filter removes a priced item, custom replacement is the only survivor
- `billing_method`-specified filters still match only that method
- `feature_id`-only filters still remove unpriced items

Full unit suite: no new failures (remaining failures are pre-existing local Redis/cluster infra tests). `bun ts` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns plan diff item filtering with the billing engine: an omitted `billing_method` now acts as a wildcard. Previously the translator only matched priced items when the filter specified `billing_method`, which kept duplicates and broke dashboard previews.

- Changes: In `shared/utils/planV1Utils/diff/applyDiff.ts`, `itemMatchesFilter` treats missing `billing_method` as wildcard; if provided, it matches that method only. This aligns `billingParamsV1ToV0`’s `applyDiff` with the engine’s `matchesPlanItemFilter` and also applies to `applyPlanItemParamsDiff`.
- Impact: Fixes “same feature, same reset interval” preview errors when removing a priced item by `feature_id` only (e.g., emails). Generated diffs from `diffPlanV1` are unaffected since they already include `billing_method`; only externally-authored filters were impacted.
- Tests: Added three unit tests covering feature-id-only removal of priced items, method-specific matching, and unpriced items.

<sup>Written for commit a9157e47f808ea6c2b74a269385ad4f09189c86d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns dashboard plan-diff filtering with the billing engine so omitted filter fields behave consistently.
- **Bug fixes:** Treats an omitted `billing_method` as a wildcard when removing plan items.
- **Improvements:** Adds regression coverage for priced, billing-method-specific, and unpriced item removal.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the matching change aligned to existing engine semantics and covered by focused regression tests.

The updated matcher treats only an omitted billing method as a wildcard, while explicit billing methods and other supplied filter fields remain restrictive.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/planV1Utils/diff/applyDiff.ts | Aligns plan-item filter matching with established engine semantics without changing explicitly specified billing-method matching. |
| server/tests/unit/shared/applyDiff.test.ts | Adds focused regression tests covering the incident and preserving explicit billing-method and unpriced-item behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 plan diff item filters match pri..."](https://github.com/useautumn/autumn/commit/a9157e47f808ea6c2b74a269385ad4f09189c86d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56317196)</sub>

<!-- /greptile_comment -->