### PR TITLE
Hide billing sheet assistant until toggled

### DIFF
--- a/vite/src/components/forms/shared/generation/BillingPromptToggle.tsx
+++ b/vite/src/components/forms/shared/generation/BillingPromptToggle.tsx
@@ -5,12 +5,16 @@ import {
 	TooltipTrigger,
 } from "@autumn/ui";
 import { SparkleIcon } from "@phosphor-icons/react";
+import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useBillingPromptVisibility } from "./useBillingPromptVisibility";
 
 export function BillingPromptToggle() {
 	const { visible, setVisible } = useBillingPromptVisibility();
 	const label = visible ? "Hide assistant" : "Show assistant";
+
+	// Each sheet opens with the assistant hidden until the user asks for it.
+	useEffect(() => () => setVisible(false), [setVisible]);
 
 	return (
 		<Tooltip>

--- a/vite/src/components/forms/shared/generation/BillingPromptToggle.tsx
+++ b/vite/src/components/forms/shared/generation/BillingPromptToggle.tsx
@@ -5,16 +5,12 @@ import {
 	TooltipTrigger,
 } from "@autumn/ui";
 import { SparkleIcon } from "@phosphor-icons/react";
-import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useBillingPromptVisibility } from "./useBillingPromptVisibility";
 
 export function BillingPromptToggle() {
 	const { visible, setVisible } = useBillingPromptVisibility();
 	const label = visible ? "Hide assistant" : "Show assistant";
-
-	// Each sheet opens with the assistant hidden until the user asks for it.
-	useEffect(() => () => setVisible(false), [setVisible]);
 
 	return (
 		<Tooltip>

--- a/vite/src/components/forms/shared/generation/useBillingPromptVisibility.ts
+++ b/vite/src/components/forms/shared/generation/useBillingPromptVisibility.ts
@@ -1,15 +1,5 @@
 import { create } from "zustand";
 
-const STORAGE_KEY = "autumn.billing_prompt_bar_visible";
-
-const readStoredVisibility = (): boolean => {
-	try {
-		return localStorage.getItem(STORAGE_KEY) === "1";
-	} catch {
-		return false;
-	}
-};
-
 type BillingPromptVisibilityState = {
 	visible: boolean;
 	setVisible: (visible: boolean) => void;
@@ -18,12 +8,7 @@ type BillingPromptVisibilityState = {
 /** One preference shared by every billing sheet's AI prompt bar. */
 export const useBillingPromptVisibility = create<BillingPromptVisibilityState>(
 	(set) => ({
-		setVisible: (visible) => {
-			try {
-				localStorage.setItem(STORAGE_KEY, visible ? "1" : "0");
-			} catch {}
-			set({ visible });
-		},
-		visible: readStoredVisibility(),
+		setVisible: (visible) => set({ visible }),
+		visible: false,
 	}),
 );


### PR DESCRIPTION
## What

The AI prompt bar in the billing sheets (Attach Product, Update Subscription, Create Schedule) was showing by default. Now it only appears when the sparkle button in the sheet header is clicked.

## Why

`useBillingPromptVisibility` persisted `visible` to `localStorage`, so the first time anyone opened the assistant it stayed open in every billing sheet forever after — across reloads.

## Changes

- `useBillingPromptVisibility.ts` — dropped the `localStorage` read/write; visibility is in-memory and starts `false`.

Visibility remains a session-wide preference: once toggled on it stays on for other sheets until toggled off or the page reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR stops saving billing-assistant visibility in browser storage and defaults the shared state to hidden. However, the shared in-memory state is not reset when a sheet closes.

- **Bug fixes:** Remove the localStorage read and write for assistant visibility.
- **Improvements:** Initialize the billing assistant as hidden when the application first loads.
</details>


<h3>Confidence Score: 4/5</h3>

This should be fixed before merging because showing the assistant once can still make it appear automatically in later billing sheets.

The storage-backed persistence is removed, but the shared Zustand state survives sheet unmounts and has no close-time reset, leaving the reported behavior reachable within the current application session.

**Files Needing Attention:** vite/src/components/forms/shared/generation/useBillingPromptVisibility.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/forms/shared/generation/useBillingPromptVisibility.ts | Removes persisted visibility, but the module-level state can remain visible across billing sheets until the page reloads. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/components/forms/shared/generation/useBillingPromptVisibility.ts:10-11
**Shared visibility never resets**

When a user shows the assistant and then closes the billing sheet, this module-level store retains `visible: true`, causing the same or another billing sheet to open with the assistant already visible without another click.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Keep assistant visibility as a session p..."](https://github.com/useautumn/autumn/commit/87e371083a415eba87042071249fc339129fb141) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56610285)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->