### PR TITLE
Restore the shared-workflow-world opt-in (regression from #3049)

### DIFF
--- a/apps/leaf/agent/agent.ts
+++ b/apps/leaf/agent/agent.ts
@@ -8,10 +8,17 @@ import {
 const isProduction =
 	process.env.NODE_ENV === "production" || process.env.EVE_EMBEDDED === "1";
 
-// The chat database is the durable workflow world; the world package reads
-// its own variable, so it is derived here rather than configured separately.
-const chatDatabaseUrl = process.env.CHAT_DATABASE_URL;
+// A shared world's queue worker EXECUTES that database's jobs: a laptop
+// pointed at prod would run prod turns with local code.
+const sharedWorldAllowed =
+	isProduction || process.env.EVE_ALLOW_SHARED_WORLD === "1";
+const chatDatabaseUrl = sharedWorldAllowed
+	? process.env.CHAT_DATABASE_URL
+	: undefined;
+// The world package reads its own variable, derived here so nothing else
+// configures a second URL.
 if (chatDatabaseUrl) process.env.WORKFLOW_POSTGRES_URL = chatDatabaseUrl;
+else delete process.env.WORKFLOW_POSTGRES_URL;
 if (!isProduction && !process.env.WORKFLOW_QUEUE_NAMESPACE) {
 	process.env.WORKFLOW_QUEUE_NAMESPACE = `local_${process.env.USER ?? "dev"}`;
 }

--- a/apps/leaf/src/internal/agentRuntime/eve/embeddedServer.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/embeddedServer.ts
@@ -57,7 +57,12 @@ const waitForEveReady = async () => {
 /** The chat database is eve's durable world only once NOTIFY delivery is
  * proven on it; otherwise eve runs on its local world and leaf logs why. */
 const durableWorldUrl = async () => {
-	const chatDatabaseUrl = process.env.CHAT_DATABASE_URL;
+	const sharedWorldAllowed =
+		process.env.NODE_ENV === "production" ||
+		process.env.EVE_ALLOW_SHARED_WORLD === "1";
+	const chatDatabaseUrl = sharedWorldAllowed
+		? process.env.CHAT_DATABASE_URL
+		: undefined;
 	if (!chatDatabaseUrl) return undefined;
 	const delivered = await verifyNotifyDelivery({
 		connectionString: chatDatabaseUrl,

--- a/apps/leaf/src/internal/agentRuntime/eve/world/readSessionEvents.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/world/readSessionEvents.ts
@@ -75,7 +75,11 @@ export async function* readSessionEvents({
 	const abort = () => void reader.cancel().catch(() => undefined);
 	signal?.addEventListener("abort", abort, { once: true });
 	let cursor = startIndex;
+	let delivered = false;
 	const probeGap = async () => {
+		// A fresh open replays the backlog from the cursor inside its first read,
+		// so a quiet gap only means a lost notification once events have flowed.
+		if (!delivered) return;
 		const tail = await journaledEventCount({ sessionId, streamName, world });
 		if (tail <= cursor) return;
 		logger.warn("Eve journal moved on while the live stream stayed quiet", {
@@ -89,6 +93,7 @@ export async function* readSessionEvents({
 			chunksWithGapProbe({ probeGap, reader }),
 		)) {
 			cursor += 1;
+			delivered = true;
 			yield parseEveEvent(JSON.parse(line));
 		}
 	} finally {

--- a/apps/leaf/tests/unit/agent/worldSelection.test.ts
+++ b/apps/leaf/tests/unit/agent/worldSelection.test.ts
@@ -25,6 +25,7 @@ describe("workflow world selection", () => {
 		delete process.env.NODE_ENV;
 		delete process.env.EVE_EMBEDDED;
 		delete process.env.WORKFLOW_QUEUE_NAMESPACE;
+		process.env.EVE_ALLOW_SHARED_WORLD = "1";
 		process.env.CHAT_DATABASE_URL = "postgres://chat-host/chat";
 
 		const agent = (await importAgent()).default as {
@@ -44,6 +45,20 @@ describe("workflow world selection", () => {
 
 		await importAgent();
 		expect(process.env.WORKFLOW_QUEUE_NAMESPACE).toBeUndefined();
+	});
+
+	test("a shared chat database outside production needs an explicit opt-in", async () => {
+		delete process.env.NODE_ENV;
+		delete process.env.EVE_EMBEDDED;
+		delete process.env.EVE_ALLOW_SHARED_WORLD;
+		process.env.CHAT_DATABASE_URL = "postgres://prod-host/chat";
+		process.env.WORKFLOW_POSTGRES_URL = "postgres://prod-host/chat";
+
+		const agent = (await importAgent()).default as {
+			experimental?: { workflow?: { world?: string } };
+		};
+		expect(agent.experimental?.workflow?.world).toBeUndefined();
+		expect(process.env.WORKFLOW_POSTGRES_URL).toBeUndefined();
 	});
 
 	test("no chat database means the local file world", async () => {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
 		"d:prod": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dev.ts --production",
 		"dx": "bun scripts/dx.ts",
 		"d:test": "ENV_FILE=.env infisical run --env=test --recursive -- bun scripts/dev.ts",
-		"p": "ENV_FILE=.env.prod infisical run --env=prod --recursive -- bun scripts/dev.ts",
+		"p": "ENV_FILE=.env.prod EVE_ALLOW_SHARED_WORLD=1 infisical run --env=prod --recursive -- bun scripts/dev.ts",
 		"s": "ENV_FILE=.env.staging infisical run --env=staging --recursive -- bun scripts/dev.ts",
 		"pw": "PW_MODE=1 ENV_FILE=.env.prod infisical run --env=prod --recursive -- bun scripts/pw/index.ts",
 		"reset-v2": "bun server/src/cron/resetV2.ts",


### PR DESCRIPTION
## Why this is urgent
#3049 collapsed the world config onto `CHAT_DATABASE_URL` and, in doing so, dropped the `EVE_ALLOW_SHARED_WORLD` guard. On dev today, **any process that inherits a shared or production `CHAT_DATABASE_URL` silently becomes a queue worker on that database** — a laptop running `bun p` (which loads prod secrets) would run `workflow-postgres-setup` against it and execute prod workflow jobs with local code. That was the exact risk the original guard existed for; collapsing the variable name removed it by accident.

## Changes
- Outside production, the Postgres world is selected only with `EVE_ALLOW_SHARED_WORLD=1`; otherwise `WORKFLOW_POSTGRES_URL` is cleared and eve uses its local file world. Same check gates `workflow-postgres-setup` and the durable-world handoff in `embeddedServer`. The `p` script keeps its explicit opt-in.
- Journal reader: don't raise a gap before the stream has delivered anything — the backlog is replayed inside the first read, so an early probe aborted a stream that was about to deliver.

## Verification
- `tests/unit/agent/worldSelection.test.ts` covers all three cases (opt-in selects Postgres, no opt-in outside production falls back to local, production unchanged); leaf suite 454/454, `tsc` and Biome clean.

## ⚠️ Do not move prod CHAT_DATABASE_URL to :5432 yet
Verified against the real prod DB: eve boots on the Postgres world there and writes durable rows (a run with 9 stream chunks), but **leaf's world reader returns 0 events from them** — eve writes a length-prefixed devalue envelope, not the NDJSON the reader assumes. With the pooler (`:6432`) the NOTIFY self-test refuses the world, so this is inert today; on `:5432` leaf would take the world path and read nothing, reproducing the hang. The reader's chunk decoding needs fixing (and testing against real chunks, not fixtures) before the port changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the explicit opt-in for using a shared/production workflow world outside production. Previously any process inheriting CHAT_DATABASE_URL would become a queue worker on that database; now we require EVE_ALLOW_SHARED_WORLD=1 and otherwise clear WORKFLOW_POSTGRES_URL so leaf uses its local file world.

**Migration**
- To run locally or in CI against a shared world, set EVE_ALLOW_SHARED_WORLD=1; the `p` script now sets this for you.
- Do not move the prod CHAT_DATABASE_URL to :5432 yet; the leaf reader cannot decode length‑prefixed envelopes and would read zero events.

**Bug Fixes**
- The journal reader no longer probes for gaps before first delivery, avoiding false aborts during initial backlog replay.

<sup>Written for commit f636f81cdce411e65aae0512e0cf64218cfce09c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores explicit authorization before a non-production Leaf process can use a shared workflow database and adjusts initial journal-stream gap detection.

- **Bug fixes:** Requires `EVE_ALLOW_SHARED_WORLD=1` before non-production agent and embedded-server paths select the shared Postgres workflow world.
- **Bug fixes:** Clears inherited `WORKFLOW_POSTGRES_URL` when shared-world access is not allowed, preventing accidental execution of jobs from a shared database.
- **Bug fixes:** Defers journal gap probing until the stream has delivered its first event, allowing initial backlog replay to complete.
- **Improvements:** Adds world-selection coverage and preserves the production-secrets development script’s explicit opt-in.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The shared workflow database is now guarded on non-production paths, inherited world configuration is cleared when unauthorized, and the initial journal read is allowed to replay before gap detection begins.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/agent/agent.ts | Adds the explicit shared-world opt-in and clears inherited Postgres world configuration when access is denied. |
| apps/leaf/src/internal/agentRuntime/eve/embeddedServer.ts | Applies the same non-production opt-in before probing and handing a durable database world to embedded Eve. |
| apps/leaf/src/internal/agentRuntime/eve/world/readSessionEvents.ts | Avoids declaring a journal gap before the initial stream read has delivered its backlog. |
| apps/leaf/tests/unit/agent/worldSelection.test.ts | Covers opted-in, non-opted-in, and production workflow-world selection. |
| package.json | Explicitly opts the production-secrets development command into the shared workflow world. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Leaf or Eve starts] --> B{NODE_ENV is production?}
  B -- Yes --> C[Consider CHAT_DATABASE_URL]
  B -- No --> D{EVE_ALLOW_SHARED_WORLD equals 1?}
  D -- Yes --> C
  D -- No --> E[Clear WORKFLOW_POSTGRES_URL]
  E --> F[Use local file world]
  C --> G{Database URL available and usable?}
  G -- Yes --> H[Use Postgres workflow world]
  G -- No --> F
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 a shared workflow world stays an..."](https://github.com/useautumn/autumn/commit/f636f81cdce411e65aae0512e0cf64218cfce09c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56606357)</sub>

<!-- /greptile_comment -->