### PR TITLE
fix(analytics): keep idle periods on the usage chart x-axis

### DIFF
--- a/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
+++ b/vite/src/views/customers/customer/analytics/AnalyticsView.tsx
@@ -9,7 +9,7 @@ import { useEnv } from "@/utils/envUtils";
 import { OnboardingGuide } from "@/views/onboarding4/OnboardingGuide";
 import { AnalyticsContext } from "./AnalyticsContext";
 import { EventsBarChart } from "./AnalyticsGraph";
-import { colors } from "./components/analytics-types";
+import { colors, type EventRow } from "./components/analytics-types";
 import { ChartLegend, type ChartLegendEntry } from "./components/ChartLegend";
 import { ChartSkeleton } from "./components/ChartSkeleton";
 import { EventsTable } from "./components/EventsTable";
@@ -31,7 +31,9 @@ import {
 	CUSTOMER_BALANCE_SUFFIX,
 	deductionsToEventsData,
 } from "./utils/deductionsToEventsData";
+import { dropZeroRowsKeepingPeriods } from "./utils/dropZeroRowsKeepingPeriods";
 import { extractPropertyKeys } from "./utils/extractPropertyKeys";
+import { fillMissingPeriods } from "./utils/fillMissingPeriods";
 import {
 	generateChartConfig,
 	parseSeriesKey,
@@ -144,11 +146,18 @@ export const AnalyticsView = () => {
 		const chartGroupBy = isDeducted
 			? (groupBy ?? "source_feature_id")
 			: groupBy;
-		const chartSource = isDeducted
-			? deductions?.length
-				? deductionsToEventsData({ deductions, splitSpillover })
-				: null
-			: events;
+		// The deductions pipe only emits buckets it has rows for; the events
+		// aggregation beside it is already zero-filled over the same window.
+		const deductionEvents =
+			isDeducted && deductions?.length
+				? fillMissingPeriods({
+						events: deductionsToEventsData({ deductions, splitSpillover }),
+						periods: (events?.data ?? []).map((row: EventRow) =>
+							String(row.period),
+						),
+					})
+				: null;
+		const chartSource = isDeducted ? deductionEvents : events;
 
 		if (!chartSource) {
 			return { chartData: null, chartConfig: null };
@@ -176,15 +185,13 @@ export const AnalyticsView = () => {
 					},
 				);
 				const keptColumns = keptMeta.map(({ name }: { name: string }) => name);
-				const filteredData = chartSource.data.map(
-					(row: Record<string, string | number>) => {
-						const slim: Record<string, string | number> = {};
-						for (const column of keptColumns) {
-							slim[column] = row[column];
-						}
-						return slim;
-					},
-				);
+				const filteredData = chartSource.data.map((row: EventRow) => {
+					const slim: EventRow = {};
+					for (const column of keptColumns) {
+						slim[column] = row[column];
+					}
+					return slim;
+				});
 				filteredEvents = {
 					...chartSource,
 					meta: keptMeta,
@@ -193,8 +200,7 @@ export const AnalyticsView = () => {
 			}
 		} else if (groupBy === "plan_id" && planDeselected.size > 0) {
 			const filteredData = chartSource.data.filter(
-				(row: Record<string, string | number>) =>
-					!planDeselected.has(String(row.plan_id ?? "")),
+				(row: EventRow) => !planDeselected.has(String(row.plan_id ?? "")),
 			);
 			filteredEvents = {
 				...chartSource,
@@ -207,8 +213,7 @@ export const AnalyticsView = () => {
 					? groupBy
 					: `properties.${groupBy}`;
 			const filteredData = chartSource.data.filter(
-				(row: Record<string, string | number>) =>
-					String(row[groupByColumn]) === groupFilter,
+				(row: EventRow) => String(row[groupByColumn]) === groupFilter,
 			);
 			filteredEvents = {
 				...chartSource,
@@ -217,8 +222,8 @@ export const AnalyticsView = () => {
 			};
 		}
 
-		// 1. Drop raw rows where every feature column is zero — cuts ~95%
-		//    of rows before the pivot so it runs on hundreds, not thousands.
+		// 1. Drop all-zero rows before the pivot — ~95% of the grouped response,
+		//    so the pivot runs on hundreds of rows rather than thousands.
 		const groupCol =
 			groupBy === "customer_id" ||
 			groupBy === "entity_id" ||
@@ -227,20 +232,10 @@ export const AnalyticsView = () => {
 				: groupBy
 					? `properties.${groupBy}`
 					: null;
-		const skipKeys = new Set(["period", groupCol].filter(Boolean) as string[]);
-		const nonZeroData = filteredEvents.data.filter(
-			(row: Record<string, string | number>) => {
-				for (const key in row) {
-					if (skipKeys.has(key)) continue;
-					if (Number(row[key]) !== 0) return true;
-				}
-				return false;
-			},
-		);
-		const nonZeroEvents =
-			nonZeroData.length === filteredEvents.data.length
-				? filteredEvents
-				: { ...filteredEvents, data: nonZeroData, rows: nonZeroData.length };
+		const nonZeroEvents = dropZeroRowsKeepingPeriods({
+			events: filteredEvents,
+			groupColumn: groupCol,
+		});
 
 		// 2. Pivot into one column per group×feature
 		const transformed = transformGroupedData({
@@ -305,8 +300,7 @@ export const AnalyticsView = () => {
 		if ((groupBy || isDeducted) && chartConfig) {
 			entries = chartConfig.map((s) => {
 				const sum = chartData.data.reduce(
-					(acc, row) =>
-						acc + Number((row as Record<string, string | number>)[s.yKey] ?? 0),
+					(acc, row) => acc + Number((row as EventRow)[s.yKey] ?? 0),
 					0,
 				);
 				return {

--- a/vite/src/views/customers/customer/analytics/components/analytics-types.ts
+++ b/vite/src/views/customers/customer/analytics/components/analytics-types.ts
@@ -1,3 +1,13 @@
+/** One `/query/events` row: a `period` plus the numeric series columns. */
+export type EventRow = Record<string, string | number>;
+
+/** The `/query/events` payload shape every stage of the chart pipeline reads and returns. */
+export interface EventsData {
+	meta: Array<{ name: string }>;
+	rows: number;
+	data: EventRow[];
+}
+
 export type Row =
 	| {
 			interval_start: string;

--- a/vite/src/views/customers/customer/analytics/utils/deductionsToEventsData.ts
+++ b/vite/src/views/customers/customer/analytics/utils/deductionsToEventsData.ts
@@ -1,12 +1,5 @@
 import type { DeductionPeriod } from "@autumn/shared";
-
-type EventRow = Record<string, string | number>;
-
-interface EventsData {
-	meta: Array<{ name: string }>;
-	rows: number;
-	data: EventRow[];
-}
+import type { EventRow, EventsData } from "../components/analytics-types";
 
 const pad = (value: number): string => String(value).padStart(2, "0");
 
@@ -24,6 +17,9 @@ const toPeriodString = (epochMs: number): string => {
 		`${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
 	);
 };
+
+/** Suffix appended to a group's series when it spent from a balance it doesn't own. */
+export const CUSTOMER_BALANCE_SUFFIX = " · customer";
 
 /**
  * Pivots the `deductions` response into the exact EventsData shape the existing
@@ -43,9 +39,6 @@ const toPeriodString = (epochMs: number): string => {
  * (e.g. a property group_by, which deductions don't serve) columns fall back to
  * one per balance-owning feature.
  */
-/** Suffix appended to a group's series when it spent from a balance it doesn't own. */
-export const CUSTOMER_BALANCE_SUFFIX = " · customer";
-
 export function deductionsToEventsData({
 	deductions,
 	splitSpillover = false,

--- a/vite/src/views/customers/customer/analytics/utils/dropZeroRowsKeepingPeriods.ts
+++ b/vite/src/views/customers/customer/analytics/utils/dropZeroRowsKeepingPeriods.ts
@@ -1,0 +1,70 @@
+import type { EventRow, EventsData } from "../components/analytics-types";
+
+const rowHasUsage = ({
+	row,
+	skipColumns,
+}: {
+	row: EventRow;
+	skipColumns: Set<string>;
+}): boolean => {
+	for (const key in row) {
+		if (skipColumns.has(key)) continue;
+		if (Number(row[key]) !== 0) return true;
+	}
+	return false;
+};
+
+/**
+ * Drops all-zero rows before the pivot, keeping one placeholder per period so an
+ * idle day still gets an x-axis slot. A wholly empty range returns no rows at all.
+ */
+export function dropZeroRowsKeepingPeriods({
+	events,
+	groupColumn,
+}: {
+	events: EventsData;
+	groupColumn: string | null;
+}): EventsData {
+	const skipColumns = new Set(
+		["period", groupColumn].filter(Boolean) as string[],
+	);
+
+	const periodOrder: string[] = [];
+	const usageRowsByPeriod = new Map<string, EventRow[]>();
+	const placeholderByPeriod = new Map<string, EventRow>();
+	let hasAnyUsage = false;
+
+	for (const row of events.data) {
+		const period = String(row.period);
+		let usageRows = usageRowsByPeriod.get(period);
+		if (!usageRows) {
+			usageRows = [];
+			usageRowsByPeriod.set(period, usageRows);
+			periodOrder.push(period);
+		}
+
+		if (rowHasUsage({ row, skipColumns })) {
+			usageRows.push(row);
+			hasAnyUsage = true;
+			continue;
+		}
+
+		if (!placeholderByPeriod.has(period)) placeholderByPeriod.set(period, row);
+	}
+
+	if (!hasAnyUsage) return { ...events, data: [], rows: 0 };
+
+	const data: EventRow[] = [];
+	for (const period of periodOrder) {
+		const usageRows = usageRowsByPeriod.get(period) ?? [];
+		if (usageRows.length > 0) {
+			data.push(...usageRows);
+			continue;
+		}
+		const placeholder = placeholderByPeriod.get(period);
+		if (placeholder) data.push(placeholder);
+	}
+
+	if (data.length === events.data.length) return events;
+	return { ...events, data, rows: data.length };
+}

--- a/vite/src/views/customers/customer/analytics/utils/fillMissingPeriods.ts
+++ b/vite/src/views/customers/customer/analytics/utils/fillMissingPeriods.ts
@@ -1,0 +1,38 @@
+import type { EventRow, EventsData } from "../components/analytics-types";
+
+/**
+ * Adds an all-zero row for every period in `periods` the data is missing, so a
+ * bucket with no usage still gets an x-axis slot. Rows outside `periods` are kept.
+ */
+export function fillMissingPeriods({
+	events,
+	periods,
+}: {
+	events: EventsData;
+	periods: string[];
+}): EventsData {
+	const seriesColumns = events.meta
+		.filter(({ name }) => name !== "period")
+		.map(({ name }) => name);
+
+	const rowByPeriod = new Map<string, EventRow>();
+	for (const row of events.data) rowByPeriod.set(String(row.period), row);
+
+	let added = 0;
+	for (const period of periods) {
+		if (rowByPeriod.has(period)) continue;
+		const zeroRow: EventRow = { period };
+		for (const column of seriesColumns) zeroRow[column] = 0;
+		rowByPeriod.set(period, zeroRow);
+		added++;
+	}
+
+	if (added === 0) return events;
+
+	// Period strings are "yyyy-MM-dd HH:mm:ss", so lexical order is chronological.
+	const data = [...rowByPeriod.values()].sort((a, b) =>
+		String(a.period).localeCompare(String(b.period)),
+	);
+
+	return { ...events, rows: data.length, data };
+}

--- a/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
+++ b/vite/src/views/customers/customer/analytics/utils/transformGroupedChartData.ts
@@ -1,20 +1,7 @@
 import type { Feature } from "@autumn/shared";
 import { FeatureType } from "@autumn/shared";
+import type { EventRow, EventsData } from "../components/analytics-types";
 import { CUSTOMER_BALANCE_SUFFIX } from "./deductionsToEventsData";
-
-/**
- * Row data from the events API
- */
-type EventRow = Record<string, string | number>;
-
-/**
- * Events data structure from the API
- */
-interface EventsData {
-	meta: Array<{ name: string }>;
-	rows: number;
-	data: EventRow[];
-}
 
 /**
  * Chart series configuration

--- a/vite/tests/views/customers/customer/analytics/utils/drop-zero-rows-keeping-periods.test.ts
+++ b/vite/tests/views/customers/customer/analytics/utils/drop-zero-rows-keeping-periods.test.ts
@@ -1,0 +1,116 @@
+// The server zero-fills every period in the window, so the count of periods it
+// returns is the x-axis the chart must render — dropping zeros must not shrink it.
+
+import { expect, test } from "bun:test";
+import { dropZeroRowsKeepingPeriods } from "@/views/customers/customer/analytics/utils/dropZeroRowsKeepingPeriods";
+
+const ungroupedEvents = {
+	meta: [{ name: "period" }, { name: "ai_credits_count" }],
+	rows: 3,
+	data: [
+		{ period: "2026-08-20 00:00:00", ai_credits_count: 0 },
+		{ period: "2026-08-21 00:00:00", ai_credits_count: 0 },
+		{ period: "2026-08-22 00:00:00", ai_credits_count: 42 },
+	],
+};
+
+test("keeps idle periods as zero rows", () => {
+	const result = dropZeroRowsKeepingPeriods({
+		events: ungroupedEvents,
+		groupColumn: null,
+	});
+
+	expect(result.data.map((row) => row.period)).toEqual([
+		"2026-08-20 00:00:00",
+		"2026-08-21 00:00:00",
+		"2026-08-22 00:00:00",
+	]);
+	expect(result.rows).toBe(3);
+});
+
+test("drops zero group rows but keeps one placeholder for an idle period", () => {
+	const result = dropZeroRowsKeepingPeriods({
+		events: {
+			meta: [
+				{ name: "period" },
+				{ name: "customer_id" },
+				{ name: "ai_credits_count" },
+			],
+			rows: 4,
+			data: [
+				{
+					period: "2026-08-20 00:00:00",
+					customer_id: "a",
+					ai_credits_count: 0,
+				},
+				{
+					period: "2026-08-20 00:00:00",
+					customer_id: "b",
+					ai_credits_count: 0,
+				},
+				{
+					period: "2026-08-21 00:00:00",
+					customer_id: "a",
+					ai_credits_count: 7,
+				},
+				{
+					period: "2026-08-21 00:00:00",
+					customer_id: "b",
+					ai_credits_count: 0,
+				},
+			],
+		},
+		groupColumn: "customer_id",
+	});
+
+	expect(result.data).toEqual([
+		{ period: "2026-08-20 00:00:00", customer_id: "a", ai_credits_count: 0 },
+		{ period: "2026-08-21 00:00:00", customer_id: "a", ai_credits_count: 7 },
+	]);
+});
+
+test("keeps periods in chronological order when the idle ones come last", () => {
+	const result = dropZeroRowsKeepingPeriods({
+		events: {
+			meta: [{ name: "period" }, { name: "ai_credits_count" }],
+			rows: 3,
+			data: [
+				{ period: "2026-08-20 00:00:00", ai_credits_count: 5 },
+				{ period: "2026-08-21 00:00:00", ai_credits_count: 0 },
+				{ period: "2026-08-22 00:00:00", ai_credits_count: 9 },
+			],
+		},
+		groupColumn: null,
+	});
+
+	expect(result.data.map((row) => row.ai_credits_count)).toEqual([5, 0, 9]);
+});
+
+test("returns no rows when the whole range is empty, so the empty state stays", () => {
+	const result = dropZeroRowsKeepingPeriods({
+		events: {
+			meta: [{ name: "period" }, { name: "ai_credits_count" }],
+			rows: 2,
+			data: [
+				{ period: "2026-08-20 00:00:00", ai_credits_count: 0 },
+				{ period: "2026-08-21 00:00:00", ai_credits_count: 0 },
+			],
+		},
+		groupColumn: null,
+	});
+
+	expect(result.data).toEqual([]);
+	expect(result.rows).toBe(0);
+});
+
+test("returns the same object when nothing was dropped", () => {
+	const events = {
+		meta: [{ name: "period" }, { name: "ai_credits_count" }],
+		rows: 1,
+		data: [{ period: "2026-08-20 00:00:00", ai_credits_count: 3 }],
+	};
+
+	expect(dropZeroRowsKeepingPeriods({ events, groupColumn: null })).toBe(
+		events,
+	);
+});

--- a/vite/tests/views/customers/customer/analytics/utils/fill-missing-periods.test.ts
+++ b/vite/tests/views/customers/customer/analytics/utils/fill-missing-periods.test.ts
@@ -1,0 +1,55 @@
+// The deductions pipe only emits buckets it has rows for; the period grid comes
+// from the events aggregation beside it, which is zero-filled over the same window.
+
+import { expect, test } from "bun:test";
+import { fillMissingPeriods } from "@/views/customers/customer/analytics/utils/fillMissingPeriods";
+
+const gridPeriods = [
+	"2026-08-20 00:00:00",
+	"2026-08-21 00:00:00",
+	"2026-08-22 00:00:00",
+];
+
+test("inserts zero rows for grid periods the deductions are missing", () => {
+	const result = fillMissingPeriods({
+		events: {
+			meta: [{ name: "period" }, { name: "ai_credits__chat" }],
+			rows: 1,
+			data: [{ period: "2026-08-22 00:00:00", ai_credits__chat: 12 }],
+		},
+		periods: gridPeriods,
+	});
+
+	expect(result.data).toEqual([
+		{ period: "2026-08-20 00:00:00", ai_credits__chat: 0 },
+		{ period: "2026-08-21 00:00:00", ai_credits__chat: 0 },
+		{ period: "2026-08-22 00:00:00", ai_credits__chat: 12 },
+	]);
+	expect(result.rows).toBe(3);
+});
+
+test("returns the same object when every grid period is already present", () => {
+	const events = {
+		meta: [{ name: "period" }, { name: "ai_credits__chat" }],
+		rows: 3,
+		data: gridPeriods.map((period) => ({ period, ai_credits__chat: 1 })),
+	};
+
+	expect(fillMissingPeriods({ events, periods: gridPeriods })).toBe(events);
+});
+
+test("keeps periods outside the grid rather than dropping them", () => {
+	const result = fillMissingPeriods({
+		events: {
+			meta: [{ name: "period" }, { name: "ai_credits__chat" }],
+			rows: 1,
+			data: [{ period: "2026-08-19 00:00:00", ai_credits__chat: 4 }],
+		},
+		periods: gridPeriods,
+	});
+
+	expect(result.data.map((row) => row.period)).toEqual([
+		"2026-08-19 00:00:00",
+		...gridPeriods,
+	]);
+});


### PR DESCRIPTION
The server zero-fills every bucket in the window, but the chart dropped all-zero rows before the pivot, so a 30-day range with usage only in the last 5 days rendered a 5-bar axis instead of 30 with 25 empty slots.

Keep one zero row per period through that filter (a range with no usage at all still returns nothing, so the empty state is unchanged), and fill the deductions series — which the pipe emits sparsely — from the zero-filled events grid returned alongside it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps idle periods on the usage chart x-axis and backfills sparse deductions so every bucket in the selected window renders. Previously the pre-pivot filter dropped all-zero rows and collapsed a 30‑day range with 5 days of usage to 5 bars; now we retain one zero row per period and align deductions with the zero-filled events grid.

- Replace the zero-row filter with keep-one-per-period logic via dropZeroRowsKeepingPeriods before the pivot; still drops superfluous zero group rows, preserves x-axis order, and returns no rows when the whole range is empty.
- In Deductions mode, fill missing periods using fillMissingPeriods with the events period grid so idle days render as zero bars.
- Centralize EventRow/EventsData in analytics-types.ts; update imports and add focused tests for both utilities; no API/DB changes and no migrations.

<sup>Written for commit 252ca68fe8157a953d35bf4e09a353827ffc61f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

