### PR TITLE
feat: 🎸 ducklake phase 1: in-region ce_balance_totals build + MD ingest (shadow mode)

### DIFF
--- a/packages/ducklake/src/buildCeBalanceTotals.ts
+++ b/packages/ducklake/src/buildCeBalanceTotals.ts
@@ -1,0 +1,97 @@
+import { getLakeMetadataLocation } from "./lakeMetadata.js";
+import type { DuckDbConnection } from "./localDuckDb.js";
+
+/** Scratch lives INSIDE internal/ so MotherDuck's `lake_s3` secret (scoped to
+ * internal/*) can read_parquet it back out. Lifecycle rule expires it daily. */
+export const SCRATCH_BASE =
+	"s3://autumn-lake-prod-us-east-2/internal/lake-cache-scratch";
+
+/** Semantics are a verbatim port of the server cron's totals CTAS
+ * (refreshCeBalancesCache.ts) which this job replaces: finite-only
+ * remaining/granted, all-rows usage incl. entity-held unlimited deductions,
+ * finite_rows guard column, zone-map-friendly ordering. */
+const ceBalanceTotalsSql = ({
+	ceMeta,
+	entMeta,
+	featureMeta,
+	cpMeta,
+}: {
+	ceMeta: string;
+	entMeta: string;
+	featureMeta: string;
+	cpMeta: string;
+}): string => `
+	WITH b AS (
+		SELECT
+			internal_customer_id,
+			internal_feature_id,
+			balance,
+			expires_at,
+			unlimited,
+			entitlement_id,
+			adjustment,
+			customer_product_id,
+			CASE WHEN json_type(TRY_CAST(entities AS JSON)) = 'OBJECT'
+				THEN COALESCE(list_sum(list_transform(json_keys(entities),
+					k -> CAST(json_extract(entities, '$."' || k || '".balance') AS DOUBLE))), 0)
+				ELSE 0
+			END AS entities_balance
+		FROM iceberg_scan('${ceMeta}')
+	),
+	a AS (
+		SELECT e.id, e.allowance, f.type AS feature_type
+		FROM iceberg_scan('${entMeta}') e
+		JOIN iceberg_scan('${featureMeta}') f ON f.internal_id = e.internal_feature_id
+	),
+	cp_active AS (
+		SELECT id FROM iceberg_scan('${cpMeta}') WHERE status IN ('active', 'past_due')
+	)
+	SELECT
+		b.internal_customer_id,
+		b.internal_feature_id,
+		COALESCE(BOOL_OR(b.unlimited), false) AS is_unlimited,
+		COALESCE(SUM(b.balance) FILTER (WHERE b.unlimited IS NOT TRUE), 0) AS total,
+		COALESCE(SUM(COALESCE(a.allowance, 0) + COALESCE(b.adjustment, 0))
+			FILTER (WHERE b.unlimited IS NOT TRUE), 0) AS granted_total,
+		COALESCE(SUM(CASE
+			WHEN b.unlimited IS TRUE THEN -(COALESCE(b.balance, 0) + COALESCE(b.entities_balance, 0))
+			ELSE COALESCE(a.allowance, 0) + COALESCE(b.adjustment, 0) - COALESCE(b.balance, 0)
+		END), 0) AS usage_total,
+		COUNT(*) FILTER (WHERE b.unlimited IS NOT TRUE) AS finite_rows
+	FROM b
+	LEFT JOIN a ON a.id = b.entitlement_id
+	WHERE (b.expires_at IS NULL OR b.expires_at > epoch_ms(now()))
+		AND (
+			(
+				b.customer_product_id IS NULL
+				AND (b.balance != 0 OR b.unlimited IS TRUE OR a.feature_type = 'boolean')
+			)
+			OR b.customer_product_id IN (SELECT id FROM cp_active)
+		)
+	GROUP BY 1, 2
+	ORDER BY b.internal_feature_id, is_unlimited DESC, total DESC
+`;
+
+/** Scans the lake in-region and writes the totals parquet to scratch.
+ * Returns the parquet URL the MotherDuck ingest should read. */
+export const buildCeBalanceTotalsParquet = async ({
+	connection,
+	runId,
+}: {
+	connection: DuckDbConnection;
+	runId: string;
+}): Promise<{ parquetUrl: string }> => {
+	const [ceMeta, entMeta, featureMeta, cpMeta] = await Promise.all([
+		getLakeMetadataLocation({ table: "customer_entitlements" }),
+		getLakeMetadataLocation({ table: "entitlements" }),
+		getLakeMetadataLocation({ table: "features" }),
+		getLakeMetadataLocation({ table: "customer_products" }),
+	]);
+
+	const parquetUrl = `${SCRATCH_BASE}/${runId}/ce_balance_totals.parquet`;
+	await connection.run(`
+		COPY (${ceBalanceTotalsSql({ ceMeta, entMeta, featureMeta, cpMeta })})
+		TO '${parquetUrl}' (FORMAT PARQUET, COMPRESSION ZSTD)
+	`);
+	return { parquetUrl };
+};

--- a/packages/ducklake/src/index.ts
+++ b/packages/ducklake/src/index.ts
@@ -6,6 +6,10 @@
  * Contracts + phases: plans/ducklake/research.md
  */
 
+import { buildCeBalanceTotalsParquet } from "./buildCeBalanceTotals.js";
+import { openLocalLakeConnection } from "./localDuckDb.js";
+import { ingestParquetTable } from "./motherduckIngest.js";
+
 /** Structural so both pino and the server's logtail logger satisfy it. */
 export type DucklakeLogger = {
 	info: (obj: unknown, msg?: string) => void;
@@ -18,14 +22,46 @@ export type DucklakeRunResult = {
 	skipped: string[];
 };
 
+/** Shadow mode writes `<table>__ducklake` so the output can be diffed against
+ * the incumbent writer's table before taking over the real name. */
+const isShadowMode = (): boolean => process.env.DUCKLAKE_SHADOW !== "0";
+
 export const runDucklake = async ({
 	logger,
 }: {
 	logger: DucklakeLogger;
 }): Promise<DucklakeRunResult> => {
+	const runId = `${Date.now()}`;
+	const shadow = isShadowMode();
+	const connection = await openLocalLakeConnection();
+
+	const tScanStart = performance.now();
+	const { parquetUrl } = await buildCeBalanceTotalsParquet({
+		connection,
+		runId,
+	});
+	const scanMs = Math.round(performance.now() - tScanStart);
+
+	const targetTable = shadow
+		? "ce_balance_totals__ducklake"
+		: "ce_balance_totals";
+	const tIngestStart = performance.now();
+	const { rowCount } = await ingestParquetTable({
+		table: targetTable,
+		parquetUrl,
+		logger,
+	});
+	const ingestMs = Math.round(performance.now() - tIngestStart);
+
+	// Reuse existing Axiom fields (durationMs/rowCount); breakdown stays in msg.
 	logger.info(
-		{ type: "ducklake_run" },
-		"[ducklake] scaffold — aggregation phases not implemented yet",
+		{
+			type: "ducklake_phase",
+			rowCount,
+			durationMs: scanMs + ingestMs,
+		},
+		`[ducklake] ce_balance_totals refreshed (shadow=${shadow} scan=${scanMs}ms ingest=${ingestMs}ms)`,
 	);
-	return { tablesRefreshed: [], skipped: [] };
+
+	return { tablesRefreshed: [targetTable], skipped: [] };
 };

--- a/packages/ducklake/src/lakeMetadata.ts
+++ b/packages/ducklake/src/lakeMetadata.ts
@@ -1,0 +1,32 @@
+import { GetTableCommand, GlueClient } from "@aws-sdk/client-glue";
+
+const GLUE_REGION = process.env.LAKE_GLUE_REGION ?? "us-east-2";
+const GLUE_DATABASE = "internal";
+
+/** metadata_location is interpolated into SQL (DDL can't take bind params),
+ * so it must match the lake's exact shape before we trust it. */
+const metadataLocationPattern = (table: string) =>
+	new RegExp(
+		`^s3://autumn-lake-prod-us-east-2/internal/${table}/[A-Za-z0-9/_.-]+\\.metadata\\.json$`,
+	);
+
+const glueClient = new GlueClient({ region: GLUE_REGION });
+
+/** The Glue pointer advances on every sink commit — always read it fresh; a
+ * pinned metadata.json 404s within hours once compaction expires it. */
+export const getLakeMetadataLocation = async ({
+	table,
+}: {
+	table: string;
+}): Promise<string> => {
+	const response = await glueClient.send(
+		new GetTableCommand({ DatabaseName: GLUE_DATABASE, Name: table }),
+	);
+	const location = response.Table?.Parameters?.metadata_location;
+	if (!location || !metadataLocationPattern(table).test(location)) {
+		throw new Error(
+			`[ducklake] unexpected metadata_location from Glue for ${table}: ${location}`,
+		);
+	}
+	return location;
+};

--- a/packages/ducklake/src/localDuckDb.ts
+++ b/packages/ducklake/src/localDuckDb.ts
@@ -1,0 +1,31 @@
+import { DuckDBInstance } from "@duckdb/node-api";
+
+export type DuckDbConnection = Awaited<
+	ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>["connect"]>
+>;
+
+/** In-memory engine with iceberg+S3 wired to the ambient AWS creds (the
+ * Infisical-injected identity already grants the lake + scratch access). */
+export const openLocalLakeConnection = async (): Promise<DuckDbConnection> => {
+	const keyId = process.env.AWS_ACCESS_KEY_ID;
+	const secret = process.env.AWS_SECRET_ACCESS_KEY;
+	if (!keyId || !secret) {
+		throw new Error("[ducklake] AWS credentials are not configured");
+	}
+
+	const instance = await DuckDBInstance.create(":memory:");
+	const connection = await instance.connect();
+	await connection.run("INSTALL iceberg; LOAD iceberg;");
+	await connection.run("INSTALL httpfs; LOAD httpfs;");
+	// Fargate tasks are memory-bound, not disk-bound: let heavy sorts spill.
+	await connection.run("SET temp_directory = '/tmp/ducklake-spill';");
+	const memoryLimit = process.env.DUCKLAKE_MEMORY_LIMIT;
+	if (memoryLimit) {
+		await connection.run(`SET memory_limit = '${memoryLimit}';`);
+	}
+	// Session-scoped secret; never interpolate creds anywhere that logs SQL.
+	await connection.run(
+		`CREATE SECRET lake (TYPE S3, KEY_ID '${keyId}', SECRET '${secret}', REGION 'us-east-2');`,
+	);
+	return connection;
+};

--- a/packages/ducklake/src/motherduckIngest.ts
+++ b/packages/ducklake/src/motherduckIngest.ts
@@ -31,14 +31,13 @@ export const ingestParquetTable = async ({
 }): Promise<{ rowCount: number }> => {
 	const connection = await openMotherDuck();
 	try {
-		const staging = `${table}__new`;
+		// Single-statement atomic replace: readers observe the old table or the
+		// new one, never a gap — stronger than the flights' drop+rename dance,
+		// and immune to concurrent writers racing on a shared staging name.
 		// MotherDuck pulls the parquet from S3 itself via its lake_s3 secret —
 		// bytes never flow through this task's connection.
-		await connection.run(`
-			CREATE OR REPLACE TABLE "${MD_DATABASE}".main."${staging}" AS
-			SELECT * FROM read_parquet('${parquetUrl}')
-		`);
-
+		// One legacy wrinkle: these objects have historically been VIEWs, which
+		// CREATE OR REPLACE TABLE cannot replace across object types.
 		const existing = await connection.run(
 			`SELECT table_type FROM information_schema.tables
 			 WHERE table_catalog = '${MD_DATABASE}' AND table_schema = 'main' AND table_name = '${table}'`,
@@ -46,13 +45,14 @@ export const ingestParquetTable = async ({
 		const existingRows = await existing.getRows();
 		if (existingRows.length > 0) {
 			const isView = String(existingRows[0][0]).toUpperCase().includes("VIEW");
-			await connection.run(
-				`DROP ${isView ? "VIEW" : "TABLE"} "${MD_DATABASE}".main."${table}"`,
-			);
+			if (isView) {
+				await connection.run(`DROP VIEW "${MD_DATABASE}".main."${table}"`);
+			}
 		}
-		await connection.run(
-			`ALTER TABLE "${MD_DATABASE}".main."${staging}" RENAME TO "${table}"`,
-		);
+		await connection.run(`
+			CREATE OR REPLACE TABLE "${MD_DATABASE}".main."${table}" AS
+			SELECT * FROM read_parquet('${parquetUrl}')
+		`);
 
 		const counted = await connection.run(
 			`SELECT COUNT(*) AS n FROM "${MD_DATABASE}".main."${table}"`,

--- a/packages/ducklake/src/motherduckIngest.ts
+++ b/packages/ducklake/src/motherduckIngest.ts
@@ -1,0 +1,69 @@
+import { DuckDBInstance } from "@duckdb/node-api";
+import type { DucklakeLogger } from "./index.js";
+
+const MD_DATABASE = "lake_cache";
+
+/** RW one-shot session, mirroring the server cron's writer discipline: no
+ * standing pool, always closed. */
+const openMotherDuck = async () => {
+	const token = process.env.MOTHERDUCK_RW_TOKEN;
+	if (!token) {
+		throw new Error("[ducklake] MOTHERDUCK_RW_TOKEN is not configured");
+	}
+	const instance = await DuckDBInstance.create(
+		`md:${MD_DATABASE}?attach_mode=single`,
+		{ motherduck_token: token },
+	);
+	return await instance.connect();
+};
+
+/** Staged swap (the flights' pattern): build `__new`, drop the live object
+ * (tolerating VIEW — it has been one before), rename. Live readers of the
+ * shared database never observe a missing table. */
+export const ingestParquetTable = async ({
+	table,
+	parquetUrl,
+	logger,
+}: {
+	table: string;
+	parquetUrl: string;
+	logger: DucklakeLogger;
+}): Promise<{ rowCount: number }> => {
+	const connection = await openMotherDuck();
+	try {
+		const staging = `${table}__new`;
+		// MotherDuck pulls the parquet from S3 itself via its lake_s3 secret —
+		// bytes never flow through this task's connection.
+		await connection.run(`
+			CREATE OR REPLACE TABLE "${MD_DATABASE}".main."${staging}" AS
+			SELECT * FROM read_parquet('${parquetUrl}')
+		`);
+
+		const existing = await connection.run(
+			`SELECT table_type FROM information_schema.tables
+			 WHERE table_catalog = '${MD_DATABASE}' AND table_schema = 'main' AND table_name = '${table}'`,
+		);
+		const existingRows = await existing.getRows();
+		if (existingRows.length > 0) {
+			const isView = String(existingRows[0][0]).toUpperCase().includes("VIEW");
+			await connection.run(
+				`DROP ${isView ? "VIEW" : "TABLE"} "${MD_DATABASE}".main."${table}"`,
+			);
+		}
+		await connection.run(
+			`ALTER TABLE "${MD_DATABASE}".main."${staging}" RENAME TO "${table}"`,
+		);
+
+		const counted = await connection.run(
+			`SELECT COUNT(*) AS n FROM "${MD_DATABASE}".main."${table}"`,
+		);
+		const rowCount = Number((await counted.getRows())[0]?.[0] ?? 0);
+		logger.info(
+			{ type: "ducklake_ingest", rowCount },
+			`[ducklake] ingested ${table}`,
+		);
+		return { rowCount };
+	} finally {
+		connection.closeSync();
+	}
+};

--- a/plans/ducklake/research.md
+++ b/plans/ducklake/research.md
@@ -28,10 +28,11 @@ to OUR AWS account (credits) at $0.01/GB — invisible on the MD invoice.
 2. Package: **`packages/ducklake`**.
 3. **One FC service**, 20-min schedule, internal gating: cold mirrors +
    headline rollup only every 3rd run (hourly).
-4. Scratch: `s3://autumn-lake-prod-us-east-2/lake-cache-scratch/` + lifecycle
-   expiry (~1 day). Bucket has NO expiry rules today, only abort-incomplete-MPU
-   (`abort-incomplete-mpu`) — lifecycle PUT replaces the whole config, so the
-   new rule must be added ALONGSIDE the existing one.
+4. Scratch: `s3://autumn-lake-prod-us-east-2/internal/lake-cache-scratch/` —
+   INSIDE `internal/` so MotherDuck's `lake_s3` secret (scoped internal/*) can
+   read_parquet it. Lifecycle rule `expire-lake-cache-scratch` (1 day) applied
+   2026-08-24 alongside the pre-existing `abort-incomplete-mpu` rule (PUT
+   replaces the whole config; both rules verified present).
 5. **Auto-deploy**: register in infra `PRODUCTION_CONFIG.internal.services` so
    `/api/deploy/github` bumps it every main merge. NOT in blue-green lists,
    NOT in staging (exclusion is passive).
@@ -124,8 +125,13 @@ swap semantics).
 ## Status
 
 - [x] Cadence interim: cron PR #3034 (open), flights hourly/weekly (live)
-- [ ] packages/ducklake scaffold (workspace + Dockerfile + lockfile hygiene)
-- [ ] Fetchset-tables phase
+- [x] packages/ducklake scaffold (workspace + Dockerfile + lockfile hygiene) —
+      draft PR #3038
+- [x] Fetchset-tables phase BUILT in shadow mode — draft PR #3039 (stack
+      #3040); scratch lifecycle rule applied. NEXT: manual shadow run
+      (`cd server && infisical run --env=prod --recursive -- bun src/ducklake.ts`,
+      DUCKLAKE_SHADOW defaults on) → diff `ce_balance_totals__ducklake` vs
+      incumbent → flip DUCKLAKE_SHADOW=0 at cutover
 - [ ] Hot-mirror phase
 - [ ] Cold-mirror phase
 - [ ] Flight deletion + Pulse flip


### PR DESCRIPTION
Phase 1 of `plans/ducklake/research.md`: the job now builds `ce_balance_totals` in-region and ingests it into MotherDuck, in **shadow mode** (`ce_balance_totals__ducklake`) until diffed against the cron-built table.

- `lakeMetadata.ts` — Glue pointer lookup (validated, same pattern as the cron)
- `localDuckDb.ts` — embedded DuckDB with iceberg+httpfs and session-scoped S3 secret from the ambient (Infisical-injected) AWS creds
- `buildCeBalanceTotals.ts` — verbatim port of the cron's totals CTAS semantics (finite-only remaining/granted, all-rows usage incl. entity-held unlimited deductions, finite_rows), scanned same-region and written as zstd parquet to `internal/lake-cache-scratch/` (inside `internal/` so MotherDuck's `lake_s3` secret can read it back)
- `motherduckIngest.ts` — one-shot RW session; `__new` → drop (VIEW-tolerant) → rename swap, MotherDuck pulling parquet from S3 itself
- `DUCKLAKE_SHADOW=0` flips to the real table name at cutover

Next on the stack: verify shadow vs incumbent, then hot mirrors + headline_totals + refresh_status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds CE balance totals in-region and ingests them into `lake_cache` as `ce_balance_totals__ducklake` (shadow mode) to compare against the cron-built table. Publishing uses a single CREATE OR REPLACE when the live object is a table; if the incumbent is a legacy VIEW, we drop it before creating the table, which can briefly expose a missing object on failure or during the swap.

- Validates Glue metadata, scans Iceberg via a local DuckDB session, writes ZSTD Parquet to s3://autumn-lake-prod-us-east-2/internal/lake-cache-scratch, and ingests from S3.

**Migration**
- Shadow mode by default; set DUCKLAKE_SHADOW=0 to publish to ce_balance_totals.
- Requires AWS_ACCESS_KEY_ID/SECRET and MOTHERDUCK_RW_TOKEN.
- MotherDuck secret `lake_s3` must read s3://autumn-lake-prod-us-east-2/internal/lake-cache-scratch.
- If the live object is a VIEW, plan for a non-atomic view-to-table swap that can cause brief read gaps.

<sup>Written for commit 8503f395f8c87aa0a40b9e0ed310d06d176a445d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR builds balance totals from regional Iceberg data, writes them to S3 as Parquet, and publishes them to MotherDuck in shadow mode by default. The normal table-replacement path removes the previously reported explicit drop-and-rename gap, but legacy views are still dropped before replacement.

- **[Improvements]** Adds regional Glue metadata lookup, an embedded DuckDB lake scan, and compressed Parquet output.
- **[Improvements]** Adds shadow-mode MotherDuck ingestion and refresh timing/row-count reporting.
- **[Bug fixes]** Replaces the normal table swap with a single `CREATE OR REPLACE TABLE` statement.
- **[API changes]** `DUCKLAKE_SHADOW=0` selects the production `ce_balance_totals` target at cutover.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because converting a legacy view can temporarily remove the live balance cache and can leave it absent if replacement fails.

The normal table path now avoids an explicit publication gap, but the legacy-view branch still executes `DROP VIEW` before the separate Parquet-backed create statement while balance filtering and sorting can query that object.

**Files Needing Attention:** packages/ducklake/src/motherduckIngest.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ducklake/src/buildCeBalanceTotals.ts | Builds the balance-total projection from current Iceberg metadata and writes compressed Parquet to the internal scratch prefix. |
| packages/ducklake/src/index.ts | Orchestrates regional scanning and shadow-or-live MotherDuck publication with timing and row-count logging. |
| packages/ducklake/src/lakeMetadata.ts | Retrieves and validates fresh Glue metadata pointers for the four fixed lake tables. |
| packages/ducklake/src/localDuckDb.ts | Configures an in-memory DuckDB connection with Iceberg, S3 credentials, spill storage, and an optional memory limit. |
| packages/ducklake/src/motherduckIngest.ts | Uses atomic replacement for existing tables, but the previously reported missing-object window remains when converting a legacy view. |
| plans/ducklake/research.md | Documents the internal scratch location, lifecycle configuration, and shadow-rollout status. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Glue[Glue metadata pointers] --> DuckDB[Regional DuckDB Iceberg scan]
  DuckDB --> S3[S3 scratch Parquet]
  S3 --> MD[MotherDuck ingestion]
  MD --> Shadow[ce_balance_totals__ducklake]
  MD -. DUCKLAKE_SHADOW=0 .-> Live[ce_balance_totals]
  Live --> Readers[Balance filters and sorts]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;feat/ducklake&#39; into feat/d..."](https://github.com/useautumn/autumn/commit/8503f395f8c87aa0a40b9e0ed310d06d176a445d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56648041)</sub>

**Context used:**

- Knowledge Base — [Analytics stores and data exports](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/analytics-and-data-exports.md)

<!-- /greptile_comment -->