### PR TITLE
feat: 🎸 ducklake phase 3: cold mirrors + refresh_status_cold, per-table skip

### DIFF
--- a/packages/ducklake/src/index.ts
+++ b/packages/ducklake/src/index.ts
@@ -119,8 +119,10 @@ export const runDucklake = async ({
 			refreshed.push(`${totalsTable}:${totalsRows}`);
 
 			for (const group of MIRROR_GROUPS) {
+				// Gate on "this run attempted mirrors" (hourly), not on scan success:
+				// the rollup below must still run when every scan failed.
+				if (!mirrorsByGroup.has(group.statusTable)) continue;
 				const mirrors = mirrorsByGroup.get(group.statusTable) ?? [];
-				if (mirrors.length === 0) continue;
 
 				const statusRows: {
 					tbl: string;
@@ -151,7 +153,9 @@ export const runDucklake = async ({
 					}
 				}
 
-				if (group.withRollup && statusRows.length > 0) {
+				// Unconditional on hourly runs: the rollup reads whatever is live;
+				// cross-table snapshot consistency is explicitly not a goal here.
+				if (group.withRollup) {
 					// Rollup runs on MD because fx_rates only exists there; reads the
 					// just-swapped mirrors (shadow-suffixed in shadow mode). Stale
 					// sources are tolerated (incumbent semantics: rollup always reads

--- a/packages/ducklake/src/index.ts
+++ b/packages/ducklake/src/index.ts
@@ -11,6 +11,7 @@ import { headlineTotalsSql } from "./headlineTotals.js";
 import { openLocalLakeConnection } from "./localDuckDb.js";
 import {
 	buildMirrorParquet,
+	COLD_MIRROR_TABLES,
 	HOT_MIRROR_TABLES,
 	type MirrorParquet,
 } from "./mirrorTables.js";
@@ -41,6 +42,25 @@ const isShadowMode = (): boolean => process.env.DUCKLAKE_SHADOW !== "0";
 const isHourlyRun = (): boolean =>
 	process.env.DUCKLAKE_FORCE_HOURLY === "1" || new Date().getMinutes() < 20;
 
+type MirrorGroup = {
+	tables: readonly string[];
+	statusTable: string;
+	withRollup: boolean;
+};
+
+const MIRROR_GROUPS: MirrorGroup[] = [
+	{
+		tables: HOT_MIRROR_TABLES,
+		statusTable: "refresh_status",
+		withRollup: true,
+	},
+	{
+		tables: COLD_MIRROR_TABLES,
+		statusTable: "refresh_status_cold",
+		withRollup: false,
+	},
+];
+
 export const runDucklake = async ({
 	logger,
 }: {
@@ -49,6 +69,7 @@ export const runDucklake = async ({
 	const runId = `${Date.now()}`;
 	const shadow = isShadowMode();
 	const hourly = isHourlyRun();
+	const skipped: string[] = [];
 	const producedName = (table: string): string =>
 		shadow ? `${table}__ducklake` : table;
 
@@ -61,10 +82,24 @@ export const runDucklake = async ({
 	});
 
 	// Sequential: one embedded engine; each scan already parallelizes inside.
-	const mirrors: MirrorParquet[] = [];
+	// A failed table skips (stale-but-present, the flights' own behavior) so
+	// one bad manifest can't take down the whole refresh.
+	const mirrorsByGroup = new Map<string, MirrorParquet[]>();
 	if (hourly) {
-		for (const table of HOT_MIRROR_TABLES) {
-			mirrors.push(await buildMirrorParquet({ connection, table, runId }));
+		for (const group of MIRROR_GROUPS) {
+			const mirrors: MirrorParquet[] = [];
+			for (const table of group.tables) {
+				try {
+					mirrors.push(await buildMirrorParquet({ connection, table, runId }));
+				} catch (error) {
+					skipped.push(table);
+					logger.warn(
+						{ type: "ducklake_skip" },
+						`[ducklake] scan failed for ${table}, leaving it stale: ${error}`,
+					);
+				}
+			}
+			mirrorsByGroup.set(group.statusTable, mirrors);
 		}
 	}
 	const scanMs = Math.round(performance.now() - tScanStart);
@@ -83,41 +118,59 @@ export const runDucklake = async ({
 			});
 			refreshed.push(`${totalsTable}:${totalsRows}`);
 
-			const statusRows: { tbl: string; snapshot: string; rowCount: number }[] =
-				[];
-			for (const mirror of mirrors) {
-				const table = producedName(mirror.table);
-				const { rowCount } = await swapInParquetTable({
-					connection: md,
-					table,
-					parquetUrl: mirror.parquetUrl,
-					logger,
-				});
-				statusRows.push({
-					tbl: mirror.table,
-					snapshot: mirror.snapshot,
-					rowCount,
-				});
-				refreshed.push(`${table}:${rowCount}`);
-			}
+			for (const group of MIRROR_GROUPS) {
+				const mirrors = mirrorsByGroup.get(group.statusTable) ?? [];
+				if (mirrors.length === 0) continue;
 
-			if (mirrors.length > 0) {
-				// Rollup runs on MD because fx_rates only exists there; reads the
-				// just-swapped mirrors (shadow-suffixed in shadow mode).
-				await md.run(
-					headlineTotalsSql({
-						targetTable: producedName("headline_totals"),
-						sourceName: producedName,
-					}),
-				);
-				refreshed.push(producedName("headline_totals"));
+				const statusRows: {
+					tbl: string;
+					snapshot: string;
+					rowCount: number;
+				}[] = [];
+				for (const mirror of mirrors) {
+					try {
+						const table = producedName(mirror.table);
+						const { rowCount } = await swapInParquetTable({
+							connection: md,
+							table,
+							parquetUrl: mirror.parquetUrl,
+							logger,
+						});
+						statusRows.push({
+							tbl: mirror.table,
+							snapshot: mirror.snapshot,
+							rowCount,
+						});
+						refreshed.push(`${table}:${rowCount}`);
+					} catch (error) {
+						skipped.push(mirror.table);
+						logger.warn(
+							{ type: "ducklake_skip" },
+							`[ducklake] ingest failed for ${mirror.table}, leaving it stale: ${error}`,
+						);
+					}
+				}
 
-				await writeRefreshStatus({
-					connection: md,
-					statusTable: producedName("refresh_status"),
-					rows: statusRows,
-				});
-				refreshed.push(producedName("refresh_status"));
+				if (group.withRollup && statusRows.length > 0) {
+					// Rollup runs on MD because fx_rates only exists there; reads the
+					// just-swapped mirrors (shadow-suffixed in shadow mode).
+					await md.run(
+						headlineTotalsSql({
+							targetTable: producedName("headline_totals"),
+							sourceName: producedName,
+						}),
+					);
+					refreshed.push(producedName("headline_totals"));
+				}
+
+				if (statusRows.length > 0) {
+					await writeRefreshStatus({
+						connection: md,
+						statusTable: producedName(group.statusTable),
+						rows: statusRows,
+					});
+					refreshed.push(producedName(group.statusTable));
+				}
 			}
 
 			return refreshed;
@@ -125,17 +178,18 @@ export const runDucklake = async ({
 	});
 	const ingestMs = Math.round(performance.now() - tIngestStart);
 
+	if (tablesRefreshed.length === 0) {
+		throw new Error("[ducklake] zero tables refreshed");
+	}
+
 	// Reuse existing Axiom fields (durationMs); breakdown stays in msg.
 	logger.info(
 		{
 			type: "ducklake_phase",
 			durationMs: scanMs + ingestMs,
 		},
-		`[ducklake] refreshed ${tablesRefreshed.join(", ")} (shadow=${shadow} hourly=${hourly} scan=${scanMs}ms ingest=${ingestMs}ms)`,
+		`[ducklake] refreshed ${tablesRefreshed.join(", ")} (shadow=${shadow} hourly=${hourly} skipped=[${skipped.join(",")}] scan=${scanMs}ms ingest=${ingestMs}ms)`,
 	);
 
-	return {
-		tablesRefreshed,
-		skipped: hourly ? [] : [...HOT_MIRROR_TABLES],
-	};
+	return { tablesRefreshed, skipped };
 };

--- a/packages/ducklake/src/index.ts
+++ b/packages/ducklake/src/index.ts
@@ -195,11 +195,12 @@ export const runDucklake = async ({
 	if (tablesRefreshed.length === 0) {
 		throw new Error("[ducklake] zero tables refreshed");
 	}
-	// Totals alone succeeding must not mask a mirror-wide failure: the
+	// A quietly-successful run must not mask a mirror-wide failure: the
 	// staleness monitor only sees the success line, so escalate instead.
-	if (hourly && skipped.length > 0 && tablesRefreshed.length === 1) {
+	const allMirrors = [...HOT_MIRROR_TABLES, ...COLD_MIRROR_TABLES];
+	if (hourly && allMirrors.every((t) => skipped.includes(t))) {
 		throw new Error(
-			`[ducklake] every mirror failed (skipped: ${skipped.join(", ")}); only ce_balance_totals refreshed`,
+			`[ducklake] every mirror failed (skipped: ${skipped.join(", ")})`,
 		);
 	}
 

--- a/packages/ducklake/src/index.ts
+++ b/packages/ducklake/src/index.ts
@@ -153,14 +153,24 @@ export const runDucklake = async ({
 
 				if (group.withRollup && statusRows.length > 0) {
 					// Rollup runs on MD because fx_rates only exists there; reads the
-					// just-swapped mirrors (shadow-suffixed in shadow mode).
-					await md.run(
-						headlineTotalsSql({
-							targetTable: producedName("headline_totals"),
-							sourceName: producedName,
-						}),
-					);
-					refreshed.push(producedName("headline_totals"));
+					// just-swapped mirrors (shadow-suffixed in shadow mode). Stale
+					// sources are tolerated (incumbent semantics: rollup always reads
+					// whatever is live), but a rollup failure must not fail the run.
+					try {
+						await md.run(
+							headlineTotalsSql({
+								targetTable: producedName("headline_totals"),
+								sourceName: producedName,
+							}),
+						);
+						refreshed.push(producedName("headline_totals"));
+					} catch (error) {
+						skipped.push("headline_totals");
+						logger.warn(
+							{ type: "ducklake_skip" },
+							`[ducklake] headline_totals rollup failed, leaving it stale: ${error}`,
+						);
+					}
 				}
 
 				if (statusRows.length > 0) {
@@ -180,6 +190,13 @@ export const runDucklake = async ({
 
 	if (tablesRefreshed.length === 0) {
 		throw new Error("[ducklake] zero tables refreshed");
+	}
+	// Totals alone succeeding must not mask a mirror-wide failure: the
+	// staleness monitor only sees the success line, so escalate instead.
+	if (hourly && skipped.length > 0 && tablesRefreshed.length === 1) {
+		throw new Error(
+			`[ducklake] every mirror failed (skipped: ${skipped.join(", ")}); only ce_balance_totals refreshed`,
+		);
 	}
 
 	// Reuse existing Axiom fields (durationMs); breakdown stays in msg.

--- a/packages/ducklake/src/mirrorTables.ts
+++ b/packages/ducklake/src/mirrorTables.ts
@@ -2,14 +2,24 @@ import { SCRATCH_BASE } from "./buildCeBalanceTotals.js";
 import { getLakeMetadataLocation } from "./lakeMetadata.js";
 import type { DuckDbConnection } from "./localDuckDb.js";
 
-/** Full-copy mirrors consumed by the revenue dives. Cold tables join this
- * list in phase 3. */
+/** Full-copy mirrors consumed by the revenue dives. */
 export const HOT_MIRROR_TABLES = [
 	"invoices",
 	"customers",
 	"organizations",
 	"products",
 	"customer_products",
+] as const;
+
+/** No dive consumers today — produced for ad-hoc analytics; freshness bar is
+ * soft, so a failed cold table skips rather than failing the run. */
+export const COLD_MIRROR_TABLES = [
+	"prices",
+	"features",
+	"entitlements",
+	"invoice_line_items",
+	"customer_prices",
+	"customer_entitlements",
 ] as const;
 
 export type MirrorParquet = {

--- a/plans/ducklake/research.md
+++ b/plans/ducklake/research.md
@@ -138,6 +138,13 @@ swap semantics).
       refresh_status w/ BIGINT row_count, wall-clock hourly gate
       (`DUCKLAKE_FORCE_HOURLY=1` to force in manual runs). Cutover: shadow
       diff → DUCKLAKE_SHADOW=0 → unschedule flight lake-cache-refresh.
-- [ ] Cold-mirror phase
-- [ ] Flight deletion + Pulse flip
-- [ ] Axiom monitor + runbook
+- [x] Cold-mirror phase BUILT in shadow mode — draft PR #3042 (per-table
+      skip-on-failure; zero-tables-refreshed still throws). FC task size:
+      4 vCPU / 16 GB.
+- [ ] Flight deletion + Pulse flip (endgame, after quiet cutover)
+- [x] Axiom monitor + runbook — draft infra PR useautumn/infra#11
+      (ducklake-staleness, Major, 90-min absence of `ducklake_phase`; deploy
+      via `bun monitors:deploy` AFTER the FC service is live)
+- [ ] Infra registry entry — BLOCKED on FC service creation (needs the
+      FC-generated serviceId); same PR should special-case the dashboard UI
+      card (scheduler has no standing ECS service → renders NOT_FOUND today)


### PR DESCRIPTION
Phase 3 of `plans/ducklake/research.md`: the six cold mirrors (prices, features, entitlements, invoice_line_items, customer_prices, customer_entitlements) + `refresh_status_cold`, completing the flight replacement. Still shadow mode.

- Cold tables ride the same hourly gate and the same single MD session as the hot group.
- Per-table try/catch on both scan and ingest: a failed table is skipped (stale-but-present — the flights' own behavior) and logged, instead of failing the run; a run that refreshes zero tables still throws.
- One flag (`DUCKLAKE_SHADOW=0`) cuts over phases 1–3 together.

FC task sizing note for the dashboard service: 4 vCPU / 16 GB (customer_entitlements is 114M×22col; spill dir configured).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cold mirrors to `ducklake` with per-table skip-on-failure and a separate `refresh_status_cold` to reduce blast radius. Hot-only `headline_totals` rollup is attempted on hourly runs and no longer fails the run.

- Adds six cold mirror tables and writes `refresh_status_cold`; logs `ducklake_skip` on scan or ingest failure and leaves the table stale.
- Runs the hot `headline_totals` rollup on hourly runs even with partial or stale sources; failures are logged and do not fail the run.
- Returns { tablesRefreshed, skipped }, where `skipped` lists only tables that failed this run (including `headline_totals`); escalates when every mirror fails on an hourly run even if `ce_balance_totals` refreshed; throws when zero tables were refreshed.

**Migration**
- If callers relied on `skipped` listing all hot tables on non-hourly runs, update them: read both `refresh_status` and `refresh_status_cold`, and treat `skipped` as only failed tables.

<sup>Written for commit 6d234b29bf0830370d6c311173a354c75e4092cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This follow-up adds six cold DuckLake mirrors and makes individual mirror failures non-fatal while preserving stale tables. The fixes now correctly escalate when every mirror fails, while the documented rollup behavior intentionally permits stale or mixed inputs.

- **[Improvements]** Adds cold mirrors for prices, features, entitlements, invoice line items, customer prices, and customer entitlements.
- **[Improvements]** Tracks cold-table refreshes separately in `refresh_status_cold`.
- **[Bug fixes]** Escalates hourly runs when every hot and cold mirror fails, even if an auxiliary totals table refreshed successfully.
- **[Improvements]** Skips individual scan, ingest, and headline-rollup failures so unaffected tables can still refresh.
- **[API changes]** Returns only tables that failed during the current run in `skipped`.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains from the previously reported issues.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ducklake/src/index.ts | Adds grouped hot/cold refresh processing, per-table failure handling, separate status tables, and a corrected mirror-wide failure guard. |
| packages/ducklake/src/mirrorTables.ts | Defines the six cold mirror tables used by the new refresh group. |
| plans/ducklake/research.md | Records completion and deployment notes for the cold-mirror phase and monitoring work. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;feat/ducklake-phase-2-hot-..."](https://github.com/useautumn/autumn/commit/6d234b29bf0830370d6c311173a354c75e4092cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56648053)</sub>

<!-- /greptile_comment -->