### PR TITLE
Hotfix: read the workflow world only for runs it holds (prod hang 2026-08-25)

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/eve/client.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/client.ts
@@ -12,7 +12,7 @@ import {
 import type { EveAuthContext, EveSessionRef } from "./types.js";
 import { readSessionEvents } from "./world/readSessionEvents.js";
 import { sessionEventCount } from "./world/sessionStream.js";
-import { hasWorkflowWorld } from "./world/workflowWorld.js";
+import { workflowWorldHoldingRun } from "./world/workflowWorld.js";
 
 const eveUrl = (path: string) => new URL(path, env.EVE_SERVER_URL).href;
 
@@ -266,7 +266,9 @@ export async function* streamEveEvents({
 	session: EveSessionRef;
 	signal?: AbortSignal;
 }): AsyncGenerator<EveEvent> {
-	const source = hasWorkflowWorld() ? "world" : "http";
+	const source = (await workflowWorldHoldingRun(session.sessionId))
+		? "world"
+		: "http";
 	logger.info("Opening eve event stream", {
 		event: "leaf.eve_stream_opened",
 		data: {

--- a/apps/leaf/src/internal/agentRuntime/eve/world/sessionRun.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/world/sessionRun.ts
@@ -1,5 +1,8 @@
 import { logger } from "../../../../lib/logger.js";
-import { isWorldNotFoundError, workflowWorld } from "./workflowWorld.js";
+import {
+	isWorldNotFoundError,
+	workflowWorldHoldingRun,
+} from "./workflowWorld.js";
 
 /** False means eve no longer holds the delivery hook: a message post would
  * silently start a new run under the same token. */
@@ -10,7 +13,7 @@ export const isContinuationTokenAlive = async ({
 	sessionId: string;
 	token: string;
 }): Promise<boolean | undefined> => {
-	const world = workflowWorld();
+	const world = await workflowWorldHoldingRun(sessionId);
 	if (!world) return undefined;
 	try {
 		await world.hooks.getByToken(token);
@@ -27,7 +30,7 @@ export const isContinuationTokenAlive = async ({
 };
 
 export const cancelSessionRun = async (sessionId: string) => {
-	const world = workflowWorld();
+	const world = await workflowWorldHoldingRun(sessionId);
 	if (!world) return false;
 	try {
 		const run = await world.runs.get(sessionId, { resolveData: "none" });

--- a/apps/leaf/src/internal/agentRuntime/eve/world/sessionStream.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/world/sessionStream.ts
@@ -1,5 +1,8 @@
 import { logger } from "../../../../lib/logger.js";
-import { type WorkflowWorld, workflowWorld } from "./workflowWorld.js";
+import {
+	type WorkflowWorld,
+	workflowWorldHoldingRun,
+} from "./workflowWorld.js";
 
 export const sessionStreamName = (sessionId: string) =>
 	`${sessionId.replace(/^wrun_/, "strm_")}_user`;
@@ -48,7 +51,7 @@ export const journaledEventCount = async ({
 export const sessionEventCount = async (
 	sessionId: string,
 ): Promise<number | undefined> => {
-	const world = workflowWorld();
+	const world = await workflowWorldHoldingRun(sessionId);
 	if (!world) return undefined;
 	const streamName = await resolveStreamName({ sessionId, world });
 	return journaledEventCount({ sessionId, streamName, world });

--- a/apps/leaf/src/internal/agentRuntime/eve/world/workflowWorld.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/world/workflowWorld.ts
@@ -20,6 +20,41 @@ export const workflowWorld = (): WorkflowWorld | undefined => {
 	return world;
 };
 
+const runPresence = new Map<string, Promise<boolean>>();
+
+const worldHoldsRun = ({
+	sessionId,
+	world,
+}: {
+	sessionId: string;
+	world: WorkflowWorld;
+}) => {
+	let presence = runPresence.get(sessionId);
+	if (!presence) {
+		presence = world.runs
+			.get(sessionId, { resolveData: "none" })
+			.then(() => true)
+			.catch((error: unknown) => {
+				if (isWorldNotFoundError(error)) return false;
+				runPresence.delete(sessionId);
+				throw error;
+			});
+		runPresence.set(sessionId, presence);
+	}
+	return presence;
+};
+
+/** The world only for a run it actually holds: eve may be journaling to a
+ * different world than leaf is configured to read (local files vs Postgres),
+ * and reading the wrong one tails an empty stream forever. */
+export const workflowWorldHoldingRun = async (
+	sessionId: string,
+): Promise<WorkflowWorld | undefined> => {
+	const world = workflowWorld();
+	if (!world) return undefined;
+	return (await worldHoldsRun({ sessionId, world })) ? world : undefined;
+};
+
 export const requireWorkflowWorld = (): WorkflowWorld => {
 	const current = workflowWorld();
 	if (!current) throw new Error("No workflow world is configured");

--- a/apps/leaf/tests/integration/world-reader.test.ts
+++ b/apps/leaf/tests/integration/world-reader.test.ts
@@ -63,4 +63,23 @@ describeWithDb("world reader (real Postgres)", () => {
 		}
 		expect(seen).toEqual(["message.completed", "session.waiting"]);
 	});
+
+	test("a run the world does not hold is not read from it", async () => {
+		const { sessionEventCount } = await import(
+			"../../src/internal/agentRuntime/eve/world/sessionStream.js"
+		);
+		const { isContinuationTokenAlive } = await import(
+			"../../src/internal/agentRuntime/eve/world/sessionRun.js"
+		);
+		const { workflowWorldHoldingRun } = await import(
+			"../../src/internal/agentRuntime/eve/world/workflowWorld.js"
+		);
+		const foreignRun = `wrun_elsewhere_${Date.now()}`;
+		expect(await workflowWorldHoldingRun(foreignRun)).toBeUndefined();
+		expect(await sessionEventCount(foreignRun)).toBeUndefined();
+		expect(
+			await isContinuationTokenAlive({ sessionId: foreignRun, token: "t" }),
+		).toBeUndefined();
+		expect(await workflowWorldHoldingRun(runId)).toBeDefined();
+	});
 });

--- a/apps/leaf/tests/unit/harness/world-run-guard.test.ts
+++ b/apps/leaf/tests/unit/harness/world-run-guard.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Prod incident 2026-08-25: leaf read the Postgres workflow journal whenever a
+ * chat DB URL existed, but eve was journaling to its local-file world, so the
+ * reader tailed an empty table forever, the liveness check saw no hook, and the
+ * exact count reset the cursor to 0.
+ *
+ * Red: with a reachable world that does not hold the run, leaf still streams,
+ * counts, and checks liveness through it.
+ * Green: every world read is skipped for a run the world does not hold, and
+ * the HTTP path is used exactly as before.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { EveSessionRef } from "../../../src/internal/agentRuntime/eve/types.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+await mockLeafModule({
+	specifier: "../../../src/lib/env.js",
+	factory: () => ({
+		env: { EVE_INTERNAL_AUTH_TOKEN: "t", EVE_SERVER_URL: "http://eve.test" },
+	}),
+});
+
+const worldCalls: string[] = [];
+const notFound = () => {
+	const error = new Error("Run not found");
+	error.name = "NotFoundError";
+	return error;
+};
+mock.module("@workflow/world-postgres", () => ({
+	createWorld: () => ({
+		events: { create: async () => undefined },
+		hooks: {
+			getByToken: async () => {
+				worldCalls.push("hooks.getByToken");
+				throw notFound();
+			},
+		},
+		runs: {
+			get: async () => {
+				worldCalls.push("runs.get");
+				throw notFound();
+			},
+		},
+		streams: {
+			get: async () => {
+				worldCalls.push("streams.get");
+				return new ReadableStream({ start: () => undefined });
+			},
+			getInfo: async () => {
+				worldCalls.push("streams.getInfo");
+				return { tailIndex: -1 };
+			},
+			list: async () => [],
+		},
+	}),
+}));
+
+process.env.WORKFLOW_POSTGRES_URL = "postgresql://world.test/postgres";
+
+const { streamEveEvents, fastForwardEveStreamIndex } = await import(
+	"../../../src/internal/agentRuntime/eve/client.js"
+);
+const { isContinuationTokenAlive } = await import(
+	"../../../src/internal/agentRuntime/eve/world/sessionRun.js"
+);
+
+const originalFetch = globalThis.fetch;
+const fetched: string[] = [];
+globalThis.fetch = (async (url: unknown) => {
+	fetched.push(String(url));
+	return new Response('{"type":"turn.started"}\n{"type":"session.waiting"}\n');
+}) as unknown as typeof fetch;
+afterAll(() => {
+	globalThis.fetch = originalFetch;
+});
+
+const session = (): EveSessionRef => ({
+	env: AppEnv.Sandbox,
+	newSession: false,
+	sessionId: "wrun_not_in_world",
+	state: {
+		version: 1,
+		continuationToken: "token_1",
+		streamIndex: 0,
+		status: "waiting",
+		lastEventAt: 0,
+		pendingRequests: [],
+	},
+	threadKey: "sandbox:slack:T1:C1:thread_1",
+});
+
+describe("world reads are guarded by run presence", () => {
+	test("a run the world does not hold streams over HTTP", async () => {
+		const seen: string[] = [];
+		for await (const event of streamEveEvents({
+			auth: {} as never,
+			session: session(),
+		})) {
+			seen.push(event.type);
+		}
+		expect(seen).toEqual(["turn.started", "session.waiting"]);
+		expect(fetched.some((url) => url.includes("/stream?startIndex=0"))).toBe(
+			true,
+		);
+		expect(worldCalls).not.toContain("streams.get");
+	});
+
+	test("liveness is unknown, not dead, for a run the world does not hold", async () => {
+		expect(
+			await isContinuationTokenAlive({
+				sessionId: "wrun_not_in_world",
+				token: "token_1",
+			}),
+		).toBeUndefined();
+		expect(worldCalls).not.toContain("hooks.getByToken");
+	});
+
+	test("fast-forward falls back to the HTTP replay count", async () => {
+		const current = session();
+		await fastForwardEveStreamIndex({ auth: {} as never, session: current });
+		expect(current.state.streamIndex).toBe(2);
+		expect(worldCalls).not.toContain("streams.getInfo");
+	});
+});

--- a/apps/leaf/tests/unit/scenarios/prod-incidents.test.ts
+++ b/apps/leaf/tests/unit/scenarios/prod-incidents.test.ts
@@ -221,7 +221,10 @@ await mockLeafModule({
 });
 await mockLeafModule({
 	specifier: "../../../src/internal/agentRuntime/eve/world/workflowWorld.js",
-	factory: () => ({ hasWorkflowWorld: () => false }),
+	factory: () => ({
+		hasWorkflowWorld: () => false,
+		workflowWorldHoldingRun: async () => undefined,
+	}),
 });
 await mockLeafModule({
 	specifier: "../../../src/internal/agentRuntime/eve/world/sessionStream.js",


### PR DESCRIPTION
## What broke
After the #3044 deploy (09:29Z), the first Slack message (09:36Z) hung: leaf opened the eve event stream with `source: "world"` at index 0, saw nothing for 2 min, reopened at 0, and never produced a turn. Rolled back via blue/green.

## Root cause
Leaf assumed eve journals to Postgres whenever a chat DB URL exists. It does not: prod `WORKFLOW_POSTGRES_URL` is unset, leaf derives it from `CHAT_DATABASE_URL` and passes it only to eve's **spawn** env, but eve picks its world in `agent.ts` at **build** time, where the variable is absent — so prod eve has always run on the ephemeral local-file world. The Postgres `workflow` schema in the chat DB exists only because leaf's own `workflow-postgres-setup` creates it; `workflow_runs` is empty. Every world-backed read in #3044 therefore targeted an empty world:
- stream reader → tailed a stream that never gets chunks (the hang)
- `hooks.getByToken` → not found → session reported dead (would drop continuations)
- `streams.getInfo` → 0 events → fast-forward reset the cursor to 0 (stale replay)

## Fix
`workflowWorldHoldingRun(sessionId)`: every world read first confirms the world holds the run (`runs.get`, cached per session); otherwise leaf uses the HTTP stream, replay count, and no liveness check — exactly the pre-#3044 behaviour. The durable-journal path stays available for deployments where eve genuinely writes to Postgres.

## Replication & validation
- `tests/unit/harness/world-run-guard.test.ts` — fake world that holds no runs: red on dev (stream hung 5 s, liveness `false`, cursor 0), green with the fix (HTTP stream, liveness `undefined`, cursor from replay).
- `tests/integration/world-reader.test.ts` — against a real local Postgres workflow schema: a foreign run is not read from the world, a held run still is.
- `prod-incidents` scenarios and the full leaf suite: 452/452; `tsc` clean.

## Follow-up (separate PR)
Make eve actually journal to Postgres in prod by passing `WORKFLOW_POSTGRES_URL` to the eve **build** env as well, verified in staging before enabling the durable path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hangs by reading the workflow world only for runs it actually holds. Previously leaf always read the configured world; now it falls back to the HTTP stream when the world doesn’t contain the run, restoring pre-change behavior and avoiding dead liveness checks and cursor resets in prod.

**Bug Fixes**
- Adds `workflowWorldHoldingRun(sessionId)` to gate world reads for streams, liveness, and event counts.
- Falls back to the HTTP stream, skips hook liveness, and derives the cursor from replay when the run is not held.
- Caches run presence per session; treats world not found as “not held” and rethrows other errors.
- Adds unit and integration tests (`world-run-guard`, `world-reader`) and updates incident scenarios; durable Postgres journaling remains used where available.

<sup>Written for commit fddbbe967ca538d02b9e795a61d9b84f2a22a254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix checks that the configured workflow world actually owns a run before reading from it, restoring HTTP behavior when the run lives elsewhere.

- **Bug fixes:** Guard event streaming, replay counting, continuation liveness checks, and cancellation with a run-presence lookup.
- **Improvements:** Cache run-presence lookups per session and add unit and PostgreSQL integration coverage for foreign and locally held runs.
- **Bug fixes:** Extend the production-incident regression scenarios to use the guarded-world interface.
</details>


<h3>Confidence Score: 4/5</h3>

The hotfix appears safe to merge, with a non-blocking concern that its process-wide presence cache grows for every historical session.

The guarded reads restore HTTP behavior for runs absent from the configured world, while the new cache lacks lifecycle cleanup and can accumulate session entries in long-running workers.

**Files Needing Attention:** apps/leaf/src/internal/agentRuntime/eve/world/workflowWorld.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/eve/world/workflowWorld.ts | Adds the ownership guard and presence cache; the cache retains every queried session for the process lifetime. |
| apps/leaf/src/internal/agentRuntime/eve/client.ts | Selects world streaming only after confirming that the world contains the requested run. |
| apps/leaf/src/internal/agentRuntime/eve/world/sessionRun.ts | Skips world-backed liveness and cancellation operations when the configured world does not own the run. |
| apps/leaf/src/internal/agentRuntime/eve/world/sessionStream.ts | Falls back from journal metadata when the configured world does not own the run. |
| apps/leaf/tests/unit/harness/world-run-guard.test.ts | Covers HTTP streaming, unknown liveness, and replay-count fallback for a foreign run. |
| apps/leaf/tests/integration/world-reader.test.ts | Verifies ownership detection against a real PostgreSQL workflow schema. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Leaf needs run data] --> B{Workflow world configured?}
    B -- No --> H[Use HTTP behavior]
    B -- Yes --> C[Look up run in world]
    C --> D{World holds run?}
    D -- No --> H
    D -- Yes --> W[Use durable world stream and metadata]
    C --> P[Cache presence by session ID]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/agentRuntime/eve/world/workflowWorld.ts:23
**Run-presence cache grows indefinitely**

Every newly queried session ID remains in the process-wide `runPresence` map after the session finishes, so a long-running worker retains IDs and promises for all historical sessions instead of only active ones. Add lifecycle-based eviction or a bounded retention policy.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 leaf reads the workflow world on..."](https://github.com/useautumn/autumn/commit/fddbbe967ca538d02b9e795a61d9b84f2a22a254) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56594379)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->