### PR TITLE
feat: billing generation understands entity scoping

### DIFF
--- a/server/src/internal/billing/v2/actions/generateRequest/compute/composeMultiAttachRequest.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/composeMultiAttachRequest.ts
@@ -1,8 +1,18 @@
-import type { CreateSchedulePlanV0 } from "@autumn/shared";
+import type {
+	CreateSchedulePlanV0,
+	MultiAttachParamsV0Input,
+} from "@autumn/shared";
 import { freeTrialParamsV1ToV0 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { resolveCustomizedPlan } from "@/internal/billing/v2/actions/resolveBillingRequest";
 import type { AttachGenerationParams } from "../generationSchemas";
+
+/** The composed multi-attach dialect the sheet seeds: MultiAttach params with
+ * the free trial already converted to its V0 shape. */
+export type GeneratedMultiAttachRequestV0 = Omit<
+	MultiAttachParamsV0Input,
+	"free_trial"
+> & { free_trial?: ReturnType<typeof freeTrialParamsV1ToV0> };
 
 const SINGLE_ATTACH_ONLY_FIELDS = [
 	"billing_cycle_anchor",
@@ -28,7 +38,7 @@ export const composeMultiAttachRequest = async ({
 	generated: AttachGenerationParams;
 	customerId: string;
 }): Promise<{
-	request: Record<string, unknown>;
+	request: GeneratedMultiAttachRequestV0;
 	unrepresentable: string[];
 }> => {
 	const additionalPlans = generated.additional_plans ?? [];

--- a/server/src/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems.ts
@@ -1,24 +1,25 @@
-import type {
-	GenerateBillingTool,
-	GeneratedBillingParams,
-} from "../generationSchemas";
+import type { CreatePlanItemParamsV1, PlanItemFilter } from "@autumn/shared";
+import type { GeneratedBillingParams } from "../generationSchemas";
 import type { GenerationContext } from "../setup/setupGenerationContext";
 
-type GenerationPlanItem = GenerationContext["plans"][number]["items"][number];
+type PlanCustomization = {
+	planId: string | undefined;
+	customize:
+		| {
+				add_items?: CreatePlanItemParamsV1[];
+				remove_items?: PlanItemFilter[];
+		  }
+		| null
+		| undefined;
+};
 
-const targetPlanId = ({
+const anchoredPlanId = ({
 	context,
 	customerProductId,
-	planId,
-	tool,
 }: {
 	context: GenerationContext;
 	customerProductId?: string;
-	planId?: string;
-	tool: GenerateBillingTool;
 }): string | undefined => {
-	if (planId !== undefined) return planId;
-	if (tool === "attach") return undefined;
 	const currentPlans = context.customer.current_plans;
 	const anchored = currentPlans.find(
 		(plan) =>
@@ -29,51 +30,84 @@ const targetPlanId = ({
 	return currentPlans.length === 1 ? currentPlans[0]?.plan_id : undefined;
 };
 
-const itemIsPriced = (item: GenerationPlanItem): boolean =>
-	"price" in item && item.price != null;
-
-export const assertNoDuplicateAddItems = ({
+/** Every generated request normalizes to plan customizations: schedule
+ * phases and unscheduled plans, or the primary plan plus additional_plans. */
+const planCustomizations = ({
 	context,
 	customerProductId,
 	generated,
-	tool,
 }: {
 	context: GenerationContext;
 	customerProductId?: string;
 	generated: GeneratedBillingParams;
-	tool: GenerateBillingTool;
-}): void => {
-	if (!("customize" in generated) || !generated.customize) return;
-	const { add_items: addItems, remove_items: removeFilters } =
-		generated.customize;
-	if (!addItems?.length) return;
+}): PlanCustomization[] => {
+	if ("phases" in generated) {
+		return [
+			...generated.phases.flatMap((phase) => phase.plans),
+			...(generated.unscheduled_plans ?? []),
+		].map((plan) => ({ planId: plan.plan_id, customize: plan.customize }));
+	}
+	return [
+		{
+			planId:
+				generated.plan_id ?? anchoredPlanId({ context, customerProductId }),
+			customize: generated.customize,
+		},
+		...("additional_plans" in generated
+			? (generated.additional_plans ?? []).map((plan) => ({
+					planId: plan.plan_id,
+					customize: plan.customize,
+				}))
+			: []),
+	];
+};
 
-	const planId = targetPlanId({
-		context,
-		customerProductId,
-		planId: generated.plan_id,
-		tool,
-	});
+const assertCustomizationAgainstCatalog = ({
+	context,
+	customization,
+}: {
+	context: GenerationContext;
+	customization: PlanCustomization;
+}): void => {
+	const { customize, planId } = customization;
 	const baseItems = context.plans.find((plan) => plan.id === planId)?.items;
-	if (!baseItems) return;
+	const addItems = customize?.add_items;
+	if (!baseItems || !addItems?.length) return;
 
 	const removedFeatureIds = new Set(
-		(removeFilters ?? [])
+		(customize?.remove_items ?? [])
 			.map((filter) => filter.feature_id)
 			.filter((id): id is string => id !== undefined),
 	);
 	for (const addItem of addItems) {
 		if (removedFeatureIds.has(addItem.feature_id)) continue;
-		const addIsPriced = addItem.price != null;
 		const duplicates = baseItems.some(
 			(item) =>
 				item.feature_id === addItem.feature_id &&
-				itemIsPriced(item) === addIsPriced,
+				(item.price != null) === (addItem.price != null),
 		);
 		if (duplicates) {
 			throw new Error(
 				`add_items entry for '${addItem.feature_id}' duplicates an item the plan already has — add_items only appends. To change the existing item, pair a remove_items filter matching it with an add_items entry copying its full definition (rollover, pooled, reset, price) with only the requested change.`,
 			);
 		}
+	}
+};
+
+export const assertNoDuplicateAddItems = ({
+	context,
+	customerProductId,
+	generated,
+}: {
+	context: GenerationContext;
+	customerProductId?: string;
+	generated: GeneratedBillingParams;
+}): void => {
+	for (const customization of planCustomizations({
+		context,
+		customerProductId,
+		generated,
+	})) {
+		assertCustomizationAgainstCatalog({ context, customization });
 	}
 };

--- a/server/src/internal/billing/v2/actions/generateRequest/generateRequest.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/generateRequest.ts
@@ -1,15 +1,27 @@
+import type { AttachParamsV0 } from "@autumn/shared";
 import { ErrCode, RecaseError } from "@autumn/shared";
 import { z } from "zod/v4";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import {
 	ResolveBillingRequestParamsSchema,
+	type ResolvedBillingRequestV0,
 	resolveBillingRequest,
 } from "@/internal/billing/v2/actions/resolveBillingRequest";
-import { composeMultiAttachRequest } from "./compute/composeMultiAttachRequest";
+import {
+	composeMultiAttachRequest,
+	type GeneratedMultiAttachRequestV0,
+} from "./compute/composeMultiAttachRequest";
 import { computeGeneratedParams } from "./compute/computeGeneratedParams";
 import { assertNoDuplicateAddItems } from "./compute/validateGeneratedAddItems";
 import type { GenerateBillingRequestParams } from "./generationSchemas";
 import { setupGenerationContext } from "./setup/setupGenerationContext";
+
+/** Attach requests keep an explicit `entity_id: null` — the sheet reads it as
+ * "clear the entity anchor", unlike an omitted key. */
+export type GeneratedBillingRequestV0 =
+	| ResolvedBillingRequestV0
+	| GeneratedMultiAttachRequestV0
+	| (Omit<AttachParamsV0, "entity_id"> & { entity_id?: string | null });
 
 export const generateRequest = async ({
 	ctx,
@@ -18,7 +30,7 @@ export const generateRequest = async ({
 	ctx: AutumnContext;
 	params: GenerateBillingRequestParams;
 }): Promise<{
-	request: Record<string, unknown>;
+	request: GeneratedBillingRequestV0;
 	unrepresentable: string[];
 }> => {
 	const { context } = await setupGenerationContext({
@@ -41,7 +53,6 @@ export const generateRequest = async ({
 				context,
 				customerProductId: params.customer_product_id,
 				generated: candidate,
-				tool: params.tool,
 			}),
 	});
 	if (repaired) {
@@ -57,11 +68,7 @@ export const generateRequest = async ({
 		);
 	}
 
-	if (
-		"additional_plans" in generated &&
-		generated.additional_plans !== undefined &&
-		generated.additional_plans.length > 0
-	) {
+	if ("additional_plans" in generated && generated.additional_plans?.length) {
 		return composeMultiAttachRequest({
 			ctx,
 			customerId: params.customer_id,
@@ -71,10 +78,6 @@ export const generateRequest = async ({
 
 	const explicitEntityScope =
 		"entity_id" in generated ? generated.entity_id : undefined;
-	if ("entity_id" in generated && generated.entity_id === null) {
-		delete generated.entity_id;
-	}
-
 	const anchoredEntityId =
 		params.tool === "update_subscription" &&
 		typeof params.current_request?.entity_id === "string"
@@ -82,6 +85,7 @@ export const generateRequest = async ({
 			: undefined;
 	const injected = {
 		...generated,
+		...(explicitEntityScope === null ? { entity_id: undefined } : {}),
 		customer_id: params.customer_id,
 		...(params.tool === "update_subscription" && params.customer_product_id
 			? { customer_product_id: params.customer_product_id }
@@ -106,7 +110,13 @@ export const generateRequest = async ({
 		params: parsedResolveParams.data,
 	});
 	if (params.tool === "attach" && explicitEntityScope !== undefined) {
-		resolved.request.entity_id = explicitEntityScope;
+		return {
+			request: {
+				...(resolved.request as AttachParamsV0),
+				entity_id: explicitEntityScope,
+			},
+			unrepresentable: resolved.unrepresentable,
+		};
 	}
 	return resolved;
 };

--- a/server/src/internal/billing/v2/actions/generateRequest/generateRequest.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/generateRequest.ts
@@ -75,12 +75,18 @@ export const generateRequest = async ({
 		delete generated.entity_id;
 	}
 
+	const anchoredEntityId =
+		params.tool === "update_subscription" &&
+		typeof params.current_request?.entity_id === "string"
+			? params.current_request.entity_id
+			: undefined;
 	const injected = {
 		...generated,
 		customer_id: params.customer_id,
 		...(params.tool === "update_subscription" && params.customer_product_id
 			? { customer_product_id: params.customer_product_id }
 			: {}),
+		...(anchoredEntityId ? { entity_id: anchoredEntityId } : {}),
 	};
 
 	const parsedResolveParams = ResolveBillingRequestParamsSchema.safeParse({

--- a/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
+++ b/server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts
@@ -1,4 +1,9 @@
-import type { Feature, FullCusProduct, FullProduct } from "@autumn/shared";
+import type {
+	Entity,
+	Feature,
+	FullCusProduct,
+	FullProduct,
+} from "@autumn/shared";
 import {
 	mapToProductV2,
 	productV2ToApiPlanV1,
@@ -44,18 +49,30 @@ const compactPlan = ({
 	};
 };
 
-const compactCustomerProduct = (customerProduct: FullCusProduct) => ({
-	customer_product_id: customerProduct.id,
-	plan_id: customerProduct.product.id,
-	status: customerProduct.status,
-	...(customerProduct.canceled ? { canceled: true } : {}),
-	...(customerProduct.trial_ends_at
-		? { trial_ends_at: customerProduct.trial_ends_at }
-		: {}),
-	...(customerProduct.options?.length
-		? { prepaid_quantities: customerProduct.options }
-		: {}),
-});
+export const compactCustomerProduct = ({
+	customerProduct,
+	entities,
+}: {
+	customerProduct: FullCusProduct;
+	entities: Entity[];
+}) => {
+	const entity = entities.find(
+		(candidate) => candidate.internal_id === customerProduct.internal_entity_id,
+	);
+	return {
+		customer_product_id: customerProduct.id,
+		plan_id: customerProduct.product.id,
+		status: customerProduct.status,
+		...(entity?.id ? { entity_id: entity.id } : {}),
+		...(customerProduct.canceled ? { canceled: true } : {}),
+		...(customerProduct.trial_ends_at
+			? { trial_ends_at: customerProduct.trial_ends_at }
+			: {}),
+		...(customerProduct.options?.length
+			? { prepaid_quantities: customerProduct.options }
+			: {}),
+	};
+};
 
 export const setupGenerationContext = async ({
 	ctx,
@@ -77,8 +94,11 @@ export const setupGenerationContext = async ({
 			customer: {
 				id: fullCustomer.id,
 				...(fullCustomer.name ? { name: fullCustomer.name } : {}),
-				current_plans: fullCustomer.customer_products.map(
-					compactCustomerProduct,
+				current_plans: fullCustomer.customer_products.map((customerProduct) =>
+					compactCustomerProduct({
+						customerProduct,
+						entities: fullCustomer.entities ?? [],
+					}),
 				),
 				entities: (fullCustomer.entities ?? []).map((entity) => ({
 					id: entity.id,

--- a/server/src/internal/billing/v2/actions/resolveBillingRequest.ts
+++ b/server/src/internal/billing/v2/actions/resolveBillingRequest.ts
@@ -1,11 +1,14 @@
 import {
+	type AttachParamsV0,
 	AttachParamsV1Schema,
 	billingParamsV1ToV0,
+	type CreateScheduleParamsV0,
 	CreateScheduleParamsV0Schema,
 	type CreateSchedulePlanV0,
 	cusProductToProduct,
 	customizePlanV1ToV0,
 	type FullProduct,
+	type UpdateSubscriptionV0Params,
 	UpdateSubscriptionV1ParamsSchema,
 } from "@autumn/shared";
 import { z } from "zod/v4";
@@ -29,6 +32,11 @@ export const ResolveBillingRequestParamsSchema = z.discriminatedUnion("tool", [
 export type ResolveBillingRequestParams = z.infer<
 	typeof ResolveBillingRequestParamsSchema
 >;
+
+export type ResolvedBillingRequestV0 =
+	| AttachParamsV0
+	| CreateScheduleParamsV0
+	| UpdateSubscriptionV0Params;
 
 /** Resolves one plan's `customize` patch into concrete V0 items against its
  * catalog plan — shared by schedule resolution and multi-attach generation. */
@@ -67,7 +75,7 @@ export const resolveBillingRequest = async ({
 	ctx: AutumnContext;
 	params: ResolveBillingRequestParams;
 }): Promise<{
-	request: Record<string, unknown>;
+	request: ResolvedBillingRequestV0;
 	unrepresentable: string[];
 }> => {
 	if (params.tool === "create_schedule") {
@@ -89,7 +97,10 @@ export const resolveBillingRequest = async ({
 					}
 				: {}),
 		};
-		return { request, unrepresentable: [] };
+		return {
+			request: request as CreateScheduleParamsV0,
+			unrepresentable: [],
+		};
 	}
 
 	let fullProduct: FullProduct;
@@ -117,9 +128,16 @@ export const resolveBillingRequest = async ({
 		});
 	}
 
-	return billingParamsV1ToV0({
+	const { request, unrepresentable } = billingParamsV1ToV0({
 		ctx,
 		fullProduct,
 		params: params.request,
 	});
+	return {
+		request:
+			params.tool === "attach"
+				? (request as AttachParamsV0)
+				: (request as UpdateSubscriptionV0Params),
+		unrepresentable,
+	};
 };

--- a/server/tests/evals/generateBillingRequest/fixtures.ts
+++ b/server/tests/evals/generateBillingRequest/fixtures.ts
@@ -325,3 +325,41 @@ export const tieredScaleBaseItems = (): ApiPlanV1["items"] =>
 			unlimited: false,
 		},
 	] as unknown as ApiPlanV1["items"];
+
+/** Two entities where only one holds the plan — the model must read
+ * current_plans entity scoping to target the other. */
+export const entityScaleContext = (): GenerationContext =>
+	({
+		customer: {
+			id: "cus_entities",
+			name: "Entities Co",
+			current_plans: [
+				{
+					customer_product_id: "cp_scale_alpha",
+					entity_id: "alpha",
+					plan_id: "scale",
+					status: "active",
+				},
+			],
+			entities: [
+				{ id: "alpha", name: "Alpha Site" },
+				{ id: "beta", name: "Beta Site" },
+			],
+		},
+		features: [{ id: "credits", name: "Credits", type: "single_use" }],
+		now,
+		plans: [
+			{
+				id: "scale",
+				name: "Scale",
+				price: { amount: 500, interval: "month" },
+				items: [
+					{
+						feature_id: "credits",
+						included: 1000,
+						reset: { interval: "month" },
+					},
+				],
+			},
+		],
+	}) as unknown as GenerationContext;

--- a/server/tests/evals/generateBillingRequest/fixtures.ts
+++ b/server/tests/evals/generateBillingRequest/fixtures.ts
@@ -361,5 +361,16 @@ export const entityScaleContext = (): GenerationContext =>
 					},
 				],
 			},
+			{
+				id: "enterprise",
+				name: "Enterprise",
+				items: [
+					{
+						feature_id: "credits",
+						included: 5000,
+						reset: { interval: "month" },
+					},
+				],
+			},
 		],
 	}) as unknown as GenerationContext;

--- a/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
+++ b/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
@@ -21,6 +21,7 @@ import type {
 import type { GenerationContext } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext";
 import {
 	creditLadderContext,
+	entityScaleContext,
 	rolloverCreditsBaseItems,
 	rolloverCreditsContext,
 	saasContext,
@@ -479,6 +480,15 @@ const cases: EvalCase[] = [
 				remove_items: [{ feature_id: "credits" }],
 			},
 		},
+	},
+	{
+		name: "attach: entity scoping read from current_plans",
+		input: {
+			context: entityScaleContext(),
+			prompt: "attach scale to the entity that doesn't have it yet",
+			tool: "attach",
+		},
+		expected: { entity_id: "beta", plan_id: "scale" },
 	},
 	{
 		name: "schedule: switch plan next month",

--- a/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
+++ b/server/tests/evals/generateBillingRequest/generate-billing-request.eval.ts
@@ -531,6 +531,53 @@ const cases: EvalCase[] = [
 			],
 		},
 	},
+	{
+		name: "schedule: per-plan entity scoping and customize stay independent",
+		input: {
+			context: entityScaleContext(),
+			prompt:
+				"starting next month, put enterprise on the alpha entity at $10k per year and scale on the beta entity",
+			tool: "create_schedule",
+		},
+		expected: {
+			phases: [
+				{
+					plans: [
+						{
+							customize: { price: { amount: 10000, interval: "year" } },
+							entity_id: "alpha",
+							plan_id: "enterprise",
+						},
+						{ entity_id: "beta", plan_id: "scale" },
+					],
+				},
+			],
+		},
+	},
+	{
+		name: "schedule: per-plan item customize uses remove+add",
+		input: {
+			context: entityScaleContext(),
+			prompt:
+				"next month move them onto scale but with 2k credits included instead of 1k",
+			tool: "create_schedule",
+		},
+		expected: {
+			phases: [
+				{
+					plans: [
+						{
+							customize: {
+								add_items: [{ feature_id: "credits", included: 2000 }],
+								remove_items: [{ feature_id: "credits" }],
+							},
+							plan_id: "scale",
+						},
+					],
+				},
+			],
+		},
+	},
 ];
 
 Eval("generate-billing-request", {

--- a/server/tests/unit/billing/generationContext.test.ts
+++ b/server/tests/unit/billing/generationContext.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import type { Entity, FullCusProduct } from "@autumn/shared";
+import { compactCustomerProduct } from "@/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext";
+
+const entities = [
+	{ id: "alpha", internal_id: "ent_internal_alpha", name: "Alpha" },
+	{ id: "beta", internal_id: "ent_internal_beta", name: "Beta" },
+] as unknown as Entity[];
+
+describe("compactCustomerProduct", () => {
+	test("an entity-scoped product carries its public entity id", () => {
+		const compact = compactCustomerProduct({
+			customerProduct: {
+				id: "cp_1",
+				internal_entity_id: "ent_internal_beta",
+				product: { id: "scale" },
+				status: "active",
+			} as unknown as FullCusProduct,
+			entities,
+		});
+		expect(compact.entity_id).toBe("beta");
+		expect(compact.customer_product_id).toBe("cp_1");
+		expect(compact.plan_id).toBe("scale");
+	});
+
+	test("a customer-level product has no entity_id", () => {
+		const compact = compactCustomerProduct({
+			customerProduct: {
+				id: "cp_2",
+				internal_entity_id: null,
+				product: { id: "pro" },
+				status: "active",
+			} as unknown as FullCusProduct,
+			entities,
+		});
+		expect(compact.entity_id).toBeUndefined();
+		expect("entity_id" in compact).toBe(false);
+		expect(compact.plan_id).toBe("pro");
+	});
+
+	test("an unknown internal entity id degrades to no entity_id", () => {
+		const compact = compactCustomerProduct({
+			customerProduct: {
+				id: "cp_3",
+				internal_entity_id: "ent_internal_missing",
+				product: { id: "pro" },
+				status: "active",
+			} as unknown as FullCusProduct,
+			entities: [],
+		});
+		expect(compact.entity_id).toBeUndefined();
+	});
+});

--- a/server/tests/unit/billing/validateGeneratedAddItems.test.ts
+++ b/server/tests/unit/billing/validateGeneratedAddItems.test.ts
@@ -66,7 +66,6 @@ describe("assertNoDuplicateAddItems", () => {
 						],
 					},
 				},
-				tool: "update_subscription",
 			}),
 		).toThrow(/pair a remove_items filter/);
 	});
@@ -93,7 +92,6 @@ describe("assertNoDuplicateAddItems", () => {
 						remove_items: [{ feature_id: "AI_CREDITS", included: 10_000 }],
 					},
 				},
-				tool: "update_subscription",
 			}),
 		).not.toThrow();
 	});
@@ -106,7 +104,6 @@ describe("assertNoDuplicateAddItems", () => {
 					customize: { add_items: [{ feature_id: "SEATS", included: 5 }] },
 					plan_id: "pro",
 				},
-				tool: "attach",
 			}),
 		).not.toThrow();
 	});
@@ -146,7 +143,6 @@ describe("assertNoDuplicateAddItems", () => {
 					},
 					plan_id: "pro",
 				},
-				tool: "attach",
 			}),
 		).not.toThrow();
 	});
@@ -159,8 +155,121 @@ describe("assertNoDuplicateAddItems", () => {
 					customize: {
 						add_items: [{ feature_id: "AI_CREDITS", included: 12_000 }],
 					},
+					plan_id: "unknown_plan",
 				},
-				tool: "attach",
+			}),
+		).not.toThrow();
+	});
+
+	test("additional_plans are checked against their own catalog plans", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context,
+				generated: {
+					additional_plans: [
+						{
+							customize: {
+								add_items: [
+									{
+										feature_id: "AI_CREDITS",
+										included: 12_000,
+										reset: { interval: ResetInterval.Month },
+									},
+								],
+							},
+							plan_id: "pro",
+						},
+					],
+					plan_id: "unknown_plan",
+				} as never,
+			}),
+		).toThrow(/pair a remove_items filter/);
+	});
+});
+
+describe("assertNoDuplicateAddItems — schedules", () => {
+	const scheduleContext = {
+		customer: { id: "cus_1", current_plans: [] },
+		features: [],
+		now: { epoch_ms: 0, iso: "1970-01-01T00:00:00.000Z" },
+		plans: [
+			{
+				id: "scale",
+				name: "Scale",
+				items: [
+					{
+						feature_id: "credits",
+						included: 1000,
+						reset: { interval: ResetInterval.Month },
+					},
+				],
+			},
+		],
+	} as unknown as GenerationContext;
+
+	test("a bare add on a scheduled plan is rejected", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context: scheduleContext,
+				generated: {
+					phases: [
+						{
+							plans: [
+								{
+									customize: {
+										add_items: [{ feature_id: "credits", included: 2000 }],
+									},
+									plan_id: "scale",
+								},
+							],
+						},
+					],
+				} as never,
+			}),
+		).toThrow(/pair a remove_items filter/);
+	});
+
+	test("a paired remove+add on a scheduled plan passes", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context: scheduleContext,
+				generated: {
+					phases: [
+						{
+							plans: [
+								{
+									customize: {
+										add_items: [{ feature_id: "credits", included: 2000 }],
+										remove_items: [{ feature_id: "credits" }],
+									},
+									plan_id: "scale",
+								},
+							],
+						},
+					],
+				} as never,
+			}),
+		).not.toThrow();
+	});
+
+	test("an unknown scheduled plan id passes conservatively", () => {
+		expect(() =>
+			assertNoDuplicateAddItems({
+				context: scheduleContext,
+				generated: {
+					phases: [
+						{
+							plans: [
+								{
+									customize: {
+										add_items: [{ feature_id: "credits", included: 2000 }],
+									},
+									plan_id: "unknown_plan",
+								},
+							],
+						},
+					],
+				} as never,
 			}),
 		).not.toThrow();
 	});


### PR DESCRIPTION
Follow-up to #3072, extending the billing-sheet generation flow to handle entity scoping and per-plan schedule configuration correctly.

## Gaps

1. **The model couldn't see entity scoping.** The generation context listed the customer's entities and their current plans, but `current_plans` never said *which entity* a subscription sits on — "attach scale to the entity that doesn't have it yet" was unanswerable, and mixed customer-level/entity attaches were guesswork.
2. **Update resolution diverged from the sheet.** The sheet's own preview calls resolve entity-scoped targets with `entity_id` from the anchored request; generation resolution never passed it, surviving only via the `customer_product_id` DB fallback — and silently auto-resolving to the wrong customer-level product for `plan_id`-only targeting.
3. **Schedules had no coverage for per-plan independence**, and the duplicate-add guard skipped `create_schedule` entirely — a bare `add_items` on a scheduled plan could still duplicate an item.

## Changes

- `compactCustomerProduct` maps `internal_entity_id` → the public `entity_id` on each `current_plans` entry (customer-level plans stay unmarked).
- `generateRequest` injects the sheet-anchored `entity_id` from `current_request` into the update-subscription resolve params, matching the sheet's own resolution path.
- `assertNoDuplicateAddItems` now walks `phases[].plans` and `unscheduled_plans` against their catalog plans (shared core with the attach/update path) instead of returning early for schedules.

## Validation

Eval suite (`expected_params` **100%**, `applied_plan` **100%**) including new cases:
- *attach: entity scoping read from current_plans* — "attach scale to the entity that doesn't have it yet" → `entity_id: beta` chosen off `current_plans` scoping
- *schedule: per-plan entity scoping and customize stay independent* — one phase carrying `enterprise@alpha` with a $10k/yr price customize alongside an uncustomized `scale@beta`
- *schedule: per-plan item customize uses remove+add* — item change inside a phase expressed as a paired `remove_items` + `add_items`

Unit tests for the entity mapping and the schedule guard path (bare add rejected, paired remove+add passes, unknown plan degrades conservatively); server unit suite at baseline; `tsc` clean.





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends billing-request generation to preserve entity scope and validate each plan customization independently.
- **[Bug fixes]** Maps current subscriptions to public entity IDs and carries the sheet's entity anchor into subscription-update resolution.
- **[Improvements]** Validates item customizations across scheduled phases, unscheduled plans, and multi-plan attachments.
- **[API changes, Improvements]** Replaces broad request records with explicit generated and resolved billing-request types.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because entity-scoped generation still receives no entity records and can produce a request for the wrong scope.

The new mapping depends on fullCustomer.entities, but setupGenerationContext still calls CusService.getFull with entity loading disabled by default, so entity-scoped current plans continue to lose their entity IDs.

**Files Needing Attention:** server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts | Adds entity IDs to compact current plans, but the unchanged customer lookup still does not load the entities required by that mapping. |
| server/src/internal/billing/v2/actions/generateRequest/generateRequest.ts | Preserves the sheet-anchored entity scope for generated subscription updates and introduces explicit request result types. |
| server/src/internal/billing/v2/actions/generateRequest/compute/validateGeneratedAddItems.ts | Normalizes attach and schedule customizations so duplicate catalog items are checked per plan. |
| server/src/internal/billing/v2/actions/resolveBillingRequest.ts | Adds explicit resolved-request unions without changing the underlying conversion behavior. |
| server/tests/unit/billing/generationContext.test.ts | Tests the mapping helper with supplied entities but does not exercise the production customer lookup that currently omits them. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Load full customer] --> B[Map current plans]
  B --> C[Build generation context]
  C --> D[Generate billing parameters]
  D --> E[Validate each plan customization]
  E --> F[Resolve billing request]
  A -. entities not requested .-> G[Empty entity list]
  G -. entity IDs omitted .-> B
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/billing/v2/actions/generateRequest/setup/setupGenerationContext.ts:100
**Entity mapping receives no entities**

When billing-sheet generation loads a customer with an entity-scoped plan, `CusService.getFull` leaves entity loading disabled and this fallback passes an empty list to `compactCustomerProduct`. The resulting `current_plans` entry omits `entity_id`, so, for example, the model cannot tell that Alpha already has Scale and can target the wrong scope instead of Beta.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["feat: 🎸 schedules respect per-plan bits..."](https://github.com/useautumn/autumn/commit/de0919031ab91bd29c6a1d95202cce6d8ce65ce8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56797867)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)
- Knowledge Base — [Customer, subject, and entitlement operations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/customer-management.md)

<!-- /greptile_comment -->