### PR TITLE
Guard invoice credit activation

### DIFF
--- a/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processConsumablePricesForInvoiceCreated.ts
+++ b/server/src/external/stripe/webhookHandlers/handleStripeInvoiceCreated/tasks/processConsumablePricesForInvoiceCreated.ts
@@ -39,25 +39,6 @@ const hasTrialJustEnded = ({
 	return trialEnd === periodStart;
 };
 
-const getUsageLineItemHash = ({
-	invoiceId,
-	lineItem,
-}: {
-	invoiceId: string;
-	lineItem: LineItem;
-}): string =>
-	createHash("sha256")
-		.update(
-			[
-				invoiceId,
-				lineItem.context.customerProduct?.id,
-				lineItem.context.customerPrice?.id,
-				lineItem.context.customerEntitlement?.id,
-				lineItem.context.entity?.id,
-			].join(":"),
-		)
-		.digest("hex");
-
 /**
  * Processes consumable (usage-in-arrear) prices for an invoice.
  * Adds usage line items to the invoice for the billing period.
@@ -138,46 +119,33 @@ export const processConsumablePricesForInvoiceCreated = async ({
 			includeLineItems: !trialJustEnded,
 		},
 	});
-	const stableConsumableLineItems = consumableLineItems.map((lineItem) => ({
-		...lineItem,
-		id: `invoice_li_usage_${getUsageLineItemHash({
-			invoiceId: stripeInvoice.id,
-			lineItem,
-		})}`,
-	}));
-	const stripeLineItems = stripeInvoice.lines.has_more
-		? await getStripeInvoiceLineItems({
-				stripeClient: ctx.stripeCli,
-				invoiceId: stripeInvoice.id,
-			})
-		: stripeInvoice.lines.data;
+	const stripeLineItems =
+		invoiceCreditLineItems.length > 0
+			? await getStripeInvoiceLineItems({
+					stripeClient: ctx.stripeCli,
+					invoiceId: stripeInvoice.id,
+				})
+			: [];
 	const existingAutumnLineItemIds = new Set(
 		stripeLineItems
 			.map((lineItem) => lineItem.metadata?.autumn_line_item_id)
 			.filter((lineItemId): lineItemId is string => Boolean(lineItemId)),
 	);
-	const pendingConsumableLineItems = stableConsumableLineItems.filter(
-		(lineItem) => !existingAutumnLineItemIds.has(lineItem.id),
-	);
 	const pendingInvoiceCreditLineItems = invoiceCreditLineItems.filter(
 		(lineItem) => !existingAutumnLineItemIds.has(lineItem.id),
 	);
 
-	if (disableOverageBilling && stableConsumableLineItems.length > 0) {
+	if (disableOverageBilling && consumableLineItems.length > 0) {
 		addToExtraLogs({ ctx, extras: { overageBillingDisabledByConfig: true } });
 	}
-	if (pendingConsumableLineItems.length > 0 && !disableOverageBilling) {
+	if (consumableLineItems.length > 0 && !disableOverageBilling) {
 		await createStripeInvoiceItems({
 			ctx,
 			invoiceItems: lineItemsToCreateInvoiceItemsParams({
 				stripeCustomerId: eventContext.stripeCustomer.id,
 				stripeInvoiceId: stripeInvoice.id,
-				lineItems: pendingConsumableLineItems,
+				lineItems: consumableLineItems,
 			}),
-			idempotencyKeys: pendingConsumableLineItems.map(
-				(lineItem) =>
-					`autumn:usage:${lineItem.id.slice("invoice_li_usage_".length)}`,
-			),
 		});
 	}
 	if (pendingInvoiceCreditLineItems.length > 0) {
@@ -229,5 +197,5 @@ export const processConsumablePricesForInvoiceCreated = async ({
 		}),
 	);
 
-	return [...stableConsumableLineItems, ...invoiceCreditLineItems];
+	return [...consumableLineItems, ...invoiceCreditLineItems];
 };

--- a/server/src/internal/analytics/actions/aggregateDeductions.ts
+++ b/server/src/internal/analytics/actions/aggregateDeductions.ts
@@ -8,14 +8,17 @@ import type {
 	FullCustomer,
 	RangeEnum,
 } from "@autumn/shared";
-import { isAnyCreditSystem, notNullish } from "@autumn/shared";
+import { findFeatureById, isAnyCreditSystem, notNullish } from "@autumn/shared";
 import { UTCDate } from "@date-fns/utc";
 import type { AggregateDeductionsPipeRow } from "@/external/tinybird/initTinybird.js";
 import { getTinybirdPipes } from "@/external/tinybird/initTinybird.js";
 import { assertDeductionGroupingUnambiguous } from "@/external/tinybird/pipes/aggregateDeductionsPipe.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { CusEntService } from "@/internal/customers/cusProducts/cusEnts/CusEntitlementService.js";
-import { getCreditCost } from "@/internal/features/creditSystemUtils.js";
+import {
+	getCreditCost,
+	getCreditRateCard,
+} from "@/internal/features/creditSystemUtils.js";
 import { calculateDateRange } from "./aggregate.js";
 
 /** The pipe buckets overflow groups here; the API surfaces the same label as the grouped list. */
@@ -123,7 +126,7 @@ const buildBalanceLookups = ({
  * number would be a lie. Reflects the CURRENT credit schema, not the rate at
  * deduction time: credit systems are edited in place rather than versioned.
  */
-const resolveCreditCost = ({
+export const resolveCreditCost = ({
 	ctx,
 	sourceFeatureId,
 	balanceFeatureId,
@@ -136,6 +139,14 @@ const resolveCreditCost = ({
 
 	const creditSystem = ctx.features.find((f) => f.id === balanceFeatureId);
 	if (!creditSystem || !isAnyCreditSystem(creditSystem.type)) return null;
+	const sourceFeature = findFeatureById({
+		features: ctx.features,
+		featureId: sourceFeatureId,
+		errorOnNotFound: false,
+	});
+	if (!sourceFeature) return null;
+	const rateCard = getCreditRateCard({ sourceFeature, creditSystem });
+	if (rateCard?.tier_behavior === "graduated") return null;
 
 	try {
 		return getCreditCost({

--- a/server/src/internal/balances/check/getCheckResponseV2.ts
+++ b/server/src/internal/balances/check/getCheckResponseV2.ts
@@ -2,18 +2,19 @@ import {
 	apiBalanceToAllowed,
 	CheckResponseV3Schema,
 	FeatureType,
+	orgToInStatuses,
 } from "@autumn/shared";
-import {
-	featureToCreditSystem,
-	getCreditRateCurrentUsage,
-} from "@/internal/features/creditSystemUtils.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { getCreditRateRequiredBalance } from "@/internal/features/creditSystemUtils.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
 
 export const getCheckResponseV2 = async ({
+	ctx,
 	checkData,
 	requiredBalance,
 	properties,
 }: {
+	ctx: AutumnContext;
 	checkData: CheckDataV2;
 	requiredBalance: number;
 	properties?: Record<string, unknown> | null;
@@ -34,15 +35,13 @@ export const getCheckResponseV2 = async ({
 		featureToUse.type === FeatureType.CreditSystem &&
 		featureToUse.id !== originalFeature.id
 	) {
-		requiredBalance = featureToCreditSystem({
-			featureId: originalFeature.id,
+		requiredBalance = getCreditRateRequiredBalance({
+			fullSubject: checkData.fullSubject,
+			sourceFeature: originalFeature,
 			creditSystem: featureToUse,
 			amount: requiredBalance,
-			currentUsage: getCreditRateCurrentUsage({
-				fullSubject: checkData.fullSubject,
-				creditSystemId: featureToUse.id,
-				sourceInternalFeatureId: originalFeature.internal_id,
-			}),
+			reverseOrder: ctx.org.config?.reverse_deduction_order,
+			inStatuses: orgToInStatuses({ org: ctx.org }),
 		});
 	}
 

--- a/server/src/internal/balances/check/runCheckV2.ts
+++ b/server/src/internal/balances/check/runCheckV2.ts
@@ -32,6 +32,7 @@ export const runCheckV2 = async ({
 					checkData,
 				})
 			: await getCheckResponseV2({
+					ctx,
 					checkData,
 					requiredBalance,
 					properties: body.properties,

--- a/server/src/internal/balances/check/runCheckWithTrackV2.ts
+++ b/server/src/internal/balances/check/runCheckWithTrackV2.ts
@@ -7,6 +7,7 @@ import {
 	featureUtils,
 	InsufficientBalanceError,
 	InternalError,
+	orgToInStatuses,
 	type ParsedCheckParams,
 	RecaseError,
 	type TrackParams,
@@ -16,10 +17,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { getTrackFeatureDeductions } from "@/internal/balances/track/utils/getFeatureDeductions.js";
 import { runTrackV3 } from "@/internal/balances/track/v3/runTrackV3.js";
 import { buildLockScheduleName } from "@/internal/balances/utils/lock/buildLockScheduleName.js";
-import {
-	featureToCreditSystem,
-	getCreditRateCurrentUsage,
-} from "@/internal/features/creditSystemUtils.js";
+import { getCreditRateRequiredBalance } from "@/internal/features/creditSystemUtils.js";
 import { workflows } from "@/queue/workflows.js";
 import type { CheckDataV2 } from "./checkTypes/CheckDataV2.js";
 
@@ -100,6 +98,20 @@ export const runCheckWithTrackV2 = async ({
 		return buildNoEntitlementResponse({ checkData, requiredBalance });
 	}
 
+	const { featureToUse, originalFeature } = checkData;
+	const responseRequiredBalance =
+		featureToUse.type === FeatureType.CreditSystem &&
+		featureToUse.id !== originalFeature.id
+			? getCreditRateRequiredBalance({
+					fullSubject: checkData.fullSubject,
+					sourceFeature: originalFeature,
+					creditSystem: featureToUse,
+					amount: requiredBalance,
+					reverseOrder: ctx.org.config?.reverse_deduction_order,
+					inStatuses: orgToInStatuses({ org: ctx.org }),
+				})
+			: requiredBalance;
+
 	const featureDeductions = getTrackFeatureDeductions({
 		ctx,
 		featureId: body.feature_id,
@@ -145,23 +157,6 @@ export const runCheckWithTrackV2 = async ({
 		}
 	}
 
-	const { featureToUse, originalFeature } = checkData;
-	if (
-		featureToUse.type === FeatureType.CreditSystem &&
-		featureToUse.id !== originalFeature.id
-	) {
-		requiredBalance = featureToCreditSystem({
-			featureId: originalFeature.id,
-			creditSystem: featureToUse,
-			amount: requiredBalance,
-			currentUsage: getCreditRateCurrentUsage({
-				fullSubject: checkData.fullSubject,
-				creditSystemId: featureToUse.id,
-				sourceInternalFeatureId: originalFeature.internal_id,
-			}),
-		});
-	}
-
 	if (body.lock?.expires_at && allowed) {
 		try {
 			const scheduleName = buildLockScheduleName({
@@ -192,7 +187,7 @@ export const runCheckWithTrackV2 = async ({
 		allowed,
 		customer_id: checkData.customerId || "",
 		entity_id: checkData.entityId,
-		required_balance: requiredBalance,
+		required_balance: responseRequiredBalance,
 		balance: checkData.apiBalance ?? null,
 		balances: trackBalances,
 		flag: checkData.apiFlag ?? null,

--- a/server/src/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems.ts
+++ b/server/src/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems.ts
@@ -51,9 +51,13 @@ export const buildAutumnLineItems = ({
 				options: {
 					includePeriodDescription: true,
 					updateNextResetAt: true,
+					invoiceCredits: {},
 				},
 			});
-			arrearLineItems.push(...arrearResult.lineItems);
+			arrearLineItems.push(
+				...arrearResult.lineItems,
+				...arrearResult.invoiceCreditLineItems,
+			);
 			updateCustomerEntitlements.push(
 				...arrearResult.updateCustomerEntitlements,
 			);

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -61,14 +61,12 @@ const validateProjectedInvoiceCreditPrices = ({
 };
 
 const validateProjectedInvoiceCreditPooling = ({
-	catalogContext,
 	updateCatalogPlan,
 }: {
-	catalogContext: UpdateCatalogContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 }): void => {
 	for (const updateFeaturePlan of updateCatalogPlan.updateFeatures) {
-		const { current, next: feature } = updateFeaturePlan;
+		const { next: feature } = updateFeaturePlan;
 		const hasPooledPlanItem = updateCatalogPlan.projected.products.some(
 			(product) =>
 				product.entitlements.some(
@@ -79,20 +77,14 @@ const validateProjectedInvoiceCreditPooling = ({
 		);
 		validateInvoiceCreditPooling({
 			feature,
-			pooled:
-				hasPooledPlanItem ||
-				catalogContext.featureStatesContext[current.id]
-					?.has_pooled_entitlements,
+			pooled: hasPooledPlanItem,
 		});
 		validateInvoiceCreditUsageBasedPricing({
 			feature,
-			usageBased:
-				!catalogContext.featureStatesContext[current.id]
-					?.has_non_consumable_entitlements &&
-				planItemsForFeatureAreUsageBased({
-					internalFeatureId: feature.internal_id,
-					updateCatalogPlan,
-				}),
+			usageBased: planItemsForFeatureAreUsageBased({
+				internalFeatureId: feature.internal_id,
+				updateCatalogPlan,
+			}),
 		});
 		validateProjectedInvoiceCreditPrices({ feature, updateCatalogPlan });
 	}
@@ -131,7 +123,7 @@ export const handleUpdateCatalogErrors = async ({
 	params: UpdateCatalogParams;
 }): Promise<void> => {
 	handleUpdateFeatureErrors({ ctx, catalogContext, updateCatalogPlan });
-	validateProjectedInvoiceCreditPooling({ catalogContext, updateCatalogPlan });
+	validateProjectedInvoiceCreditPooling({ updateCatalogPlan });
 	handleRemoveFeatureErrors({ updateCatalogPlan });
 	handleRemovePlanErrors({
 		updateCatalogPlan,

--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/detectFeatureUpdateBlockers.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/detectFeatureUpdateBlockers.ts
@@ -3,8 +3,8 @@ import {
 	type FeatureUpdateBlocker,
 	keyToTitle,
 } from "@autumn/shared";
-import type { UpdateFeaturePlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateFeaturePlan";
 import type { FeatureState } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext";
+import type { UpdateFeaturePlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateFeaturePlan";
 import { featureChangeFlags } from "@/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/featureChangeFlags";
 
 const isCreditSystemSwitch = (from: FeatureType, to: FeatureType): boolean =>
@@ -39,8 +39,12 @@ export const detectFeatureUpdateBlockers = ({
 	projectedCreditSystemFeatureIds: string[];
 }): FeatureUpdateBlocker[] => {
 	const { current, next } = updateFeaturePlan;
-	const { isChangingId, isChangingType, isChangingUsageType } =
-		featureChangeFlags({ current, next });
+	const {
+		isChangingId,
+		isChangingType,
+		isChangingUsageType,
+		isEnablingInvoiceCredits,
+	} = featureChangeFlags({ current, next });
 	const blockers: FeatureUpdateBlocker[] = [];
 	const hasCreditSystems = projectedCreditSystemFeatureIds.length > 0;
 
@@ -133,6 +137,14 @@ export const detectFeatureUpdateBlockers = ({
 				message: `Cannot set to ${usageTypeTitle} because it is / was used by customers`,
 			});
 		}
+	}
+
+	if (isEnablingInvoiceCredits && featureState?.has_customers) {
+		blockers.push({
+			field: "invoice_credit",
+			code: "attached_to_customer",
+			message: `Cannot enable invoice credits for feature ${current.id} because it has been attached to a customer before`,
+		});
 	}
 
 	return blockers;

--- a/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/featureChangeFlags.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/utils/featureUpdateUtils/featureChangeFlags.ts
@@ -1,4 +1,5 @@
 import { type Feature, FeatureType } from "@autumn/shared";
+import { isEnablingInvoiceCreditFeature } from "@/internal/features/creditSystemUtils.js";
 
 /** Which blockable dimensions a resolved current → next update touches. */
 export const featureChangeFlags = ({
@@ -14,4 +15,8 @@ export const featureChangeFlags = ({
 		current.type !== FeatureType.Boolean &&
 		next.type !== FeatureType.Boolean &&
 		current.config?.usage_type !== next.config?.usage_type,
+	isEnablingInvoiceCredits: isEnablingInvoiceCreditFeature({
+		currentFeature: current,
+		nextFeature: next,
+	}),
 });

--- a/server/src/internal/features/creditSystemUtils.ts
+++ b/server/src/internal/features/creditSystemUtils.ts
@@ -1,6 +1,8 @@
 import {
 	type CreditSchemaItem,
 	type CreditTier,
+	type CusProductStatus,
+	cusEntToCurrentBalance,
 	ErrCode,
 	type Feature,
 	FeatureType,
@@ -308,24 +310,128 @@ export const getCreditSystemsFromFeature = ({
 	);
 };
 
-export const getCreditRateCurrentUsage = ({
+const getCreditRateFundedUnits = ({
+	featureId,
+	creditSystem,
+	currentUsage,
+	requestedUnits,
+	availableCredits,
+}: {
+	featureId: string;
+	creditSystem: Feature;
+	currentUsage: number;
+	requestedUnits: number;
+	availableCredits: number;
+}): number => {
+	if (requestedUnits <= 0) return 0;
+	const requestedCredits = featureToCreditSystem({
+		featureId,
+		creditSystem,
+		amount: requestedUnits,
+		currentUsage,
+	});
+	if (requestedCredits <= availableCredits) return requestedUnits;
+	if (availableCredits <= 0) return 0;
+
+	let lowerBound = 0;
+	let upperBound = requestedUnits;
+	for (let iteration = 0; iteration < 60; iteration++) {
+		const candidateUnits = new Decimal(lowerBound)
+			.add(upperBound)
+			.div(2)
+			.toNumber();
+		const candidateCredits = featureToCreditSystem({
+			featureId,
+			creditSystem,
+			amount: candidateUnits,
+			currentUsage,
+		});
+		if (candidateCredits <= availableCredits) {
+			lowerBound = candidateUnits;
+		} else {
+			upperBound = candidateUnits;
+		}
+	}
+
+	return lowerBound;
+};
+
+export const getCreditRateRequiredBalance = ({
 	fullSubject,
-	creditSystemId,
-	sourceInternalFeatureId,
+	sourceFeature,
+	creditSystem,
+	amount,
+	reverseOrder = false,
+	inStatuses,
 }: {
 	fullSubject: FullSubject;
-	creditSystemId: string;
-	sourceInternalFeatureId: string;
-}) => {
-	const customerEntitlement = fullSubjectToCustomerEntitlements({
+	sourceFeature: Feature;
+	creditSystem: Feature;
+	amount: number;
+	reverseOrder?: boolean;
+	inStatuses?: CusProductStatus[];
+}): number => {
+	const customerEntitlements = fullSubjectToCustomerEntitlements({
 		fullSubject,
-		featureIds: [creditSystemId],
-	})[0];
+		featureIds: [creditSystem.id],
+		reverseOrder,
+		inStatuses,
+	});
+	if (customerEntitlements.length === 0) {
+		return featureToCreditSystem({
+			featureId: sourceFeature.id,
+			creditSystem,
+			amount,
+		});
+	}
 
-	return (
-		customerEntitlement?.usage_attribution?.[sourceInternalFeatureId]?.units ??
-		0
-	);
+	let remainingUnits = new Decimal(amount);
+	let requiredCredits = new Decimal(0);
+	let finalUsage = 0;
+	let finalCreditSystem = creditSystem;
+
+	for (const customerEntitlement of customerEntitlements) {
+		if (remainingUnits.lte(0)) break;
+		const entitlementCreditSystem = customerEntitlement.entitlement.feature;
+		const currentUsage =
+			customerEntitlement.usage_attribution?.[sourceFeature.internal_id]
+				?.units ?? 0;
+		const availableCredits = cusEntToCurrentBalance({
+			cusEnt: customerEntitlement,
+			entityId: fullSubject.entity?.id ?? undefined,
+			withRollovers: true,
+		});
+		const fundedUnits = getCreditRateFundedUnits({
+			featureId: sourceFeature.id,
+			creditSystem: entitlementCreditSystem,
+			currentUsage,
+			requestedUnits: remainingUnits.toNumber(),
+			availableCredits,
+		});
+		const fundedCredits = featureToCreditSystem({
+			featureId: sourceFeature.id,
+			creditSystem: entitlementCreditSystem,
+			amount: fundedUnits,
+			currentUsage,
+		});
+		requiredCredits = requiredCredits.add(fundedCredits);
+		remainingUnits = remainingUnits.sub(fundedUnits);
+		finalUsage = currentUsage + fundedUnits;
+		finalCreditSystem = entitlementCreditSystem;
+
+		if (remainingUnits.lte(1e-10)) return requiredCredits.toNumber();
+	}
+
+	return requiredCredits
+		.add(
+			featureToCreditSystem({
+				featureId: sourceFeature.id,
+				creditSystem: finalCreditSystem,
+				amount: remainingUnits.toNumber(),
+				currentUsage: finalUsage,
+			}),
+		)
+		.toNumber();
 };
 
 export const featureToCreditSystem = ({

--- a/server/src/internal/features/creditSystemUtils.ts
+++ b/server/src/internal/features/creditSystemUtils.ts
@@ -371,6 +371,18 @@ export const getCreditRateRequiredBalance = ({
 	reverseOrder?: boolean;
 	inStatuses?: CusProductStatus[];
 }): number => {
+	const schemaItem = getCreditSchemaItem({
+		featureId: sourceFeature.id,
+		creditSystem,
+	});
+	if (schemaItem?.tier_behavior !== "graduated") {
+		return featureToCreditSystem({
+			featureId: sourceFeature.id,
+			creditSystem,
+			amount,
+		});
+	}
+
 	const customerEntitlements = fullSubjectToCustomerEntitlements({
 		fullSubject,
 		featureIds: [creditSystem.id],

--- a/server/src/internal/features/utils/updateFeatureUtils/detectFeatureUpdateBlockers.ts
+++ b/server/src/internal/features/utils/updateFeatureUtils/detectFeatureUpdateBlockers.ts
@@ -5,6 +5,7 @@ import {
 	keyToTitle,
 	notNullish,
 } from "@autumn/shared";
+import { isEnablingInvoiceCreditFeature } from "../../creditSystemUtils.js";
 import type { ObjectsUsingFeature } from "./getObjectsUsingFeature.js";
 
 const isCreditSystemSwitch = (from: FeatureType, to: FeatureType): boolean =>
@@ -26,7 +27,20 @@ export const isBlockableFeatureChange = ({
 		feature.type !== FeatureType.Boolean &&
 		updates.type !== FeatureType.Boolean &&
 		feature.config?.usage_type !== updates.config?.usage_type;
-	return isChangingType || isChangingId || isChangingUsageType;
+	const isEnablingInvoiceCredits = isEnablingInvoiceCreditFeature({
+		currentFeature: feature,
+		nextFeature: {
+			...feature,
+			type: updates.type ?? feature.type,
+			config: updates.config ?? feature.config,
+		},
+	});
+	return (
+		isChangingType ||
+		isChangingId ||
+		isChangingUsageType ||
+		isEnablingInvoiceCredits
+	);
 };
 
 /**
@@ -56,6 +70,14 @@ export const detectFeatureUpdateBlockers = ({
 		feature.type !== FeatureType.Boolean &&
 		updates.type !== FeatureType.Boolean &&
 		feature.config?.usage_type !== updates.config?.usage_type;
+	const isEnablingInvoiceCredits = isEnablingInvoiceCreditFeature({
+		currentFeature: feature,
+		nextFeature: {
+			...feature,
+			type: updates.type ?? feature.type,
+			config: updates.config ?? feature.config,
+		},
+	});
 
 	if (isChangingType && updates.type) {
 		const newType = updates.type;
@@ -148,6 +170,14 @@ export const detectFeatureUpdateBlockers = ({
 				message: `Cannot set to ${usageTypeTitle} because it is / was used by customers`,
 			});
 		}
+	}
+
+	if (isEnablingInvoiceCredits && cusEnts.length > 0) {
+		blockers.push({
+			field: "invoice_credit",
+			code: "attached_to_customer",
+			message: `Cannot enable invoice credits for feature ${feature.id} because it has been attached to a customer before`,
+		});
 	}
 
 	return blockers;

--- a/server/src/internal/features/validateInvoiceCreditPooling.ts
+++ b/server/src/internal/features/validateInvoiceCreditPooling.ts
@@ -63,7 +63,11 @@ export const validateInvoiceCreditPrice = ({
 							tier.flat_amount === undefined ||
 							tier.flat_amount === 0) &&
 						(tier.additional_currencies ?? []).every(
-							(currency) => currency.amount === billingUnits,
+							(currency) =>
+								currency.amount === billingUnits &&
+								(currency.flat_amount === null ||
+									currency.flat_amount === undefined ||
+									currency.flat_amount === 0),
 						),
 				));
 

--- a/server/src/internal/misc/configs/handlers/handlePushOrganisationConfiguration.ts
+++ b/server/src/internal/misc/configs/handlers/handlePushOrganisationConfiguration.ts
@@ -60,6 +60,7 @@ export const handlePushOrganisationConfiguration = createRoute({
 						type: dbFeature.type,
 						config: dbFeature.config,
 						event_names: dbFeature.event_names,
+						model_markups: dbFeature.model_markups,
 					},
 				});
 			}

--- a/server/src/internal/misc/pricingAgent/handlers/handleSyncPreviewPricing.ts
+++ b/server/src/internal/misc/pricingAgent/handlers/handleSyncPreviewPricing.ts
@@ -114,6 +114,7 @@ export const handleSyncPreviewPricing = createRoute({
 					type: dbFeature.type,
 					config: dbFeature.config,
 					event_names: dbFeature.event_names,
+					model_markups: dbFeature.model_markups,
 				},
 				skipGenerateDisplay: true,
 			});

--- a/server/src/internal/misc/pricingAgent/pricingAgentSchemas.ts
+++ b/server/src/internal/misc/pricingAgent/pricingAgentSchemas.ts
@@ -1,6 +1,8 @@
 import {
 	ApiCreditSchemaItemSchema,
 	CreateFeatureV0ParamsSchema,
+	ModelMarkupsSchema,
+	ProviderMarkupsSchema,
 } from "@autumn/shared";
 import { z } from "zod/v4";
 
@@ -62,6 +64,9 @@ export const PricingAgentFeatureInputSchema =
 		type: AgentFeatureType,
 		credit_schema: z.array(ApiCreditSchemaItemSchema).nullish(),
 		invoice_credit: z.boolean().optional(),
+		model_markups: ModelMarkupsSchema.optional(),
+		default_markup: z.number().min(-100).optional(),
+		provider_markups: ProviderMarkupsSchema.optional(),
 	});
 
 const ProductItemInterval = z.enum([

--- a/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
+++ b/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
@@ -157,9 +157,11 @@ test.concurrent(`${chalk.yellowBright("lazy reset rollover (cache): caps rollove
 test.concurrent(
 	`${chalk.yellowBright("invoice-credit cached reset: clears prior attribution and rates new-cycle rollover usage from zero")}`,
 	async () => {
-		const tieredCreditsItem = items.free({
+		const tieredCreditsItem = items.consumable({
 			featureId: TestFeature.TieredCredits,
 			includedUsage: 1_000,
+			price: 1,
+			billingUnits: 1,
 			rolloverConfig: {
 				max: 1_000,
 				length: 1,
@@ -242,9 +244,11 @@ test.concurrent(
 test.concurrent(
 	`${chalk.yellowBright("invoice-credit rollover: Postgres fallback advances new-cycle attribution atomically")}`,
 	async () => {
-		const tieredCreditsItem = items.free({
+		const tieredCreditsItem = items.consumable({
 			featureId: TestFeature.TieredCredits,
 			includedUsage: 1_000,
+			price: 1,
+			billingUnits: 1,
 			rolloverConfig: {
 				max: 1_000,
 				length: 1,

--- a/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
+++ b/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
@@ -176,7 +176,7 @@ test.concurrent(
 		const { customerId, autumnV2_3, ctx } = await initScenario({
 			customerId: "invoice-credit-reset-rollover",
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.billing.attach({ productId: product.id })],
@@ -262,7 +262,7 @@ test.concurrent(
 		const { customerId, autumnV2_3, ctx } = await initScenario({
 			customerId: "invoice-credit-postgres-rollover",
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.billing.attach({ productId: product.id })],

--- a/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
+++ b/server/tests/integration/balances/track/basic/track-credit-system-all-balances.test.ts
@@ -8,12 +8,12 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
 
 // ═══════════════════════════════════════════════════════════════════
-// Scenario A: track feature_id linked to 2 credit systems
-// Action1 → Credits (entitled) + Credits3 (not entitled → null entry).
+// Scenario A: track feature_id linked to 3 credit systems
+// Action1 → Credits (entitled) + InvoiceCredits and Credits3 (not entitled).
 // ═══════════════════════════════════════════════════════════════════
 
 test.concurrent(
-	`${chalk.yellowBright("track-all-balances-A: track feature_id linked to credit system returns both balances")}`,
+	`${chalk.yellowBright("track-all-balances-A: track feature_id returns every linked credit-system balance")}`,
 	async () => {
 		const action1Item = items.free({
 			featureId: TestFeature.Action1,
@@ -49,17 +49,23 @@ test.concurrent(
 		// `balances` exposes the feature plus every linked credit system
 		expect(trackRes.balances).toBeDefined();
 		expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
-			[TestFeature.Action1, TestFeature.Credits, TestFeature.Credits3].sort(),
+			[
+				TestFeature.Action1,
+				TestFeature.Credits,
+				TestFeature.InvoiceCredits,
+				TestFeature.Credits3,
+			].sort(),
 		);
 		expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
 		expect(trackRes.balances?.[TestFeature.Credits]).not.toBeNull();
+		expect(trackRes.balances?.[TestFeature.InvoiceCredits]).toBeNull();
 		expect(trackRes.balances?.[TestFeature.Credits3]).toBeNull();
 	},
 );
 
 // ═══════════════════════════════════════════════════════════════════
 // Scenario B: event_name → 2 features with their credit systems
-// "action-event" matches Action1 (→ Credits, Credits3) and Action3
+// "action-event" matches Action1 (→ Credits, InvoiceCredits, Credits3) and Action3
 // (→ Credits2). Credits3 is unentitled → null entry.
 // ═══════════════════════════════════════════════════════════════════
 
@@ -110,6 +116,7 @@ test.concurrent(
 				TestFeature.Action3,
 				TestFeature.Credits,
 				TestFeature.Credits2,
+				TestFeature.InvoiceCredits,
 				TestFeature.Credits3,
 			].sort(),
 		);
@@ -122,6 +129,7 @@ test.concurrent(
 			expect(trackRes.balances?.[fid]).not.toBeNull();
 		}
 		expect(trackRes.balances?.[TestFeature.Credits3]).toBeNull();
+		expect(trackRes.balances?.[TestFeature.InvoiceCredits]).toBeNull();
 	},
 );
 
@@ -244,10 +252,16 @@ test.concurrent(
 		// `balances` includes null entries for the missing entitlements
 		expect(trackRes.balances).toBeDefined();
 		expect(Object.keys(trackRes.balances ?? {}).sort()).toEqual(
-			[TestFeature.Action1, TestFeature.Credits, TestFeature.Credits3].sort(),
+			[
+				TestFeature.Action1,
+				TestFeature.Credits,
+				TestFeature.InvoiceCredits,
+				TestFeature.Credits3,
+			].sort(),
 		);
 		expect(trackRes.balances?.[TestFeature.Action1]).not.toBeNull();
 		expect(trackRes.balances?.[TestFeature.Credits]).toBeNull();
+		expect(trackRes.balances?.[TestFeature.InvoiceCredits]).toBeNull();
 		expect(trackRes.balances?.[TestFeature.Credits3]).toBeNull();
 	},
 );

--- a/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
@@ -44,9 +44,11 @@ const makeCreditProduct = ({
 						}),
 					]
 				: []),
-			items.free({
+			items.consumable({
 				featureId: TestFeature.TieredCredits,
 				includedUsage: creditAllowance,
+				price: 1,
+				billingUnits: 1,
 			}),
 		],
 	});

--- a/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
@@ -93,7 +93,7 @@ test.concurrent(
 		const { autumnV2_3 } = await initScenario({
 			customerId,
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [baseProduct, addOnProduct] }),
 			],
 			actions: [
@@ -128,7 +128,7 @@ test.concurrent(
 		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
 			customerId,
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.attach({ productId: product.id })],
@@ -280,7 +280,7 @@ test.concurrent(
 		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
 			customerId,
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.attach({ productId: product.id })],
@@ -325,7 +325,7 @@ test.concurrent(
 		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
 			customerId,
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.attach({ productId: product.id })],
@@ -391,7 +391,7 @@ test.concurrent(
 		const { autumnV1, autumnV2_3, customer, ctx } = await initScenario({
 			customerId,
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.attach({ productId: product.id })],
@@ -442,7 +442,7 @@ test.concurrent(
 		const { autumnV2_3, customer, ctx } = await initScenario({
 			customerId,
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.attach({ productId: product.id })],

--- a/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
@@ -24,12 +24,17 @@ import { getCachedFeatureBalance } from "@/internal/customers/cache/fullSubject/
 const makeCreditProduct = ({
 	id,
 	withOwnAllowance = false,
+	isAddOn = false,
+	creditAllowance = 1_000,
 }: {
 	id: string;
 	withOwnAllowance?: boolean;
+	isAddOn?: boolean;
+	creditAllowance?: number;
 }) =>
 	products.base({
 		id,
+		isAddOn,
 		items: [
 			...(withOwnAllowance
 				? [
@@ -41,7 +46,7 @@ const makeCreditProduct = ({
 				: []),
 			items.free({
 				featureId: TestFeature.TieredCredits,
-				includedUsage: 1_000,
+				includedUsage: creditAllowance,
 			}),
 		],
 	});
@@ -69,6 +74,49 @@ const getPersistedCreditEntitlement = async ({
 
 	return rows[0];
 };
+
+test.concurrent(
+	`${chalk.yellowBright("graduated-credit-rating: check rates each credit entitlement from its own tier position")}`,
+	async () => {
+		const customerId = "graduated-credit-rating-multiple-entitlements";
+		const baseProduct = makeCreditProduct({
+			id: "graduated-credit-multiple-base",
+			creditAllowance: 100,
+		});
+		const addOnProduct = makeCreditProduct({
+			id: "graduated-credit-multiple-addon",
+			isAddOn: true,
+			creditAllowance: 0.9,
+		});
+		const { autumnV2_3 } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ testClock: false }),
+				s.products({ list: [baseProduct, addOnProduct] }),
+			],
+			actions: [
+				s.attach({ productId: baseProduct.id }),
+				s.attach({ productId: addOnProduct.id }),
+			],
+		});
+
+		await autumnV2_3.track({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			value: 10_000,
+		});
+
+		const check = await autumnV2_3.check({
+			customer_id: customerId,
+			feature_id: TestFeature.TieredAction,
+			required_balance: 100,
+		});
+
+		expect(check.allowed).toBe(false);
+		expect(check.required_balance).toBeCloseTo(1, 10);
+	},
+	{ timeout: 120_000 },
+);
 
 test.concurrent(
 	`${chalk.yellowBright("graduated-credit-rating: Redis handles checks, concurrent boundary crossing, and refunds")}`,

--- a/server/tests/integration/balances/track/basic/track-invoice-credit-attribution.test.ts
+++ b/server/tests/integration/balances/track/basic/track-invoice-credit-attribution.test.ts
@@ -28,7 +28,7 @@ test.concurrent(
 		const { autumnV2_3, customer, ctx } = await initScenario({
 			customerId,
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [s.billing.attach({ productId: product.id })],

--- a/server/tests/integration/balances/track/basic/track-invoice-credit-attribution.test.ts
+++ b/server/tests/integration/balances/track/basic/track-invoice-credit-attribution.test.ts
@@ -17,9 +17,11 @@ test.concurrent(
 		const product = products.base({
 			id: "invoice-credit-flat-attribution",
 			items: [
-				items.free({
+				items.consumable({
 					featureId: TestFeature.InvoiceCredits,
 					includedUsage: 1_000,
+					price: 1,
+					billingUnits: 1,
 				}),
 			],
 		});

--- a/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
+++ b/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
@@ -26,7 +26,7 @@ test.concurrent(
 		const { autumnV2, customerId } = await initScenario({
 			customerId: "invoice-credit-mutation-guards",
 			setup: [
-				s.customer({ testClock: false }),
+				s.customer({ paymentMethod: "success", testClock: false }),
 				s.products({ list: [product] }),
 			],
 			actions: [

--- a/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
+++ b/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
@@ -15,9 +15,11 @@ test.concurrent(
 		const product = products.base({
 			id: "invoice-credit-mutation-guards",
 			items: [
-				items.free({
+				items.consumable({
 					featureId: TestFeature.InvoiceCredits,
 					includedUsage: 100,
+					price: 1,
+					billingUnits: 1,
 				}),
 			],
 		});

--- a/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-basic.test.ts
+++ b/server/tests/integration/billing/attach/params/carry-over-usages/carry-over-usage-basic.test.ts
@@ -83,13 +83,17 @@ test.concurrent(
 test.concurrent(
 	`${chalk.yellowBright("carry-over-usage invoice credit: tier position follows the carried balance usage")}`,
 	async () => {
-		const oldCredits = items.free({
+		const oldCredits = items.consumable({
 			featureId: TestFeature.InvoiceCredits,
 			includedUsage: 1_000,
+			price: 1,
+			billingUnits: 1,
 		});
-		const newCredits = items.free({
+		const newCredits = items.consumable({
 			featureId: TestFeature.InvoiceCredits,
 			includedUsage: 2_000,
+			price: 1,
+			billingUnits: 1,
 		});
 		const oldPlan = products.pro({
 			id: "invoice-credit-carry-old",

--- a/server/tests/integration/catalog-v2/features/credit-rate-card.test.ts
+++ b/server/tests/integration/catalog-v2/features/credit-rate-card.test.ts
@@ -1,5 +1,12 @@
 import { expect, test } from "bun:test";
-import { ErrCode, FeatureType, FeatureUsageType } from "@autumn/shared";
+import {
+	BillingInterval,
+	BillingMethod,
+	ErrCode,
+	FeatureType,
+	FeatureUsageType,
+	ResetInterval,
+} from "@autumn/shared";
 import { expectAutumnError } from "@tests/utils/expectUtils/expectErrUtils.js";
 import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
 import chalk from "chalk";
@@ -312,6 +319,182 @@ test.concurrent(
 						credit_schema: creditSchema,
 					}),
 			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 credit rate card: allows unpooling and enabling invoice credits atomically")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const meteredFeatureId = uniqueTestId("rate_atomic_pool_metered");
+		const creditSystemId = uniqueTestId("rate_atomic_pool_credits");
+		const planId = uniqueTestId("rate_atomic_pool_plan");
+		const featureIds = [meteredFeatureId, creditSystemId];
+		const creditSchema = [
+			{ metered_feature_id: meteredFeatureId, credit_cost: 1 },
+		];
+		const usagePrice = {
+			amount: 1,
+			interval: BillingInterval.Month,
+			billing_method: BillingMethod.UsageBased,
+			billing_units: 1,
+		};
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		await deleteDbFeatures({ ctx, featureIds });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: meteredFeatureId,
+						name: meteredFeatureId,
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+					{
+						feature_id: creditSystemId,
+						name: creditSystemId,
+						type: FeatureType.CreditSystem,
+						invoice_credit: false,
+						credit_schema: creditSchema,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: planId,
+						items: [
+							{
+								feature_id: creditSystemId,
+								included: 100,
+								pooled: true,
+								reset: { interval: ResetInterval.Month },
+								price: usagePrice,
+							},
+						],
+					},
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: creditSystemId,
+						name: creditSystemId,
+						type: FeatureType.CreditSystem,
+						invoice_credit: true,
+						credit_schema: creditSchema,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: planId,
+						items: [
+							{
+								feature_id: creditSystemId,
+								included: 100,
+								pooled: false,
+								reset: { interval: ResetInterval.Month },
+								price: usagePrice,
+							},
+						],
+					},
+				],
+			});
+
+			expect(response.features[0]).toMatchObject({ invoice_credit: true });
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+			await deleteDbFeatures({ ctx, featureIds });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 credit rate card: allows converting included usage to priced usage while enabling invoice credits")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const meteredFeatureId = uniqueTestId("rate_atomic_price_metered");
+		const creditSystemId = uniqueTestId("rate_atomic_price_credits");
+		const planId = uniqueTestId("rate_atomic_price_plan");
+		const featureIds = [meteredFeatureId, creditSystemId];
+		const creditSchema = [
+			{ metered_feature_id: meteredFeatureId, credit_cost: 1 },
+		];
+
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		await deleteDbFeatures({ ctx, featureIds });
+
+		try {
+			await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: meteredFeatureId,
+						name: meteredFeatureId,
+						type: FeatureType.Metered,
+						consumable: true,
+					},
+					{
+						feature_id: creditSystemId,
+						name: creditSystemId,
+						type: FeatureType.CreditSystem,
+						invoice_credit: false,
+						credit_schema: creditSchema,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: planId,
+						items: [
+							{
+								feature_id: creditSystemId,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				],
+			});
+
+			const response = await autumnV2_3.catalogV2.update({
+				features: [
+					{
+						feature_id: creditSystemId,
+						name: creditSystemId,
+						type: FeatureType.CreditSystem,
+						invoice_credit: true,
+						credit_schema: creditSchema,
+					},
+				],
+				plans: [
+					{
+						plan_id: planId,
+						name: planId,
+						items: [
+							{
+								feature_id: creditSystemId,
+								included: 100,
+								reset: { interval: ResetInterval.Month },
+								price: {
+									amount: 1,
+									interval: BillingInterval.Month,
+									billing_method: BillingMethod.UsageBased,
+									billing_units: 1,
+								},
+							},
+						],
+					},
+				],
+			});
+
+			expect(response.features[0]).toMatchObject({ invoice_credit: true });
 		} finally {
 			await deleteDbPlans({ ctx, planIds: [planId] });
 			await deleteDbFeatures({ ctx, featureIds });

--- a/server/tests/integration/pricing-agent/ai-credit-markups.test.ts
+++ b/server/tests/integration/pricing-agent/ai-credit-markups.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { FeatureType } from "@autumn/shared";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { FeatureService } from "@/internal/features/FeatureService.js";
+import { deleteDbFeatures } from "../catalog-v2/utils/expectCatalogFeatures.js";
+import { uniqueTestId } from "../catalog-v2/utils/uniqueTestId.js";
+
+test.concurrent(
+	`${chalk.yellowBright("pricing agent: configuration sync preserves AI credit markups")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const featureId = uniqueTestId("pricing_agent_ai_credits");
+		const modelMarkups = {
+			"anthropic/claude-sonnet-4": { markup: 25 },
+		};
+
+		await deleteDbFeatures({ ctx, featureIds: [featureId] });
+
+		try {
+			await autumnV2_3.post("/configs/push", {
+				features: [
+					{
+						id: featureId,
+						name: "AI credits",
+						type: FeatureType.AiCreditSystem,
+						display: { singular: "credit", plural: "credits" },
+						model_markups: modelMarkups,
+						default_markup: 10,
+						provider_markups: { anthropic: { markup: 15 } },
+					},
+				],
+				products: [],
+			});
+
+			const feature = await FeatureService.get({
+				db: ctx.db,
+				id: featureId,
+				orgId: ctx.org.id,
+				env: ctx.env,
+			});
+
+			expect(feature?.model_markups).toEqual(modelMarkups);
+			expect(feature?.config).toMatchObject({
+				default_markup: 10,
+				provider_markups: { anthropic: { markup: 15 } },
+			});
+		} finally {
+			await deleteDbFeatures({ ctx, featureIds: [featureId] });
+		}
+	},
+	{ timeout: 120_000 },
+);

--- a/server/tests/unit/analytics/aggregate-deductions-credit-cost.test.ts
+++ b/server/tests/unit/analytics/aggregate-deductions-credit-cost.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { FeatureType, FeatureUsageType } from "@autumn/shared";
+import { features } from "@tests/utils/fixtures/db/features.js";
+import { resolveCreditCost } from "@/internal/analytics/actions/aggregateDeductions.js";
+
+const sourceFeature = features.create({
+	id: "source",
+	internalId: "internal_source",
+	name: "Source",
+});
+
+const makeContext = ({ graduated }: { graduated: boolean }) => ({
+	features: [
+		sourceFeature,
+		features.create({
+			id: "credits",
+			internalId: "internal_credits",
+			name: "Credits",
+			type: FeatureType.CreditSystem,
+			config: {
+				usage_type: FeatureUsageType.Single,
+				schema: [
+					graduated
+						? {
+								metered_feature_id: sourceFeature.id,
+								feature_amount: 100,
+								tier_behavior: "graduated" as const,
+								tiers: [
+									{ to: 10_000, credit_amount: 1 },
+									{ to: "inf" as const, credit_amount: 0.5 },
+								],
+							}
+						: {
+								metered_feature_id: sourceFeature.id,
+								feature_amount: 100,
+								credit_amount: 1,
+							},
+				],
+			},
+		}),
+	],
+});
+
+describe("deduction analytics credit cost", () => {
+	test("returns a constant rate for a flat card", () => {
+		expect(
+			resolveCreditCost({
+				ctx: makeContext({ graduated: false }) as never,
+				sourceFeatureId: sourceFeature.id,
+				balanceFeatureId: "credits",
+			}),
+		).toBe(0.01);
+	});
+
+	test("returns no single rate for a graduated card", () => {
+		expect(
+			resolveCreditCost({
+				ctx: makeContext({ graduated: true }) as never,
+				sourceFeatureId: sourceFeature.id,
+				balanceFeatureId: "credits",
+			}),
+		).toBeNull();
+	});
+});

--- a/server/tests/unit/billing/invoice-credit-line-items.test.ts
+++ b/server/tests/unit/billing/invoice-credit-line-items.test.ts
@@ -13,6 +13,7 @@ import { customerProducts } from "@tests/utils/fixtures/db/customerProducts.js";
 import { features } from "@tests/utils/fixtures/db/features.js";
 import { prices } from "@tests/utils/fixtures/db/prices.js";
 import { products } from "@tests/utils/fixtures/db/products.js";
+import { buildAutumnLineItems } from "@/internal/billing/v2/compute/computeAutumnUtils/buildAutumnLineItems.js";
 import { lineItemsToCreateInvoiceItemsParams } from "@/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams.js";
 import { billingPlanToNextCycleLineItems } from "@/internal/billing/v2/utils/billingPlan/toNextCyclePreview/billingPlanToNextCycleLineItems.js";
 import { customerProductToArrearLineItems } from "@/internal/billing/v2/utils/lineItems/customerProductToArrearLineItems.js";
@@ -316,6 +317,30 @@ describe("invoice credit line items", () => {
 		);
 	});
 
+	test("balances partially funded fractional credits in Stripe minor units", () => {
+		const fixture = makeFixture({
+			balance: -0.012,
+			usageAttribution: {
+				[SOURCE_A_INTERNAL_ID]: { units: 1, credits: 0.506 },
+				[SOURCE_B_INTERNAL_ID]: { units: 1, credits: 0.506 },
+			},
+		});
+
+		const result = customerProductToArrearLineItems({
+			...fixture,
+			options: { invoiceCredits: { idempotencyScope: "invoice_partial" } },
+		});
+		const stripeInvoiceItems = lineItemsToCreateInvoiceItemsParams({
+			stripeCustomerId: "stripe_customer",
+			stripeInvoiceId: "stripe_invoice",
+			lineItems: result.invoiceCreditLineItems,
+		});
+
+		expect(stripeInvoiceItems.map((invoiceItem) => invoiceItem.amount)).toEqual(
+			[51, 51, -101],
+		);
+	});
+
 	test("emits no lines for empty attribution but still prepares the reset", () => {
 		const fixture = makeFixture({ balance: 1_000 });
 
@@ -341,6 +366,35 @@ describe("invoice credit line items", () => {
 		expect(result.lineItems).toEqual([]);
 		expect(result.invoiceCreditLineItems).toEqual([]);
 		expect(result.updateCustomerEntitlements).toHaveLength(1);
+	});
+
+	test("includes invoice-credit usage when a plan is replaced immediately", () => {
+		const fixture = makeFixture({
+			balance: 960,
+			usageAttribution: {
+				[SOURCE_A_INTERNAL_ID]: { units: 200, credits: 40 },
+			},
+		});
+
+		const result = buildAutumnLineItems({
+			ctx: fixture.ctx,
+			newCustomerProducts: [],
+			deletedCustomerProducts: [fixture.customerProduct],
+			billingContext: fixture.billingContext,
+			includeArrearLineItems: true,
+		});
+
+		expect(
+			result.allLineItems
+				.filter((lineItem) => lineItem.context.billingTiming === "in_arrear")
+				.map((lineItem) => ({
+					amount: lineItem.amount,
+					description: lineItem.description,
+				})),
+		).toEqual([
+			{ amount: 40, description: "Feature A, 200 units" },
+			{ amount: -40, description: "Credits applied" },
+		]);
 	});
 
 	test("fully offsets overage when overage billing is disabled", () => {

--- a/server/tests/unit/features/get-credit-cost.test.ts
+++ b/server/tests/unit/features/get-credit-cost.test.ts
@@ -145,6 +145,66 @@ describe("getCreditRateCard — invoice attribution descriptors", () => {
 	);
 });
 
+describe("getCreditRateRequiredBalance — flat rate cards", () => {
+	test("keeps flat required credit totals exact above the available balance", () => {
+		const flatCreditFeature: Feature = {
+			...flatInvoiceCreditFeature,
+			config: {
+				usage_type: FeatureUsageType.Single,
+				schema: [
+					{
+						metered_feature_id: sourceFeature.id,
+						feature_amount: 1,
+						credit_amount: 0.6,
+					},
+				],
+			},
+		};
+		const fullSubject = {
+			subjectType: "customer",
+			entity: null,
+			customer_products: [
+				{
+					status: "active",
+					customer_entitlements: [
+						{
+							id: "flat_credits",
+							balance: 100,
+							additional_balance: 0,
+							rollovers: [],
+							usage_attribution: {},
+							entitlement: {
+								feature: flatCreditFeature,
+								allowance_type: AllowanceType.Fixed,
+								entity_feature_id: null,
+								interval: null,
+								interval_count: 1,
+							},
+						},
+					],
+				},
+			],
+			extra_customer_entitlements: [],
+			pooled_customer_entitlements: [],
+		} as unknown as FullSubject;
+
+		expect(
+			getCreditRateRequiredBalance({
+				fullSubject,
+				sourceFeature,
+				creditSystem: flatCreditFeature,
+				amount: 167.33,
+			}),
+		).toBe(
+			getCreditCost({
+				featureId: sourceFeature.id,
+				creditSystem: flatCreditFeature,
+				amount: 167.33,
+			}),
+		);
+	});
+});
+
 describe("getCreditCost — graduated rate cards", () => {
 	test("rates a check across each entitlement's independent tier position", () => {
 		const makeCustomerEntitlement = ({

--- a/server/tests/unit/features/get-credit-cost.test.ts
+++ b/server/tests/unit/features/get-credit-cost.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+	AllowanceType,
 	ErrCode,
 	type Feature,
 	FeatureType,
 	FeatureUsageType,
+	type FullSubject,
 } from "@autumn/shared";
 
 import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
@@ -18,9 +20,8 @@ await mockModuleWithRestore(
 const { getModelCreditCost, getModelCreditCostBreakdown } = await import(
 	"@/internal/features/aiCreditSystemUtils.js"
 );
-const { getCreditCost, getCreditRateCard } = await import(
-	"@/internal/features/creditSystemUtils.js"
-);
+const { getCreditCost, getCreditRateCard, getCreditRateRequiredBalance } =
+	await import("@/internal/features/creditSystemUtils.js");
 
 // custom/* models price from model_markups; pricing data is mocked empty.
 const CUSTOM_MODEL = "custom/foo";
@@ -145,6 +146,77 @@ describe("getCreditRateCard — invoice attribution descriptors", () => {
 });
 
 describe("getCreditCost — graduated rate cards", () => {
+	test("rates a check across each entitlement's independent tier position", () => {
+		const makeCustomerEntitlement = ({
+			id,
+			balance,
+			currentUsage,
+		}: {
+			id: string;
+			balance: number;
+			currentUsage: number;
+		}) => ({
+			id,
+			balance,
+			additional_balance: 0,
+			rollovers: [],
+			usage_attribution: {
+				[sourceFeature.internal_id]: {
+					units: currentUsage,
+					credits: getCreditCost({
+						featureId: sourceFeature.id,
+						creditSystem: graduatedCreditFeature,
+						amount: currentUsage,
+					}),
+				},
+			},
+			entitlement: {
+				feature: graduatedCreditFeature,
+				allowance_type: AllowanceType.Fixed,
+				entity_feature_id: null,
+				interval: null,
+				interval_count: 1,
+			},
+		});
+		const fullSubject = {
+			subjectType: "customer",
+			entity: null,
+			customer_products: [
+				{
+					status: "active",
+					customer_entitlements: [
+						makeCustomerEntitlement({
+							id: "base_credits",
+							balance: 0.5,
+							currentUsage: 9_950,
+						}),
+					],
+				},
+				{
+					status: "active",
+					customer_entitlements: [
+						makeCustomerEntitlement({
+							id: "addon_credits",
+							balance: 0.9,
+							currentUsage: 0,
+						}),
+					],
+				},
+			],
+			extra_customer_entitlements: [],
+			pooled_customer_entitlements: [],
+		} as unknown as FullSubject;
+
+		expect(
+			getCreditRateRequiredBalance({
+				fullSubject,
+				sourceFeature,
+				creditSystem: graduatedCreditFeature,
+				amount: 100,
+			}),
+		).toBeCloseTo(1, 10);
+	});
+
 	test("charges the marginal cost when usage crosses one tier", () => {
 		const cost = getCreditCost({
 			featureId: "messages",

--- a/server/tests/unit/features/invoice-credit-activation.test.ts
+++ b/server/tests/unit/features/invoice-credit-activation.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type Feature,
+	FeatureType,
+	type FeatureUpdateBlocker,
+} from "@autumn/shared";
+import { features } from "@tests/utils/fixtures/db/features.js";
+import { detectFeatureUpdateBlockers as detectCatalogV2FeatureUpdateBlockers } from "@/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/detectFeatureUpdateBlockers.js";
+import type { FeatureState } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/index.js";
+import type { UpdateFeaturePlan } from "@/internal/catalogV2/actions/updateCatalog/types/updateFeaturePlan.js";
+import {
+	detectFeatureUpdateBlockers,
+	isBlockableFeatureChange,
+} from "@/internal/features/utils/updateFeatureUtils/detectFeatureUpdateBlockers.js";
+import type { ObjectsUsingFeature } from "@/internal/features/utils/updateFeatureUtils/getObjectsUsingFeature.js";
+
+const current = features.create({
+	id: "enterprise_credits",
+	name: "Enterprise credits",
+	type: FeatureType.CreditSystem,
+	config: { invoice_credit: false, schema: [] },
+}) as Feature;
+const next = {
+	...current,
+	config: { ...current.config, invoice_credit: true },
+} as Feature;
+
+const objectsUsingFeature = ({
+	hasCustomers,
+}: {
+	hasCustomers: boolean;
+}): ObjectsUsingFeature => ({
+	entitlements: [],
+	prices: [],
+	creditSystems: [],
+	linkedEntitlements: [],
+	cusEnts: hasCustomers ? ([{ id: "customer_entitlement" }] as never[]) : [],
+});
+
+const featureState = ({
+	hasCustomers,
+}: {
+	hasCustomers: boolean;
+}): FeatureState => ({
+	has_customers: hasCustomers,
+	has_entitlements: true,
+	has_pooled_entitlements: false,
+	has_non_consumable_entitlements: false,
+	has_loose_entitlements: false,
+	has_entity_feature_entitlements: false,
+	has_loose_entity_feature_entitlements: false,
+	has_prices: true,
+	credit_system_feature_ids: [],
+	creditSystems: [],
+	entitlementsOverflow: false,
+	entityFeatureIdEntitlementsOverflow: false,
+	pricesOverflow: false,
+});
+
+const updateFeaturePlan = {
+	current,
+	next,
+	previousAttributes: { invoice_credit: false },
+	hasCustomerEntitlements: true,
+	regenerateDisplay: false,
+	clearCreditSystemCache: true,
+	rewrites: {
+		typeChange: null,
+		idChange: null,
+		usageTypeChange: null,
+		updateCreditSystemSchemas: [],
+	},
+} satisfies UpdateFeaturePlan;
+
+describe("invoice-credit activation", () => {
+	test("treats enabling invoice credits as a dependency-sensitive update", () => {
+		expect(isBlockableFeatureChange({ feature: current, updates: next })).toBe(
+			true,
+		);
+	});
+
+	test("allows activation before the first customer attachment", () => {
+		expect(
+			detectFeatureUpdateBlockers({
+				feature: current,
+				updates: next,
+				objectsUsingFeature: objectsUsingFeature({ hasCustomers: false }),
+				allFeatures: [current],
+			}),
+		).toEqual([]);
+	});
+
+	test("blocks activation after a customer has been attached in both update paths", () => {
+		const expectedBlocker = {
+			field: "invoice_credit",
+			code: "attached_to_customer",
+			message:
+				"Cannot enable invoice credits for feature enterprise_credits because it has been attached to a customer before",
+		} satisfies FeatureUpdateBlocker;
+
+		expect(
+			detectFeatureUpdateBlockers({
+				feature: current,
+				updates: next,
+				objectsUsingFeature: objectsUsingFeature({ hasCustomers: true }),
+				allFeatures: [current],
+			}),
+		).toContainEqual(expectedBlocker);
+		expect(
+			detectCatalogV2FeatureUpdateBlockers({
+				updateFeaturePlan,
+				takenFeatureIds: new Set(),
+				featureState: featureState({ hasCustomers: true }),
+				projectedCreditSystemFeatureIds: [],
+			}),
+		).toContainEqual(expectedBlocker);
+	});
+
+	test("allows invoice credits to be disabled after customer attachment", () => {
+		expect(
+			detectFeatureUpdateBlockers({
+				feature: next,
+				updates: current,
+				objectsUsingFeature: objectsUsingFeature({ hasCustomers: true }),
+				allFeatures: [next],
+			}),
+		).toEqual([]);
+		expect(
+			detectCatalogV2FeatureUpdateBlockers({
+				updateFeaturePlan: {
+					...updateFeaturePlan,
+					current: next,
+					next: current,
+					previousAttributes: { invoice_credit: true },
+				},
+				takenFeatureIds: new Set(),
+				featureState: featureState({ hasCustomers: true }),
+				projectedCreditSystemFeatureIds: [],
+			}),
+		).toEqual([]);
+	});
+});

--- a/server/tests/unit/pricingAgent/credit-rate-card-schema.test.ts
+++ b/server/tests/unit/pricingAgent/credit-rate-card-schema.test.ts
@@ -53,4 +53,22 @@ describe("pricing-agent credit rate-card schema", () => {
 			creditFeature,
 		);
 	});
+
+	test("preserves AI credit-system markup fields", () => {
+		const aiCreditFeature = {
+			id: "ai_credits",
+			name: "AI credits",
+			type: "ai_credit_system" as const,
+			display: { singular: "credit", plural: "credits" },
+			model_markups: {
+				"anthropic/claude-sonnet-4": { markup: 25 },
+			},
+			default_markup: 10,
+			provider_markups: { anthropic: { markup: 15 } },
+		};
+
+		expect(PricingAgentFeatureInputSchema.parse(aiCreditFeature)).toMatchObject(
+			aiCreditFeature,
+		);
+	});
 });

--- a/server/tests/unit/products/invoice-credit-product-item-validation.test.ts
+++ b/server/tests/unit/products/invoice-credit-product-item-validation.test.ts
@@ -74,4 +74,28 @@ describe("invoice-credit product item validation", () => {
 			"Invoice-credit features require a price of one currency unit per credit",
 		);
 	});
+
+	test("rejects flat fees in an additional currency tier", () => {
+		const item: ProductItem = {
+			feature_id: invoiceCreditFeature.id,
+			included_usage: 100,
+			interval: ProductItemInterval.Month,
+			usage_model: UsageModel.PayPerUse,
+			billing_units: 1,
+			base_currency: "usd",
+			tiers: [
+				{
+					to: "inf",
+					amount: 1,
+					additional_currencies: [
+						{ currency: "eur", amount: 1, flat_amount: 2 },
+					],
+				},
+			],
+		};
+
+		expect(() => validate(item)).toThrow(
+			"Invoice-credit features require a price of one currency unit per credit",
+		);
+	});
 });

--- a/server/tests/unit/webhooks/invoice-created-consumable-idempotency.test.ts
+++ b/server/tests/unit/webhooks/invoice-created-consumable-idempotency.test.ts
@@ -26,13 +26,27 @@ const regularLineItems = [
 	},
 ];
 
+let consumableLineItems = regularLineItems;
+let invoiceCreditLineItems: typeof regularLineItems = [];
+let liveStripeLineItemIds: string[] = [];
+
 await mockModuleWithRestore("@/external/stripe/webhookHandlers/common", () => ({
 	eventContextToArrearLineItems: async () => ({
-		lineItems: regularLineItems,
-		invoiceCreditLineItems: [],
+		lineItems: consumableLineItems,
+		invoiceCreditLineItems,
 		updateCustomerEntitlements: [],
 	}),
 }));
+
+await mockModuleWithRestore(
+	"@/external/stripe/invoices/lineItems/operations/getStripeInvoiceLineItems.js",
+	() => ({
+		getStripeInvoiceLineItems: async () =>
+			liveStripeLineItemIds.map((lineItemId) => ({
+				metadata: { autumn_line_item_id: lineItemId },
+			})),
+	}),
+);
 
 await mockModuleWithRestore(
 	"@/internal/billing/v2/providers/stripe/utils/invoiceLines/lineItemsToCreateInvoiceItemsParams",
@@ -112,57 +126,61 @@ const ctx = {
 describe("invoice.created consumable idempotency", () => {
 	beforeEach(() => {
 		createInvoiceItemCalls.length = 0;
+		consumableLineItems = regularLineItems;
+		invoiceCreditLineItems = [];
+		liveStripeLineItemIds = [];
 	});
 
-	test("uses stable unique keys for ordinary usage items across webhook retries", async () => {
+	test("keeps ordinary usage items on the existing creation path", async () => {
 		await processConsumablePricesForInvoiceCreated({
 			ctx,
 			eventContext: makeEventContext(),
 		});
-		const firstKeys = createInvoiceItemCalls[0]?.idempotencyKeys;
 
-		createInvoiceItemCalls.length = 0;
-		await processConsumablePricesForInvoiceCreated({
-			ctx,
-			eventContext: makeEventContext(),
-		});
-		const retryKeys = createInvoiceItemCalls[0]?.idempotencyKeys;
-
-		expect(firstKeys).toHaveLength(2);
-		expect(new Set(firstKeys).size).toBe(2);
-		expect(firstKeys?.every((key) => key.startsWith("autumn:usage:"))).toBe(
-			true,
-		);
-		expect(retryKeys).toEqual(firstKeys);
-	});
-
-	test("does not recreate an invoice item already added by a partial delivery", async () => {
-		await processConsumablePricesForInvoiceCreated({
-			ctx,
-			eventContext: makeEventContext(),
-		});
-		const firstCall = createInvoiceItemCalls[0];
-		const firstLineItemIds = firstCall?.invoiceItems?.map(
-			(invoiceItem) => invoiceItem.metadata?.autumn_line_item_id,
-		);
-
-		createInvoiceItemCalls.length = 0;
-		await processConsumablePricesForInvoiceCreated({
-			ctx,
-			eventContext: makeEventContext({
-				existingLineItemIds: [firstLineItemIds?.[0] ?? ""],
-			}),
-		});
-
-		expect(createInvoiceItemCalls).toHaveLength(1);
-		expect(createInvoiceItemCalls[0]?.invoiceItems).toHaveLength(1);
+		expect(createInvoiceItemCalls[0]?.idempotencyKeys).toBeUndefined();
 		expect(
-			createInvoiceItemCalls[0]?.invoiceItems?.[0]?.metadata
-				?.autumn_line_item_id,
-		).toBe(firstLineItemIds?.[1]);
-		expect(createInvoiceItemCalls[0]?.idempotencyKeys).toEqual(
-			firstCall?.idempotencyKeys?.slice(1),
-		);
+			createInvoiceItemCalls[0]?.invoiceItems?.map(
+				(invoiceItem) => invoiceItem.metadata?.autumn_line_item_id,
+			),
+		).toEqual(regularLineItems.map((lineItem) => lineItem.id));
+	});
+
+	test("reads current Stripe lines before retrying an invoice-credit item", async () => {
+		const existingLineItem = {
+			...regularLineItems[0],
+			id: "invoice_li_credit_invoice_retry_entitlement_source",
+		};
+		consumableLineItems = [];
+		invoiceCreditLineItems = [existingLineItem];
+		liveStripeLineItemIds = [existingLineItem.id];
+
+		await processConsumablePricesForInvoiceCreated({
+			ctx,
+			eventContext: makeEventContext(),
+		});
+
+		expect(createInvoiceItemCalls).toEqual([]);
+	});
+
+	test("uses stable keys for new invoice-credit items", async () => {
+		const invoiceCreditLineItem = {
+			...regularLineItems[0],
+			id: "invoice_li_credit_invoice_retry_entitlement_source",
+		};
+		consumableLineItems = [];
+		invoiceCreditLineItems = [invoiceCreditLineItem];
+
+		await processConsumablePricesForInvoiceCreated({
+			ctx,
+			eventContext: makeEventContext(),
+		});
+
+		expect(createInvoiceItemCalls[0]?.idempotencyKeys).toHaveLength(1);
+		expect(
+			createInvoiceItemCalls[0]?.idempotencyKeys?.[0]?.startsWith(
+				"autumn:invoice-credit:",
+			),
+		).toBe(true);
 	});
 });
 

--- a/server/tests/utils/fixtures/items.ts
+++ b/server/tests/utils/fixtures/items.ts
@@ -613,6 +613,7 @@ const tieredOneOffMessages = ({
  * @param entityFeatureId - Entity feature ID for per-entity balances
  * @param interval - Billing interval (default: month)
  * @param maxPurchase - Maximum overage allowed (usage_limit = maxPurchase + includedUsage)
+ * @param rolloverConfig - Optional balance rollover configuration
  */
 const consumable = ({
 	featureId,
@@ -622,6 +623,7 @@ const consumable = ({
 	entityFeatureId,
 	interval = ProductItemInterval.Month,
 	maxPurchase,
+	rolloverConfig,
 }: {
 	featureId: string;
 	includedUsage?: number;
@@ -630,6 +632,7 @@ const consumable = ({
 	entityFeatureId?: string;
 	interval?: ProductItemInterval;
 	maxPurchase?: number;
+	rolloverConfig?: RolloverConfig;
 }): LimitedItem =>
 	constructArrearItem({
 		featureId,
@@ -638,6 +641,7 @@ const consumable = ({
 		billingUnits,
 		entityFeatureId,
 		interval,
+		rolloverConfig,
 		usageLimit:
 			maxPurchase !== undefined ? maxPurchase + includedUsage : undefined,
 	}) as LimitedItem;

--- a/shared/api/catalog/previewUpdateCatalogResponse.ts
+++ b/shared/api/catalog/previewUpdateCatalogResponse.ts
@@ -48,7 +48,7 @@ export type CatalogPlanPreview = z.infer<typeof CatalogPlanPreviewSchema>;
 
 /** Reason a feature update would be rejected, surfaced before the write is attempted. */
 export const FeatureUpdateBlockerSchema = z.object({
-	field: z.enum(["type", "id", "usage_type"]),
+	field: z.enum(["type", "id", "usage_type", "invoice_credit"]),
 	code: z.enum([
 		"type_switch_credit_system",
 		"attached_to_customer",

--- a/shared/utils/billingUtils/invoicingUtils/lineItemBuilders/invoiceCreditCustomerEntitlementToLineItems.ts
+++ b/shared/utils/billingUtils/invoicingUtils/lineItemBuilders/invoiceCreditCustomerEntitlementToLineItems.ts
@@ -102,16 +102,17 @@ export const invoiceCreditCustomerEntitlementToLineItems = ({
 	}
 
 	const overage = cusEntToInvoiceOverage({ cusEnt: customerEntitlement });
+	const roundedOverage = roundToCurrency({
+		amount: overage,
+		currency: context.currency,
+	});
 	const creditsApplied = fullyOffsetOverage
 		? totalCredits
 		: Decimal.max(totalCredits.sub(overage), 0);
 	if (creditsApplied.isZero()) return lineItems;
-	const roundedCreditsApplied = creditsApplied.eq(totalCredits)
+	const roundedCreditsApplied = fullyOffsetOverage
 		? totalRoundedCredits.toNumber()
-		: roundToCurrency({
-				amount: creditsApplied.toNumber(),
-				currency: context.currency,
-			});
+		: Decimal.max(totalRoundedCredits.sub(roundedOverage), 0).toNumber();
 
 	const offsetLineItem = buildLineItem({
 		context: {


### PR DESCRIPTION
## Cubic summary

Prevents invoice credits from being enabled after a feature has already been attached to a customer, because earlier usage has no invoice-ready attribution. Activation remains allowed before the first attachment, and disabling remains allowed.

Stack: #2867 -> #2897 -> #2938 -> #3024 -> #3037 -> #3058 -> this PR.

## What changed

- Treats enabling `invoice_credit` as a dependency-sensitive feature update.
- Rejects activation when customer-entitlement history already exists for the feature.
- Applies the same rule to direct feature updates and Catalog V2 preview/apply flows.
- Adds `invoice_credit` as a typed feature-update blocker field so previews can explain the rejection.
- Keeps activation opt-in: new or unattached features may enable it, and enabled features may disable it later.

## Why

Attribution is collected only while invoice-credit behavior is active. Enabling it after customers have already used or held the feature could produce an incomplete first invoice breakdown. Blocking that transition gives v1 a clear cycle boundary without adding historical reconstruction, snapshots, or versioning.

## Scope

This is the rollout and compatibility guard for enterprise credit rate cards. It does not add schema, rating, deduction, attribution, balance-mutation, invoice-rendering, or UI behavior.

## Testing

- 4 focused unit tests covering dependency detection, clean activation, post-attachment rejection in both update paths, and later disabling.
- `cd server && bun ts`
- Scoped Biome on all changed files.
- Commit hooks: repo-wide Knip and server typecheck.
- `git diff --check`













<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds guards intended to prevent invoice-credit activation after a feature has been attached, while retaining support for clean activation and later disabling.
- **[Bug fixes]** Adds invoice-credit activation blockers to direct feature updates and Catalog V2 preview/apply flows.
- **[API changes]** Adds `invoice_credit` as a typed feature-update blocker field.
- **[Improvements]** Extends invoice-credit attribution, graduated rate-card handling, validation, and focused test coverage across billing and balance flows.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because deleting the final entitlement still allows invoice credits to be enabled for a feature with prior customer usage.

The new guard checks only current customer-entitlement rows in both update paths; a supported balance-deletion flow hard-deletes those rows, leaving the previously reported activation bypass reachable.

**Files Needing Attention:** server/src/internal/features/utils/updateFeatureUtils/detectFeatureUpdateBlockers.ts, server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/detectFeatureUpdateBlockers.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/features/utils/updateFeatureUtils/detectFeatureUpdateBlockers.ts | Adds the direct-update activation guard, but it still relies on currently retained entitlement rows and therefore does not fully enforce historical attachment. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateFeatureErrors/detectFeatureUpdateBlockers.ts | Adds the Catalog V2 equivalent guard with the same deleted-history gap through `has_customers`. |
| server/tests/unit/features/invoice-credit-activation.test.ts | Covers attached and unattached states but does not cover a previously attached feature after its final entitlement row is deleted. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Enable invoice credits] --> B{Current entitlement row exists?}
  B -->|Yes| C[Reject activation]
  B -->|No| D[Allow activation]
  E[Previously attached customer] --> F[Delete final entitlement row]
  F --> B
  D --> G[Earlier usage lacks invoice attribution]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix invoice credit integration fixtures"](https://github.com/useautumn/autumn/commit/17b15688086646dc2b13cffa324965eea7a1a8a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56724252)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)

<!-- /greptile_comment -->