### PR TITLE
fix: keep tool plumbing out of Slack status lines

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/watchSubagentProgress.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/watchSubagentProgress.ts
@@ -1,10 +1,10 @@
 import { ms } from "@autumn/shared";
 import { logger } from "../../../../../lib/logger.js";
 import { EveStreamIdleTimeoutError } from "../../../eve/client.js";
-import { labelForAction } from "../../../eve/events.js";
+import { displayEveToolLabel, labelForAction } from "../../../eve/events.js";
 import { streamEveEventsWithReconnect } from "../../../eve/streamWithReconnect.js";
 import type { EveAuthContext, EveSessionRef } from "../../../eve/types.js";
-import { toolGerund } from "../../../tools/toolPolicy.js";
+import { isSilentTool } from "../../../tools/toolPolicy.js";
 import type { EveEventContext } from "./applyEveEvent.js";
 
 /** A delegated child can think for minutes between events, so the relay
@@ -56,8 +56,9 @@ export const watchSubagentProgress = ({
 			if (event.type === "actions.requested") {
 				for (const action of event.actions) {
 					const label = labelForAction(action);
+					if (isSilentTool(label)) continue;
 					await onAction?.({
-						label: toolGerund(label),
+						label: displayEveToolLabel(action),
 						phase: "started",
 						toolName: label,
 					});

--- a/apps/leaf/src/internal/agentRuntime/tools/toolPolicy.ts
+++ b/apps/leaf/src/internal/agentRuntime/tools/toolPolicy.ts
@@ -18,10 +18,19 @@ const labels: Record<string, string> = {
 	updateSubscription: "Update subscription",
 };
 
-// Pure utility tools the agent calls constantly — not worth a progress line.
+// Plumbing the user should never see: date maths, file rummaging, and the
+// agent's own bookkeeping. A status line is for what is being done to their
+// billing, not how the agent gets there.
 const silentTools = new Set([
 	"dateToEpochMilliseconds",
 	"epochMillisecondsToDate",
+	"bash",
+	"glob",
+	"grep",
+	"read",
+	"read_file",
+	"todo",
+	"connection_search",
 ]);
 
 export const isSilentTool = (toolName: string) =>
@@ -73,7 +82,8 @@ const gerunds: Record<string, string> = {
 	updateAgentRules: "Updating your agent rules",
 	updatePlan: "Updating the plan",
 	listBalances: "Checking balances",
-	connection_search: "Finding the right tool",
+	listRewards: "Looking through your rewards",
+	load_skill: "Reading a playbook",
 };
 
 export const toolGerund = (toolName: string) =>

--- a/apps/leaf/src/providers/web/history/buildLegacyClaudeHistory.ts
+++ b/apps/leaf/src/providers/web/history/buildLegacyClaudeHistory.ts
@@ -71,7 +71,7 @@ const replaySession = async (sessionId: string) => {
 				id: event.id,
 				type: "data-step",
 			});
-		} else if (event.type === "agent.tool_use") {
+		} else if (event.type === "agent.tool_use" && !isSilentTool(event.name)) {
 			assistant().msg.parts.push({
 				data: {
 					label: sandboxToolLabel(event.name, event.input),


### PR DESCRIPTION
Slack was showing `Date To Epoch Milliseconds` and bare one-word lines like `Read` / `Bash` between the meaningful steps.

## Root cause

The epoch tools were **already** in `silentTools` — one code path just ignored it.

`watchSubagentProgress.ts` (the relay that streams a delegated subagent's progress onto the parent turn's status channel) had **no `isSilentTool` check**, unlike `eveTurnReducer` which filters at lines 136 and 182. Since nearly all real work happens inside subagents, that relay is the *main* source of Slack status lines, and it was the one path with no filter.

It also called `toolGerund(label)` rather than `displayEveToolLabel(action)`, losing the `load_skill` special-casing. With no gerund mapped, tools fell through to the raw camelCase splitter:

```
dateToEpochMilliseconds  -> "Date To Epoch Milliseconds"
read                     -> "Read"
bash                     -> "Bash"
```

That accounts for both the epoch noise and the too-short lines.

## Changes

- **The relay honors the silent list** and uses `displayEveToolLabel`.
- **Silenced the plumbing** rather than relabelling it — `bash`, `glob`, `grep`, `read`, `read_file`, `todo`, `connection_search`, plus the two epoch tools. A status line should say what is happening to the user's billing, not how the agent gets there.
- **Fixed the same hole in web history** — `buildLegacyClaudeHistory` applied `isSilentTool` only to Autumn MCP tools; sandbox builtins took a separate unfiltered branch.
- **Added the two missing gerunds** — `listRewards`, `load_skill`. Found by diffing the tool allowlist against the gerund map; they were the only real tools without friendly phrasing.

## Result

A realistic billing turn now reads:

```
Reading a playbook            Previewing the attach
Reading your billing setup    Attaching the plan
Looking up the customer       Updating the customer
Looking through your plans
```

with the date maths, file reads, and bookkeeping hidden.

**Skill loading still shows** ("Reading a playbook"; skill file reads render as "Reading the billing skill") — it is real work the user waits on, so hiding it would leave dead air. Easy to silence too if you'd rather.

## Validation

leaf unit **471 pass / 0 fail**, typecheck clean, Biome clean on the three files.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes internal tool plumbing from Slack progress updates and legacy web history while retaining friendly labels for meaningful work.
- **Bug fixes:** Applies the silent-tool policy to delegated subagent progress and legacy sandbox-tool history.
- **Improvements:** Hides file, shell, search, date-conversion, and bookkeeping tools from user-facing status lines.
- **Improvements:** Adds friendly progress labels for reward listing and skill loading.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness or security issues identified.

The changes consistently filter cosmetic plumbing steps from progress and history while preserving meaningful action labels and conversation content.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/watchSubagentProgress.ts | Filters silent delegated actions and uses the shared action-aware display-label function. |
| apps/leaf/src/internal/agentRuntime/tools/toolPolicy.ts | Expands the silent plumbing-tool set and adds friendly labels for reward listing and skill loading. |
| apps/leaf/src/providers/web/history/buildLegacyClaudeHistory.ts | Prevents silent sandbox tools from appearing as status steps in legacy web history. |

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 keep tool plumbing out of Slack ..."](https://github.com/useautumn/autumn/commit/f7011618dba1d8cd7825d6bb61c86778c7794028) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56797710)</sub>

<!-- /greptile_comment -->