### PR TITLE
feat: 🎸 ducklake phase 2: hot mirrors, headline_totals rollup, refresh_status

### DIFF
--- a/packages/ducklake/src/headlineTotals.ts
+++ b/packages/ducklake/src/headlineTotals.ts
@@ -1,0 +1,32 @@
+/** Verbatim port of the hot flight's rollup. Runs ON MotherDuck at ingest
+ * time because fx_rates exists only there (the fx flight writes it directly).
+ * `sourceName` maps table names through the shadow suffix; fx_rates is always
+ * the real table. */
+export const headlineTotalsSql = ({
+	targetTable,
+	sourceName,
+}: {
+	targetTable: string;
+	sourceName: (table: string) => string;
+}): string => `
+	CREATE OR REPLACE TABLE lake_cache.main."${targetTable}" AS
+	WITH base AS (
+		SELECT i.total / coalesce(fx.per_usd, 1) AS usd, i.created_at
+		FROM lake_cache.main."${sourceName("invoices")}" i
+		JOIN lake_cache.main."${sourceName("customers")}" c ON c.internal_id = i.internal_customer_id
+		JOIN lake_cache.main."${sourceName("organizations")}" o ON o.id = c.org_id
+		LEFT JOIN lake_cache.main.fx_rates fx ON fx.currency = lower(i.currency)
+		WHERE c.env = 'live' AND i.status = 'paid'
+			AND i.hosted_invoice_url LIKE '%live%'
+			AND o.slug NOT IN ('welcome-back-1747670264')
+	)
+	SELECT * FROM (
+		SELECT 'l30d' AS period, SUM(usd) AS volume, count(*) AS invoices FROM base
+			WHERE created_at >= extract(epoch FROM now() - INTERVAL 30 DAY) * 1000
+		UNION ALL
+		SELECT 'ytd', SUM(usd), count(*) FROM base
+			WHERE created_at >= extract(epoch FROM date_trunc('year', now())) * 1000
+		UNION ALL
+		SELECT 'all', SUM(usd), count(*) FROM base
+	)
+`;

--- a/packages/ducklake/src/headlineTotals.ts
+++ b/packages/ducklake/src/headlineTotals.ts
@@ -1,7 +1,8 @@
-/** Verbatim port of the hot flight's rollup. Runs ON MotherDuck at ingest
- * time because fx_rates exists only there (the fx flight writes it directly).
- * `sourceName` maps table names through the shadow suffix; fx_rates is always
- * the real table. */
+/** Verbatim port of the hot flight's rollup. Authored here, EXECUTED on
+ * MotherDuck: the string is sent over the ingest session's connection because
+ * its inputs (fx_rates + the just-swapped mirrors) only exist in MotherDuck —
+ * unlike the scan SQL, which runs on the local embedded engine. `sourceName`
+ * maps mirror names through the shadow suffix; fx_rates is always real. */
 export const headlineTotalsSql = ({
 	targetTable,
 	sourceName,

--- a/packages/ducklake/src/index.ts
+++ b/packages/ducklake/src/index.ts
@@ -7,8 +7,18 @@
  */
 
 import { buildCeBalanceTotalsParquet } from "./buildCeBalanceTotals.js";
+import { headlineTotalsSql } from "./headlineTotals.js";
 import { openLocalLakeConnection } from "./localDuckDb.js";
-import { ingestParquetTable } from "./motherduckIngest.js";
+import {
+	buildMirrorParquet,
+	HOT_MIRROR_TABLES,
+	type MirrorParquet,
+} from "./mirrorTables.js";
+import {
+	swapInParquetTable,
+	withMotherDuckSession,
+	writeRefreshStatus,
+} from "./motherduckIngest.js";
 
 /** Structural so both pino and the server's logtail logger satisfy it. */
 export type DucklakeLogger = {
@@ -22,9 +32,14 @@ export type DucklakeRunResult = {
 	skipped: string[];
 };
 
-/** Shadow mode writes `<table>__ducklake` so the output can be diffed against
- * the incumbent writer's table before taking over the real name. */
+/** Shadow mode suffixes every produced table so output can be diffed against
+ * the incumbent writers before taking over the real names. */
 const isShadowMode = (): boolean => process.env.DUCKLAKE_SHADOW !== "0";
+
+/** The job fires every 20 minutes; mirrors are hourly. The container is
+ * stateless, so gate by wall-clock: only the top-of-hour run mirrors. */
+const isHourlyRun = (): boolean =>
+	process.env.DUCKLAKE_FORCE_HOURLY === "1" || new Date().getMinutes() < 20;
 
 export const runDucklake = async ({
 	logger,
@@ -33,35 +48,94 @@ export const runDucklake = async ({
 }): Promise<DucklakeRunResult> => {
 	const runId = `${Date.now()}`;
 	const shadow = isShadowMode();
-	const connection = await openLocalLakeConnection();
+	const hourly = isHourlyRun();
+	const producedName = (table: string): string =>
+		shadow ? `${table}__ducklake` : table;
 
+	const connection = await openLocalLakeConnection();
 	const tScanStart = performance.now();
-	const { parquetUrl } = await buildCeBalanceTotalsParquet({
+
+	const { parquetUrl: totalsParquetUrl } = await buildCeBalanceTotalsParquet({
 		connection,
 		runId,
 	});
+
+	// Sequential: one embedded engine; each scan already parallelizes inside.
+	const mirrors: MirrorParquet[] = [];
+	if (hourly) {
+		for (const table of HOT_MIRROR_TABLES) {
+			mirrors.push(await buildMirrorParquet({ connection, table, runId }));
+		}
+	}
 	const scanMs = Math.round(performance.now() - tScanStart);
 
-	const targetTable = shadow
-		? "ce_balance_totals__ducklake"
-		: "ce_balance_totals";
 	const tIngestStart = performance.now();
-	const { rowCount } = await ingestParquetTable({
-		table: targetTable,
-		parquetUrl,
-		logger,
+	const tablesRefreshed = await withMotherDuckSession({
+		run: async (md) => {
+			const refreshed: string[] = [];
+
+			const totalsTable = producedName("ce_balance_totals");
+			const { rowCount: totalsRows } = await swapInParquetTable({
+				connection: md,
+				table: totalsTable,
+				parquetUrl: totalsParquetUrl,
+				logger,
+			});
+			refreshed.push(`${totalsTable}:${totalsRows}`);
+
+			const statusRows: { tbl: string; snapshot: string; rowCount: number }[] =
+				[];
+			for (const mirror of mirrors) {
+				const table = producedName(mirror.table);
+				const { rowCount } = await swapInParquetTable({
+					connection: md,
+					table,
+					parquetUrl: mirror.parquetUrl,
+					logger,
+				});
+				statusRows.push({
+					tbl: mirror.table,
+					snapshot: mirror.snapshot,
+					rowCount,
+				});
+				refreshed.push(`${table}:${rowCount}`);
+			}
+
+			if (mirrors.length > 0) {
+				// Rollup runs on MD because fx_rates only exists there; reads the
+				// just-swapped mirrors (shadow-suffixed in shadow mode).
+				await md.run(
+					headlineTotalsSql({
+						targetTable: producedName("headline_totals"),
+						sourceName: producedName,
+					}),
+				);
+				refreshed.push(producedName("headline_totals"));
+
+				await writeRefreshStatus({
+					connection: md,
+					statusTable: producedName("refresh_status"),
+					rows: statusRows,
+				});
+				refreshed.push(producedName("refresh_status"));
+			}
+
+			return refreshed;
+		},
 	});
 	const ingestMs = Math.round(performance.now() - tIngestStart);
 
-	// Reuse existing Axiom fields (durationMs/rowCount); breakdown stays in msg.
+	// Reuse existing Axiom fields (durationMs); breakdown stays in msg.
 	logger.info(
 		{
 			type: "ducklake_phase",
-			rowCount,
 			durationMs: scanMs + ingestMs,
 		},
-		`[ducklake] ce_balance_totals refreshed (shadow=${shadow} scan=${scanMs}ms ingest=${ingestMs}ms)`,
+		`[ducklake] refreshed ${tablesRefreshed.join(", ")} (shadow=${shadow} hourly=${hourly} scan=${scanMs}ms ingest=${ingestMs}ms)`,
 	);
 
-	return { tablesRefreshed: [targetTable], skipped: [] };
+	return {
+		tablesRefreshed,
+		skipped: hourly ? [] : [...HOT_MIRROR_TABLES],
+	};
 };

--- a/packages/ducklake/src/mirrorTables.ts
+++ b/packages/ducklake/src/mirrorTables.ts
@@ -1,0 +1,43 @@
+import { SCRATCH_BASE } from "./buildCeBalanceTotals.js";
+import { getLakeMetadataLocation } from "./lakeMetadata.js";
+import type { DuckDbConnection } from "./localDuckDb.js";
+
+/** Full-copy mirrors consumed by the revenue dives. Cold tables join this
+ * list in phase 3. */
+export const HOT_MIRROR_TABLES = [
+	"invoices",
+	"customers",
+	"organizations",
+	"products",
+	"customer_products",
+] as const;
+
+export type MirrorParquet = {
+	table: string;
+	parquetUrl: string;
+	/** Numeric prefix of the metadata filename — cosmetic version label the
+	 * dashboards' refresh_status rows carry. */
+	snapshot: string;
+};
+
+/** SELECT * so the type fingerprint (DECIMAL(38,10), epoch-ms, VARCHAR[])
+ * survives untouched — dive arithmetic depends on it. */
+export const buildMirrorParquet = async ({
+	connection,
+	table,
+	runId,
+}: {
+	connection: DuckDbConnection;
+	table: string;
+	runId: string;
+}): Promise<MirrorParquet> => {
+	const meta = await getLakeMetadataLocation({ table });
+	const snapshot =
+		meta.match(/\/(\d+)[^/]*\.metadata\.json$/)?.[1] ?? "unknown";
+	const parquetUrl = `${SCRATCH_BASE}/${runId}/${table}.parquet`;
+	await connection.run(`
+		COPY (SELECT * FROM iceberg_scan('${meta}'))
+		TO '${parquetUrl}' (FORMAT PARQUET, COMPRESSION ZSTD)
+	`);
+	return { table, parquetUrl, snapshot };
+};

--- a/packages/ducklake/src/motherduckIngest.ts
+++ b/packages/ducklake/src/motherduckIngest.ts
@@ -3,9 +3,17 @@ import type { DucklakeLogger } from "./index.js";
 
 const MD_DATABASE = "lake_cache";
 
-/** RW one-shot session, mirroring the server cron's writer discipline: no
- * standing pool, always closed. */
-const openMotherDuck = async () => {
+type MdConnection = Awaited<
+	ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>["connect"]>
+>;
+
+/** One RW session per run — every extra MotherDuck touch bills a full
+ * startup+cooldown window, so all swaps/status/rollup share this connection. */
+export const withMotherDuckSession = async <T>({
+	run,
+}: {
+	run: (connection: MdConnection) => Promise<T>;
+}): Promise<T> => {
 	const token = process.env.MOTHERDUCK_RW_TOKEN;
 	if (!token) {
 		throw new Error("[ducklake] MOTHERDUCK_RW_TOKEN is not configured");
@@ -14,56 +22,81 @@ const openMotherDuck = async () => {
 		`md:${MD_DATABASE}?attach_mode=single`,
 		{ motherduck_token: token },
 	);
-	return await instance.connect();
+	const connection = await instance.connect();
+	try {
+		return await run(connection);
+	} finally {
+		connection.closeSync();
+	}
 };
 
 /** Staged swap (the flights' pattern): build `__new`, drop the live object
  * (tolerating VIEW — it has been one before), rename. Live readers of the
  * shared database never observe a missing table. */
-export const ingestParquetTable = async ({
+export const swapInParquetTable = async ({
+	connection,
 	table,
 	parquetUrl,
 	logger,
 }: {
+	connection: MdConnection;
 	table: string;
 	parquetUrl: string;
 	logger: DucklakeLogger;
 }): Promise<{ rowCount: number }> => {
-	const connection = await openMotherDuck();
-	try {
-		const staging = `${table}__new`;
-		// MotherDuck pulls the parquet from S3 itself via its lake_s3 secret —
-		// bytes never flow through this task's connection.
-		await connection.run(`
-			CREATE OR REPLACE TABLE "${MD_DATABASE}".main."${staging}" AS
-			SELECT * FROM read_parquet('${parquetUrl}')
-		`);
+	const staging = `${table}__new`;
+	// MotherDuck pulls the parquet from S3 itself via its lake_s3 secret —
+	// bytes never flow through this task's connection.
+	await connection.run(`
+		CREATE OR REPLACE TABLE "${MD_DATABASE}".main."${staging}" AS
+		SELECT * FROM read_parquet('${parquetUrl}')
+	`);
 
-		const existing = await connection.run(
-			`SELECT table_type FROM information_schema.tables
-			 WHERE table_catalog = '${MD_DATABASE}' AND table_schema = 'main' AND table_name = '${table}'`,
-		);
-		const existingRows = await existing.getRows();
-		if (existingRows.length > 0) {
-			const isView = String(existingRows[0][0]).toUpperCase().includes("VIEW");
-			await connection.run(
-				`DROP ${isView ? "VIEW" : "TABLE"} "${MD_DATABASE}".main."${table}"`,
-			);
-		}
+	const existing = await connection.run(
+		`SELECT table_type FROM information_schema.tables
+		 WHERE table_catalog = '${MD_DATABASE}' AND table_schema = 'main' AND table_name = '${table}'`,
+	);
+	const existingRows = await existing.getRows();
+	if (existingRows.length > 0) {
+		const isView = String(existingRows[0][0]).toUpperCase().includes("VIEW");
 		await connection.run(
-			`ALTER TABLE "${MD_DATABASE}".main."${staging}" RENAME TO "${table}"`,
+			`DROP ${isView ? "VIEW" : "TABLE"} "${MD_DATABASE}".main."${table}"`,
 		);
-
-		const counted = await connection.run(
-			`SELECT COUNT(*) AS n FROM "${MD_DATABASE}".main."${table}"`,
-		);
-		const rowCount = Number((await counted.getRows())[0]?.[0] ?? 0);
-		logger.info(
-			{ type: "ducklake_ingest", rowCount },
-			`[ducklake] ingested ${table}`,
-		);
-		return { rowCount };
-	} finally {
-		connection.closeSync();
 	}
+	await connection.run(
+		`ALTER TABLE "${MD_DATABASE}".main."${staging}" RENAME TO "${table}"`,
+	);
+
+	const counted = await connection.run(
+		`SELECT COUNT(*) AS n FROM "${MD_DATABASE}".main."${table}"`,
+	);
+	const rowCount = Number((await counted.getRows())[0]?.[0] ?? 0);
+	logger.info(
+		{ type: "ducklake_ingest", rowCount },
+		`[ducklake] ingested ${table}`,
+	);
+	return { rowCount };
+};
+
+/** Full-replace status table the Leaderboard freshness widget reads
+ * (`max(refreshed_at)`); row_count widened to BIGINT (INTEGER was within 19x
+ * of overflow at customer_entitlements' 114M). */
+export const writeRefreshStatus = async ({
+	connection,
+	statusTable,
+	rows,
+}: {
+	connection: MdConnection;
+	statusTable: string;
+	rows: { tbl: string; snapshot: string; rowCount: number }[];
+}): Promise<void> => {
+	if (rows.length === 0) return;
+	const values = rows
+		.map((r) => `('${r.tbl}', '${r.snapshot}', CAST(${r.rowCount} AS BIGINT))`)
+		.join(", ");
+	await connection.run(`
+		CREATE OR REPLACE TABLE "${MD_DATABASE}".main."${statusTable}" AS
+		SELECT tbl, snapshot, row_count, now() AS refreshed_at
+		FROM (VALUES ${values}) AS t(tbl, snapshot, row_count)
+	`);
 };

--- a/plans/ducklake/research.md
+++ b/plans/ducklake/research.md
@@ -132,7 +132,12 @@ swap semantics).
       (`cd server && infisical run --env=prod --recursive -- bun src/ducklake.ts`,
       DUCKLAKE_SHADOW defaults on) → diff `ce_balance_totals__ducklake` vs
       incumbent → flip DUCKLAKE_SHADOW=0 at cutover
-- [ ] Hot-mirror phase
+- [x] Hot-mirror phase BUILT in shadow mode — draft PR #3041: generic mirror
+      module (phase 3 = +6 table names), single MD session per run,
+      headline_totals rollup executed on MD (fx_rates lives only there),
+      refresh_status w/ BIGINT row_count, wall-clock hourly gate
+      (`DUCKLAKE_FORCE_HOURLY=1` to force in manual runs). Cutover: shadow
+      diff → DUCKLAKE_SHADOW=0 → unschedule flight lake-cache-refresh.
 - [ ] Cold-mirror phase
 - [ ] Flight deletion + Pulse flip
 - [ ] Axiom monitor + runbook


### PR DESCRIPTION
Phase 2 of `plans/ducklake/research.md`: the job now also produces the hot revenue-analytics mirrors, the `headline_totals` rollup, and `refresh_status` — everything flight `lake-cache-refresh` does — still in **shadow mode** (every table suffixed `__ducklake`) until diffed.

- `mirrorTables.ts` — generic `SELECT * FROM iceberg_scan` → zstd parquet per table (invoices, customers, organizations, products, customer_products); type fingerprint (DECIMAL(38,10), epoch-ms, VARCHAR[]) survives untouched. Phase 3 = adding six names to this list.
- `motherduckIngest.ts` — refactored to ONE MotherDuck session per run (every extra touch bills a startup+cooldown window); adds `writeRefreshStatus` with `row_count` widened to BIGINT.
- `headlineTotals.ts` — the flight's rollup SQL verbatim, executed ON MotherDuck at ingest time because `fx_rates` only exists there.
- Hourly gating by wall-clock (mirrors only on the top-of-hour run; the job itself fires every 20 min); `DUCKLAKE_FORCE_HOURLY=1` for manual testing.

Cutover after shadow diff: flip `DUCKLAKE_SHADOW=0`, co-write with the hourly flight briefly, then unschedule the flight (rollback = reschedule it).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds hourly hot mirrors for invoices, customers, organizations, products, and customer_products, and adds `headline_totals` and `refresh_status` on MotherDuck. Previously only `ce_balance_totals` refreshed; now top-of-hour runs also mirror hot tables, compute the headline rollup on MotherDuck, and write per-table freshness while logs list all refreshed tables.

- Review
  - Runs every 20 minutes; mirrors run only when minutes < 20 or `DUCKLAKE_FORCE_HOURLY=1`.
  - Off-hour runs skip mirrors and return them via `skipped`.
  - Shadow mode writes `<table>__ducklake` until `DUCKLAKE_SHADOW=0`.
  - Uses one MotherDuck session per run and atomic table swaps; requires `MOTHERDUCK_RW_TOKEN`; MotherDuck reads Parquet from S3.
  - Computes `headline_totals` on MotherDuck after mirror swaps because `fx_rates` exists only there.
  - Replaces `refresh_status` each run with (tbl, snapshot, row_count BIGINT, refreshed_at); snapshot is the Iceberg metadata numeric prefix.
  - Logs list all refreshed tables and per-table counts via `ducklake_ingest`.

- Rollout
  - No read-path change until `DUCKLAKE_SHADOW=0`.
  - To cut over: set `DUCKLAKE_SHADOW=0`, point dashboards to unsuffixed tables, add the `refresh_status` widget, then unschedule the `lake-cache-refresh` flight.
  - Use `DUCKLAKE_FORCE_HOURLY=1` to exercise mirrors and rollup in staging.

<sup>Written for commit 9f536b8d46871803fe58511f98c2f661df7d6a1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the DuckLake refresh job with hourly analytics mirrors, a revenue rollup, and refresh metadata while retaining shadow-mode output names.
- **[Improvements]** Mirrors invoices, customers, organizations, products, and customer-products data into MotherDuck.
- **[Improvements]** Computes `headline_totals` from the refreshed mirrors and MotherDuck exchange rates.
- **[Improvements]** Writes per-table snapshot, row-count, and refresh-time metadata to `refresh_status`.
- **[Improvements]** Reuses one MotherDuck session for all swaps and rollup work in a run.
- **[API changes]** Expands the run result and logging to report all refreshed or skipped tables.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a delayed top-of-hour run can skip every hourly analytics refresh until the following hour.

The previously reported timing issue remains: the job only refreshes mirrors when it starts during the first 20 minutes of an hour, and no later invocation compensates when that window is missed.

**Files Needing Attention:** packages/ducklake/src/index.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ducklake/src/index.ts | Coordinates always-on balance refreshes with gated mirror, rollup, and refresh-status updates through one MotherDuck session. |
| packages/ducklake/src/mirrorTables.ts | Adds generic Iceberg-to-Parquet generation for the five hot analytics mirrors. |
| packages/ducklake/src/motherduckIngest.ts | Refactors ingestion around a shared session and adds full replacement of refresh-status metadata. |
| packages/ducklake/src/headlineTotals.ts | Adds the MotherDuck SQL used to calculate 30-day, year-to-date, and all-time revenue totals. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Scheduled DuckLake run] --> B[Build ce_balance_totals Parquet]
  A --> C{Hourly run?}
  C -->|Yes| D[Build hot mirror Parquet files]
  C -->|No| E[Skip hot mirrors]
  B --> F[Open one MotherDuck session]
  D --> F
  F --> G[Swap ce_balance_totals]
  F --> H[Swap hot mirrors]
  H --> I[Compute headline_totals]
  I --> J[Write refresh_status]
  G --> K[Close MotherDuck session]
  J --> K
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;feat/ducklake-phase-1-in-r..."](https://github.com/useautumn/autumn/commit/9f536b8d46871803fe58511f98c2f661df7d6a1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56648049)</sub>

<!-- /greptile_comment -->