### PR TITLE
fix: prefer stored RevenueCat processor id in customer response

### DIFF
--- a/server/src/internal/customers/cusUtils/cusResponseUtils/getCusProcessors.ts
+++ b/server/src/internal/customers/cusUtils/cusResponseUtils/getCusProcessors.ts
@@ -16,8 +16,10 @@ import {
  * Vercel: only the public-safe subset (`installation_id`, `account_id`).
  * NEVER include `access_token` or `custom_payment_method_id`.
  *
- * RevenueCat: surfaces only when the customer has at least one ACTIVE
- * customer_product whose processor type is RevenueCat.
+ * RevenueCat: prefer the stored `processors.revenuecat` row when present;
+ * otherwise surface only when the customer has at least one ACTIVE
+ * customer_product whose processor type is RevenueCat (id falls back to
+ * `customer.id`).
  */
 export const getCusProcessors = ({
 	customer,
@@ -42,9 +44,10 @@ export const getCusProcessors = ({
 		customerProducts: customer_products,
 		processorType: ProcessorType.RevenueCat,
 	}).filter(customerProductHasActiveStatus);
-	const revenuecat =
-		rcProducts.length > 0
-			? { id: customer.processors?.revenuecat?.id ?? customer.id ?? null }
+	const revenuecat = customer.processors?.revenuecat
+		? { id: customer.processors.revenuecat.id }
+		: rcProducts.length > 0
+			? { id: customer.id ?? null }
 			: undefined;
 
 	if (!stripe && !vercel && !revenuecat) return undefined;

--- a/server/tests/integration/crud/customers/customer-processors.test.ts
+++ b/server/tests/integration/crud/customers/customer-processors.test.ts
@@ -31,12 +31,16 @@ import { generateId } from "@/utils/genUtils.js";
 //
 // Behaviors:
 //   - no signals (no customer.processor.id, no customer.processors.vercel,
-//     no active RC cusProduct) ⇒ processors === undefined (key omitted entirely)
+//     no processors.revenuecat, no active RC cusProduct)
+//                                      ⇒ processors === undefined (key omitted entirely)
 //   - stripe.id present                ⇒ { stripe: { id } }
 //   - customer.processors.vercel set   ⇒ { vercel: { installation_id, account_id } }
 //                                        NEVER includes access_token or
 //                                        custom_payment_method_id
-//   - ≥1 ACTIVE RC cusProduct          ⇒ { revenuecat: { id: customer.id ?? null } }
+//   - customer.processors.revenuecat set
+//                                      ⇒ { revenuecat: { id: processors.revenuecat.id } }
+//                                        (even with no active RC cusProduct)
+//   - else ≥1 ACTIVE RC cusProduct     ⇒ { revenuecat: { id: customer.id ?? null } }
 //                                        Inactive-only RC products do NOT trigger.
 //   - multi-PSP                        ⇒ all applicable keys present together
 //   - earlier API versions             ⇒ no `processors` key at all
@@ -259,7 +263,7 @@ test.concurrent(`${chalk.yellowBright("customer processors: vercel customer expo
 	expect(dbVercel?.custom_payment_method_id).toBe("pm_test_xxx");
 });
 
-// 4a. Active RC cusProduct — seeded directly via DB.
+// 4a. Active RC cusProduct, no processors.revenuecat row — falls back to customer.id.
 test.concurrent(`${chalk.yellowBright("customer processors: active RevenueCat cusProduct surfaces revenuecat.id = customer.id")}`, async () => {
 	const customerId = "customer-processors-rc-active";
 	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
@@ -319,6 +323,108 @@ test.concurrent(`${chalk.yellowBright("customer processors: active RevenueCat cu
 			cp.status === CusProductStatus.Active,
 	);
 	expect(rcRows.length).toBeGreaterThan(0);
+});
+
+// 4a2. Stored processors.revenuecat — surfaces even with no active RC product.
+test.concurrent(`${chalk.yellowBright("customer processors: stored processors.revenuecat surfaces without active RC cusProduct")}`, async () => {
+	const customerId = "customer-processors-rc-stored";
+	const revenueCatId = "rc-app-user-stored";
+
+	const { autumnV2_1, ctx } = await initScenario({
+		setup: [s.deleteCustomer({ customerId })],
+		actions: [],
+	});
+
+	await autumnV2_1.customers.create({
+		id: customerId,
+		name: "RC Stored",
+		email: `${customerId}@example.com`,
+	});
+
+	await CusService.update({
+		ctx,
+		idOrInternalId: customerId,
+		update: {
+			processors: {
+				revenuecat: { id: revenueCatId, aliases: [] },
+			},
+		},
+	});
+	await deleteCachedFullCustomer({
+		ctx,
+		customerId,
+		source: "test:rc-stored-seed",
+	});
+
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.processors?.revenuecat).toEqual({ id: revenueCatId });
+	expect(cached.processors?.vercel).toBeUndefined();
+
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.processors?.revenuecat).toEqual({ id: revenueCatId });
+});
+
+// 4a3. Stored processors.revenuecat wins over the active-RC customer.id fallback.
+test.concurrent(`${chalk.yellowBright("customer processors: stored processors.revenuecat id preferred over customer.id fallback")}`, async () => {
+	const customerId = "customer-processors-rc-prefer-stored";
+	const revenueCatId = "rc-app-user-prefer-stored";
+	const messagesItem = items.monthlyMessages({ includedUsage: 100 });
+	const pro = products.pro({
+		id: "rc-prefer-stored-pro",
+		items: [messagesItem],
+	});
+
+	const { autumnV2_1, ctx } = await initScenario({
+		customerId,
+		setup: [s.customer({}), s.products({ list: [pro] })],
+		actions: [],
+	});
+
+	const customer = await CusService.getFull({
+		ctx,
+		idOrInternalId: customerId,
+	});
+	const product = await ProductService.get({
+		db: ctx.db,
+		id: pro.id,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+	expect(product).toBeDefined();
+
+	await CusService.update({
+		ctx,
+		idOrInternalId: customerId,
+		update: {
+			processors: {
+				revenuecat: { id: revenueCatId, aliases: [] },
+			},
+		},
+	});
+	await seedCusProduct({
+		ctx,
+		internalCustomerId: customer.internal_id,
+		internalProductId: product!.internal_id,
+		productId: product!.id,
+		customerId,
+		status: CusProductStatus.Active,
+		processorType: ProcessorType.RevenueCat,
+	});
+	await deleteCachedFullCustomer({
+		ctx,
+		customerId,
+		source: "test:rc-prefer-stored-seed",
+	});
+
+	const cached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
+	expect(cached.processors?.revenuecat).toEqual({ id: revenueCatId });
+
+	const uncached = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+		skip_cache: "true",
+	});
+	expect(uncached.processors?.revenuecat).toEqual({ id: revenueCatId });
 });
 
 // 4b. Expired-only RC cusProduct — must NOT surface revenuecat.

--- a/server/tests/integration/external-psps/revenuecat/revenuecat-dual-key.test.ts
+++ b/server/tests/integration/external-psps/revenuecat/revenuecat-dual-key.test.ts
@@ -7,8 +7,9 @@
  * auto-creates an email-`app_user_id` customer with a non-email id.
  *
  * Additive-only: a customer with no `processors.revenuecat` must resolve exactly
- * as today (customer_id fallback), and the getCusProcessors response invariant
- * (presence gated on an ACTIVE RC product, never on the DB column) must hold.
+ * as today (customer_id fallback). getCusProcessors prefers the stored
+ * `processors.revenuecat` row when present; otherwise it falls back to an
+ * ACTIVE RC product with `customer.id`.
  */
 
 import { expect, test } from "bun:test";
@@ -451,14 +452,15 @@ test.concurrent(
 );
 
 // ═══════════════════════════════════════════════════════════════════
-// TEST 6: getCusProcessors invariant — DB column set but no ACTIVE RC
-// product ⇒ response omits processors.revenuecat.
+// TEST 6: getCusProcessors — stored processors.revenuecat surfaces
+// even with no ACTIVE RC product.
 // ═══════════════════════════════════════════════════════════════════
 
 test.concurrent(
-	`${chalk.yellowBright("rc dual-key: getCusProcessors omits revenuecat when no active RC product (invariant)")}`,
+	`${chalk.yellowBright("rc dual-key: getCusProcessors surfaces stored revenuecat id without active RC product")}`,
 	async () => {
 		const customerId = "rc-invariant-cus";
+		const revenueCatId = "rc-invariant-appuser";
 		const proMonthly = rcProMonthly({ id: "rc-invariant-pro" });
 
 		await setupRevenueCatOrg();
@@ -476,11 +478,13 @@ test.concurrent(
 		// DB column is set, but the customer has no active RC customer_product.
 		await seedProcessorsRevenueCatId({
 			customerId,
-			revenueCatId: "rc-invariant-appuser",
+			revenueCatId,
 		});
 
-		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId);
-		expect(customer.processors?.revenuecat).toBeUndefined();
+		const customer = await autumnV2_1.customers.get<ApiCustomerV5>(customerId, {
+			skip_cache: "true",
+		});
+		expect(customer.processors?.revenuecat).toEqual({ id: revenueCatId });
 	},
 );
 


### PR DESCRIPTION
Prefer the stored `processors.revenuecat` row when projecting the V5 customer `processors` field, instead of only surfacing RevenueCat when an active RC customer product exists.

### Changes
- `getCusProcessors`: if `customer.processors.revenuecat` is set, return `{ id: processors.revenuecat.id }`; otherwise keep the previous active-RC fallback of `{ id: customer.id ?? null }`.
- Update `customer-processors` contract comments and add coverage for stored-id presence and preference over the customer-id fallback.
- Flip the dual-key `getCusProcessors` assertion to expect the stored RC id without an active RC product (uncached read after direct DB seed).

### Why
Customers can already have a RevenueCat app user id on `processors.revenuecat` before/without an active RC product. The API should expose that id rather than omitting the key or only falling back through active products.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefers the stored RevenueCat app user id in the V5 customer processors response. Previously the revenuecat key appeared only with an ACTIVE RC customer_product and its id defaulted to customer.id; now we return the stored processors.revenuecat.id when present (even without an active product) and otherwise retain the old fallback, so presence of processors.revenuecat no longer guarantees an active RC product.

**Migration**
- If you used processors.revenuecat presence as a proxy for an active RC product, update logic to check active RC customer_products instead.

<sup>Written for commit b2fde119235b5996c9513605bad2a8e832f80339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the V5 customer response to prefer a stored RevenueCat app-user ID, including when the customer has no active RevenueCat product.

- **[Bug fixes, API changes]** Return `processors.revenuecat.id` from the stored processor record when available.
- **[Improvements]** Preserve the existing customer-ID fallback for active RevenueCat products without a stored processor record.
- **[Improvements]** Add cached and uncached integration coverage for stored-ID presence and precedence.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The stored RevenueCat identity conforms to the persisted and public response shapes, both customer projection paths share the updated helper, and tests cover stored-ID presence, precedence, and cached versus uncached reads.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/customers/cusUtils/cusResponseUtils/getCusProcessors.ts | Safely prioritizes the typed stored RevenueCat ID while preserving the active-product fallback. |
| server/tests/integration/crud/customers/customer-processors.test.ts | Adds focused coverage for stored RevenueCat IDs across cached and uncached customer reads. |
| server/tests/integration/external-psps/revenuecat/revenuecat-dual-key.test.ts | Updates the dual-key integration expectation to match the new stored-ID projection behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix: prefer stored RevenueCat processor ..."](https://github.com/useautumn/autumn/commit/b2fde119235b5996c9513605bad2a8e832f80339) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56645903)</sub>

<!-- /greptile_comment -->