### PR TITLE
fix: generated billing edits keep item settings and never duplicate

### DIFF
--- a/packages/render/src/billing/itemMatchesFilter.ts
+++ b/packages/render/src/billing/itemMatchesFilter.ts
@@ -1,29 +1,9 @@
-import { asRecord } from "../records.js";
+import { loosePlanItemMatchesFilter } from "@autumn/shared";
 
-/** Whether a plan item satisfies a `remove_items` filter. Every field the
- * filter names must match; fields it omits are wildcards. */
 export const itemMatchesFilter = ({
 	filter,
 	item,
 }: {
 	filter: unknown;
 	item: unknown;
-}): boolean => {
-	const itemRecord = asRecord(item);
-	const filterRecord = asRecord(filter);
-	if (!(itemRecord && filterRecord)) return false;
-	const price = asRecord(itemRecord.price);
-	const reset = asRecord(itemRecord.reset);
-	return [
-		[filterRecord.feature_id, itemRecord.feature_id],
-		[filterRecord.billing_method, price?.billing_method],
-		[filterRecord.interval, price?.interval ?? reset?.interval],
-		[
-			filterRecord.interval_count,
-			// An item that omits interval_count means 1, so a filter saying 1 matches.
-			price?.interval_count ?? reset?.interval_count ?? 1,
-		],
-	].every(
-		([expected, actual]) => expected === undefined || expected === actual,
-	);
-};
+}): boolean => loosePlanItemMatchesFilter({ item, filter });

--- a/server/src/internal/billing/v2/actions/generateRequest/compute/buildGenerationPrompts.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/buildGenerationPrompts.ts
@@ -26,8 +26,13 @@ export const buildSystemPrompt = (tool: GenerateBillingTool) => {
 		"- The operation always targets the customer in the context. Ignore any other customer mentioned in the request.",
 		"- Compute timestamps yourself from `now` in the context (epoch milliseconds).",
 		"- Your output schema is a subset of the full billing params: invoice mode, redirect/checkout params, and the approval flow are handled by the system. Omit anything the schema does not define.",
+		"- customize.add_items strictly appends and never replaces — re-adding a feature the plan already has duplicates it. To CHANGE an existing item, emit BOTH: a remove_items filter matching exactly that one item, AND an add_items entry copying that item's ENTIRE definition from the context (rollover, pooled, reset, price with all its tiers, billing_units — every field) with only the requested change applied. A field you drop is a setting you delete.",
+		"- When a feature has several items (e.g. an included allowance plus a usage price), the remove_items filter must single one out: add billing_method, or included set to the item's current included amount from the context.",
+		"- Context plans carry `price` (the base price) and `items` in EXACTLY the shape customize.add_items and customize.items accept — copy item fields verbatim, no renaming or restructuring.",
+		"- Prepaid tier boundaries (price.tiers[].to) span included plus paid usage. When changing `included` on a tiered item, shift every numeric `to` by the same delta so each paid tier keeps its size (e.g. raising included 1000 -> 2000 turns to 3000/6000 into 4000/7000). Never drop or reprice tiers you were not asked to change.",
 		"- Free trials must set both duration_length and duration_type explicitly (e.g. a 14 day trial is duration_length 14, duration_type 'day').",
 		"- Set only the fields the request asks for; unset fields may be omitted or set to JSON null.",
+		"- Never emit keys your output schema does not define — in particular never copy customer_id or customer_product_id from the current request; the system injects identifiers.",
 	];
 
 	return rules.join("\n");

--- a/server/src/internal/billing/v2/actions/generateRequest/compute/composeMultiAttachRequest.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/composeMultiAttachRequest.ts
@@ -2,6 +2,7 @@ import type { CreateSchedulePlanV0 } from "@autumn/shared";
 import { freeTrialParamsV1ToV0 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { resolveCustomizedPlan } from "@/internal/billing/v2/actions/resolveBillingRequest";
+import type { AttachGenerationParams } from "../generationSchemas";
 
 const SINGLE_ATTACH_ONLY_FIELDS = [
 	"billing_cycle_anchor",
@@ -13,7 +14,7 @@ const SINGLE_ATTACH_ONLY_FIELDS = [
 	"no_billing_changes",
 	"plan_schedule",
 	"remove_plan_ids",
-] as const;
+] as const satisfies readonly (keyof AttachGenerationParams)[];
 
 /** Maps a generated attach with `additional_plans` into the resolved
  * multi-attach dialect: `plans[]` with customize resolved to concrete items,
@@ -24,21 +25,18 @@ export const composeMultiAttachRequest = async ({
 	customerId,
 }: {
 	ctx: AutumnContext;
-	generated: Record<string, unknown>;
+	generated: AttachGenerationParams;
 	customerId: string;
 }): Promise<{
 	request: Record<string, unknown>;
 	unrepresentable: string[];
 }> => {
-	const additionalPlans = generated.additional_plans as CreateSchedulePlanV0[];
-	const primaryCustomize = generated.customize as
-		| Record<string, unknown>
-		| undefined;
+	const additionalPlans = generated.additional_plans ?? [];
 	const {
 		free_trial: primaryFreeTrial,
 		upsert_licenses: primaryLicenses,
 		...planCustomize
-	} = primaryCustomize ?? {};
+	} = generated.customize ?? {};
 
 	const primaryPlan = {
 		plan_id: generated.plan_id,
@@ -61,7 +59,7 @@ export const composeMultiAttachRequest = async ({
 	);
 
 	const freeTrial = freeTrialParamsV1ToV0({
-		freeTrialParamsV1: primaryFreeTrial as never,
+		freeTrialParamsV1: primaryFreeTrial,
 	});
 
 	const unrepresentable = SINGLE_ATTACH_ONLY_FIELDS.filter(

--- a/server/src/internal/billing/v2/actions/generateRequest/compute/computeGeneratedParams.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/computeGeneratedParams.ts
@@ -4,6 +4,7 @@ import { generateObject } from "ai";
 import { generationErrorMessage } from "../errors/handleGenerationErrors";
 import {
 	type GenerateBillingTool,
+	type GeneratedBillingParams,
 	generationRegistry,
 } from "../generationSchemas";
 import type { GenerationContext } from "../setup/setupGenerationContext";
@@ -25,13 +26,15 @@ export const computeGeneratedParams = async ({
 	prompt,
 	context,
 	currentRequest,
+	validate,
 }: {
 	tool: GenerateBillingTool;
 	prompt: string;
 	context: GenerationContext;
 	currentRequest?: Record<string, unknown>;
+	validate?: (params: GeneratedBillingParams) => Promise<void> | void;
 }): Promise<{
-	params: Record<string, unknown>;
+	params: GeneratedBillingParams;
 	repaired: boolean;
 	repairReason?: string;
 	salvaged: boolean;
@@ -76,7 +79,9 @@ export const computeGeneratedParams = async ({
 			inputTokens: result.usage.inputTokens ?? 0,
 			outputTokens: result.usage.outputTokens ?? 0,
 		};
-		return result.object as Record<string, unknown>;
+		const params = result.object as GeneratedBillingParams;
+		await validate?.(params);
+		return params;
 	};
 
 	let lastUsage: GenerationUsage | undefined;

--- a/server/src/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems.ts
@@ -1,0 +1,79 @@
+import type {
+	GenerateBillingTool,
+	GeneratedBillingParams,
+} from "../generationSchemas";
+import type { GenerationContext } from "../setup/setupGenerationContext";
+
+type GenerationPlanItem = GenerationContext["plans"][number]["items"][number];
+
+const targetPlanId = ({
+	context,
+	customerProductId,
+	planId,
+	tool,
+}: {
+	context: GenerationContext;
+	customerProductId?: string;
+	planId?: string;
+	tool: GenerateBillingTool;
+}): string | undefined => {
+	if (planId !== undefined) return planId;
+	if (tool === "attach") return undefined;
+	const currentPlans = context.customer.current_plans;
+	const anchored = currentPlans.find(
+		(plan) =>
+			customerProductId !== undefined &&
+			plan.customer_product_id === customerProductId,
+	);
+	if (anchored) return anchored.plan_id;
+	return currentPlans.length === 1 ? currentPlans[0]?.plan_id : undefined;
+};
+
+const itemIsPriced = (item: GenerationPlanItem): boolean =>
+	"price" in item && item.price != null;
+
+export const assertNoDuplicateAddItems = ({
+	context,
+	customerProductId,
+	generated,
+	tool,
+}: {
+	context: GenerationContext;
+	customerProductId?: string;
+	generated: GeneratedBillingParams;
+	tool: GenerateBillingTool;
+}): void => {
+	if (!("customize" in generated) || !generated.customize) return;
+	const { add_items: addItems, remove_items: removeFilters } =
+		generated.customize;
+	if (!addItems?.length) return;
+
+	const planId = targetPlanId({
+		context,
+		customerProductId,
+		planId: generated.plan_id,
+		tool,
+	});
+	const baseItems = context.plans.find((plan) => plan.id === planId)?.items;
+	if (!baseItems) return;
+
+	const removedFeatureIds = new Set(
+		(removeFilters ?? [])
+			.map((filter) => filter.feature_id)
+			.filter((id): id is string => id !== undefined),
+	);
+	for (const addItem of addItems) {
+		if (removedFeatureIds.has(addItem.feature_id)) continue;
+		const addIsPriced = addItem.price != null;
+		const duplicates = baseItems.some(
+			(item) =>
+				item.feature_id === addItem.feature_id &&
+				itemIsPriced(item) === addIsPriced,
+		);
+		if (duplicates) {
+			throw new Error(
+				`add_items entry for '${addItem.feature_id}' duplicates an item the plan already has — add_items only appends. To change the existing item, pair a remove_items filter matching it with an add_items entry copying its full definition (rollover, pooled, reset, price) with only the requested change.`,
+			);
+		}
+	}
+};

--- a/server/src/internal/billing/v2/actions/generateRequest/generateRequest.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/generateRequest.ts
@@ -7,6 +7,7 @@ import {
 } from "@/internal/billing/v2/actions/resolveBillingRequest";
 import { composeMultiAttachRequest } from "./compute/composeMultiAttachRequest";
 import { computeGeneratedParams } from "./compute/computeGeneratedParams";
+import { assertNoDuplicateAddItems } from "./compute/validateGeneratedAddItems";
 import type { GenerateBillingRequestParams } from "./generationSchemas";
 import { setupGenerationContext } from "./setup/setupGenerationContext";
 
@@ -35,6 +36,13 @@ export const generateRequest = async ({
 		currentRequest: params.current_request,
 		prompt: params.prompt,
 		tool: params.tool,
+		validate: (candidate) =>
+			assertNoDuplicateAddItems({
+				context,
+				customerProductId: params.customer_product_id,
+				generated: candidate,
+				tool: params.tool,
+			}),
 	});
 	if (repaired) {
 		ctx.logger.warn(
@@ -50,8 +58,8 @@ export const generateRequest = async ({
 	}
 
 	if (
-		params.tool === "attach" &&
-		Array.isArray(generated.additional_plans) &&
+		"additional_plans" in generated &&
+		generated.additional_plans !== undefined &&
 		generated.additional_plans.length > 0
 	) {
 		return composeMultiAttachRequest({
@@ -61,8 +69,9 @@ export const generateRequest = async ({
 		});
 	}
 
-	const explicitEntityScope = generated.entity_id;
-	if (generated.entity_id === null) {
+	const explicitEntityScope =
+		"entity_id" in generated ? generated.entity_id : undefined;
+	if ("entity_id" in generated && generated.entity_id === null) {
 		delete generated.entity_id;
 	}
 

--- a/server/src/internal/billing/v2/actions/generateRequest/generationSchemas.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/generationSchemas.ts
@@ -103,6 +103,18 @@ export const createScheduleGenerationSchema = z
 		}
 	});
 
+export type AttachGenerationParams = z.infer<typeof attachGenerationSchema>;
+export type UpdateSubscriptionGenerationParams = z.infer<
+	typeof updateSubscriptionGenerationSchema
+>;
+export type CreateScheduleGenerationParams = z.infer<
+	typeof createScheduleGenerationSchema
+>;
+export type GeneratedBillingParams =
+	| AttachGenerationParams
+	| UpdateSubscriptionGenerationParams
+	| CreateScheduleGenerationParams;
+
 export const GENERATE_BILLING_TOOLS = [
 	"attach",
 	"create_schedule",

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -1,5 +1,9 @@
 import type { Feature, FullCusProduct, FullProduct } from "@autumn/shared";
-import { mapToProductV2 } from "@autumn/shared";
+import {
+	mapToProductV2,
+	productV2ToApiPlanV1,
+	toCreatePlanItemParams,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { CusService } from "@/internal/customers/CusService";
 import { FeatureService } from "@/internal/features/FeatureService";
@@ -13,25 +17,30 @@ const compactPlan = ({
 	features: Feature[];
 }) => {
 	const productV2 = mapToProductV2({ features, product });
+	const apiPlan = productV2ToApiPlanV1({
+		features,
+		includeProration: true,
+		product: productV2,
+	});
 	return {
 		id: productV2.id,
 		name: productV2.name,
 		...(productV2.group ? { group: productV2.group } : {}),
 		...(productV2.is_add_on ? { is_add_on: true } : {}),
 		...(productV2.free_trial ? { free_trial: productV2.free_trial } : {}),
-		items: productV2.items.map((item) => ({
-			...(item.feature_id ? { feature_id: item.feature_id } : {}),
-			...(item.included_usage !== undefined && item.included_usage !== null
-				? { included_usage: item.included_usage }
-				: {}),
-			...(item.price !== undefined && item.price !== null
-				? { price: item.price }
-				: {}),
-			...(item.billing_units ? { billing_units: item.billing_units } : {}),
-			...(item.interval ? { interval: item.interval } : {}),
-			...(item.usage_model ? { usage_model: item.usage_model } : {}),
-			...(item.tiers ? { tiers: item.tiers } : {}),
-		})),
+		...(apiPlan.price
+			? {
+					price: {
+						amount: apiPlan.price.amount,
+						interval: apiPlan.price.interval,
+						...(apiPlan.price.interval_count &&
+						apiPlan.price.interval_count !== 1
+							? { interval_count: apiPlan.price.interval_count }
+							: {}),
+					},
+				}
+			: {}),
+		items: apiPlan.items.map((item) => toCreatePlanItemParams(item)),
 	};
 };
 

--- a/server/tests/evals/generateBillingRequest/fixtures.ts
+++ b/server/tests/evals/generateBillingRequest/fixtures.ts
@@ -1,3 +1,4 @@
+import type { ApiPlanV1 } from "@autumn/shared";
 import type { GenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext";
 
 const NOW_MS = Date.UTC(2026, 7, 24, 12, 0, 0);
@@ -33,22 +34,26 @@ export const saasContext = ({
 			{
 				id: "pro",
 				name: "Pro",
+				price: { amount: 20, interval: "month" },
 				items: [
-					{ interval: "month", price: 20 },
 					{
-						billing_units: 100,
 						feature_id: "messages",
-						included_usage: 0,
-						interval: "month",
-						price: 10,
-						usage_model: "prepaid",
+						included: 0,
+						price: {
+							amount: 10,
+							billing_method: "prepaid",
+							billing_units: 100,
+							interval: "month",
+						},
+						reset: { interval: "month" },
 					},
 				],
 			},
 			{
 				id: "premium",
 				name: "Premium",
-				items: [{ interval: "month", price: 50 }, { feature_id: "sso" }],
+				price: { amount: 50, interval: "month" },
+				items: [{ feature_id: "sso" }],
 			},
 		],
 	}) as unknown as GenerationContext;
@@ -71,14 +76,18 @@ export const creditLadderContext = (): GenerationContext =>
 				items: [
 					{
 						feature_id: "credits",
-						included_usage: 1000,
-						interval: "month",
-						usage_model: "prepaid",
-						tiers: [
-							{ amount: 0, flat_amount: 90, to: 10000 },
-							{ amount: 0, flat_amount: 400, to: 50000 },
-							{ amount: 0, flat_amount: 700, to: "inf" },
-						],
+						included: 1000,
+						price: {
+							billing_method: "prepaid",
+							interval: "month",
+							tier_behavior: "volume",
+							tiers: [
+								{ amount: 0, flat_amount: 90, to: 11000 },
+								{ amount: 0, flat_amount: 400, to: 51000 },
+								{ amount: 0, flat_amount: 700, to: "inf" },
+							],
+						},
+						reset: { interval: "month" },
 					},
 				],
 			},
@@ -95,7 +104,7 @@ export const variantLadderContext = (): GenerationContext =>
 			current_plans: [],
 		},
 		features: [{ id: "credits", name: "Credits", type: "single_use" }],
-		now: { epoch_ms: NOW_MS, iso: new Date(NOW_MS).toISOString() },
+		now,
 		plans: [
 			{
 				id: "enterprise",
@@ -103,40 +112,216 @@ export const variantLadderContext = (): GenerationContext =>
 				items: [
 					{
 						feature_id: "credits",
-						included_usage: 1000,
-						interval: "month",
-						usage_model: "prepaid",
-						tiers: [
-							{ amount: 0, flat_amount: 200, to: 2000 },
-							{ amount: 0, flat_amount: 400, to: 5000 },
-							{ amount: 0, flat_amount: 600, to: "inf" },
-						],
+						included: 1000,
+						price: {
+							billing_method: "prepaid",
+							interval: "month",
+							tier_behavior: "volume",
+							tiers: [
+								{ amount: 0, flat_amount: 200, to: 3000 },
+								{ amount: 0, flat_amount: 400, to: 6000 },
+								{ amount: 0, flat_amount: 600, to: "inf" },
+							],
+						},
+						reset: { interval: "month" },
 					},
 				],
 			},
 			{
 				id: "scale",
 				name: "Scale",
+				price: { amount: 1000, interval: "month" },
 				items: [
-					{ interval: "month", price: 1000 },
 					{
 						feature_id: "credits",
-						included_usage: 1000,
-						interval: "month",
+						included: 1000,
+						reset: { interval: "month" },
 					},
 				],
 			},
 			{
 				id: "scale_yearly",
 				name: "Scale (Yearly)",
+				price: { amount: 10000, interval: "year" },
 				items: [
-					{ interval: "year", price: 10000 },
 					{
 						feature_id: "credits",
-						included_usage: 1000,
-						interval: "month",
+						included: 1000,
+						reset: { interval: "month" },
 					},
 				],
 			},
 		],
 	}) as unknown as GenerationContext;
+
+export const rolloverCreditsContext = (): GenerationContext =>
+	({
+		customer: {
+			id: "cus_mintlify_like",
+			name: "Mintlify-like Co",
+			current_plans: [
+				{ customer_product_id: "cp_pro_1", plan_id: "pro", status: "active" },
+			],
+			entities: [],
+		},
+		features: [
+			{ id: "AI_CREDITS", name: "AI Credits", type: "credit_system" },
+			{ id: "ADMIN_API_ACCESS", name: "Admin API Access", type: "static" },
+		],
+		now,
+		plans: [
+			{
+				id: "pro",
+				name: "Pro",
+				price: { amount: 540, interval: "month" },
+				items: [
+					{
+						feature_id: "AI_CREDITS",
+						included: 10_000,
+						pooled: true,
+						reset: { interval: "month" },
+						rollover: {
+							expiry_duration_length: 1,
+							expiry_duration_type: "month",
+							max_percentage: 50,
+						},
+					},
+					{
+						feature_id: "AI_CREDITS",
+						included: 0,
+						price: {
+							amount: 0.01,
+							billing_method: "usage_based",
+							billing_units: 1,
+							interval: "month",
+						},
+						reset: { interval: "month" },
+					},
+					{ feature_id: "ADMIN_API_ACCESS" },
+				],
+			},
+		],
+	}) as unknown as GenerationContext;
+
+export const rolloverCreditsBaseItems = (): ApiPlanV1["items"] =>
+	[
+		{
+			feature_id: "AI_CREDITS",
+			included: 10_000,
+			pooled: true,
+			price: null,
+			reset: { interval: "month" },
+			rollover: {
+				expiry_duration_length: 1,
+				expiry_duration_type: "month",
+				max: null,
+				max_percentage: 50,
+			},
+			unlimited: false,
+		},
+		{
+			feature_id: "AI_CREDITS",
+			included: 0,
+			price: {
+				amount: 0.01,
+				billing_method: "usage_based",
+				billing_units: 1,
+				interval: "month",
+				max_purchase: null,
+			},
+			reset: { interval: "month" },
+			unlimited: false,
+		},
+		{ feature_id: "ADMIN_API_ACCESS", included: 0, price: null, reset: null },
+	] as unknown as ApiPlanV1["items"];
+
+/** Tiered prepaid credits on the customer's live plan — changing `included`
+ * must shift tier boundaries, not drop or reprice tiers. */
+export const tieredScaleContext = (): GenerationContext =>
+	({
+		customer: {
+			id: "cus_scale",
+			name: "Scale Co",
+			current_plans: [
+				{
+					customer_product_id: "cp_scale_1",
+					plan_id: "scale",
+					status: "active",
+				},
+			],
+			entities: [],
+		},
+		features: [{ id: "credits", name: "Credits", type: "single_use" }],
+		now,
+		plans: [
+			{
+				id: "scale",
+				name: "Scale",
+				price: { amount: 500, interval: "month" },
+				items: [
+					{
+						feature_id: "credits",
+						included: 1000,
+						price: {
+							billing_method: "prepaid",
+							billing_units: 1000,
+							interval: "month",
+							tier_behavior: "volume",
+							tiers: [
+								{ amount: 0, flat_amount: 200, to: 3000 },
+								{ amount: 0, flat_amount: 400, to: 6000 },
+								{ amount: 0, flat_amount: 600, to: "inf" },
+							],
+						},
+						reset: { interval: "month" },
+					},
+					{
+						feature_id: "credits",
+						included: 0,
+						price: {
+							amount: 0.1,
+							billing_method: "usage_based",
+							billing_units: 1,
+							interval: "month",
+						},
+						reset: { interval: "month" },
+					},
+				],
+			},
+		],
+	}) as unknown as GenerationContext;
+
+export const tieredScaleBaseItems = (): ApiPlanV1["items"] =>
+	[
+		{
+			feature_id: "credits",
+			included: 1000,
+			price: {
+				billing_method: "prepaid",
+				billing_units: 1000,
+				interval: "month",
+				max_purchase: null,
+				tier_behavior: "volume",
+				tiers: [
+					{ amount: 0, flat_amount: 200, to: 3000 },
+					{ amount: 0, flat_amount: 400, to: 6000 },
+					{ amount: 0, flat_amount: 600, to: "inf" },
+				],
+			},
+			reset: { interval: "month" },
+			unlimited: false,
+		},
+		{
+			feature_id: "credits",
+			included: 0,
+			price: {
+				amount: 0.1,
+				billing_method: "usage_based",
+				billing_units: 1,
+				interval: "month",
+				max_purchase: null,
+			},
+			reset: { interval: "month" },
+			unlimited: false,
+		},
+	] as unknown as ApiPlanV1["items"];

--- a/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
+++ b/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
@@ -6,13 +6,26 @@
  * Run: bun eval:generation  (needs ANTHROPIC_API_KEY + BRAINTRUST_API_KEY)
  */
 
+import {
+	type ApiPlanV1,
+	applyCustomizeToPlan,
+	composeMatchKey,
+	type DiffablePlanV1,
+} from "@autumn/shared";
 import { Eval } from "braintrust";
 import { computeGeneratedParams } from "@/internal/billing/v2/actions/generateRequest/compute/computeGeneratedParams";
-import type { GenerateBillingTool } from "@/internal/billing/v2/actions/generateRequest/generationSchemas";
+import type {
+	GenerateBillingTool,
+	GeneratedBillingParams,
+} from "@/internal/billing/v2/actions/generateRequest/generationSchemas";
 import type { GenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext";
 import {
 	creditLadderContext,
+	rolloverCreditsBaseItems,
+	rolloverCreditsContext,
 	saasContext,
+	tieredScaleBaseItems,
+	tieredScaleContext,
 	variantLadderContext,
 } from "./fixtures";
 
@@ -22,10 +35,12 @@ type EvalInput = {
 	context: GenerationContext;
 	currentRequest?: Record<string, unknown>;
 	forbiddenKeys?: string[];
+	applyToItems?: ApiPlanV1["items"];
+	expectedApplied?: Record<string, unknown>[];
 };
 
 type EvalOutput = {
-	params: Record<string, unknown> | null;
+	params: GeneratedBillingParams | null;
 	repaired: boolean;
 	repairReason?: string;
 	error?: string;
@@ -120,7 +135,10 @@ const expectedParams = ({
 	const mismatches: string[] = [];
 	subsetMatches(expected ?? {}, output.params, "params", mismatches);
 	for (const key of input.forbiddenKeys ?? []) {
-		if (output.params[key] !== undefined) {
+		const value = Object.entries(output.params).find(
+			([paramKey]) => paramKey === key,
+		)?.[1];
+		if (value !== undefined) {
 			mismatches.push(`params.${key}: expected to be absent`);
 		}
 	}
@@ -131,6 +149,54 @@ const expectedParams = ({
 	}
 	return {
 		name: "expected_params",
+		score: mismatches.length === 0 ? 1 : 0,
+		...(mismatches.length ? { metadata: { mismatches } } : {}),
+	};
+};
+
+const appliedPlan = ({
+	input,
+	output,
+}: {
+	input: EvalInput;
+	output: EvalOutput;
+}) => {
+	if (!input.applyToItems || !output.params) return null;
+	const mismatches: string[] = [];
+	const customize =
+		"customize" in output.params ? output.params.customize : undefined;
+	if (!customize) {
+		mismatches.push("applied: no customize in output");
+	}
+	const applied = customize
+		? applyCustomizeToPlan({
+				customize,
+				plan: { items: input.applyToItems, price: null } as DiffablePlanV1,
+			})
+		: { items: input.applyToItems };
+	const keyCounts = new Map<string, number>();
+	for (const item of applied.items) {
+		const key = composeMatchKey(item);
+		keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
+	}
+	for (const [key, count] of keyCounts) {
+		if (count > 1) {
+			mismatches.push(`applied: ${count} items share identity ${key}`);
+		}
+	}
+	subsetMatches(
+		input.expectedApplied ?? [],
+		applied.items,
+		"applied",
+		mismatches,
+	);
+	if (mismatches.length) {
+		console.warn(
+			`[applied_plan] ${input.tool}: "${input.prompt}"\n  ${mismatches.join("\n  ")}`,
+		);
+	}
+	return {
+		name: "applied_plan",
 		score: mismatches.length === 0 ? 1 : 0,
 		...(mismatches.length ? { metadata: { mismatches } } : {}),
 	};
@@ -340,6 +406,81 @@ const cases: EvalCase[] = [
 		},
 	},
 	{
+		name: "update: change credits allowance preserves rollover (live-incident shape)",
+		input: {
+			applyToItems: rolloverCreditsBaseItems(),
+			context: rolloverCreditsContext(),
+			currentRequest: {
+				customer_id: "cus_mintlify_like",
+				customer_product_id: "cp_pro_1",
+				product_id: "pro",
+			},
+			expectedApplied: [
+				{
+					feature_id: "AI_CREDITS",
+					included: 12_000,
+					pooled: true,
+					reset: { interval: "month" },
+					rollover: { max_percentage: 50 },
+				},
+				{ feature_id: "AI_CREDITS", price: { amount: 0.01 } },
+			],
+			prompt: "update credits to 12k",
+			tool: "update_subscription",
+		},
+		expected: {
+			customize: {
+				add_items: [
+					{
+						feature_id: "AI_CREDITS",
+						included: 12_000,
+						pooled: true,
+						reset: { interval: "month" },
+						rollover: { max_percentage: 50 },
+					},
+				],
+				remove_items: [{ feature_id: "AI_CREDITS" }],
+			},
+		},
+	},
+	{
+		name: "update: raising included on a tiered item shifts boundaries and keeps tiers",
+		input: {
+			applyToItems: tieredScaleBaseItems(),
+			context: tieredScaleContext(),
+			currentRequest: {
+				customer_id: "cus_scale",
+				customer_product_id: "cp_scale_1",
+				product_id: "scale",
+			},
+			expectedApplied: [
+				{
+					feature_id: "credits",
+					included: 2000,
+					price: {
+						billing_method: "prepaid",
+						billing_units: 1000,
+						tiers: [
+							{ amount: 0, flat_amount: 200, to: 4000 },
+							{ amount: 0, flat_amount: 400, to: 7000 },
+							{ amount: 0, flat_amount: 600, to: "inf" },
+						],
+					},
+					reset: { interval: "month" },
+				},
+				{ feature_id: "credits", price: { amount: 0.1 } },
+			],
+			prompt: "lets do 2k credits included",
+			tool: "update_subscription",
+		},
+		expected: {
+			customize: {
+				add_items: [{ feature_id: "credits", included: 2000 }],
+				remove_items: [{ feature_id: "credits" }],
+			},
+		},
+	},
+	{
 		name: "schedule: switch plan next month",
 		input: {
 			context: saasContext({ onPro: true }),
@@ -391,7 +532,7 @@ Eval("generate-billing-request", {
 			tags: [input.tool],
 			// biome-ignore lint/suspicious/noExplicitAny: braintrust's case type is looser than ours
 		})) as any,
-	scores: [schemaFirstTry, expectedParams],
+	scores: [schemaFirstTry, expectedParams, appliedPlan],
 	task: async (input: EvalInput): Promise<EvalOutput> => {
 		try {
 			const { params, repaired, repairReason } = await computeGeneratedParams({

--- a/server/tests/unit/billing/validateGeneratedAddItems.test.ts
+++ b/server/tests/unit/billing/validateGeneratedAddItems.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillingMethod,
+	ResetInterval,
+	RolloverExpiryDurationType,
+} from "@autumn/shared";
+import { assertNoDuplicateAddItems } from "@/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems";
+import type { GenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext";
+
+const context = {
+	customer: {
+		id: "cus_1",
+		current_plans: [
+			{ customer_product_id: "cp_pro_1", plan_id: "pro", status: "active" },
+		],
+	},
+	features: [],
+	now: { epoch_ms: 0, iso: "1970-01-01T00:00:00.000Z" },
+	plans: [
+		{
+			id: "pro",
+			name: "Pro",
+			price: { amount: 540, interval: BillingInterval.Month },
+			items: [
+				{
+					feature_id: "AI_CREDITS",
+					included: 10_000,
+					pooled: true,
+					reset: { interval: ResetInterval.Month },
+					rollover: {
+						expiry_duration_type: RolloverExpiryDurationType.Month,
+						max_percentage: 50,
+					},
+				},
+				{
+					feature_id: "AI_CREDITS",
+					included: 0,
+					price: {
+						amount: 0.01,
+						billing_method: BillingMethod.UsageBased,
+						billing_units: 1,
+						interval: BillingInterval.Month,
+					},
+					reset: { interval: ResetInterval.Month },
+				},
+			],
+		},
+	],
+} as unknown as GenerationContext;
+
+describe("assertNoDuplicateAddItems", () => {
+	test("a bare add for an existing allowance is rejected with pairing guidance", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context,
+				customerProductId: "cp_pro_1",
+				generated: {
+					customize: {
+						add_items: [
+							{
+								feature_id: "AI_CREDITS",
+								included: 12_000,
+								reset: { interval: ResetInterval.Month },
+							},
+						],
+					},
+				},
+				tool: "update_subscription",
+			}),
+		).toThrow(/pair a remove_items filter/);
+	});
+
+	test("the same add paired with a remove filter passes", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context,
+				customerProductId: "cp_pro_1",
+				generated: {
+					customize: {
+						add_items: [
+							{
+								feature_id: "AI_CREDITS",
+								included: 12_000,
+								pooled: true,
+								reset: { interval: ResetInterval.Month },
+								rollover: {
+									expiry_duration_type: RolloverExpiryDurationType.Month,
+									max_percentage: 50,
+								},
+							},
+						],
+						remove_items: [{ feature_id: "AI_CREDITS", included: 10_000 }],
+					},
+				},
+				tool: "update_subscription",
+			}),
+		).not.toThrow();
+	});
+
+	test("adding a genuinely new feature passes", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context,
+				generated: {
+					customize: { add_items: [{ feature_id: "SEATS", included: 5 }] },
+					plan_id: "pro",
+				},
+				tool: "attach",
+			}),
+		).not.toThrow();
+	});
+
+	test("a usage-priced add does not collide with the free allowance item", () => {
+		const slim = {
+			...context,
+			plans: [
+				{
+					id: "pro",
+					name: "Pro",
+					items: [
+						{
+							feature_id: "SEATS",
+							included: 5,
+							reset: { interval: ResetInterval.Month },
+						},
+					],
+				},
+			],
+		} as unknown as GenerationContext;
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context: slim,
+				generated: {
+					customize: {
+						add_items: [
+							{
+								feature_id: "SEATS",
+								price: {
+									amount: 10,
+									billing_method: BillingMethod.UsageBased,
+									interval: BillingInterval.Month,
+								},
+							},
+						],
+					},
+					plan_id: "pro",
+				},
+				tool: "attach",
+			}),
+		).not.toThrow();
+	});
+
+	test("an unknown target plan is conservative and passes", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context,
+				generated: {
+					customize: {
+						add_items: [{ feature_id: "AI_CREDITS", included: 12_000 }],
+					},
+				},
+				tool: "attach",
+			}),
+		).not.toThrow();
+	});
+});

--- a/shared/api/billing/common/customizePlan/mappers/customizePlanV1ToV0.ts
+++ b/shared/api/billing/common/customizePlan/mappers/customizePlanV1ToV0.ts
@@ -23,6 +23,7 @@ const patchStyleCustomizeToItems = ({
 }): CustomizePlanV0 => {
 	const basePlan = productV2ToApiPlanV1({
 		features: ctx.features,
+		includeProration: true,
 		product: mapToProductV2({ features: ctx.features, product: fullProduct }),
 	});
 	const applied = applyCustomizeToPlan({

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -44,6 +44,7 @@ export * from "./planV1Utils/diff/applyDiff";
 export * from "./planV1Utils/diff/deduplicateAddPlanItems";
 export * from "./planV1Utils/diff/diffPlanV1";
 export * from "./planV1Utils/diff/diffPlanV1PreviewFields";
+export * from "./planV1Utils/diff/planItemMatchesFilter";
 export * from "./planV1Utils/diff/replayPlanDiff";
 export * from "./planV1Utils/licenses/applyLicenseCustomizeToBasePlan";
 export * from "./planV1Utils/licenses/diffLicensePlanCustomize";
@@ -68,8 +69,8 @@ export * from "./productUtils/priceUtils/index";
 // Price match utils
 export * from "./productUtils/priceUtils/match/copyStripeResourcesToMatchingPrice";
 export * from "./productUtils/priceUtils/match/getPriceStripeReuseLevel";
-export * from "./productUtils/priceUtils/match/stripePriceIdForInitializedPrice";
 export * from "./productUtils/priceUtils/match/priceStripeObjectsMatch";
+export * from "./productUtils/priceUtils/match/stripePriceIdForInitializedPrice";
 export * from "./productV2Utils/mapToProductV2";
 export * from "./productV2Utils/productItemUtils/classifyItemUtils";
 export * from "./productV2Utils/productItemUtils/getItemType";

--- a/shared/utils/planV1Utils/diff/applyDiff.ts
+++ b/shared/utils/planV1Utils/diff/applyDiff.ts
@@ -9,6 +9,7 @@ import {
 	type DiffablePlanV1,
 	type DiffedCustomizePlanV1,
 } from "./diffPlanV1.js";
+import { planItemMatchesFilter } from "./planItemMatchesFilter.js";
 
 export type ApplyDiffOutput = {
 	price: ApiPlanV1["price"];
@@ -30,37 +31,13 @@ const applyPrice = (
 	return { ...diff };
 };
 
-const itemMatchesFilter = (
-	item: ApiPlanItem | CreatePlanItemParamsV1,
-	filter: PlanItemFilter,
-): boolean => {
-	if (filter.feature_id !== undefined && item.feature_id !== filter.feature_id)
-		return false;
-	// Omitted billing_method is a wildcard — same rule as the engine's
-	// matchesPlanItemFilter, so a feature_id-only filter matches priced items.
-	if (
-		filter.billing_method !== undefined &&
-		item.price?.billing_method !== filter.billing_method
-	) {
-		return false;
-	}
-	if (filter.interval !== undefined) {
-		const itemInterval = item.price?.interval ?? item.reset?.interval;
-		if (String(itemInterval) !== String(filter.interval)) return false;
-	}
-	if (filter.interval_count !== undefined) {
-		const itemCount = item.price?.interval_count ?? item.reset?.interval_count;
-		if ((itemCount ?? 1) !== filter.interval_count) return false;
-	}
-	return true;
-};
-
 const removeItems = (
 	items: ApiPlanV1["items"],
 	removeFilters: PlanItemFilter[],
 ): ApiPlanV1["items"] => {
 	return items.filter(
-		(item) => !removeFilters.some((filter) => itemMatchesFilter(item, filter)),
+		(item) =>
+			!removeFilters.some((filter) => planItemMatchesFilter({ item, filter })),
 	);
 };
 
@@ -147,7 +124,8 @@ export const applyPlanItemParamsDiff = ({
 	let next = [...items];
 	if (remove_items) {
 		next = next.filter(
-			(item) => !remove_items.some((filter) => itemMatchesFilter(item, filter)),
+			(item) =>
+				!remove_items.some((filter) => planItemMatchesFilter({ item, filter })),
 		);
 	}
 	if (add_items) {

--- a/shared/utils/planV1Utils/diff/planItemMatchesFilter.test.ts
+++ b/shared/utils/planV1Utils/diff/planItemMatchesFilter.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { planItemMatchesFilter } from "./planItemMatchesFilter.js";
+
+const allowance = {
+	feature_id: "credits",
+	included: 10_000,
+	reset: { interval: "month" },
+	unlimited: false,
+};
+const usagePrice = {
+	feature_id: "credits",
+	included: 0,
+	price: {
+		billing_method: "usage_based",
+		interval: "month",
+	},
+	reset: { interval: "month" },
+	unlimited: false,
+};
+
+describe("planItemMatchesFilter — included", () => {
+	test("included narrows to the item whose grant equals it", () => {
+		const filter = { feature_id: "credits", included: 10_000 };
+		expect(planItemMatchesFilter({ filter, item: allowance })).toBe(true);
+		expect(planItemMatchesFilter({ filter, item: usagePrice })).toBe(false);
+	});
+
+	test("omitted included stays a wildcard", () => {
+		const filter = { feature_id: "credits" };
+		expect(planItemMatchesFilter({ filter, item: allowance })).toBe(true);
+		expect(planItemMatchesFilter({ filter, item: usagePrice })).toBe(true);
+	});
+
+	test("an unlimited item never matches a numeric included", () => {
+		expect(
+			planItemMatchesFilter({
+				filter: { feature_id: "credits", included: 0 },
+				item: { feature_id: "credits", unlimited: true },
+			}),
+		).toBe(false);
+	});
+
+	test("an item without included matches included 0", () => {
+		expect(
+			planItemMatchesFilter({
+				filter: { feature_id: "sso", included: 0 },
+				item: { feature_id: "sso" },
+			}),
+		).toBe(true);
+	});
+});

--- a/shared/utils/planV1Utils/diff/planItemMatchesFilter.ts
+++ b/shared/utils/planV1Utils/diff/planItemMatchesFilter.ts
@@ -1,0 +1,72 @@
+import { z } from "zod/v4";
+import {
+	type PlanItemFilter,
+	PlanItemFilterSchema,
+} from "../../../api/products/items/filter/planItemFilter.js";
+
+const FilterablePlanItemSchema = z.object({
+	feature_id: z.string().nullish(),
+	included: z.number().nullish(),
+	unlimited: z.boolean().nullish(),
+	price: z
+		.object({
+			billing_method: z.string().nullish(),
+			interval: z.string().nullish(),
+			interval_count: z.number().nullish(),
+		})
+		.nullish(),
+	reset: z
+		.object({
+			interval: z.string().nullish(),
+			interval_count: z.number().nullish(),
+		})
+		.nullish(),
+});
+
+export type FilterablePlanItem = z.input<typeof FilterablePlanItemSchema>;
+
+export const planItemMatchesFilter = ({
+	item,
+	filter,
+}: {
+	item: FilterablePlanItem;
+	filter: PlanItemFilter;
+}): boolean => {
+	if (filter.feature_id !== undefined && item.feature_id !== filter.feature_id)
+		return false;
+	if (
+		filter.billing_method !== undefined &&
+		item.price?.billing_method !== filter.billing_method
+	) {
+		return false;
+	}
+	if (filter.interval !== undefined) {
+		const itemInterval = item.price?.interval ?? item.reset?.interval;
+		if (String(itemInterval) !== String(filter.interval)) return false;
+	}
+	if (filter.interval_count !== undefined) {
+		const itemCount = item.price?.interval_count ?? item.reset?.interval_count;
+		if ((itemCount ?? 1) !== filter.interval_count) return false;
+	}
+	if (filter.included !== undefined) {
+		if (item.unlimited === true) return false;
+		if ((item.included ?? 0) !== filter.included) return false;
+	}
+	return true;
+};
+
+export const loosePlanItemMatchesFilter = ({
+	item,
+	filter,
+}: {
+	item: unknown;
+	filter: unknown;
+}): boolean => {
+	const parsedItem = FilterablePlanItemSchema.safeParse(item);
+	const parsedFilter = PlanItemFilterSchema.safeParse(filter);
+	return (
+		parsedItem.success &&
+		parsedFilter.success &&
+		planItemMatchesFilter({ item: parsedItem.data, filter: parsedFilter.data })
+	);
+};

--- a/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.roundTrip.test.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.roundTrip.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import type { ProductItem, ProductV2 } from "@autumn/shared";
+import type { Feature } from "../../../models/featureModels/featureModels.js";
+import { productV2ToApiPlanV1 } from "../productV2ToApiPlanV1.js";
+import { itemsAreSame } from "./compareItemUtils.js";
+
+const same = (item1: ProductItem, item2: ProductItem) =>
+	itemsAreSame({ item1, item2 }).same;
+
+describe("itemsAreSame — dialect round-trip normalization", () => {
+	test("reset_usage_when_enabled undefined equals false", () => {
+		const sparse = {
+			feature_id: "approval_chains",
+			feature_type: "static",
+		} as unknown as ProductItem;
+		const roundTripped = {
+			feature_id: "approval_chains",
+			feature_type: "static",
+			included_usage: 0,
+			interval: null,
+			pooled: false,
+			reset_usage_when_enabled: false,
+		} as unknown as ProductItem;
+		expect(same(sparse, roundTripped)).toBe(true);
+	});
+
+	test("a flat per-unit price equals its single-tier form", () => {
+		const tiered = {
+			feature_id: "credits",
+			usage_model: "pay_per_use",
+			interval: "month",
+			billing_units: 1,
+			tiers: [{ amount: 0.1, to: "inf", flat_amount: null }],
+		} as unknown as ProductItem;
+		const flat = {
+			feature_id: "credits",
+			usage_model: "pay_per_use",
+			interval: "month",
+			billing_units: 1,
+			included_usage: 0,
+			price: 0.1,
+			reset_usage_when_enabled: false,
+		} as unknown as ProductItem;
+		expect(same(tiered, flat)).toBe(true);
+	});
+
+	test("a flat price still differs from a different single tier", () => {
+		const tiered = {
+			feature_id: "credits",
+			usage_model: "pay_per_use",
+			interval: "month",
+			tiers: [{ amount: 0.2, to: "inf" }],
+		} as unknown as ProductItem;
+		const flat = {
+			feature_id: "credits",
+			usage_model: "pay_per_use",
+			interval: "month",
+			price: 0.1,
+		} as unknown as ProductItem;
+		expect(same(tiered, flat)).toBe(false);
+	});
+
+	test("default proration config equals an absent one", () => {
+		const explicit = {
+			feature_id: "credits",
+			usage_model: "prepaid",
+			interval: "month",
+			price: 10,
+			config: { on_increase: "prorate_immediately", on_decrease: "prorate" },
+		} as unknown as ProductItem;
+		const absent = {
+			feature_id: "credits",
+			usage_model: "prepaid",
+			interval: "month",
+			price: 10,
+		} as unknown as ProductItem;
+		expect(same(explicit, absent)).toBe(true);
+	});
+
+	test("non-default proration config differs from an absent one", () => {
+		const explicit = {
+			feature_id: "credits",
+			usage_model: "prepaid",
+			interval: "month",
+			price: 10,
+			config: { on_increase: "bill_immediately", on_decrease: "prorate" },
+		} as unknown as ProductItem;
+		const absent = {
+			feature_id: "credits",
+			usage_model: "prepaid",
+			interval: "month",
+			price: 10,
+		} as unknown as ProductItem;
+		expect(same(explicit, absent)).toBe(false);
+	});
+
+	test("rollover max null equals undefined", () => {
+		const withNull = {
+			feature_id: "credits",
+			included_usage: 1000,
+			interval: "month",
+			config: {
+				rollover: {
+					duration: "month",
+					length: 1,
+					max: null,
+					max_percentage: 50,
+				},
+			},
+		} as unknown as ProductItem;
+		const withUndefined = {
+			feature_id: "credits",
+			included_usage: 1000,
+			interval: "month",
+			config: {
+				rollover: { duration: "month", length: 1, max_percentage: 50 },
+			},
+		} as unknown as ProductItem;
+		expect(same(withNull, withUndefined)).toBe(true);
+	});
+});
+
+describe("productV2ToApiPlanV1 — proration fidelity", () => {
+	const features = [
+		{
+			id: "credits",
+			name: "Credits",
+			type: "credit_system",
+			config: { usage_type: "single_use" },
+		},
+	] as unknown as Feature[];
+	const product = {
+		id: "scale",
+		name: "Scale",
+		env: "sandbox",
+		items: [
+			{
+				type: "priced_feature",
+				feature_id: "credits",
+				feature_type: "single_use",
+				included_usage: 1000,
+				interval: "month",
+				usage_model: "prepaid",
+				billing_units: 1,
+				tier_behavior: "volume",
+				tiers: [
+					{ to: 2000, amount: 0, flat_amount: 200 },
+					{ to: "inf", amount: 0, flat_amount: 600 },
+				],
+				config: {
+					on_increase: "prorate_immediately",
+					on_decrease: "prorate_immediately",
+				},
+			},
+		],
+	} as unknown as ProductV2;
+
+	test("plan responses keep stripping proration", () => {
+		const plan = productV2ToApiPlanV1({ features, product });
+		expect(plan.items[0]?.proration).toBeUndefined();
+	});
+
+	test("diff and patch bases keep proration with includeProration", () => {
+		const plan = productV2ToApiPlanV1({
+			features,
+			includeProration: true,
+			product,
+		});
+		expect(plan.items[0]?.proration).toEqual({
+			on_increase: "prorate_immediately",
+			on_decrease: "prorate_immediately",
+		});
+	});
+});

--- a/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
+++ b/shared/utils/productV2Utils/compareProductUtils/compareItemUtils.ts
@@ -6,7 +6,11 @@ import type { UsageTier } from "../../../models/productModels/priceModels/priceC
 import type { FeatureItem } from "../../../models/productV2Models/productItemModels/featureItem.js";
 import type { FeaturePriceItem } from "../../../models/productV2Models/productItemModels/featurePriceItem.js";
 import type { PriceItem } from "../../../models/productV2Models/productItemModels/priceItem.js";
-import { AllocatedBillingBehavior } from "../../../models/productV2Models/productItemModels/productItemEnums.js";
+import {
+	AllocatedBillingBehavior,
+	OnDecrease,
+	OnIncrease,
+} from "../../../models/productV2Models/productItemModels/productItemEnums.js";
 import type {
 	ProductItem,
 	ProductItemConfig,
@@ -143,12 +147,20 @@ const tiersAreSame = (tiers1: TierLike[] | null, tiers2: TierLike[] | null) => {
 		(tier, index) =>
 			tier.amount === tiers2[index].amount &&
 			tier.to === tiers2[index].to &&
-			tier.flat_amount === tiers2[index].flat_amount &&
+			(tier.flat_amount ?? null) === (tiers2[index].flat_amount ?? null) &&
 			additionalCurrenciesAreSame(
 				tier.additional_currencies,
 				tiers2[index].additional_currencies,
 			),
 	);
+};
+
+/** A flat per-unit price and a single infinite tier describe the same
+ * pricing — canonicalize to tiers so the two shapes compare equal. */
+const itemPricingTiers = (item: FeaturePriceItem): TierLike[] | null => {
+	if (item.tiers?.length) return item.tiers as TierLike[];
+	if (item.price != null) return [{ amount: item.price, to: "inf" }];
+	return null;
 };
 
 // Helper to normalize included_usage for comparison (null and 0 are equivalent)
@@ -196,7 +208,8 @@ export const featureItemsAreSame = ({
 		},
 		reset_usage_when_enabled: {
 			condition:
-				item1.reset_usage_when_enabled == item2.reset_usage_when_enabled,
+				(item1.reset_usage_when_enabled ?? false) ===
+				(item2.reset_usage_when_enabled ?? false),
 			message: `Reset usage when enabled different: ${item1.reset_usage_when_enabled} !== ${item2.reset_usage_when_enabled}`,
 		},
 		rollover_config: {
@@ -261,8 +274,10 @@ const prorationConfigsAreSame = ({
 	config2?: ProductItemConfig;
 }) => {
 	return (
-		config1?.on_increase === config2?.on_increase &&
-		config1?.on_decrease === config2?.on_decrease
+		(config1?.on_increase ?? OnIncrease.ProrateImmediately) ===
+			(config2?.on_increase ?? OnIncrease.ProrateImmediately) &&
+		(config1?.on_decrease ?? OnDecrease.Prorate) ===
+			(config2?.on_decrease ?? OnDecrease.Prorate)
 	);
 };
 
@@ -305,8 +320,9 @@ const rolloversAreSame = ({
 		return false;
 	}
 	return (
-		rollover1?.max === rollover2?.max &&
-		rollover1?.max_percentage === rollover2?.max_percentage &&
+		(rollover1?.max ?? null) === (rollover2?.max ?? null) &&
+		(rollover1?.max_percentage ?? null) ===
+			(rollover2?.max_percentage ?? null) &&
 		rollover1?.duration === rollover2?.duration &&
 		rollover1?.length === rollover2?.length
 	);
@@ -337,7 +353,8 @@ export const featurePriceItemsAreSame = ({
 		},
 		reset_usage_when_enabled: {
 			condition:
-				item1.reset_usage_when_enabled == item2.reset_usage_when_enabled,
+				(item1.reset_usage_when_enabled ?? false) ===
+				(item2.reset_usage_when_enabled ?? false),
 			message: `Reset usage when enabled different: ${item1.reset_usage_when_enabled} !== ${item2.reset_usage_when_enabled}`,
 		},
 		proration_config: {
@@ -394,9 +411,9 @@ export const featurePriceItemsAreSame = ({
 			condition: item1.usage_model === item2.usage_model,
 			message: `Usage model different: ${item1.usage_model} != ${item2.usage_model}`,
 		},
-		price: {
-			condition: item1.price == item2.price,
-			message: `Price different: ${item1.price} != ${item2.price}`,
+		pricing: {
+			condition: tiersAreSame(itemPricingTiers(item1), itemPricingTiers(item2)),
+			message: `Pricing different: ${JSON.stringify(itemPricingTiers(item1))} != ${JSON.stringify(itemPricingTiers(item2))}`,
 		},
 		additional_currencies: {
 			condition: additionalCurrenciesAreSame(
@@ -405,12 +422,12 @@ export const featurePriceItemsAreSame = ({
 			),
 			message: `Additional currencies different`,
 		},
-		tiers: {
-			condition: tiersAreSame(item1.tiers || null, item2.tiers || null),
-			message: `Tiers different`,
-		},
 		tier_behavior: {
-			condition: item1.tier_behavior == item2.tier_behavior,
+			condition:
+				(itemPricingTiers(item1)?.length ?? 0) <= 1 &&
+				(itemPricingTiers(item2)?.length ?? 0) <= 1
+					? true
+					: item1.tier_behavior == item2.tier_behavior,
 			message: `Tiers type different: ${item1.tier_behavior} != ${item2.tier_behavior}`,
 		},
 		billing_units: {
@@ -419,7 +436,8 @@ export const featurePriceItemsAreSame = ({
 		},
 		reset_usage_when_enabled: {
 			condition:
-				item1.reset_usage_when_enabled == item2.reset_usage_when_enabled,
+				(item1.reset_usage_when_enabled ?? false) ===
+				(item2.reset_usage_when_enabled ?? false),
 			message: `Reset usage when enabled different: ${item1.reset_usage_when_enabled} !== ${item2.reset_usage_when_enabled}`,
 		},
 	};

--- a/shared/utils/productV2Utils/productItemUtils/matchPlanItem.ts
+++ b/shared/utils/productV2Utils/productItemUtils/matchPlanItem.ts
@@ -1,6 +1,6 @@
 import { BillingMethod } from "../../../api/products/components/billingMethod.js";
 import type { PlanItemFilter } from "../../../api/products/items/filter/planItemFilter.js";
-import { ResetInterval } from "../../../models/productModels/intervals/resetInterval.js";
+import type { ResetInterval } from "../../../models/productModels/intervals/resetInterval.js";
 import {
 	type ProductItem,
 	UsageModel,
@@ -52,6 +52,16 @@ export const matchesPlanItemFilter = ({
 		// itemToEntIntervalCount({ item }) !== filter.interval_count
 	)
 		return false;
+
+	if (filter.included !== undefined) {
+		const grant =
+			typeof item.included_usage === "number"
+				? item.included_usage
+				: item.included_usage == null
+					? 0
+					: null;
+		if (grant !== filter.included) return false;
+	}
 
 	return true;
 };

--- a/shared/utils/productV2Utils/productV2ToApiPlanV1.ts
+++ b/shared/utils/productV2Utils/productV2ToApiPlanV1.ts
@@ -28,12 +28,16 @@ export const productV2ToApiPlanV1 = ({
 	currency,
 	customerEligibility,
 	licenses,
+	includeProration = false,
 }: {
 	product: ProductV2;
 	features: Feature[];
 	currency?: string;
 	customerEligibility?: ApiPlanV1["customer_eligibility"];
 	licenses?: ApiPlanLicenseV1[];
+	/** Proration is internal and stripped from plan responses; diff and patch
+	 * bases need it kept or every rebuilt item silently loses the config. */
+	includeProration?: boolean;
 }): ApiPlanV1 & { licenses?: ApiPlanLicenseV1[] } => {
 	const sortedItems = sortProductItems(product.items, features);
 
@@ -76,7 +80,9 @@ export const productV2ToApiPlanV1 = ({
 		items: featureItems,
 		features,
 		currency,
-	}).map((item) => ({ ...item, proration: undefined }));
+	}).map((item) =>
+		includeProration ? item : { ...item, proration: undefined },
+	);
 
 	const freeTrial: ApiPlanV1["free_trial"] = product.free_trial
 		? {


### PR DESCRIPTION
## Problem

In the billing-flow sheets, prompting item changes ("update credits to 12k", "lets do 2k credits included") on a plan that already carries those items produced broken requests and an unreadable diff (live incidents):

- the allowance was **duplicated** — old and new items side by side
- the replacement item **lost settings** — rollover, `pooled`, monthly reset
- on tiered prepaid items, **tiers were dropped or repriced** ($200 tier vanishing)
- the sheet rendered **every item as removed + re-added** even when only one changed

## Root causes

1. **The documented `included` filter was a no-op.** `PlanItemFilter.included` was implemented in the live-engine pair matcher but silently ignored by the three plan-item-space matchers — no `remove_items` filter could precisely target one item of a feature that carries several.
2. **The generation context spoke a different dialect than the model writes.** Context items were compact V2 shape (tiers *relative* to the allowance) while `customize.add_items` takes V1 (boundaries *including* the allowance). The model's verbatim tier copy failed the `tiers[0].to must be greater than included` refinement and its repair deleted the first tier — the exact live symptom. Rollover/`pooled` weren't in the context at all.
3. **`productV2ToApiPlanV1` strips `proration` from every item** (internal field, hidden in responses) — but that converter is also the diff/patch base, so any patch-style customize silently dropped proration config from rebuilt items.
4. **`itemsAreSame` treated dialect round-trip artifacts as changes**: `reset_usage_when_enabled` undefined vs false (`==` fails), flat per-unit price vs its single-tier form, default proration vs absent, rollover `null` vs `undefined`. Every item on the sheet paired but compared "changed" → the full red/green wall.

## Fix (no API changes; `update_items` stays deprecated)

- **One shared `planItemMatchesFilter`** with `included` implemented; `applyDiff`, `@autumn/render`, and the engine matcher delegate to it.
- **The context now speaks V1** — built with the same converters the diff machinery uses (`productV2ToApiPlanV1` + `toCreatePlanItemParams`); "copy the item" is literal, tier boundaries arrive absolute.
- **Prompt rules**: `add_items` appends — changing an item means a precise `remove_items` filter paired with a verbatim copy; tier boundaries shift by the `included` delta; never emit identifiers the schema doesn't define.
- **Duplicate-add guard** wired through a `validate` hook in `computeGeneratedParams` — collisions re-enter the repair loop.
- **`productV2ToApiPlanV1` gains `includeProration`** (responses unchanged; the customize patch base and generation context pass it) — patch-style edits no longer lose proration config.
- **`itemsAreSame` normalizes dialect-equivalent shapes**: `reset_usage_when_enabled ?? false`, flat price ≡ single infinite tier (tier_behavior ignored below two tiers), proration compared against engine defaults, rollover nullish-normalized. This comparator also drives server in-place-update/versioning/attach-branch decisions, so spurious "custom" classification shrinks too.
- Generation params typed end-to-end via schema-inferred `GeneratedBillingParams`.

## Validation

- **Braintrust eval suite**: `expected_params` **100%** (baseline 87.50%), `applied_plan` scorer (applies model output via `applyCustomizeToPlan`, asserts no duplicate identities + preserved settings incl. shifted tiers) **100%**, `schema_first_try` 97.22%.
- **Live replication** against a real customized subscription (14 items): before the comparator fix every pair compared "changed"; after, 13/14 pairs identical and the only difference is the requested `included 1000 → 2000` — the sheet renders one changed row instead of the wall.
- Unit: matcher, guard, and comparator round-trip tests (incl. proration fidelity both ways); shared 365 pass, server unit suite at baseline (remaining failures are the pre-existing local-infra flaky set, verified identical on a stashed baseline run), `tsc` clean in server, shared, render, vite.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns generated billing context with the customization input format and centralizes item-filter matching so replacements retain their settings.
- **[Bug fixes]** Implements shared matching for precise item removal, including matching by included allowance.
- **[Bug fixes, Improvements]** Converts plan context into the same item shape accepted by generated customization requests, preserving reset, rollover, pooling, and tier settings.
- **[Improvements]** Adds generated-item validation and repair-loop integration intended to prevent duplicate additions.
- **[Improvements]** Strengthens generated parameter typing and adds incident-oriented tests and evaluations.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the duplicate guard can still allow a new allowance beside an existing allowance when the removal targets a priced sibling.

The validator treats any removal for a feature as if every existing item of that feature were removed, while the actual diff logic applies the full filter and may remove only one sibling. For example, removing the usage-priced credits item and adding a replacement allowance can delete usage pricing while leaving two allowances.

**Files Needing Attention:** server/src/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts | Converts catalog plans into customization-compatible context while retaining item and reset settings. |
| shared/utils/planV1Utils/diff/planItemMatchesFilter.ts | Centralizes plan-item filter semantics and adds included-allowance matching. |
| server/src/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems.ts | Adds duplicate-add validation, but its previously reported same-feature sibling handling remains unresolved. |
| server/src/internal/billing/v2/actions/generateRequest/compute/computeGeneratedParams.ts | Runs semantic validation after schema decoding and routes validation failures through the existing repair attempt. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Catalog plan] --> B[Convert to customization-compatible context]
  B --> C[Generate remove and add parameters]
  C --> D[Validate duplicate additions]
  D -->|Valid| E[Resolve customized billing request]
  D -->|Invalid| F[Repair generation]
  F --> C
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix: 🐛 generated billing edits keep ite..."](https://github.com/useautumn/autumn/commit/87e7e847123779b27654a2b861ee5621291beaae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56748919)</sub>

<!-- /greptile_comment -->