### PR TITLE
Default balance filter and sort basis to usage

### DIFF
--- a/vite/src/views/customers/components/filter-dropdown/BalanceFilterSubMenu.tsx
+++ b/vite/src/views/customers/components/filter-dropdown/BalanceFilterSubMenu.tsx
@@ -87,7 +87,7 @@ export const BalanceFilterSubMenu = ({
 			balanceFeature: "",
 			balanceOp: ">",
 			balanceValue: "",
-			balanceBasis: "remaining",
+			balanceBasis: "usage",
 		});
 	};
 

--- a/vite/src/views/customers/hooks/useCustomerFilters.tsx
+++ b/vite/src/views/customers/hooks/useCustomerFilters.tsx
@@ -112,14 +112,14 @@ function buildRestoredState({
 				: null,
 		sortFeature: filters?.sortFeature || null,
 		sortBasis:
-			filters?.sortBasis && filters.sortBasis !== "remaining"
+			filters?.sortBasis && filters.sortBasis !== "usage"
 				? filters.sortBasis
 				: null,
 		balanceFeature: filters?.balanceFeature || null,
 		balanceOp: filters?.balanceOp === "<" ? filters.balanceOp : null,
 		balanceValue: filters?.balanceValue || null,
 		balanceBasis:
-			filters?.balanceBasis && filters.balanceBasis !== "remaining"
+			filters?.balanceBasis && filters.balanceBasis !== "usage"
 				? filters.balanceBasis
 				: null,
 		joinedFrom: filters?.joinedFrom ?? null,
@@ -142,7 +142,7 @@ const queryStatesConfig = {
 	sortFeature: parseAsString.withDefault(""),
 	sortBasis: parseAsStringLiteral(
 		FeatureBalanceSortBasisSchema.options,
-	).withDefault("remaining"),
+	).withDefault("usage"),
 	balanceFeature: parseAsString.withDefault(""),
 	balanceOp: parseAsStringLiteral(BalanceFilterOpSchema.options).withDefault(
 		">",
@@ -151,7 +151,7 @@ const queryStatesConfig = {
 	balanceValue: parseAsString.withDefault(""),
 	balanceBasis: parseAsStringLiteral(
 		FeatureBalanceSortBasisSchema.options,
-	).withDefault("remaining"),
+	).withDefault("usage"),
 	joinedFrom: parseAsInteger,
 	joinedTo: parseAsInteger,
 };

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx
@@ -63,7 +63,7 @@ export function CustomerListFilterButton({
 			balanceFeature: "",
 			balanceOp: ">",
 			balanceValue: "",
-			balanceBasis: "remaining",
+			balanceBasis: "usage",
 			joinedFrom: null,
 			joinedTo: null,
 		});

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListSortButton.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListSortButton.tsx
@@ -245,7 +245,7 @@ export function CustomerListSortButton() {
 									sortBy: field.value,
 									sort: order,
 									sortFeature: "",
-									sortBasis: "remaining",
+									sortBasis: "usage",
 								});
 								setOpen(false);
 							}}
@@ -270,7 +270,7 @@ export function CustomerListSortButton() {
 							sortBy: "created_at",
 							sort: "desc",
 							sortFeature: "",
-							sortBasis: "remaining",
+							sortBasis: "usage",
 						});
 						setOpen(false);
 					}}

--- a/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx
@@ -148,7 +148,7 @@ export function CustomerListTable({
 				sort: createdAtSort && !createdAtSort.desc ? "asc" : "desc",
 				sortBy: "created_at",
 				sortFeature: "",
-				sortBasis: "remaining",
+				sortBasis: "usage",
 			});
 		},
 		[sorting, setFilters],


### PR DESCRIPTION
The customer list's Balance filter and the Features sort both defaulted their basis to `remaining`. Both now default to `usage`.

- URL query-state defaults (`sortBasis`, `balanceBasis`) are now `usage`, so the param only appears when a non-default basis is picked
- Clear / reset paths in the filter dropdown, sort dropdown, filter button, and header-click sort reset to `usage`

Server-side fallback (`FeatureBalanceSortBasisSchema.default("remaining")`) is unchanged — the dashboard always sends the basis explicitly, so it only affects direct API calls that omit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults the customer balance filter and feature sort basis to usage instead of remaining. This reduces noisy URL params and aligns all reset paths to the same basis.

- URL query defaults for `sortBasis` and `balanceBasis` are `usage`, so the params are omitted unless a non-default is chosen.
- Clearing or resetting via the filter dropdown, sort dropdown, filter button, or header-click sort now sets basis to `usage`.
- Server-side fallback stays `remaining` in `FeatureBalanceSortBasisSchema`, affecting only direct API calls that omit the basis; the dashboard continues to send it explicitly.

<sup>Written for commit 0d8598d6dde08940608973cd70d638c25bcb809b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The customer list now consistently uses usage rather than remaining as the default basis for balance filters and feature sorting.

- **[Improvements]** Changes the URL query-state defaults for `sortBasis` and `balanceBasis` to `usage`, keeping default values out of the URL.
- **[Improvements]** Aligns filter clearing, sort clearing, non-feature sort selection, and table-header sorting with the new usage default.
- **[Improvements]** Updates persisted-filter restoration so explicit non-default bases remain preserved while omitted bases use the new default.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because all relevant dashboard defaults and reset paths consistently use usage while explicit non-default selections remain preserved.

Active customer-list requests include the resolved basis explicitly, persisted remaining selections continue to restore as remaining, and no inconsistent reset path or applicable repository-rule violation remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers/hooks/useCustomerFilters.tsx | Changes query-state and restored-state defaults to usage while preserving explicitly persisted non-default basis values. |
| vite/src/views/customers/components/filter-dropdown/BalanceFilterSubMenu.tsx | Resets a cleared balance filter to the new usage basis. |
| vite/src/views/customers2/components/table/customer-list/CustomerListFilterButton.tsx | Aligns the customer-filter clear action with the usage default. |
| vite/src/views/customers2/components/table/customer-list/CustomerListSortButton.tsx | Aligns non-feature sort selection and sort clearing with the usage default. |
| vite/src/views/customers2/components/table/customer-list/CustomerListTable.tsx | Resets feature-sort state to the usage basis when sorting through the created-at table header. |

<sub>Reviews (1): Last reviewed commit: ["fix: default customer balance filter and..."](https://github.com/useautumn/autumn/commit/0d8598d6dde08940608973cd70d638c25bcb809b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56690974)</sub>

<!-- /greptile_comment -->