### PR TITLE
Approval cards: destructive style on Dismiss

### DIFF
--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -1451,6 +1451,7 @@ export const approvalCard = ({
 				Button({
 					id: "cancel_billing_action",
 					label: "Dismiss",
+					style: "danger",
 					value: id,
 				}),
 				...(editable


### PR DESCRIPTION
Dismiss on the shared approval card now renders with Slack's danger (red) style, matching its discard semantics. Approve stays primary. The card builder is shared by every gated write (billing, schedules, catalog, grouped multi-writes), so all Dismiss buttons pick this up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Dismiss on approval cards use Slack’s danger (red) style to signal a destructive action. Previously it was neutral; Approve remains primary. Visual change only.

- Adds `style: "danger"` to the Dismiss button in the shared `approvalCard` builder.
- Applies to all gated writes using this card (billing, schedules, catalog, grouped multi-writes).
- No changes to IDs, handlers, or payloads; interactions are unchanged.

<sup>Written for commit 7c4259fc3906de761b0b4a0fc9466205cad69928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the shared Slack approval card so Dismiss is visually marked as destructive while Approve remains the primary action.

- **Improvements:** Applies Slack’s red danger style to Dismiss across gated billing, scheduling, catalog, and grouped-write approval cards.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only changes the presentation of the existing Dismiss action.

The existing action ID, value, and behavior remain unchanged, while the button receives Slack’s recognized danger style.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/ui/blocks.ts | Adds the supported Slack danger style to the shared approval card’s Dismiss button; no actionable issues identified. |

<sub>Reviews (1): Last reviewed commit: ["feat: 🎸 dismiss renders as a destructiv..."](https://github.com/useautumn/autumn/commit/7c4259fc3906de761b0b4a0fc9466205cad69928) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56382951)</sub>

**Context used:**

- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)

<!-- /greptile_comment -->