### PR TITLE
Braintrust: local turns trace to a per-developer project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ tests/
 !packages/mcp/tests
 !packages/gateway/tests
 !apps/leaf/tests
+!packages/render/tests
 !vite/tests
 .secrets
 

--- a/apps/leaf/agent/instrumentation.ts
+++ b/apps/leaf/agent/instrumentation.ts
@@ -9,6 +9,16 @@ import { defineInstrumentation } from "eve/instrumentation";
  *
  * Without BRAINTRUST_API_KEY no exporter is registered, so a missing key
  * costs traces, never turns. */
+
+/** A laptop's turns must not land in the project used to investigate
+ * production incidents. Matches how the agent identifies production
+ * elsewhere, so the two can never disagree. */
+const projectName = () => {
+	if (process.env.BRAINTRUST_PROJECT) return process.env.BRAINTRUST_PROJECT;
+	const isProduction =
+		process.env.NODE_ENV === "production" || process.env.EVE_EMBEDDED === "1";
+	return isProduction ? "leaf" : `leaf-local-${process.env.USER ?? "dev"}`;
+};
 export default defineInstrumentation({
 	setup: ({ agentName }) => {
 		if (!process.env.BRAINTRUST_API_KEY) return;
@@ -16,7 +26,7 @@ export default defineInstrumentation({
 			serviceName: agentName,
 			traceExporter: new BraintrustExporter({
 				filterAISpans: true,
-				parent: `project_name:${process.env.BRAINTRUST_PROJECT ?? "leaf"}`,
+				parent: `project_name:${projectName()}`,
 			}),
 		});
 	},

--- a/packages/render/tests/unit/customizeChanges.test.ts
+++ b/packages/render/tests/unit/customizeChanges.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildCustomizeChanges,
+	customizeNeedsCurrentPlan,
+} from "../../src/billing/customizeChanges.js";
+
+// Every change is an add or a remove — the verb is a property of the diff
+// against the customer's current plan, never a hardcoded label. That is the
+// model the dashboard renders, and Slack must render the same one.
+
+const currentPlan = {
+	id: "enterprise",
+	items: [
+		{ feature_id: "contacts", included: 250_000 },
+		{ feature_id: "seats", included: 5 },
+	],
+	name: "Enterprise",
+	price: { amount: 50, interval: "month" },
+};
+
+describe("buildCustomizeChanges — base price", () => {
+	test("changing the price is a remove of the old and an add of the new", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan,
+				customize: { price: { amount: 80, interval: "month" } },
+			}),
+		).toEqual([
+			{
+				kind: "remove",
+				subject: "price",
+				price: { amount: 50, interval: "month" },
+			},
+			{
+				kind: "add",
+				subject: "price",
+				price: { amount: 80, interval: "month" },
+			},
+		]);
+	});
+
+	test("setting a price where none existed is just an add", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan: { ...currentPlan, price: null },
+				customize: { price: { amount: 80, interval: "month" } },
+			}),
+		).toEqual([
+			{
+				kind: "add",
+				subject: "price",
+				price: { amount: 80, interval: "month" },
+			},
+		]);
+	});
+
+	test("price null removes the current price", () => {
+		expect(
+			buildCustomizeChanges({ currentPlan, customize: { price: null } }),
+		).toEqual([
+			{
+				kind: "remove",
+				subject: "price",
+				price: { amount: 50, interval: "month" },
+			},
+		]);
+	});
+
+	test("a fresh attach has no current plan, so everything is an add", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan: null,
+				customize: { price: { amount: 80, interval: "month" } },
+			}),
+		).toEqual([
+			{
+				kind: "add",
+				subject: "price",
+				price: { amount: 80, interval: "month" },
+			},
+		]);
+	});
+});
+
+describe("buildCustomizeChanges — items", () => {
+	test("add_items are adds", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan,
+				customize: {
+					add_items: [{ feature_id: "contacts", included: 500_000 }],
+				},
+			}),
+		).toEqual([
+			{
+				kind: "add",
+				subject: "item",
+				item: { feature_id: "contacts", included: 500_000 },
+			},
+		]);
+	});
+
+	// A remove_items entry is a filter. The quantity being removed is whatever
+	// the customer currently holds, resolved from the current plan.
+	test("remove_items resolve the removed quantity from the current plan", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan,
+				customize: { remove_items: [{ feature_id: "contacts" }] },
+			}),
+		).toEqual([
+			{
+				kind: "remove",
+				subject: "item",
+				item: { feature_id: "contacts", included: 250_000 },
+			},
+		]);
+	});
+
+	test("a remove filter that matches nothing still names the feature", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan,
+				customize: { remove_items: [{ feature_id: "widgets" }] },
+			}),
+		).toEqual([
+			{ kind: "remove", subject: "item", item: { feature_id: "widgets" } },
+		]);
+	});
+
+	test("items (PUT) replaces: removes every current item, adds every new one", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan,
+				customize: { items: [{ feature_id: "seats", included: 10 }] },
+			}),
+		).toEqual([
+			{
+				kind: "remove",
+				subject: "item",
+				item: { feature_id: "contacts", included: 250_000 },
+			},
+			{
+				kind: "remove",
+				subject: "item",
+				item: { feature_id: "seats", included: 5 },
+			},
+			{
+				kind: "add",
+				subject: "item",
+				item: { feature_id: "seats", included: 10 },
+			},
+		]);
+	});
+
+	test("removes come before adds so the table reads old → new", () => {
+		const changes = buildCustomizeChanges({
+			currentPlan,
+			customize: {
+				add_items: [{ feature_id: "contacts", included: 500_000 }],
+				remove_items: [{ feature_id: "contacts" }],
+			},
+		});
+		expect(changes.map((c) => c.kind)).toEqual(["remove", "add"]);
+	});
+
+	test("nothing to change yields no changes", () => {
+		expect(buildCustomizeChanges({ currentPlan, customize: {} })).toEqual([]);
+		expect(
+			buildCustomizeChanges({ currentPlan, customize: undefined }),
+		).toEqual([]);
+	});
+});
+
+describe("buildCustomizeChanges — ordering", () => {
+	test("all removes precede all adds, price before items within each", () => {
+		const changes = buildCustomizeChanges({
+			currentPlan: {
+				items: [{ feature_id: "contacts", included: 250_000 }],
+				price: { amount: 50, interval: "month" },
+			},
+			customize: {
+				add_items: [{ feature_id: "contacts", included: 500_000 }],
+				price: { amount: 80, interval: "month" },
+				remove_items: [{ feature_id: "contacts" }],
+			},
+		});
+		expect(changes.map((c) => `${c.kind}:${c.subject}`)).toEqual([
+			"remove:price",
+			"remove:item",
+			"add:price",
+			"add:item",
+		]);
+	});
+});
+
+describe("buildCustomizeChanges — remove filter matching", () => {
+	// An item that omits interval_count means 1; a filter that says 1 explicitly
+	// must still match it, or the remove row loses the quantity being removed.
+	test("a filter with interval_count 1 matches an item that omits it", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan: {
+					items: [
+						{
+							feature_id: "seats",
+							included: 5,
+							price: { interval: "month" },
+						},
+					],
+				},
+				customize: {
+					remove_items: [
+						{ feature_id: "seats", interval: "month", interval_count: 1 },
+					],
+				},
+			}),
+		).toEqual([
+			{
+				kind: "remove",
+				subject: "item",
+				item: {
+					feature_id: "seats",
+					included: 5,
+					price: { interval: "month" },
+				},
+			},
+		]);
+	});
+});
+
+describe("buildCustomizeChanges — free trial", () => {
+	const withTrial = {
+		free_trial: {
+			card_required: true,
+			duration_length: 14,
+			duration_type: "day",
+		},
+		items: [],
+	};
+
+	test("setting a trial on a plan with none is an add", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan: { items: [] },
+				customize: {
+					free_trial: { duration_length: 14, duration_type: "day" },
+				},
+			}),
+		).toEqual([
+			{
+				kind: "add",
+				subject: "free_trial",
+				trial: { duration_length: 14, duration_type: "day" },
+			},
+		]);
+	});
+
+	test("changing a trial is a remove of the old and an add of the new", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan: withTrial,
+				customize: {
+					free_trial: { duration_length: 1, duration_type: "month" },
+				},
+			}),
+		).toEqual([
+			{
+				kind: "remove",
+				subject: "free_trial",
+				trial: {
+					card_required: true,
+					duration_length: 14,
+					duration_type: "day",
+				},
+			},
+			{
+				kind: "add",
+				subject: "free_trial",
+				trial: { duration_length: 1, duration_type: "month" },
+			},
+		]);
+	});
+
+	test("free_trial null removes the current trial", () => {
+		expect(
+			buildCustomizeChanges({
+				currentPlan: withTrial,
+				customize: { free_trial: null },
+			}),
+		).toEqual([
+			{
+				kind: "remove",
+				subject: "free_trial",
+				trial: {
+					card_required: true,
+					duration_length: 14,
+					duration_type: "day",
+				},
+			},
+		]);
+	});
+});
+
+// Callers use this to decide whether to fetch the current plan at all; a miss
+// here silently degrades every remove row above into an add-only diff.
+describe("customizeNeedsCurrentPlan", () => {
+	test("true for every customize shape that diffs against the current plan", () => {
+		expect(customizeNeedsCurrentPlan({ price: { amount: 40 } })).toBe(true);
+		expect(customizeNeedsCurrentPlan({ price: null })).toBe(true);
+		expect(
+			customizeNeedsCurrentPlan({ free_trial: { duration_length: 14 } }),
+		).toBe(true);
+		expect(customizeNeedsCurrentPlan({ free_trial: null })).toBe(true);
+		expect(customizeNeedsCurrentPlan({ items: [] })).toBe(true);
+		expect(
+			customizeNeedsCurrentPlan({ remove_items: [{ feature_id: "seats" }] }),
+		).toBe(true);
+	});
+
+	test("false for pure additions and empty patches", () => {
+		expect(
+			customizeNeedsCurrentPlan({ add_items: [{ feature_id: "seats" }] }),
+		).toBe(false);
+		expect(customizeNeedsCurrentPlan({})).toBe(false);
+		expect(customizeNeedsCurrentPlan(undefined)).toBe(false);
+		expect(customizeNeedsCurrentPlan(null)).toBe(false);
+	});
+});

--- a/packages/render/tests/unit/previewDisplay.test.ts
+++ b/packages/render/tests/unit/previewDisplay.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { buildBillingPreviewDisplay } from "../../src/billing/previewDisplay.js";
+
+const phaseChange = (name: string, planId: string) => ({
+	plan: { name },
+	plan_id: planId,
+});
+
+describe("buildBillingPreviewDisplay changes", () => {
+	test("a plan repeated across schedule phases renders once", () => {
+		const display = buildBillingPreviewDisplay({
+			preview: {
+				currency: "usd",
+				incoming: [
+					phaseChange("Transactional Pro", "transactional_pro"),
+					phaseChange("Transactional Pro", "transactional_pro"),
+					phaseChange("Transactional Pro", "transactional_pro"),
+				],
+				outgoing: [phaseChange("Transactional Free", "transactional_free")],
+			},
+		});
+		expect(display.changes.incoming).toEqual([
+			{ name: "Transactional Pro", planId: "transactional_pro" },
+		]);
+		expect(display.changes.summaryText).toBe(
+			"Attaching Transactional Pro and removing Transactional Free",
+		);
+	});
+
+	test("distinct plans all render", () => {
+		const display = buildBillingPreviewDisplay({
+			preview: {
+				currency: "usd",
+				incoming: [
+					phaseChange("Pro", "pro"),
+					phaseChange("Starter", "starter"),
+				],
+				outgoing: [],
+			},
+		});
+		expect(display.changes.summaryText).toBe("Attaching Pro, Starter");
+	});
+});


### PR DESCRIPTION
Two commits that landed after #3067 merged.

## 1. Local traces no longer pollute the production project
Every environment wrote to the same `leaf` Braintrust project, so a laptop's turns would land in the dataset you search during a production incident — and two developers testing at once would interleave.

| environment | project |
|---|---|
| production | `leaf` |
| local dev | `leaf-local-<user>` |
| explicit | `BRAINTRUST_PROJECT` overrides both |

Production is detected exactly as `agent.ts` detects it (`NODE_ENV === "production" || EVE_EMBEDDED === "1"`), so the project name cannot disagree with how the agent identifies its own environment — if that test changes, both move together.

Verified all four resolutions: `NODE_ENV`, `EVE_EMBEDDED`, local, and explicit override.

The investigate skill's `braintrust.md` is updated to match, so someone hunting a trace they just produced locally is pointed at `leaf-local-<user>` rather than finding `leaf` empty (submodule `3a075e8`).

## 2. The render package's tests were gitignored
`packages/render/tests` matched an ignore rule, so **19 passing tests** for the customize-change and preview-display builders were never committed. The code they cover is on dev; the coverage was not. Now tracked.

## Validation
- leaf suite **471/471**, render **19/19**, `tsc` clean
- Braintrust project resolution verified for each environment

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR separates local Braintrust traces from production traces and commits previously ignored render-package tests.

- **Bug fixes:** Routes production traces to `leaf` and local traces to a user-derived project, while preserving an explicit `BRAINTRUST_PROJECT` override.
- **Improvements:** Updates the Leaf investigation documentation through the `ai` submodule.
- **Improvements:** Tracks render-package tests for customize-change and preview-display behavior.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking limitation where developers sharing the same process username can still have local traces interleaved.

Production routing matches the deployed environment contract, while local isolation is weaker than described because the project identity is based only on a potentially shared or missing `USER` value.

**Files Needing Attention:** apps/leaf/agent/instrumentation.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/agent/instrumentation.ts | Adds environment-aware Braintrust project selection, but shared or missing `USER` values do not provide reliable per-developer isolation. |
| .gitignore | Adds a targeted exception so render tests are tracked. |
| packages/render/tests/unit/customizeChanges.test.ts | Adds broad coverage for billing customization diff construction and current-plan requirements. |
| packages/render/tests/unit/previewDisplay.test.ts | Adds coverage for deduplicating repeated plans and rendering distinct preview changes. |
| ai | Advances the documentation submodule to describe the new Braintrust project selection. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/agent/instrumentation.ts:20
**Shared local trace identity**

If developers run the agent under the same process username, such as `root` in development containers, this expression assigns them the same Braintrust project, so their local traces remain interleaved despite the intended per-developer isolation. A stable developer-specific identity or documented override would avoid that collision.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: 💍 stop gitignoring the render pac..."](https://github.com/useautumn/autumn/commit/3e27e10b5bfe68058ab228bba74e6d3827c76d7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56709618)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->