### PR TITLE
Guard invoice credit balance mutations

### DIFF
--- a/server/src/_luaScriptsV2/fullSubjectDeduction/lock/unwindLockV2.lua
+++ b/server/src/_luaScriptsV2/fullSubjectDeduction/lock/unwindLockV2.lua
@@ -74,6 +74,8 @@ local function calculate_rate_card_unwind_change(params)
   local attribution_unwind_magnitude = direction > 0
       and math.min(unwind_magnitude, current_units)
     or unwind_magnitude
+  -- Attribution stops at zero, but the caller consumes the full receipt segment;
+  -- any excess is net-negative usage, which rate cards do not credit.
   local inverse_units = -direction * attribution_unwind_magnitude
   local restored_units = math.max(0, current_units + inverse_units)
   local inverse_credits = credit_rate_cost_at_usage(

--- a/server/src/internal/balances/autoTopUp/compute/computeRebalancedAutoTopUp.ts
+++ b/server/src/internal/balances/autoTopUp/compute/computeRebalancedAutoTopUp.ts
@@ -9,6 +9,7 @@ import {
 import { runDeductionPass } from "@/internal/balances/track/deductUtils/deductFromCusEntsTypescript.js";
 import type { DeductionUpdates } from "@/internal/balances/utils/types/deductionUpdate.js";
 import type { MutationLogItem } from "@/internal/balances/utils/types/mutationLogItem.js";
+import { validateInvoiceCreditBalanceMutation } from "@/internal/balances/utils/validateInvoiceCreditBalanceMutation.js";
 
 export type AutoTopupRebalanceDelta = {
 	cusEntId: string;
@@ -79,6 +80,10 @@ export const computeRebalancedAutoTopUp = ({
 	);
 
 	if (!prepaidCusEnt) return { deltas: [] };
+
+	validateInvoiceCreditBalanceMutation({
+		feature: prepaidCusEnt.entitlement.feature,
+	});
 
 	const candidates = cusEntsForFeature.filter(
 		(cusEnt) =>

--- a/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
+++ b/server/src/internal/balances/createBalance/prepareNewBalanceForInsertion.ts
@@ -9,6 +9,7 @@ import {
 	type FullCustomer,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { validateInvoiceCreditBalanceMutation } from "@/internal/balances/utils/validateInvoiceCreditBalanceMutation.js";
 import { initCustomerEntitlement } from "@/internal/billing/v2/utils/initFullCustomerProduct/initCustomerEntitlement/initCustomerEntitlement";
 import { toFeature } from "@/internal/products/product-items/productItemUtils/itemToPriceAndEnt";
 
@@ -26,6 +27,8 @@ export const prepareNewBalanceForInsertion = async ({
 	newEntitlement: Entitlement;
 	newCustomerEntitlement: CustomerEntitlement;
 }> => {
+	validateInvoiceCreditBalanceMutation({ feature });
+
 	const planItem = createBalanceParamsV0ToPlanItemV0({
 		ctx,
 		params,

--- a/server/src/internal/balances/deleteBalance/deleteBalance.ts
+++ b/server/src/internal/balances/deleteBalance/deleteBalance.ts
@@ -13,6 +13,7 @@ import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntit
 import { deleteCachedFullCustomer } from "@/internal/customers/cusUtils/fullCustomerCacheUtils/deleteCachedFullCustomer";
 import { buildCustomerEntitlementFilters } from "../utils/buildCustomerEntitlementFilters";
 import { reapplyFeatureUsageDeduction } from "../utils/reapplyFeatureUsageDeduction";
+import { validateInvoiceCreditBalanceMutation } from "../utils/validateInvoiceCreditBalanceMutation.js";
 import {
 	findOverageCusEnt,
 	markCusProductCustom,
@@ -60,6 +61,10 @@ export const deleteBalance = async ({
 	}
 
 	for (const cusEnt of customerEntitlements) {
+		validateInvoiceCreditBalanceMutation({
+			feature: cusEnt.entitlement.feature,
+		});
+
 		if (isPaidCustomerEntitlement(cusEnt)) {
 			throw new RecaseError({
 				message: `Cannot delete paid balance for feature ${feature_id} and customer ${customer_id}`,

--- a/server/src/internal/balances/handlers/handleSetUsage.ts
+++ b/server/src/internal/balances/handlers/handleSetUsage.ts
@@ -3,6 +3,7 @@ import { createRoute } from "@/honoMiddlewares/routeHandler.js";
 import { getOrCreateCachedFullSubject } from "@/internal/customers/cache/fullSubject/actions/getOrCreateCachedFullSubject.js";
 import { isFullSubjectRolloutEnabled } from "@/internal/misc/rollouts/fullSubjectRolloutUtils.js";
 import { updateUsageV2 } from "../updateBalance/v2/updateUsageV2.js";
+import { validateInvoiceCreditBalanceMutation } from "../utils/validateInvoiceCreditBalanceMutation.js";
 
 export const handleSetUsage = createRoute({
 	scopes: [Scopes.Balances.Write],
@@ -14,6 +15,10 @@ export const handleSetUsage = createRoute({
 
 		if (isFullSubjectRolloutEnabled({ ctx })) {
 		}
+
+		validateInvoiceCreditBalanceMutation({
+			feature: ctx.features.find((feature) => feature.id === body.feature_id),
+		});
 
 		const fullSubject = await getOrCreateCachedFullSubject({
 			ctx,

--- a/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
+++ b/server/src/internal/balances/recalculateBalance/computeRecalculateBalance.ts
@@ -15,6 +15,7 @@ import { deductFromCusEntsTypescript } from "@/internal/balances/track/deductUti
 import { CusService } from "@/internal/customers/CusService";
 import { getResetBalancesUpdate } from "@/internal/customers/cusProducts/cusEnts/groupByUtils";
 import { buildCustomerEntitlementFilters } from "../utils/buildCustomerEntitlementFilters";
+import { validateInvoiceCreditBalanceMutation } from "../utils/validateInvoiceCreditBalanceMutation.js";
 
 const resetCusEntInPlace = ({
 	cusEnt,
@@ -88,6 +89,11 @@ export const computeRecalculateBalance = async ({
 		throw new RecaseError({
 			message: `Balance not found for feature ${feature_id} and customer ${customer_id}`,
 			statusCode: 404,
+		});
+	}
+	for (const customerEntitlement of before) {
+		validateInvoiceCreditBalanceMutation({
+			feature: customerEntitlement.entitlement.feature,
 		});
 	}
 	const entityId = fullCustomer.entity?.id ?? undefined;

--- a/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
+++ b/server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts
@@ -11,6 +11,7 @@ import { JobName } from "@/queue/JobName.js";
 import { addTaskToQueue } from "@/queue/queueUtils.js";
 import { getUpdateBalanceProducerQueueUrl } from "@/queue/trackAsyncQueueUrls.js";
 import { buildCustomerEntitlementFilters } from "../../utils/buildCustomerEntitlementFilters.js";
+import { validateInvoiceCreditBalanceMutation } from "../../utils/validateInvoiceCreditBalanceMutation.js";
 import { updateExpiresAtV2 } from "./updateExpiresAtV2.js";
 import { updateIncludedGrantV2 } from "./updateIncludedGrantV2.js";
 import { updateNextResetAtV2 } from "./updateNextResetAtV2.js";
@@ -19,6 +20,28 @@ import { updateUsageV2 } from "./updateUsageV2.js";
 
 const ASYNC_UPDATE_BALANCE_UNAVAILABLE_MESSAGE =
 	"Async balance update is not available right now";
+
+const validateBalanceMutation = ({
+	ctx,
+	params,
+	targetBalance,
+}: {
+	ctx: AutumnContext;
+	params: UpdateBalanceParamsV0;
+	targetBalance?: number;
+}) => {
+	const changesBalance =
+		notNullish(targetBalance) ||
+		notNullish(params.remaining) ||
+		notNullish(params.add_to_balance) ||
+		notNullish(params.usage) ||
+		notNullish(params.included_grant);
+	if (!changesBalance) return;
+
+	validateInvoiceCreditBalanceMutation({
+		feature: ctx.features.find((feature) => feature.id === params.feature_id),
+	});
+};
 
 /** Update balance using the FullSubject cache path. */
 export const runUpdateBalanceV2 = async ({
@@ -30,6 +53,8 @@ export const runUpdateBalanceV2 = async ({
 	params: UpdateBalanceParamsV0;
 	targetBalance?: number;
 }) => {
+	validateBalanceMutation({ ctx, params, targetBalance });
+
 	const fullSubject = await getOrSetCachedFullSubject({
 		ctx,
 		customerId: params.customer_id,
@@ -158,6 +183,7 @@ export const updateBalanceV2 = async ({
 			ctx.testOptions?.asyncBalanceUpdate);
 
 	if (asyncBalanceUpdateEnabled) {
+		validateBalanceMutation({ ctx, params, targetBalance });
 		return queueUpdateBalanceV2({ ctx, params, targetBalance });
 	}
 

--- a/server/src/internal/balances/utils/sql/creditRateUtils.sql
+++ b/server/src/internal/balances/utils/sql/creditRateUtils.sql
@@ -290,6 +290,8 @@ BEGIN
     WHEN direction > 0 THEN LEAST(unwind_magnitude, current_units)
     ELSE unwind_magnitude
   END;
+  -- Attribution stops at zero, but the caller consumes the full receipt segment;
+  -- any excess is net-negative usage, which rate cards do not credit.
   inverse_units := -direction * attribution_unwind_magnitude;
   restored_units := GREATEST(0, current_units + inverse_units);
   inverse_credits := credit_rate_cost_at_usage(rate_card, restored_units)

--- a/server/src/internal/balances/utils/validateInvoiceCreditBalanceMutation.ts
+++ b/server/src/internal/balances/utils/validateInvoiceCreditBalanceMutation.ts
@@ -1,0 +1,19 @@
+import { ErrCode, type Feature, RecaseError } from "@autumn/shared";
+import { isInvoiceCreditFeature } from "@/internal/features/creditSystemUtils.js";
+
+export const INVOICE_CREDIT_BALANCE_MUTATION_MESSAGE =
+	"Invoice-credit balances can only be changed through tracked usage and billing-cycle resets";
+
+export const validateInvoiceCreditBalanceMutation = ({
+	feature,
+}: {
+	feature?: Feature;
+}): void => {
+	if (!isInvoiceCreditFeature({ feature })) return;
+
+	throw new RecaseError({
+		message: INVOICE_CREDIT_BALANCE_MUTATION_MESSAGE,
+		code: ErrCode.InvalidRequest,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
+++ b/server/src/internal/billing/v2/actions/attach/compute/computeOneOffPurchaseRebalance.ts
@@ -6,6 +6,7 @@ import {
 	orgPersistFreeOverage,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { validateInvoiceCreditBalanceMutation } from "@/internal/balances/utils/validateInvoiceCreditBalanceMutation.js";
 import { oneOffPrepaidCusEntsByFeatureId } from "@/internal/billing/v2/utils/handleOneOffPrepaidCarryOvers/cusProductToOneOffPrepaidCarryOvers";
 
 export type OneOffPurchaseRebalance = {
@@ -33,6 +34,10 @@ export const computeOneOffPurchaseRebalance = ({
 	).flatMap(([featureId, customerEntitlement]) => {
 		const quantity = customerEntitlement.balance ?? 0;
 		if (quantity <= 0) return [];
+
+		validateInvoiceCreditBalanceMutation({
+			feature: customerEntitlement.entitlement.feature,
+		});
 
 		customerEntitlement.balance = 0;
 		return [

--- a/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
+++ b/server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts
@@ -1,6 +1,7 @@
 import {
 	addCusProductToCusEnt,
 	cusEntsToUsage,
+	ErrCode,
 	type ExistingUsages,
 	type FullCusProduct,
 	featureUtils,
@@ -8,6 +9,7 @@ import {
 	isEntityScopedCusEnt,
 	isOneOffPrepaidConsumableCustomerEntitlement,
 	isUnlimitedCusEnt,
+	RecaseError,
 } from "@autumn/shared";
 import { Decimal } from "decimal.js";
 
@@ -76,13 +78,20 @@ export const cusProductToExistingUsages = ({
 			)) {
 				const currentAttribution =
 					mergedUsageAttribution[sourceInternalFeatureId];
+				if (currentAttribution) {
+					throw new RecaseError({
+						message: `carry_over_usages cannot merge multiple attribution positions for credit feature '${cusEnt.entitlement.feature.id}'.`,
+						code: ErrCode.InvalidRequest,
+						statusCode: 400,
+						data: {
+							featureId: cusEnt.entitlement.feature.id,
+							sourceInternalFeatureId,
+						},
+					});
+				}
 				mergedUsageAttribution[sourceInternalFeatureId] = {
-					units: new Decimal(currentAttribution?.units ?? 0)
-						.add(attribution.units)
-						.toNumber(),
-					credits: new Decimal(currentAttribution?.credits ?? 0)
-						.add(attribution.credits)
-						.toNumber(),
+					units: attribution.units,
+					credits: attribution.credits,
 				};
 			}
 			currentExistingUsage.usageAttribution = mergedUsageAttribution;

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -10,6 +10,46 @@ import { handleUpsertProductVersioningErrors } from "@/internal/catalogV2/action
 import { handleUpsertProductVersionSlugErrors } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpsertProductVersionSlugErrors";
 import type { UpdateCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
 import type { UpdateCatalogPlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogPlan";
+import { validateInvoiceCreditPooling } from "@/internal/features/validateInvoiceCreditPooling.js";
+
+const validateProjectedInvoiceCreditPooling = ({
+	catalogContext,
+	updateCatalogPlan,
+}: {
+	catalogContext: UpdateCatalogContext;
+	updateCatalogPlan: UpdateCatalogPlan;
+}): void => {
+	for (const updateFeaturePlan of updateCatalogPlan.updateFeatures) {
+		const { current, next: feature } = updateFeaturePlan;
+		const hasPooledPlanItem = updateCatalogPlan.projected.products.some(
+			(product) =>
+				product.entitlements.some(
+					(entitlement) =>
+						entitlement.internal_feature_id === feature.internal_id &&
+						entitlement.pooled,
+				),
+		);
+		validateInvoiceCreditPooling({
+			feature,
+			pooled:
+				hasPooledPlanItem ||
+				catalogContext.featureStatesContext[current.id]
+					?.has_pooled_entitlements,
+		});
+	}
+
+	for (const feature of updateCatalogPlan.insertFeatures) {
+		const hasPooledPlanItem = updateCatalogPlan.projected.products.some(
+			(product) =>
+				product.entitlements.some(
+					(entitlement) =>
+						entitlement.internal_feature_id === feature.internal_id &&
+						entitlement.pooled,
+				),
+		);
+		validateInvoiceCreditPooling({ feature, pooled: hasPooledPlanItem });
+	}
+};
 
 /** Throws on anything that should fail the whole batch before any write. */
 export const handleUpdateCatalogErrors = async ({
@@ -24,6 +64,7 @@ export const handleUpdateCatalogErrors = async ({
 	params: UpdateCatalogParams;
 }): Promise<void> => {
 	handleUpdateFeatureErrors({ ctx, catalogContext, updateCatalogPlan });
+	validateProjectedInvoiceCreditPooling({ catalogContext, updateCatalogPlan });
 	handleRemoveFeatureErrors({ updateCatalogPlan });
 	handleRemovePlanErrors({
 		updateCatalogPlan,

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupFeatureStatesContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupFeatureStatesContext.ts
@@ -1,11 +1,11 @@
 import type { Feature, UpdateCatalogParams } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
-import { featureUpdateCanRewriteReferences } from "@/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/featureUpdateCanRewriteReferences";
-import { paramsToTouchedFeatures } from "@/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/paramsToTouchedFeatures";
 import type {
 	FeatureState,
 	UpdateCatalogContext,
 } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import { featureUpdateCanRewriteReferences } from "@/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/featureUpdateCanRewriteReferences";
+import { paramsToTouchedFeatures } from "@/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/paramsToTouchedFeatures";
 import { getCreditSystemsFromFeature } from "@/internal/features/creditSystemUtils.js";
 import { listFeatureStates } from "@/internal/features/repos/listFeatureStates.js";
 
@@ -16,6 +16,7 @@ const emptyFeatureState = ({
 }): FeatureState => ({
 	has_customers: false,
 	has_entitlements: false,
+	has_pooled_entitlements: false,
 	has_loose_entitlements: false,
 	has_entity_feature_entitlements: false,
 	has_loose_entity_feature_entitlements: false,
@@ -88,6 +89,7 @@ export const setupFeatureStatesContext = async ({
 			...base,
 			has_customers: row?.has_customers ?? false,
 			has_entitlements: row?.has_entitlements ?? false,
+			has_pooled_entitlements: row?.has_pooled_entitlements ?? false,
 			has_loose_entitlements: row?.has_loose_entitlements ?? false,
 			has_entity_feature_entitlements:
 				row?.has_entity_feature_entitlements ?? false,

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/featureState.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/featureState.ts
@@ -7,6 +7,7 @@ import type { Feature } from "@autumn/shared";
 export type FeatureState = {
 	has_customers: boolean;
 	has_entitlements: boolean;
+	has_pooled_entitlements: boolean;
 	has_loose_entitlements: boolean;
 	has_entity_feature_entitlements: boolean;
 	has_loose_entity_feature_entitlements: boolean;

--- a/server/src/internal/features/creditSystemUtils.ts
+++ b/server/src/internal/features/creditSystemUtils.ts
@@ -28,6 +28,14 @@ export type CreditRateCard = {
 	  }
 );
 
+export const isInvoiceCreditFeature = ({
+	feature,
+}: {
+	feature?: Feature;
+}): boolean =>
+	feature?.type === FeatureType.CreditSystem &&
+	feature.config?.invoice_credit === true;
+
 const invalidCreditRateCard = ({
 	featureId,
 	creditSystemId,

--- a/server/src/internal/features/featureActions/updateFeature.ts
+++ b/server/src/internal/features/featureActions/updateFeature.ts
@@ -26,6 +26,7 @@ import { getObjectsUsingFeature } from "../utils/updateFeatureUtils/getObjectsUs
 import { handleFeatureIdChanged } from "../utils/updateFeatureUtils/handleFeatureIdChanged.js";
 import { handleFeatureTypeChanged } from "../utils/updateFeatureUtils/handleFeatureTypeChanged.js";
 import { handleFeatureUsageTypeChanged } from "../utils/updateFeatureUtils/handleFeatureUsageTypeChanged.js";
+import { validateInvoiceCreditPooling } from "../validateInvoiceCreditPooling.js";
 import { hasCreditRateCardChanged } from "./hasCreditRateCardChanged.js";
 import type { ClearCreditSystemCachePayload } from "./runClearCreditSystemCacheTask.js";
 
@@ -165,11 +166,33 @@ export const updateFeature = async ({
 		feature.config?.usage_type !== updates.config?.usage_type;
 
 	const isChangingName = updates.name && feature.name !== updates.name;
+	const isEnablingInvoiceCredits =
+		feature.config?.invoice_credit !== true &&
+		(updates.type ?? feature.type) === FeatureType.CreditSystem &&
+		updates.config?.invoice_credit === true;
 
-	if (isChangingType || isChangingId || isChangingUsageType) {
+	if (
+		isChangingType ||
+		isChangingId ||
+		isChangingUsageType ||
+		isEnablingInvoiceCredits
+	) {
 		const objectsUsingFeature = await getObjectsUsingFeature({
 			ctx,
 			feature,
+		});
+
+		validateInvoiceCreditPooling({
+			feature: {
+				...feature,
+				type: updates.type ?? feature.type,
+				config: updates.config ?? feature.config,
+			},
+			pooled:
+				isEnablingInvoiceCredits &&
+				objectsUsingFeature.entitlements.some(
+					(entitlement) => entitlement.pooled,
+				),
 		});
 
 		// Validate the whole change before any mutation so it stays atomic.

--- a/server/src/internal/features/repos/listFeatureStates.ts
+++ b/server/src/internal/features/repos/listFeatureStates.ts
@@ -10,6 +10,7 @@ export const FeatureStateRowSchema = z.object({
 	internal_feature_id: z.string(),
 	feature_id: z.string(),
 	has_entitlements: z.boolean(),
+	has_pooled_entitlements: z.boolean(),
 	has_loose_entitlements: z.boolean(),
 	has_entity_feature_entitlements: z.boolean(),
 	has_loose_entity_feature_entitlements: z.boolean(),
@@ -49,6 +50,7 @@ export const buildFeatureStatesQuery = ({
 			candidate.internal_feature_id,
 			candidate.feature_id,
 			entitlement_product.found IS NOT NULL AS has_entitlements,
+			pooled_entitlement.found IS NOT NULL AS has_pooled_entitlements,
 			entitlement_loose.found IS NOT NULL AS has_loose_entitlements,
 			entity_product.found IS NOT NULL AS has_entity_feature_entitlements,
 			entity_loose.found IS NOT NULL AS has_loose_entity_feature_entitlements,
@@ -78,6 +80,19 @@ export const buildFeatureStatesQuery = ({
 				AND entitlement.internal_product_id IS NOT NULL
 			LIMIT 1
 		) entitlement_product ON true
+		LEFT JOIN LATERAL (
+			SELECT 1 AS found
+			FROM entitlements entitlement
+			JOIN features feature
+				ON feature.internal_id = entitlement.internal_feature_id
+			WHERE entitlement.internal_feature_id COLLATE "C"
+				= candidate.internal_feature_id
+				AND feature.org_id = ${orgId}
+				AND feature.env = ${env}
+				AND entitlement.internal_product_id IS NOT NULL
+				AND entitlement.pooled
+			LIMIT 1
+		) pooled_entitlement ON true
 		LEFT JOIN LATERAL (
 			SELECT 1 AS found
 			FROM entitlements entitlement

--- a/server/src/internal/features/validateInvoiceCreditPooling.ts
+++ b/server/src/internal/features/validateInvoiceCreditPooling.ts
@@ -1,0 +1,18 @@
+import { ErrCode, type Feature, RecaseError } from "@autumn/shared";
+import { isInvoiceCreditFeature } from "./creditSystemUtils.js";
+
+export const validateInvoiceCreditPooling = ({
+	feature,
+	pooled,
+}: {
+	feature?: Feature;
+	pooled?: boolean;
+}): void => {
+	if (!pooled || !isInvoiceCreditFeature({ feature })) return;
+
+	throw new RecaseError({
+		message: "Invoice-credit features cannot use pooled plan items",
+		code: ErrCode.InvalidProductItem,
+		statusCode: 400,
+	});
+};

--- a/server/src/internal/products/product-items/validateProductItems.ts
+++ b/server/src/internal/products/product-items/validateProductItems.ts
@@ -23,6 +23,7 @@ import {
 } from "@autumn/shared";
 import { createFeaturesFromItems } from "@server/internal/products/product-items/createFeaturesFromItems";
 import { StatusCodes } from "http-status-codes";
+import { validateInvoiceCreditPooling } from "@/internal/features/validateInvoiceCreditPooling.js";
 import {
 	isBooleanFeatureItem,
 	isFeatureItem,
@@ -67,6 +68,8 @@ const validateProductItem = ({
 			statusCode: StatusCodes.BAD_REQUEST,
 		});
 	}
+
+	validateInvoiceCreditPooling({ feature, pooled: item.pooled });
 
 	if (
 		item.pooled &&

--- a/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
@@ -7,6 +7,7 @@ import { expect, test } from "bun:test";
 import {
 	type ApiCustomerV3,
 	customerEntitlements,
+	findFeatureById,
 	fullSubjectToCustomerEntitlements,
 } from "@autumn/shared";
 import { TestFeature } from "@tests/setup/v2Features.js";
@@ -326,6 +327,59 @@ test.concurrent(
 			units: 10_000,
 			credits: 100,
 		});
+	},
+	{ timeout: 120_000 },
+);
+
+test.concurrent(
+	`${chalk.yellowBright("graduated-credit-rating: lock release keeps net-negative usage floored at zero")}`,
+	async () => {
+		const customerId = "graduated-credit-rating-lock-zero-floor";
+		const product = makeCreditProduct({
+			id: "graduated-credit-lock-zero-floor",
+		});
+		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [s.attach({ productId: product.id })],
+		});
+		const lockId = `${customerId}-release`;
+
+		await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			required_balance: 100,
+			lock: { enabled: true, lock_id: lockId },
+		});
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: -100,
+		});
+		await autumnV2_3.balances.finalize({
+			lock_id: lockId,
+			action: "release",
+		});
+
+		const response = await autumnV1.customers.get<ApiCustomerV3>(customerId);
+		expect(response.features[TestFeature.TieredCredits].balance).toBe(1_000);
+
+		await timeout(3_000);
+		const persisted = await getPersistedCreditEntitlement({
+			ctx,
+			internalCustomerId: customer.internal_id,
+		});
+		const sourceInternalFeatureId = findFeatureById({
+			features: ctx.features,
+			featureId: TestFeature.TieredAction,
+			errorOnNotFound: true,
+		}).internal_id;
+		expect(
+			persisted?.usageAttribution[sourceInternalFeatureId],
+		).toBeUndefined();
 	},
 	{ timeout: 120_000 },
 );

--- a/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
+++ b/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test";
+import { type ApiCustomer, ErrCode } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+
+const errorMessage =
+	"Invoice-credit balances can only be changed through tracked usage and billing-cycle resets";
+
+test.concurrent(
+	"invoice-credit balances reject source-less mutations but allow metadata updates",
+	async () => {
+		const product = products.base({
+			id: "invoice-credit-mutation-guards",
+			items: [
+				items.free({
+					featureId: TestFeature.InvoiceCredits,
+					includedUsage: 100,
+				}),
+			],
+		});
+		const { autumnV2, customerId } = await initScenario({
+			customerId: "invoice-credit-mutation-guards",
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [product] }),
+			],
+			actions: [
+				s.attach({ productId: product.id }),
+				s.track({ featureId: TestFeature.Action1, value: 50 }),
+			],
+		});
+
+		const expectRejected = (func: () => Promise<unknown>) =>
+			expectAutumnError({
+				errCode: ErrCode.InvalidRequest,
+				errMessage: errorMessage,
+				func,
+			});
+
+		for (const mutation of [
+			{ remaining: 70 },
+			{ remaining: 110 },
+			{ add_to_balance: 10 },
+			{ add_to_balance: -10 },
+			{ usage: 30 },
+			{ included_grant: 200 },
+		]) {
+			await expectRejected(() =>
+				autumnV2.balances.update({
+					customer_id: customerId,
+					feature_id: TestFeature.InvoiceCredits,
+					...mutation,
+				}),
+			);
+		}
+
+		await expectRejected(() =>
+			autumnV2.usage({
+				customer_id: customerId,
+				feature_id: TestFeature.InvoiceCredits,
+				value: 30,
+			}),
+		);
+		await expectRejected(() =>
+			autumnV2.balances.create({
+				customer_id: customerId,
+				feature_id: TestFeature.InvoiceCredits,
+				included_grant: 50,
+			}),
+		);
+		await expectRejected(() =>
+			autumnV2.balances.delete({
+				customer_id: customerId,
+				feature_id: TestFeature.InvoiceCredits,
+			}),
+		);
+		await expectRejected(() =>
+			autumnV2.balances.recalculate({
+				customer_id: customerId,
+				feature_id: TestFeature.InvoiceCredits,
+			}),
+		);
+		await expectRejected(() =>
+			autumnV2.balances.previewRecalculate({
+				customer_id: customerId,
+				feature_id: TestFeature.InvoiceCredits,
+			}),
+		);
+
+		const nextResetAt = Date.now() + 24 * 60 * 60 * 1000;
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.InvoiceCredits,
+			next_reset_at: nextResetAt,
+		});
+		await autumnV2.balances.update({
+			customer_id: customerId,
+			feature_id: TestFeature.InvoiceCredits,
+			expires_at: nextResetAt + 24 * 60 * 60 * 1000,
+		});
+
+		const customer = await autumnV2.customers.get<ApiCustomer>(customerId);
+		expect(customer.balances[TestFeature.InvoiceCredits]).toMatchObject({
+			granted_balance: 100,
+			current_balance: 90,
+			usage: 10,
+		});
+	},
+);

--- a/server/tests/integration/catalog-v2/features/credit-rate-card.test.ts
+++ b/server/tests/integration/catalog-v2/features/credit-rate-card.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
-import { FeatureType, FeatureUsageType } from "@autumn/shared";
+import { ErrCode, FeatureType, FeatureUsageType } from "@autumn/shared";
+import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
+import { deleteDbPlans } from "../plans/utils/expectCatalogPlans.js";
 import {
 	deleteDbFeatures,
 	expectDbFeaturesCorrect,
@@ -149,6 +151,90 @@ test.concurrent(
 				],
 			});
 		} finally {
+			await deleteDbFeatures({ ctx, featureIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 credit rate card: rejects enabling invoice credits on a pooled feature")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const meteredFeatureId = uniqueTestId("rate_pooled_metered");
+		const creditSystemId = uniqueTestId("rate_pooled_credits");
+		const planId = uniqueTestId("rate_pooled_plan");
+		const featureIds = [meteredFeatureId, creditSystemId];
+		const creditSchema = [
+			{
+				metered_feature_id: meteredFeatureId,
+				credit_cost: 1,
+			},
+		];
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		await deleteDbFeatures({ ctx, featureIds });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: meteredFeatureId,
+						name: meteredFeatureId,
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+					{
+						feature_id: creditSystemId,
+						name: creditSystemId,
+						type: FeatureType.CreditSystem,
+						invoice_credit: false,
+						credit_schema: creditSchema,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: planId,
+						items: [
+							{
+								feature_id: creditSystemId,
+								included: 100,
+								pooled: true,
+							},
+						],
+					},
+				],
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidProductItem,
+				errMessage: "Invoice-credit features cannot use pooled plan items",
+				func: () =>
+					autumnV2_3.catalogV2.update({
+						features: [
+							{
+								feature_id: creditSystemId,
+								name: creditSystemId,
+								type: FeatureType.CreditSystem,
+								invoice_credit: true,
+								credit_schema: creditSchema,
+							},
+						],
+					}),
+			});
+
+			await expectAutumnError({
+				errCode: ErrCode.InvalidProductItem,
+				errMessage: "Invoice-credit features cannot use pooled plan items",
+				func: () =>
+					autumnV2_3.post("/features.update", {
+						feature_id: creditSystemId,
+						invoice_credit: true,
+						credit_schema: creditSchema,
+					}),
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
 			await deleteDbFeatures({ ctx, featureIds });
 		}
 	},

--- a/server/tests/integration/crud/plans/create/pooled-item-validation.test.ts
+++ b/server/tests/integration/crud/plans/create/pooled-item-validation.test.ts
@@ -136,3 +136,18 @@ test.concurrent(
 		});
 	},
 );
+
+test.concurrent(
+	"pooled item validation: rejects invoice-credit features",
+	async () => {
+		await expectPooledItemRejected({
+			planId: `pooled-invoice-credit-${crypto.randomUUID()}`,
+			item: {
+				feature_id: TestFeature.InvoiceCredits,
+				included: 100,
+				pooled: true,
+			},
+			errMessage: "Invoice-credit features cannot use pooled plan items",
+		});
+	},
+);

--- a/server/tests/unit/balances/auto-topup/compute-rebalanced-auto-topup.test.ts
+++ b/server/tests/unit/balances/auto-topup/compute-rebalanced-auto-topup.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
-	BillWhen,
 	BillingInterval,
+	BillWhen,
 	type EntityBalance,
+	FeatureType,
 	type FullCusEntWithFullCusProduct,
 	type FullCustomer,
 	PriceType,
@@ -18,6 +19,7 @@ const createCustomerEntitlement = ({
 	createdAt = 1,
 	allowance = 0,
 	entityFeatureId = null,
+	invoiceCredit = false,
 }: {
 	id: string;
 	balance: number;
@@ -27,6 +29,7 @@ const createCustomerEntitlement = ({
 	createdAt?: number;
 	allowance?: number;
 	entityFeatureId?: string | null;
+	invoiceCredit?: boolean;
 }): FullCusEntWithFullCusProduct => {
 	const entitlementId = `ent-${id}`;
 	const customerProductId = `cus-prod-${id}`;
@@ -72,8 +75,8 @@ const createCustomerEntitlement = ({
 				id: "messages",
 				internal_id: "internal-feature-messages",
 				name: "Messages",
-				type: "metered",
-				config: {},
+				type: invoiceCredit ? FeatureType.CreditSystem : FeatureType.Metered,
+				config: invoiceCredit ? { invoice_credit: true } : {},
 				org_id: "org-1",
 				env: "sandbox",
 				created_at: 1,
@@ -210,6 +213,24 @@ const buildFullCustomer = (
 };
 
 describe("computeRebalancedAutoTopUp", () => {
+	test("rejects invoice-credit balance rebalances", () => {
+		const prepaid = createCustomerEntitlement({
+			id: "prepaid",
+			balance: 0,
+			invoiceCredit: true,
+		});
+		const fullCustomer = buildFullCustomer([prepaid]);
+
+		expect(() =>
+			computeRebalancedAutoTopUp({
+				fullCustomer,
+				featureId: "messages",
+				quantity: 100,
+				prepaidCustomerEntitlementId: prepaid.id,
+			}),
+		).toThrow(/invoice-credit/i);
+	});
+
 	test("1. no overage: single delta to prepaid for full quantity", () => {
 		const prepaid = createCustomerEntitlement({ id: "prepaid", balance: 0 });
 		const base = createCustomerEntitlement({

--- a/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
+++ b/server/tests/unit/balances/updateBalance/updateBalanceV2-async.test.ts
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
 	ApiVersionClass,
 	AppEnv,
+	ErrCode,
+	type Feature,
+	FeatureType,
 	LATEST_VERSION,
 	type UpdateBalanceParamsV0,
 } from "@autumn/shared";
@@ -75,7 +78,7 @@ await mockModuleWithRestore(
 	() => ({ updateExpiresAtV2: async () => {} }),
 );
 
-const { updateBalanceV2 } = await import(
+const { runUpdateBalanceV2, updateBalanceV2 } = await import(
 	// @ts-expect-error - Bun cache-busting query isolates module mocks.
 	"@/internal/balances/updateBalance/v2/updateBalanceV2.js?asyncUpdate"
 );
@@ -104,6 +107,18 @@ const params = {
 	feature_id: "messages",
 	remaining: 40,
 } satisfies UpdateBalanceParamsV0;
+
+const invoiceCreditFeature = {
+	id: "invoice_credits",
+	type: FeatureType.CreditSystem,
+	config: { invoice_credit: true },
+} as Feature;
+
+const createInvoiceCreditCtx = () => {
+	const ctx = createCtx();
+	ctx.features = [invoiceCreditFeature];
+	return ctx;
+};
 
 describe("updateBalanceV2 async routing", () => {
 	const originalQueueUrl = process.env.TRACK_ASYNC_SQS_QUEUE_URL;
@@ -223,6 +238,72 @@ describe("updateBalanceV2 async routing", () => {
 		).rejects.toMatchObject({ statusCode: 503 });
 
 		expect(state.getFullSubjectCalls).toHaveLength(0);
+		expect(state.updateRemainingCalls).toHaveLength(0);
+	});
+
+	test("rejects invoice-credit balance mutations before enqueue", async () => {
+		_setAsyncBalanceUpdateConfigForTesting({
+			config: { enabledOrgIds: ["test-org"] },
+		});
+
+		for (const mutation of [
+			{ remaining: 40 },
+			{ add_to_balance: 10 },
+			{ add_to_balance: -10 },
+			{ usage: 60 },
+			{ included_grant: 100 },
+		] satisfies Partial<UpdateBalanceParamsV0>[]) {
+			await expect(
+				updateBalanceV2({
+					ctx: createInvoiceCreditCtx(),
+					params: {
+						customer_id: "cus_123",
+						feature_id: invoiceCreditFeature.id,
+						...mutation,
+					},
+					targetBalance: mutation.remaining,
+				}),
+			).rejects.toMatchObject({
+				code: ErrCode.InvalidRequest,
+				statusCode: 400,
+			});
+		}
+
+		expect(state.queueCommands).toHaveLength(0);
+		expect(state.getFullSubjectCalls).toHaveLength(0);
+		expect(state.updateRemainingCalls).toHaveLength(0);
+	});
+
+	test("rejects invoice-credit balance mutations in the worker core", async () => {
+		await expect(
+			runUpdateBalanceV2({
+				ctx: createInvoiceCreditCtx(),
+				params: {
+					customer_id: "cus_123",
+					feature_id: invoiceCreditFeature.id,
+					usage: 60,
+				},
+			}),
+		).rejects.toMatchObject({
+			code: ErrCode.InvalidRequest,
+			statusCode: 400,
+		});
+
+		expect(state.getFullSubjectCalls).toHaveLength(0);
+		expect(state.updateRemainingCalls).toHaveLength(0);
+	});
+
+	test("allows metadata-only invoice-credit updates", async () => {
+		await runUpdateBalanceV2({
+			ctx: createInvoiceCreditCtx(),
+			params: {
+				customer_id: "cus_123",
+				feature_id: invoiceCreditFeature.id,
+				next_reset_at: Date.now() + 60_000,
+			},
+		});
+
+		expect(state.getFullSubjectCalls).toHaveLength(1);
 		expect(state.updateRemainingCalls).toHaveLength(0);
 	});
 });

--- a/server/tests/unit/billing/existing-usages/credit-rate-card-attribution-carry.test.ts
+++ b/server/tests/unit/billing/existing-usages/credit-rate-card-attribution-carry.test.ts
@@ -121,7 +121,7 @@ describe("credit-rate usage attribution carry-over", () => {
 	);
 
 	test.concurrent(
-		"sums duplicate source entries from multiple credit entitlements",
+		"rejects duplicate source positions from multiple credit entitlements",
 		() => {
 			const customerProduct = customerProducts.create({
 				customerEntitlements: [
@@ -142,19 +142,14 @@ describe("credit-rate usage attribution carry-over", () => {
 				],
 			});
 
-			const existingUsages = cusProductToExistingUsages({
-				cusProduct: customerProduct,
-				carryAllConsumableFeatures: true,
-			});
-
-			expect(existingUsages[CREDIT_INTERNAL_FEATURE_ID]).toEqual({
-				usage: 20,
-				entityUsages: {},
-				usageAttribution: {
-					[SOURCE_A_INTERNAL_ID]: { units: 1_500, credits: 15 },
-					[SOURCE_B_INTERNAL_ID]: { units: 50, credits: 5 },
-				},
-			});
+			expect(() =>
+				cusProductToExistingUsages({
+					cusProduct: customerProduct,
+					carryAllConsumableFeatures: true,
+				}),
+			).toThrow(
+				"carry_over_usages cannot merge multiple attribution positions for credit feature 'invoice_credits'.",
+			);
 		},
 	);
 

--- a/server/tests/unit/queue/processMessage-update-balance.test.ts
+++ b/server/tests/unit/queue/processMessage-update-balance.test.ts
@@ -22,6 +22,7 @@ await mockModuleWithRestore("@/queue/createWorkerContext.js", () => ({
 			id: "req_123",
 			org: { id: "org_123", slug: "test-org" },
 			env: AppEnv.Sandbox,
+			features: [],
 			customerId: "cus_123",
 			logger: {
 				error: mock(() => {}),


### PR DESCRIPTION
## Cubic summary

Prevents invoice-credit balances from being pooled or mutated through paths that cannot preserve per-feature usage attribution, while keeping normal tracking, billing resets, and metadata-only updates working.

Stack: #2867 -> #2897 -> #2938 -> #3024 -> this PR.

## What changed

- Rejects direct invoice-credit balance changes through `remaining`, `current_balance`, `add_to_balance`, `usage`, and `included_grant`.
- Applies the same validation before async enqueue and again in the worker for synchronous/queued parity.
- Covers internal mutation paths including loose balance create/delete, recalculation, auto/manual top-ups, one-off purchase rebalancing, and the legacy usage setter.
- Rejects pooled invoice-credit product items across plan create/update and attach customization.
- Rejects enabling `invoice_credit` on a feature already used by a pooled entitlement, including Catalog V2 updates.
- Rejects ambiguous carry-over when the same source attribution exists on multiple independently rated credit entitlements.
- Documents and tests the existing zero-floor invariant when a lock is released after negative usage.

## Scope

This is step 5 of the enterprise credit rate-card stack. It protects the deliberately narrow attribution model introduced by #3024.

It does not add pooled rate-card support or Stripe invoice rendering. Those require explicit attribution semantics and remain separate follow-up work.

## Testing

- Full unit suite: 3,666 passed, 0 failed, 9 skipped.
- Focused guard verification: 18 unit tests and 10 integration tests passed.
- Existing balance, usage, auto-top-up, and credit-system regressions: 14 tests and 80 assertions passed.
- Graduated-credit runtime integration: 5 passed, 0 failed against an isolated local server, Dragonfly, ElasticMQ, DynamoDB, and Neon branch.
- Server typecheck and scoped Biome passed.
- Commit hooks: `knip` and server typecheck.
- `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards invoice-credit features from source-less balance changes and pooling to preserve per-feature usage attribution. Previously, balances could be mutated via generic paths and pooled items were allowed; now only tracked usage and billing-cycle resets change invoice-credit balances, and pooled plan items are rejected.

- Rejects invoice-credit balance mutations via remaining/current_balance/add_to_balance/usage/included_grant across all paths (create/delete/recalculate/auto-top-up/one-off rebalancing/legacy setter). Validates both before enqueue and in the worker for async parity. Metadata-only updates (next_reset_at/expires_at) still succeed.
- Blocks pooled invoice-credit items on plan create/update and customization attach, and rejects enabling invoice_credit on features already used by pooled entitlements (including Catalog V2 updates).
- Rejects ambiguous carry-over when multiple independently rated credit entitlements share the same source attribution. Documents/tests zero-floor when releasing a lock after net-negative usage.

Bolded title not required per instructions.

<sup>Written for commit d547df44232dca7c025f5f2ba0778c443a7a81f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR protects invoice-credit attribution by restricting unsupported balance and pooling operations.

- **[Bug fixes, API changes]** Rejects direct invoice-credit balance mutations across synchronous, queued, and internal mutation paths.
- **[Bug fixes, API changes]** Prevents pooled invoice-credit items and ambiguous attribution carry-over.
- **[Improvements]** Adds coverage for mutation guards, catalog validation, attribution carry-over, and zero-floor lock release behavior.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a valid atomic catalog transition remains blocked by stale persisted pooling state.

When a request enables invoice credits while deleting the feature's last unused pooled plan, the projected catalog no longer contains that item, but validation still ORs in the pre-update pooled flag and returns an error before executing the valid transition.

**Files Needing Attention:** server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/utils/validateInvoiceCreditBalanceMutation.ts | Introduces the shared validation error used to block source-less invoice-credit balance changes. |
| server/src/internal/balances/updateBalance/v2/updateBalanceV2.ts | Applies invoice-credit mutation validation before asynchronous enqueue and again in worker execution. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts | Adds projected-catalog validation preventing pooled invoice-credit configurations. |
| server/src/internal/features/validateInvoiceCreditPooling.ts | Centralizes rejection of pooled plan items for invoice-credit features. |
| server/src/internal/billing/v2/utils/handleExistingUsages/cusProductToExistingUsages.ts | Rejects merging multiple attribution positions for the same credit source. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Balance or catalog request] --> Guard{Invoice-credit guard}
  Guard -->|Unsupported direct mutation or pooling| Reject[Return validation error]
  Guard -->|Tracked usage, reset, or metadata update| Process[Continue normal processing]
  Process --> Attribution[Preserve per-feature attribution]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Guard invoice credit balance mutations"](https://github.com/useautumn/autumn/commit/de6e3f24a66fd1b4da7d642b838a17ba9a816113) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56351739)</sub>

<!-- /greptile_comment -->