### PR TITLE
Leaf: replay recount across chunk boundaries, eval principal, sonnet reasoning level

### DIFF
--- a/apps/leaf/agent/channels/eve.ts
+++ b/apps/leaf/agent/channels/eve.ts
@@ -48,6 +48,29 @@ const leafInternalAuth = (): AuthFn<Request> => async (request) => {
 	};
 };
 
+/** Evals and local tooling reach eve without leaf's headers; outside
+ * production an env-configured org/user stands in so connections authorize. */
+const localEvalAuth = (): AuthFn<Request> => async () => {
+	if (process.env.NODE_ENV === "production") return null;
+	const orgId = process.env.LEAF_EVAL_ORG_ID;
+	const providerUserId = process.env.LEAF_EVAL_USER_ID;
+	if (!(orgId && providerUserId)) return null;
+	return {
+		attributes: {
+			appEnv: process.env.LEAF_EVAL_APP_ENV ?? "sandbox",
+			channelId: "eval",
+			orgId,
+			provider: "web",
+			providerUserId,
+			threadId: "eval",
+			workspaceId: orgId,
+		},
+		authenticator: "leaf-eval",
+		principalId: providerUserId,
+		principalType: "user",
+	};
+};
+
 export default eveChannel({
-	auth: [leafInternalAuth(), vercelOidc(), localDev()],
+	auth: [leafInternalAuth(), vercelOidc(), localEvalAuth(), localDev()],
 });

--- a/apps/leaf/agent/lib/model.ts
+++ b/apps/leaf/agent/lib/model.ts
@@ -49,12 +49,11 @@ export const leafModel = (agent: LeafAgentConnection) => {
 	);
 };
 
-const REASONING_BY_AGENT: Record<LeafAgentConnection, "minimal" | "none"> = {
-	billing: "minimal",
-	catalog: "minimal",
-	investigator: "minimal",
-	// Routing needs no deliberation: "minimal" still emits thinking blocks
-	// before the delegation call; "none" disables them entirely.
+// Routing needs no deliberation; "none" disables thinking blocks entirely.
+const REASONING_BY_AGENT: Record<LeafAgentConnection, "low" | "none"> = {
+	billing: "low",
+	catalog: "low",
+	investigator: "low",
 	orchestrator: "none",
 };
 

--- a/apps/leaf/src/internal/agentRuntime/eve/client.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/client.ts
@@ -382,11 +382,14 @@ const countEveReplayableEvents = async ({
 			{ headers: eveHeaders(auth), signal: controller.signal },
 		);
 		if (!response.ok || !response.body) return count;
-		for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
-			clearTimeout(quietTimer);
-			quietTimer = setTimeout(() => controller.abort(), REPLAY_QUIET_GAP_MS);
-			for await (const _line of ndjsonLines([chunk])) count += 1;
-		}
+		const chunks = async function* () {
+			for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
+				clearTimeout(quietTimer);
+				quietTimer = setTimeout(() => controller.abort(), REPLAY_QUIET_GAP_MS);
+				yield chunk;
+			}
+		};
+		for await (const _line of ndjsonLines(chunks())) count += 1;
 	} catch (error) {
 		const quietGapReached =
 			error instanceof Error && error.name === "AbortError";

--- a/apps/leaf/src/internal/agentRuntime/eve/ndjson.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/ndjson.ts
@@ -1,5 +1,5 @@
 export async function* ndjsonLines(
-	chunks: AsyncIterable<Uint8Array> | Iterable<Uint8Array>,
+	chunks: AsyncIterable<Uint8Array>,
 ): AsyncGenerator<string> {
 	const decoder = new TextDecoder();
 	let buffer = "";

--- a/apps/leaf/tests/unit/harness/replay-count-split-records.test.ts
+++ b/apps/leaf/tests/unit/harness/replay-count-split-records.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Without the durable journal, the replay recount frames NDJSON per HTTP chunk.
+ * A record whose newline arrives at the head of the next chunk is dropped, so
+ * the fast-forward cursor lands short and stale events replay as this turn.
+ *
+ * Red: two records split as `{…}` | `\n{…}\n` count as 1.
+ * Green: the count is 2 regardless of where chunk boundaries fall.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { EveSessionRef } from "../../../src/internal/agentRuntime/eve/types.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+await mockLeafModule({
+	specifier: "../../../src/lib/env.js",
+	factory: () => ({
+		env: {
+			EVE_INTERNAL_AUTH_TOKEN: "t",
+			EVE_SERVER_URL: "http://eve.test",
+		},
+	}),
+});
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/world/sessionStream.js",
+	factory: () => ({ sessionEventCount: async () => undefined }),
+});
+
+const { fastForwardEveStreamIndex } = await import(
+	"../../../src/internal/agentRuntime/eve/client.js"
+);
+
+const originalFetch = globalThis.fetch;
+afterAll(() => {
+	globalThis.fetch = originalFetch;
+});
+
+/** One chunk per read, with a tick between, so the boundary is real. */
+const streamOf = (chunks: string[]) => {
+	const pending = [...chunks];
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			await Bun.sleep(5);
+			const next = pending.shift();
+			if (next === undefined) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(new TextEncoder().encode(next));
+		},
+	});
+};
+
+const session = (): EveSessionRef => ({
+	env: AppEnv.Sandbox,
+	newSession: false,
+	sessionId: "eve_session_1",
+	state: {
+		version: 1,
+		continuationToken: "token_1",
+		streamIndex: 0,
+		status: "waiting",
+		lastEventAt: 0,
+		pendingRequests: [],
+	},
+	threadKey: "sandbox:slack:T1:C1:thread_1",
+});
+
+describe("replay recount across chunk boundaries", () => {
+	test("a record whose newline opens the next chunk is still counted", async () => {
+		globalThis.fetch = (async () =>
+			new Response(
+				streamOf(['{"type":"turn.started"}', '\n{"type":"session.waiting"}\n']),
+			)) as unknown as typeof fetch;
+		const current = session();
+		await fastForwardEveStreamIndex({ auth: {} as never, session: current });
+		expect(current.state.streamIndex).toBe(2);
+	});
+});


### PR DESCRIPTION
## Summary
- **Replay recount frames NDJSON across HTTP chunk boundaries** — without the durable journal, the fast-forward recount re-framed each chunk with its own parser, dropping a record whose newline opened the next chunk and landing the cursor short (stale events could replay as the current turn). Red/green in `tests/unit/harness/replay-count-split-records.test.ts`. (This fix missed #3044's merge window.)
- **Local evals get a real principal** — eval sessions carried no leaf headers, so eve scoped them to `local-dev` and the user-scoped Autumn connection failed with `principal_required`. Outside production, `LEAF_EVAL_ORG_ID` + `LEAF_EVAL_USER_ID` (+ optional `LEAF_EVAL_APP_ENV`) now stand in as the session principal, so billing/investigator tools authorize in evals.
- **Reasoning level** — specialists request `low` (supported by claude-sonnet-5) instead of `minimal`, which the AI SDK remapped with a warning on every call.

## Verification
- leaf unit suite green, `tsc --noEmit` clean, Biome clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts NDJSON replay lines across HTTP chunk boundaries and authenticates local eval sessions with a real principal. This prevents dropped records that caused stale events to replay and stops SDK warnings by switching specialists to reasoning level low.

- Bug Fixes
  - Count NDJSON records across continuous chunks so the replay index advances correctly.
  - Pass a single async stream to `ndjsonLines` and restrict it to `AsyncIterable`.
  - Add a unit test that splits records across chunks to guard the fix.

- New Features
  - Outside production, `LEAF_EVAL_ORG_ID` and `LEAF_EVAL_USER_ID` (optional `LEAF_EVAL_APP_ENV`) set the session principal for evals so connections authorize.
  - Specialists request reasoning level `low`; orchestrator remains `none`.

<sup>Written for commit 902e41246a998100d858428e093db5d62d7ebe1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes replay-event counting across streamed HTTP chunk boundaries, supplies an explicit principal for local eval sessions, and updates specialist reasoning configuration.
- **Bug fixes:** Preserves NDJSON parser state across response chunks so split replay records are counted correctly.
- **Improvements:** Uses configured organization, user, and environment values to authorize local eval sessions outside production.
- **Improvements:** Changes specialist reasoning from `minimal` to the supported `low` level while keeping orchestrator reasoning disabled.
- **Bug fixes:** Adds a regression test covering an NDJSON record whose newline arrives in the following chunk.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The replay recount now maintains one parser across all response chunks, existing NDJSON callers satisfy the narrowed async contract, and the remaining authentication and model changes have no established reachable failure in repository context.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/agent/channels/eve.ts | Adds a non-production eval authenticator that derives a user principal from explicitly configured environment values. |
| apps/leaf/agent/lib/model.ts | Changes specialist reasoning configuration from `minimal` to `low` while retaining `none` for routing. |
| apps/leaf/src/internal/agentRuntime/eve/client.ts | Feeds the complete replay response stream through one NDJSON parser, preserving records split across HTTP chunks. |
| apps/leaf/src/internal/agentRuntime/eve/ndjson.ts | Narrows the parser input type to the async-iterable contract used by every repository caller. |
| apps/leaf/tests/unit/harness/replay-count-split-records.test.ts | Adds focused regression coverage proving that replay records split at a chunk boundary are both counted. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[HTTP replay response] --> B[Async stream of chunks]
  B --> C[Single NDJSON parser]
  C --> D[Preserved partial-record buffer]
  D --> E[Complete replay lines]
  E --> F[Advance stream index]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 local evals get a real principal..."](https://github.com/useautumn/autumn/commit/902e41246a998100d858428e093db5d62d7ebe1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56590163)</sub>

<!-- /greptile_comment -->