### PR TITLE
feat: point balance cache at TRANSIENT lake_cache_v2

### DIFF
--- a/packages/ducklake/src/headlineTotals.ts
+++ b/packages/ducklake/src/headlineTotals.ts
@@ -3,6 +3,8 @@
  * its inputs (fx_rates + the just-swapped mirrors) only exist in MotherDuck —
  * unlike the scan SQL, which runs on the local embedded engine. `sourceName`
  * maps mirror names through the shadow suffix; fx_rates is always real. */
+import { MD_DATABASE } from "./motherduckIngest.js";
+
 export const headlineTotalsSql = ({
 	targetTable,
 	sourceName,
@@ -10,13 +12,13 @@ export const headlineTotalsSql = ({
 	targetTable: string;
 	sourceName: (table: string) => string;
 }): string => `
-	CREATE OR REPLACE TABLE lake_cache.main."${targetTable}" AS
+	CREATE OR REPLACE TABLE ${MD_DATABASE}.main."${targetTable}" AS
 	WITH base AS (
 		SELECT i.total / coalesce(fx.per_usd, 1) AS usd, i.created_at
-		FROM lake_cache.main."${sourceName("invoices")}" i
-		JOIN lake_cache.main."${sourceName("customers")}" c ON c.internal_id = i.internal_customer_id
-		JOIN lake_cache.main."${sourceName("organizations")}" o ON o.id = c.org_id
-		LEFT JOIN lake_cache.main.fx_rates fx ON fx.currency = lower(i.currency)
+		FROM ${MD_DATABASE}.main."${sourceName("invoices")}" i
+		JOIN ${MD_DATABASE}.main."${sourceName("customers")}" c ON c.internal_id = i.internal_customer_id
+		JOIN ${MD_DATABASE}.main."${sourceName("organizations")}" o ON o.id = c.org_id
+		LEFT JOIN ${MD_DATABASE}.main.fx_rates fx ON fx.currency = lower(i.currency)
 		WHERE c.env = 'live' AND i.status = 'paid'
 			AND i.hosted_invoice_url LIKE '%live%'
 			AND o.slug NOT IN ('welcome-back-1747670264')

--- a/packages/ducklake/src/motherduckIngest.ts
+++ b/packages/ducklake/src/motherduckIngest.ts
@@ -1,7 +1,8 @@
 import { DuckDBInstance } from "@duckdb/node-api";
 import type { DucklakeLogger } from "./index.js";
 
-const MD_DATABASE = "lake_cache";
+/** TRANSIENT database — see initMotherDuck.ts in the server for why. */
+export const MD_DATABASE = "lake_cache_v2";
 
 type MdConnection = Awaited<
 	ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>["connect"]>

--- a/server/experiments/refreshV2CacheOnce.ts
+++ b/server/experiments/refreshV2CacheOnce.ts
@@ -19,6 +19,10 @@ const consoleLogger = {
 
 console.log("Refreshing lake_cache_v2 balance tables...");
 const startedAt = performance.now();
-await refreshCeBalancesCache({ logger: consoleLogger });
+const { ok } = await refreshCeBalancesCache({ logger: consoleLogger });
+if (!ok) {
+	console.error("Refresh FAILED — v2 is not seeded; do not merge/deploy.");
+	process.exit(1);
+}
 console.log(`Done in ${((performance.now() - startedAt) / 1000).toFixed(1)}s`);
 process.exit(0);

--- a/server/experiments/refreshV2CacheOnce.ts
+++ b/server/experiments/refreshV2CacheOnce.ts
@@ -1,0 +1,24 @@
+// One-off manual refresh of the TRANSIENT lake_cache_v2 balance tables.
+// Must run from the branch/commit where DEFAULT_DATABASE = "lake_cache_v2"
+// (feat/lake-cache-v2-transient or later) — the deployed cron keeps writing
+// v1 until that code ships, so this seeds v2 ahead of the reader flip.
+// Requires MOTHERDUCK_RW_TOKEN and AWS creds with glue:GetTable.
+//   infisical run --env=prod --recursive -- bun run server/experiments/refreshV2CacheOnce.ts
+import type { Logger } from "../src/external/logtail/logtailUtils";
+import { refreshCeBalancesCache } from "../src/external/motherduck/refreshCeBalancesCache";
+
+// Console-backed logger: the pino/logtail logger buffers asynchronously and
+// process.exit() drops its output, which made failures here silent.
+const consoleLogger = {
+	info: (...args: unknown[]) => console.log("[info]", ...args),
+	warn: (...args: unknown[]) => console.warn("[warn]", ...args),
+	error: (...args: unknown[]) => console.error("[error]", ...args),
+	debug: (...args: unknown[]) => console.log("[debug]", ...args),
+	trace: (...args: unknown[]) => console.log("[trace]", ...args),
+} as unknown as Logger;
+
+console.log("Refreshing lake_cache_v2 balance tables...");
+const startedAt = performance.now();
+await refreshCeBalancesCache({ logger: consoleLogger });
+console.log(`Done in ${((performance.now() - startedAt) / 1000).toFixed(1)}s`);
+process.exit(0);

--- a/server/src/external/motherduck/initMotherDuck.ts
+++ b/server/src/external/motherduck/initMotherDuck.ts
@@ -14,7 +14,11 @@ const mdSchema = { ceBalancesCache };
 export type MotherDuckDb = DuckDBDatabase<typeof mdSchema>;
 
 const DEFAULT_POOL_SIZE = 4;
-const DEFAULT_DATABASE = "lake_cache";
+// v2 is a TRANSIENT database (no historical snapshots, 1-day failsafe):
+// CREATE OR REPLACE churn on the old lake_cache parked every prior version in
+// a 7-day failsafe window and billed it. This is a cache rebuilt from Iceberg;
+// nothing in it ever needs recovery.
+const DEFAULT_DATABASE = "lake_cache_v2";
 /** Shed to the caller's unavailable-path instead of queueing behind a
  * saturated pool — a lesson from the PgBouncer era. */
 const ACQUIRE_TIMEOUT_MS = 2_000;

--- a/server/src/external/motherduck/refreshCeBalancesCache.ts
+++ b/server/src/external/motherduck/refreshCeBalancesCache.ts
@@ -148,7 +148,7 @@ export const refreshCeBalancesCache = async ({
 				metadataLocation: ceMetadataLocation,
 				durationMs: Math.round(performance.now() - startedAt),
 			},
-			"[refreshCeBalancesCache] rebuilt lake_cache.main.ce_balances",
+			"[refreshCeBalancesCache] rebuilt balance cache tables",
 		);
 	})();
 

--- a/server/src/external/motherduck/refreshCeBalancesCache.ts
+++ b/server/src/external/motherduck/refreshCeBalancesCache.ts
@@ -40,16 +40,18 @@ export const getCurrentLakeMetadataLocation = async ({
 
 let inFlight: Promise<void> | null = null;
 
+/** Never throws (a failed tick must not crash the cron); returns whether the
+ * refresh actually completed so one-shot callers can fail loudly. */
 export const refreshCeBalancesCache = async ({
 	logger,
 }: {
 	logger: Logger;
-}): Promise<void> => {
+}): Promise<{ ok: boolean }> => {
 	if (inFlight) {
 		logger.info(
 			"[refreshCeBalancesCache] previous refresh still running — skipping tick",
 		);
-		return;
+		return { ok: true };
 	}
 
 	inFlight = (async () => {
@@ -154,11 +156,13 @@ export const refreshCeBalancesCache = async ({
 
 	try {
 		await inFlight;
+		return { ok: true };
 	} catch (error) {
 		logger.error(
 			{ type: "md_cache_refresh_failed", error: String(error) },
 			"[refreshCeBalancesCache] refresh failed",
 		);
+		return { ok: false };
 	} finally {
 		inFlight = null;
 	}


### PR DESCRIPTION
Moves the MotherDuck cache database from `lake_cache` to `lake_cache_v2`, created `TRANSIENT` (no historical snapshots, 1-day failsafe). The old database's CREATE-OR-REPLACE churn parked every prior table version in a fixed 7-day failsafe window and billed it (~7× daily rewrite volume, indefinitely); transient is the correct mode for a cache rebuilt from Iceberg — recommended by MotherDuck support.

Code-only flip (no env var): server resolver reads + cron refresh writes move together on deploy. ducklake's constants updated to match (`MD_DATABASE` now exported and shared with the headline rollup SQL). Adds `server/experiments/refreshV2CacheOnce.ts` to seed v2 ahead of the deploy.

Cutover choreography (dual-DB, v1 untouched until an explicit later drop): v2 already created + fx_rates copied → seed script run → flights repointed to v2 (API) → share of v2 created and both dives repointed (API) → this PR deploys and the server jumps to v2 → soak → DROP lake_cache.



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves MotherDuck cache reads and writes together from `lake_cache` to the transient `lake_cache_v2` database and adds a one-shot seeding workflow with reliable failure signaling.

- **Improvements, API changes:** Centralizes the Ducklake database name for ingestion and headline-rollup SQL, targeting `lake_cache_v2`.
- **Improvements, API changes:** Repoints server-side balance-cache reads and refresh writes to `lake_cache_v2`.
- **Bug fixes:** Returns explicit refresh success status so the v2 seed script exits unsuccessfully when metadata lookup or cache rebuilding fails.
- **Improvements:** Adds a manual script for seeding the new cache before the production reader cutover.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ducklake/src/headlineTotals.ts | Replaces hard-coded v1 database references with the shared Ducklake v2 database constant. |
| packages/ducklake/src/motherduckIngest.ts | Exports the Ducklake database constant and changes ingestion to target `lake_cache_v2`. |
| server/experiments/refreshV2CacheOnce.ts | Adds the one-shot v2 seed command and now exits with a failure status when refreshing fails. |
| server/src/external/motherduck/initMotherDuck.ts | Repoints server MotherDuck connections to the transient v2 cache database. |
| server/src/external/motherduck/refreshCeBalancesCache.ts | Adds an explicit success result while retaining non-throwing behavior for scheduled refreshes. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Iceberg[(Iceberg source)] --> Seed[One-off v2 seed]
  Seed --> V2[(lake_cache_v2 transient cache)]
  Cron[Scheduled refresh] --> V2
  V2 --> Resolver[Balance resolvers]
  Resolver --> Requests[Balance requests]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 seed script exits nonzero when t..."](https://github.com/useautumn/autumn/commit/ab05238433f1c165ec3ff45a3a189edf0c74a510) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56731355)</sub>

<!-- /greptile_comment -->