### PR TITLE
fix(webhooks): scope billing.updated plan changes to their entity

### DIFF
--- a/server/src/internal/billing/v2/actions/buildBillingChanges/autumnBillingPlanToCustomerPlanChanges/autumnBillingPlanToCustomerPlanChanges.ts
+++ b/server/src/internal/billing/v2/actions/buildBillingChanges/autumnBillingPlanToCustomerPlanChanges/autumnBillingPlanToCustomerPlanChanges.ts
@@ -21,7 +21,12 @@ export const autumnBillingPlanToCustomerPlanChanges = ({
 	});
 
 	const changes = transitions
-		.map((transition) => buildCustomerPlanChange(transition))
+		.map((transition) =>
+			buildCustomerPlanChange({
+				...transition,
+				entities: originalFullCustomer?.entities,
+			}),
+		)
 		.filter((change): change is CustomerPlanChange => change !== undefined);
 
 	return mergeUpdatedPlanChanges(changes);

--- a/server/src/internal/billing/v2/actions/buildBillingChanges/buildBillingChangeResponse.ts
+++ b/server/src/internal/billing/v2/actions/buildBillingChanges/buildBillingChangeResponse.ts
@@ -6,6 +6,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { buildBillingChanges } from "./buildBillingChanges";
+import { planChangesToEntityId } from "./planChangesToEntityId";
 
 export const buildBillingChangeResponse = ({
 	ctx: _ctx,
@@ -18,13 +19,15 @@ export const buildBillingChangeResponse = ({
 	autumnBillingPlan: AutumnBillingPlan;
 	tags?: string[];
 }): BillingChangeResponse => {
-	// entity_id comes from the enriched FullCustomer (set when the operation
-	// is scoped to a single entity via `enrichFullCustomerWithEntity`).
-	const entityId = originalFullCustomer.entity?.id ?? undefined;
 	const { planChanges } = buildBillingChanges({
 		autumnBillingPlan,
 		originalFullCustomer,
 	});
+
+	// Prefer the request's entity scope; webhook-driven flows have none, so fall
+	// back to the changes themselves when they all share one entity.
+	const entityId =
+		originalFullCustomer.entity?.id ?? planChangesToEntityId({ planChanges });
 
 	return BillingChangeResponseSchema.parse({
 		object: "billing.updated",

--- a/server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/buildCustomerPlanChange.ts
+++ b/server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/buildCustomerPlanChange.ts
@@ -3,10 +3,12 @@ import {
 	type CustomerPlanChange,
 	cusProductToProduct,
 	customerProductToApiSubscriptionStatus,
+	type Entity,
 	type FullCusProduct,
 } from "@autumn/shared";
 import { buildPlanChangeFromFullProducts } from "@/internal/catalogV2/actions/buildPlanChange";
 import { buildLifecyclePreviousAttributes } from "./buildLifecyclePreviousAttributes";
+import { customerProductToEntityId } from "./customerProductToEntityId";
 import { toCustomerPlanSnapshot } from "./toCustomerPlanSnapshot";
 
 export type CustomerProductTransition = {
@@ -45,14 +47,22 @@ export const deriveCustomerPlanChangeAction = ({
 export const buildCustomerPlanChange = ({
 	before,
 	after,
-}: CustomerProductTransition): CustomerPlanChange | undefined => {
+	entities,
+}: CustomerProductTransition & {
+	entities?: Entity[];
+}): CustomerPlanChange | undefined => {
 	if (after === null) return undefined;
 
 	const action = deriveCustomerPlanChangeAction({ before, after });
 	const snapshot = toCustomerPlanSnapshot({ cusProduct: after });
+	const entityId = customerProductToEntityId({
+		customerProduct: after,
+		entities,
+	});
 
 	if (before === null) {
 		return {
+			entity_id: entityId,
 			action,
 			...snapshot,
 			previous_attributes: null,
@@ -61,6 +71,7 @@ export const buildCustomerPlanChange = ({
 	}
 
 	return {
+		entity_id: entityId,
 		action,
 		...snapshot,
 		previous_attributes: buildLifecyclePreviousAttributes({ before, after }),

--- a/server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/customerProductToEntityId.ts
+++ b/server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/customerProductToEntityId.ts
@@ -1,0 +1,20 @@
+import type { Entity, FullCusProduct } from "@autumn/shared";
+
+/**
+ * Public entity id a customer product is scoped to, or null for customer-level.
+ * Prefers the live entities join over the row's snapshot, which predates
+ * `entity_id` on older rows.
+ */
+export const customerProductToEntityId = ({
+	customerProduct,
+	entities = [],
+}: {
+	customerProduct: FullCusProduct;
+	entities?: Entity[];
+}): string | null => {
+	const internalEntityId = customerProduct.internal_entity_id;
+	if (!internalEntityId) return null;
+
+	const entity = entities.find((e) => e.internal_id === internalEntityId);
+	return entity?.id ?? customerProduct.entity_id ?? null;
+};

--- a/server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/mergeUpdatedPlanChanges.ts
+++ b/server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/mergeUpdatedPlanChanges.ts
@@ -7,6 +7,7 @@ const updatedChangeMergeKey = (
 		const subscription = change.subscription;
 		return [
 			"subscription",
+			change.entity_id ?? "",
 			subscription.plan_id,
 			subscription.status,
 			subscription.started_at,
@@ -20,6 +21,7 @@ const updatedChangeMergeKey = (
 		const purchase = change.purchase;
 		return [
 			"purchase",
+			change.entity_id ?? "",
 			purchase.plan_id,
 			purchase.status,
 			purchase.expires_at,
@@ -28,7 +30,8 @@ const updatedChangeMergeKey = (
 };
 
 /** Dedupes `updated` changes that describe the same post-change snapshot
- * (e.g. a patch and a license update touching the same product). */
+ * (e.g. a patch and a license update touching the same product). Keyed by
+ * entity too, so identical plans on different entities stay separate. */
 export const mergeUpdatedPlanChanges = (
 	changes: CustomerPlanChange[],
 ): CustomerPlanChange[] => {

--- a/server/src/internal/billing/v2/actions/buildBillingChanges/planChangesToEntityId.ts
+++ b/server/src/internal/billing/v2/actions/buildBillingChanges/planChangesToEntityId.ts
@@ -1,0 +1,16 @@
+import type { CustomerPlanChange } from "@autumn/shared";
+
+/**
+ * Entity the whole event is scoped to, or undefined when the changes span
+ * several entities — one Stripe subscription can carry products for many.
+ */
+export const planChangesToEntityId = ({
+	planChanges,
+}: {
+	planChanges: CustomerPlanChange[];
+}): string | undefined => {
+	const entityIds = new Set(planChanges.map((change) => change.entity_id));
+	if (entityIds.size !== 1) return undefined;
+
+	return planChanges[0].entity_id ?? undefined;
+};

--- a/server/src/internal/migrations/v2/webhookDelivery/sendBatchBillingUpdatedWebhooks/sendBatchBillingUpdatedWebhooks.ts
+++ b/server/src/internal/migrations/v2/webhookDelivery/sendBatchBillingUpdatedWebhooks/sendBatchBillingUpdatedWebhooks.ts
@@ -21,7 +21,11 @@ const sendBillingUpdated = async ({
 			object: "billing.updated",
 			customer_id: record.customerId,
 			...(record.entityId ? { entity_id: record.entityId } : {}),
-			plan_changes: record.planChanges,
+			// Records are already grouped per (customer, entity).
+			plan_changes: record.planChanges.map((planChange) => ({
+				...planChange,
+				entity_id: record.entityId,
+			})),
 			tags: [],
 		} satisfies BillingChangeResponse,
 		tags: customerToSvixTags({

--- a/shared/api/billing/common/customerPlanChange.ts
+++ b/shared/api/billing/common/customerPlanChange.ts
@@ -83,6 +83,10 @@ export const CustomerPlanPreviousAttributesSchema =
 	}).partial();
 
 export const CustomerPlanChangeSchema = z.object({
+	entity_id: z.string().nullable().optional().meta({
+		description:
+			"The ID of the entity this plan is scoped to, or null when the plan is customer-level. A single event can carry changes for several entities.",
+	}),
 	action: PlanChangeActionEnum.meta({
 		description:
 			"The lifecycle action applied to this plan: activated (newly active on the customer), scheduled (queued for a future start), updated (mutated in place), or expired (ended).",


### PR DESCRIPTION
## Problem

Reported by a customer: cancel an entity-scoped paid plan and the `billing.updated` payload correctly carries `entity_id`. Let the scheduled downgrade to the default plan actually take effect, and the follow-up `billing.updated` has no `entity_id` at all — so there's no reliable way to tell which entity just lost its paid plan.

Not a Stripe-simulator artifact. `entity_id` is read once from `fullCustomer.entity`, which is only set when the *request* was entity-scoped:

```
Cancel (API call w/ entity_id)          Schedule takes effect (Stripe webhook)
  executeBillingPlan                      handleStripeSubscriptionDeleted
    fullCustomer.entity = enti_123          ctx.fullCustomer <- loaded from
    -> entity_id in payload                    Stripe customer id only
                                            fullCustomer.entity = undefined
                                            -> entity_id MISSING
```

## Why a single top-level field can't fix it

The scoping unit is the **Stripe subscription**, and one subscription can carry products for several entities — entity match in `getTargetSubscriptionCusProduct` is a *sort preference*, not a filter, so entity B's plan merges into entity A's existing sub unless `new_subscription: true` was passed.

`multiAttach` / `multiUpdate` make this explicit: both accept a per-item `entity_id` that "overrides the top-level entity_id", which the webhook then silently dropped. A multiUpdate across two entities emits one webhook labelled with the wrong entity.

Affected paths before this change:

| Path | `entity_id` |
|---|---|
| `multiAttach` / `multiUpdate` | top-level request entity only; per-item overrides dropped |
| `createSchedule` | same |
| Stripe `sub.updated` / `sub.deleted` | absent (the reported case) |
| trial-expiry cron | absent |
| `checkout.session.completed` | whatever the original request had |
| batch migrations | correct — grouped per (customer, entity) |

## Change

Migrations were already doing it right, so this generalises their approach: put the entity on the change, not just on the envelope.

- `entity_id` added to `CustomerPlanChangeSchema`, resolved per product from `internal_entity_id` via the entities join (falls back to the row snapshot for older rows)
- top-level `entity_id` kept, now derived from the changes when they all share one entity — absent rather than guessed when they differ
- `mergeUpdatedPlanChanges` keyed by entity
- batch-migration records stamp the field too, so consumers see it uniformly

Additive — no existing field changes shape, so current integrations are unaffected.

## Second bug found on the way

`mergeUpdatedPlanChanges` deduped `updated` changes by plan + status + timestamps with no entity component. Two entities on the same plan with identical timestamps collapsed into a single change, dropping one entity from the payload entirely. Fixed by including `entity_id` in the merge key.

## Testing

`bun ts` clean. 241 existing unit tests pass across the billing, migrations, and entity suites.

Not included: no new test covers this. The natural home is `server/tests/integration/billing/autumn-webhooks/billing-updated/` — happy to add one asserting `plan_changes[].entity_id` survives a `sub.deleted` event if you'd like it in this PR.

## Open question

Should multi-entity operations fan out to one webhook per entity, like migrations do? Cleaner for consumers, but it changes delivery counts for existing integrations, so I left it alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes `billing.updated` to the correct entity and prevents cross-entity dedupe. Previously Stripe-driven downgrades and updates often omitted `entity_id`, and identical plan updates across entities collapsed into one change.

- Adds `entity_id` to `CustomerPlanChangeSchema` and stamps it per plan change from the entities join (falls back to row snapshot for older data).
- Derives top-level `entity_id` from the changes when they all share one entity; omits it when they span multiple entities.
- Keys `mergeUpdatedPlanChanges` by `entity_id` to keep identical plans on different entities separate.
- Stamps `entity_id` on batch-migration `plan_changes` so all delivery paths are consistent.
- No breaking changes; consumers may rely on `plan_changes[].entity_id` and should not assume a top-level `entity_id` is always present.

<sup>Written for commit 843e66ad945435939192fac3eb5a9044fe7a1688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds entity attribution to individual `billing.updated` plan changes and prevents updates for identical plans on different entities from being merged together.

- **[Bug fixes, API changes]** Adds nullable `entity_id` to each plan change and resolves it from the associated customer product.
- **[Bug fixes]** Includes entity scope in the updated-change merge key.
- **[Improvements, API changes]** Derives event-level entity scope from plan changes and stamps batch-migration changes consistently.
- **[Bug fixes]** One multiAttach path still prefers the request's top-level entity even when item-level overrides produce changes for other entities.
</details>


<h3>Confidence Score: 4/5</h3>

The multiAttach entity-scoping defect should be fixed before merging because mixed-entity requests can label the resulting webhook with the wrong top-level entity.

The new per-change attribution works, but buildBillingChangeResponse bypasses its mixed-entity check whenever multiAttach supplied a top-level entity, allowing the event envelope to disagree with its plan changes.

**Files Needing Attention:** server/src/internal/billing/v2/actions/buildBillingChanges/buildBillingChangeResponse.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/buildBillingChanges/buildBillingChangeResponse.ts | Adds plan-derived fallback scope, but request scope still incorrectly overrides mixed per-change entities in multiAttach. |
| server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/customerProductToEntityId.ts | Resolves each customer product's public entity ID from the live entity join with a snapshot fallback. |
| server/src/internal/billing/v2/actions/buildBillingChanges/buildCustomerPlanChanges/mergeUpdatedPlanChanges.ts | Adds entity scope to merge keys so equivalent changes for separate entities remain distinct. |
| server/src/internal/billing/v2/actions/buildBillingChanges/planChangesToEntityId.ts | Correctly returns a top-level entity only when every plan change has the same entity. |
| server/src/internal/migrations/v2/webhookDelivery/sendBatchBillingUpdatedWebhooks/sendBatchBillingUpdatedWebhooks.ts | Consistently stamps the entity-group key onto migration plan changes. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["multiAttach: top-level entity A"] --> B["Item overrides: entities B and C"]
  B --> C["Plan changes labelled B and C"]
  A --> D["originalFullCustomer.entity = A"]
  C --> E["buildBillingChangeResponse"]
  D --> E
  E --> F["Webhook top-level entity_id = A"]
  E --> G["plan_changes entity_ids = B and C"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/billing/v2/actions/buildBillingChanges/buildBillingChangeResponse.ts:30
**Mixed changes get wrong scope**

When `multiAttach` uses top-level entity A with item-level overrides for B or C, this expression labels the whole webhook as entity A even though its plan changes belong to B or C, causing consumers that route by the top-level `entity_id` to update the wrong workspace or miss the affected entities.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(webhooks): scope billing.updated pla..."](https://github.com/useautumn/autumn/commit/843e66ad945435939192fac3eb5a9044fe7a1688) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56656407)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Webhook contracts and delivery events](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/webhook-contracts.md)

<!-- /greptile_comment -->