### PR TITLE
fix: grouped bare writes show what changes instead of an empty billing table

### DIFF
--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -733,7 +733,7 @@ const approvalTitle = ({
 	toolName: string;
 }) => {
 	const fallback = toolLabel(toolName);
-	if (!["updateCatalog", "updatePlan"].includes(normalizeToolName(toolName))) {
+	if (!CATALOG_TOOLS.has(normalizeToolName(toolName))) {
 		return fallback;
 	}
 	const { plan, planName } = catalogApprovalContext(preview);
@@ -885,6 +885,8 @@ const BILLING_ACTION_TOOLS = new Set([
 	"updateSubscription",
 ]);
 
+const CATALOG_TOOLS = new Set(["updateCatalog", "updatePlan"]);
+
 /** A homogeneous group shows one heading and one row per target instead of
  * repeating the whole body. */
 const isHomogeneousGroup = ({
@@ -899,6 +901,18 @@ const isHomogeneousGroup = ({
 		(write) =>
 			normalizeToolName(write.toolName) === normalizeToolName(toolName),
 	);
+
+/** Catalog writes carry structured previews a fan-out row cannot hold, so a
+ * grouped catalog card keeps a titled section per write. */
+const rendersAsFanOut = ({
+	writes,
+	toolName,
+}: {
+	writes: ReadonlyArray<{ toolName: string }>;
+	toolName: string;
+}) =>
+	isHomogeneousGroup({ writes, toolName }) &&
+	!CATALOG_TOOLS.has(normalizeToolName(toolName));
 
 const writeTotal = (preview?: unknown) =>
 	getNumber(getPreviewBody(preview).total) ?? 0;
@@ -1035,7 +1049,7 @@ const approvalBodyBlocks = ({
 	toolName: string;
 }): CardChild[] => {
 	const groupedWrites = writes ?? withheldWritesFromToolArgs(toolArgs);
-	if (isHomogeneousGroup({ writes: groupedWrites, toolName })) {
+	if (rendersAsFanOut({ writes: groupedWrites, toolName })) {
 		return fanOutBlocks({
 			env,
 			preview,
@@ -1509,7 +1523,7 @@ export const approvalCard = ({
 	const editable = normalizeToolName(toolName) === "attach";
 	const groupedWrites = writes ?? withheldWritesFromToolArgs(toolArgs);
 
-	const fanOut = isHomogeneousGroup({
+	const fanOut = rendersAsFanOut({
 		writes: groupedWrites,
 		toolName,
 	});
@@ -1758,18 +1772,10 @@ export const approvalStatusCard = ({
 		});
 	}
 
-	// A mixed group already states each write with its own marker; the card-level
-	// line would just repeat the first one.
-	const resolvedWrites =
-		groupedWrites ?? withheldWritesFromToolArgs(toolArgs) ?? [];
-	const groupStatesEachWrite =
-		resolvedWrites.length > 1 &&
-		!isHomogeneousGroup({ writes: resolvedWrites, toolName });
-
 	return Card({
 		title: approvalTitle({ preview, toolName }),
 		children: [
-			...(groupStatesEachWrite ? [] : [CardText(`✅ ${phrases.done}`)]),
+			CardText(`✅ ${phrases.done}`),
 			...resolvedBody,
 			...(outcome.lines.length ? [CardText(outcome.lines.join("\n"))] : []),
 			...(outcome.links.length || dashboardUrl

--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -630,7 +630,8 @@ const humanizeKey = (key: string) =>
 	key.replace(/_/g, " ").replace(/^./, (char) => char.toUpperCase());
 
 const compactValue = (value: unknown): string | null => {
-	if (value === null || value === undefined) return null;
+	if (value === null) return "cleared";
+	if (value === undefined) return null;
 	if (typeof value === "string") {
 		if (!value.trim()) return null;
 		return value.length > REQUEST_FIELD_VALUE_MAX
@@ -662,6 +663,28 @@ const requestSummaryFields = (
 		if (fields.length >= MAX_REQUEST_FIELDS) break;
 	}
 	return fields;
+};
+
+/** One-line summary of a bare write's fields, for fan-out rows where the
+ * per-card field list has no room. */
+const requestChangesText = (
+	toolArgs?: Record<string, unknown>,
+): string | null => {
+	const request = toolRequestFromArgs(toolArgs) ?? {};
+	const parts: string[] = [];
+	let overflow = 0;
+	for (const [key, value] of Object.entries(request)) {
+		if (HIDDEN_REQUEST_KEYS.has(key) || key.startsWith("_")) continue;
+		const rendered = compactValue(value);
+		if (rendered === null) continue;
+		if (parts.length >= MAX_REQUEST_FIELDS) {
+			overflow += 1;
+			continue;
+		}
+		parts.push(`${humanizeKey(key)}: ${rendered}`);
+	}
+	if (overflow > 0) parts.push(`+${overflow} more`);
+	return parts.length ? parts.join(" · ") : null;
 };
 
 const catalogApprovalContext = (preview: unknown) => {
@@ -891,6 +914,24 @@ const fanOutBlocks = ({
 	toolName: string;
 }): CardChild[] => {
 	const all = [{ input: toolArgs, preview, toolName }, ...writes];
+	if (!BILLING_ACTION_TOOLS.has(normalizeToolName(toolName))) {
+		return [
+			fanOutTable({
+				align: ["left", "left"],
+				caption: `${all.length} customers`,
+				headers: ["Customer", "Update"],
+				rows: all.map((write) => [
+					actionPhrases({
+						env,
+						preview: write.preview,
+						toolArgs: write.input,
+						toolName: write.toolName,
+					}).labels.plainCustomer,
+					requestChangesText(write.input) ?? "—",
+				]),
+			}),
+		];
+	}
 	const rows = all.map((write) => {
 		const phrases = actionPhrases({
 			env,
@@ -924,6 +965,12 @@ const fanOutBlocks = ({
  * the tense tracks whether the card is still in progress. */
 type StepTense = "done" | "failed" | "running";
 
+const STEP_TENSE_ICONS: Record<StepTense, string> = {
+	done: "✅ ",
+	failed: "⚠️ ",
+	running: "",
+};
+
 const withheldWriteBlocks = ({
 	env,
 	writes,
@@ -946,7 +993,9 @@ const withheldWriteBlocks = ({
 			CardText(
 				`*${approvalTitle({ preview: write.preview, toolName: write.toolName })}*`,
 			),
-			CardText(phrases[tense]),
+			// Every write in a resolved group carries its own marker; without one
+			// the later writes read as unapplied next to the first write's tick.
+			CardText(`${STEP_TENSE_ICONS[tense]}${phrases[tense]}`),
 			...approvalPreviewBlocks({
 				env,
 				preview: write.preview,
@@ -1698,10 +1747,18 @@ export const approvalStatusCard = ({
 		});
 	}
 
+	// A mixed group already states each write with its own marker; the card-level
+	// line would just repeat the first one.
+	const resolvedWrites =
+		groupedWrites ?? withheldWritesFromToolArgs(toolArgs) ?? [];
+	const groupStatesEachWrite =
+		resolvedWrites.length > 1 &&
+		!isHomogeneousGroup({ writes: resolvedWrites, toolName });
+
 	return Card({
 		title: approvalTitle({ preview, toolName }),
 		children: [
-			CardText(`✅ ${phrases.done}`),
+			...(groupStatesEachWrite ? [] : [CardText(`✅ ${phrases.done}`)]),
 			...resolvedBody,
 			...(outcome.lines.length ? [CardText(outcome.lines.join("\n"))] : []),
 			...(outcome.links.length || dashboardUrl

--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -348,8 +348,17 @@ const actionPhrases = ({
 				};
 			}
 			case "updateCustomer": {
+				const renamedId = getString(request.id);
+				const renamedLabel = renamedId
+					? autumnDashboardLabel({
+							env,
+							id: renamedId,
+							label: customerText ?? renamedId,
+							resource: "customers",
+						})
+					: customerLabel;
 				return {
-					done: `Updated ${customerLabel}`,
+					done: `Updated ${renamedLabel}`,
 					failed: `Couldn't update ${customerLabel}`,
 					pending: `Update ${customerLabel}`,
 					running: `Updating ${customerLabel}`,

--- a/apps/leaf/src/ui/blocks.ts
+++ b/apps/leaf/src/ui/blocks.ts
@@ -657,41 +657,44 @@ const compactValue = (value: unknown): string | null => {
 		: json;
 };
 
-// Bare CRUD writes (update customer, create entity…) have no billing preview —
-// show what's being written as label/value fields so the card is never empty.
-const requestSummaryFields = (
+const requestFieldEntries = (
 	toolArgs?: Record<string, unknown>,
-): FieldElement[] => {
+): { label: string; value: string }[] => {
 	const request = toolRequestFromArgs(toolArgs) ?? {};
-	const fields: FieldElement[] = [];
+	const entries: { label: string; value: string }[] = [];
 	for (const [key, value] of Object.entries(request)) {
 		if (HIDDEN_REQUEST_KEYS.has(key) || key.startsWith("_")) continue;
 		const rendered = compactValue(value);
 		if (rendered === null) continue;
-		fields.push(Field({ label: humanizeKey(key), value: rendered }));
-		if (fields.length >= MAX_REQUEST_FIELDS) break;
+		entries.push({ label: humanizeKey(key), value: rendered });
 	}
-	return fields;
+	return entries;
+};
+
+// Bare CRUD writes (update customer, create entity…) have no billing preview —
+// the fields being written render as the change table so the card is never empty.
+const requestChangesTable = (
+	toolArgs?: Record<string, unknown>,
+): CardChild | null => {
+	const entries = requestFieldEntries(toolArgs);
+	if (entries.length === 0) return null;
+	return Table({
+		align: ["left", "left"],
+		caption: "Changes",
+		headers: ["Field", "Change"],
+		rows: entries.map((entry) => [entry.label, entry.value]),
+	});
 };
 
 /** One-line summary of a bare write's fields, for fan-out rows where the
- * per-card field list has no room. */
+ * per-card table has no room. */
 const requestChangesText = (
 	toolArgs?: Record<string, unknown>,
 ): string | null => {
-	const request = toolRequestFromArgs(toolArgs) ?? {};
-	const parts: string[] = [];
-	let overflow = 0;
-	for (const [key, value] of Object.entries(request)) {
-		if (HIDDEN_REQUEST_KEYS.has(key) || key.startsWith("_")) continue;
-		const rendered = compactValue(value);
-		if (rendered === null) continue;
-		if (parts.length >= MAX_REQUEST_FIELDS) {
-			overflow += 1;
-			continue;
-		}
-		parts.push(`${humanizeKey(key)}: ${rendered}`);
-	}
+	const entries = requestFieldEntries(toolArgs);
+	const shown = entries.slice(0, MAX_REQUEST_FIELDS);
+	const overflow = entries.length - shown.length;
+	const parts = shown.map((entry) => `${entry.label}: ${entry.value}`);
 	if (overflow > 0) parts.push(`+${overflow} more`);
 	return parts.length ? parts.join(" · ") : null;
 };
@@ -1061,10 +1064,9 @@ const approvalPreviewBlocks = ({
 	const blocks: CardChild[] = [];
 	const normalizedToolName = normalizeToolName(toolName);
 	if (isFailedApprovalPreview(preview)) {
-		blocks.push(
-			CardText(PREVIEW_UNAVAILABLE_MESSAGE, { style: "muted" }),
-			Fields(requestSummaryFields(toolArgs)),
-		);
+		blocks.push(CardText(PREVIEW_UNAVAILABLE_MESSAGE, { style: "muted" }));
+		const changes = requestChangesTable(toolArgs);
+		if (changes) blocks.push(changes);
 		return blocks;
 	}
 	const structured = previewElements(preview);
@@ -1089,8 +1091,8 @@ const approvalPreviewBlocks = ({
 		pushMoney();
 		// Nothing structured to show — fall back to the write's own fields.
 		if (blocks.length === 0) {
-			const fields = requestSummaryFields(toolArgs);
-			if (fields.length) blocks.push(Fields(fields));
+			const changes = requestChangesTable(toolArgs);
+			if (changes) blocks.push(changes);
 		}
 		const mutedLine = contextLine([
 			structured ? null : nextCycleNote(preview),

--- a/apps/leaf/src/ui/changeTable.ts
+++ b/apps/leaf/src/ui/changeTable.ts
@@ -150,17 +150,23 @@ export const writeOutcomeTable = ({
 /** One operation applied to several targets — collapses the repeated sections
  * a fan-out would otherwise produce into a single scannable table. */
 export const fanOutTable = ({
+	align,
 	caption,
 	headers,
 	rows,
 }: {
+	align?: ("left" | "right")[];
 	caption: string;
-	headers: [string, string, string];
-	rows: ReadonlyArray<[string, string, string]>;
+	headers: readonly string[];
+	rows: ReadonlyArray<readonly string[]>;
 }) =>
 	Table({
-		align: ["left", "left", "right"],
+		align:
+			align ??
+			headers.map((_, index) =>
+				index === headers.length - 1 ? "right" : "left",
+			),
 		caption,
-		headers,
+		headers: [...headers],
 		rows: rows.map((row) => [...row]),
 	});

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -1296,6 +1296,83 @@ describe("homogeneous fan-out", () => {
 		expect(rendered).toContain("1,200");
 	});
 
+	test("non-billing fan-outs show each write's fields instead of money", () => {
+		const updateStep = (email: string, id: string) => ({
+			input: { request: { customer_id: email, id } },
+			requestId: `req_${email}`,
+			toolName: "autumn__updateCustomer",
+		});
+		const card = approvalCard({
+			id: "fanout-update",
+			env: AppEnv.Sandbox,
+			toolArgs: {
+				_eveWithheldWrites: [
+					updateStep("ilvernon32@gmail.com", "user_beta"),
+					updateStep("greaterinvestments@gmail.com", "user_gamma"),
+				],
+				request: {
+					customer_id: "cassidy2flawless@yahoo.com",
+					id: "user_alpha",
+				},
+			},
+			toolName: "updateCustomer",
+		});
+
+		const rendered = JSON.stringify(cardToBlockKit(card));
+		expect(rendered).toContain("Update");
+		expect(rendered).toContain("Id: user_alpha");
+		expect(rendered).toContain("Id: user_beta");
+		expect(rendered).toContain("Id: user_gamma");
+		expect(rendered).not.toContain("Due now");
+		expect(rendered).not.toContain("Total");
+		expect(rendered).not.toContain("$0.00");
+	});
+
+	test("fan-out rows render every field kind: sets, clears, objects, overflow", () => {
+		const card = approvalCard({
+			id: "fanout-fields",
+			env: AppEnv.Sandbox,
+			toolArgs: {
+				_eveWithheldWrites: [
+					{
+						input: {
+							request: { customer_id: "b@x.com", email: null, name: "Beta" },
+						},
+						requestId: "req_b",
+						toolName: "autumn__updateCustomer",
+					},
+					{
+						input: {
+							request: { customer_id: "c@x.com", id: "user_gamma" },
+						},
+						requestId: "req_c",
+						toolName: "autumn__updateCustomer",
+					},
+				],
+				request: {
+					customer_id: "a@x.com",
+					email: "new@x.com",
+					fingerprint: "fp_1",
+					id: "user_alpha",
+					metadata: { source: "revenuecat" },
+					name: "Alpha",
+					stripe_id: "cus_stripe1",
+					tax_exempt: true,
+				},
+			},
+			toolName: "updateCustomer",
+		});
+
+		const rendered = JSON.stringify(cardToBlockKit(card));
+		expect(rendered).toContain("Email: new@x.com");
+		expect(rendered).toContain("Id: user_alpha");
+		expect(rendered).toContain("Metadata: {");
+		expect(rendered).toContain("revenuecat");
+		expect(rendered).toContain("+1 more");
+		expect(rendered).toContain("Email: cleared");
+		expect(rendered).toContain("Name: Beta");
+	});
+
 	test("keeps per-step sections when the writes differ", () => {
 		const card = approvalCard({
 			id: "mixed",

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -831,6 +831,35 @@ describe("approval details modal", () => {
 });
 
 describe("approval status card", () => {
+	test("a mixed resolved group keeps the primary's applied marker", () => {
+		const card = approvalStatusCard({
+			status: "approved",
+			env: AppEnv.Sandbox,
+			toolName: "updateCustomer",
+			toolArgs: {
+				_eveWithheldWrites: [
+					{
+						input: { request: { customer_id: "cus_1", plan_id: "pro" } },
+						requestId: "req_2",
+						toolName: "autumn__attach",
+					},
+					{
+						input: { request: { customer_id: "cus_2", plan_id: "pro" } },
+						requestId: "req_3",
+						toolName: "autumn__attach",
+					},
+				],
+				request: { customer_id: "cus_1", name: "Renamed" },
+			},
+			actorId: "U1",
+			result: { result: wrapMcpResult({ customer_id: "cus_1" }) },
+		});
+
+		const json = JSON.stringify(card);
+		// Primary marker plus one per withheld write — nothing reads as unapplied.
+		expect(json.split("✅").length - 1).toBe(3);
+	});
+
 	test("shows no progress line until the action reports progress", () => {
 		const card = approvalStatusCard({
 			status: "running",
@@ -1327,6 +1356,30 @@ describe("homogeneous fan-out", () => {
 		expect(rendered).not.toContain("Due now");
 		expect(rendered).not.toContain("Total");
 		expect(rendered).not.toContain("$0.00");
+	});
+
+	test("grouped catalog writes keep their structured sections", () => {
+		const catalogStep = (planId: string) => ({
+			input: { request: { plans: [{ items: [], plan_id: planId }] } },
+			requestId: `req_${planId}`,
+			toolName: "autumn__updateCatalog",
+		});
+		const card = approvalCard({
+			id: "fanout-catalog",
+			env: AppEnv.Sandbox,
+			toolArgs: {
+				_eveWithheldWrites: [catalogStep("growth"), catalogStep("scale")],
+				request: { plans: [{ items: [], plan_id: "launch" }] },
+			},
+			toolName: "updateCatalog",
+		});
+
+		const rendered = JSON.stringify(cardToBlockKit(card));
+		expect(rendered).not.toContain("3 customers");
+		// One titled section per grouped write, not one fan-out row.
+		expect(rendered.split("Update catalog").length - 1).toBeGreaterThanOrEqual(
+			2,
+		);
 	});
 
 	test("fan-out rows render every field kind: sets, clears, objects, overflow", () => {

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -761,8 +761,9 @@ describe("approval card", () => {
 
 		const json = JSON.stringify(card);
 		expect(json).toContain("Update **Acme**?");
-		expect(json).toContain('"label":"Name","value":"Acme"');
-		expect(json).toContain('"label":"Email","value":"billing@example.com"');
+		expect(json).toContain('"headers":["Field","Change"]');
+		expect(json).toContain('["Name","Acme"]');
+		expect(json).toContain('["Email","billing@example.com"]');
 		expect(json).not.toContain('"customer_id"');
 	});
 

--- a/apps/leaf/tests/unit/ui/blocks.test.ts
+++ b/apps/leaf/tests/unit/ui/blocks.test.ts
@@ -1373,6 +1373,36 @@ describe("homogeneous fan-out", () => {
 		expect(rendered).toContain("Name: Beta");
 	});
 
+	test("a completed id change links the new customer id, pending links the old", () => {
+		const toolArgs = {
+			request: { customer_id: "edge-mt33ohxl", id: "user_fresh" },
+		};
+		const pending = JSON.stringify(
+			cardToBlockKit(
+				approvalCard({
+					id: "rename-pending",
+					env: AppEnv.Sandbox,
+					toolArgs,
+					toolName: "updateCustomer",
+				}),
+			),
+		);
+		expect(pending).toContain("customers/edge-mt33ohxl");
+
+		const done = JSON.stringify(
+			cardToBlockKit(
+				approvalStatusCard({
+					env: AppEnv.Sandbox,
+					status: "approved",
+					toolArgs,
+					toolName: "updateCustomer",
+				}),
+			),
+		);
+		expect(done).toContain("customers/user_fresh");
+		expect(done).not.toContain("customers/edge-mt33ohxl");
+	});
+
 	test("keeps per-step sections when the writes differ", () => {
 		const card = approvalCard({
 			id: "mixed",


### PR DESCRIPTION
## Problem

[Live thread](https://autumnpricing.slack.com/archives/C0BCAQQK0KS/p1787730449900869?thread_ts=1787729929.096999&cid=C0BCAQQK0KS): the agent grouped three `updateCustomer` writes (setting each customer's `id`), and the approval card rendered the **billing** fan-out table:

| Customer | Plan | Due now |
|---|---|---|
| cassidy2flawless@yahoo.com | — | $0.00 |

…with a `Total $0.00` line and **no trace of the actual update** — the approver had to ask "What update are you making here?" in the thread.

## Root cause

`fanOutBlocks` collapses any homogeneous write group into the plan/money table, which is only meaningful for billing tools. A single bare write's card falls back to `requestSummaryFields` (label/value fields like `Id: user_…`), but the fan-out path bypasses that fallback entirely — so grouped non-billing writes showed nothing but dashes and zeros.

## Fix

Non-billing homogeneous groups now render a `Customer | Update` table, with each row summarizing that write's request fields (same fields, same hiding rules as the single-card fallback), and no money/Total line:

| Customer | Update |
|---|---|
| cassidy2flawless@yahoo.com | Id: user_3GDvjxJ7slvBh0y4A7nFjjxYCxq |

Every field kind renders: strings/numbers/booleans as `Field: value` (long values truncated), objects as compact JSON, explicit `null` as **`Field: cleared`** (previously an explicit clear rendered nothing — this also fixes the single-card field list, which shares `compactValue`), and past six fields a `+N more` marker instead of silent truncation. Billing fan-outs (attach/update/schedule) are unchanged. `fanOutTable` generalized from fixed three-column to arbitrary columns with alignment.

## Validation

- Regression tests: the incident replay (grouped `updateCustomer` shows the `Update` column with each id and no `Due now`/`Total`/`$0.00`), plus an all-field-kinds case (set email, id, metadata object, boolean, null clear → `cleared`, 7-field overflow → `+1 more`).
- Existing fan-out tests (billing collapse + combined total) still pass; leaf UI suite 89 tests green, `tsc` clean.

## Follow-up: stale customer link after an id change

The done card's customer link came from `request.customer_id` — the selector — so after an `updateCustomer` that renames the id, ✅ *Updated …* linked the dead old id. The **done** tense now links `request.id` when the write sets one; **pending/running/failed** keep the old id, which is still the live one in those states. Regression test covers both directions.





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves grouped approval cards so bare customer updates show their requested changes, catalog writes retain structured previews, and completed customer renames link to the new ID. It also restores per-operation completion markers, but partial failures can now display status sentences that contradict the accurate outcome table.

- **[Bug fixes]** Show field changes instead of an empty billing table for grouped non-billing writes, including explicit clears and overflow counts.
- **[Bug fixes]** Preserve structured catalog previews when catalog writes are grouped.
- **[Bug fixes]** Link completed customer-ID changes to the new customer ID.
- **[Improvements]** Generalize fan-out tables and add status markers to grouped operations.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a partial grouped failure can label an already-applied operation as failed and skipped operations as failed.

Group execution records distinct Applied, Failed, and Not run outcomes, but the changed grouped-section rendering applies the overall failed tense to every operation, producing contradictory status information on the approval card.

**Files Needing Attention:** apps/leaf/src/ui/blocks.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/ui/blocks.ts | Adds non-billing change tables, catalog grouping safeguards, rename links, and grouped status markers; partial failures give all sections the group-level failed label despite divergent outcomes. |
| apps/leaf/src/ui/changeTable.ts | Safely generalizes fan-out tables to arbitrary columns and caller-provided alignment. |
| apps/leaf/tests/unit/ui/blocks.test.ts | Adds coverage for the reported rendering regressions, but the grouped-status test covers only the all-success case. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Execute grouped writes] --> B[Primary applies]
  B --> C[Later write fails]
  C --> D[Remaining writes skipped]
  D --> E[Overall status becomes failed]
  E --> F[Every section receives failed tense]
  F --> G[Applied and skipped sections show failure labels]
  D --> H[Outcome table records actual per-write states]
  G --> I[Card displays contradictory statuses]
  H --> I
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/ui/blocks.ts:1024
**Grouped statuses contradict outcomes**

When the primary write succeeds and a later grouped write fails, every section receives the group-level failed tense. This labels the applied primary write and skipped writes as failed while the outcome table on the same card reports them as Applied and Not run.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: 🐛 mixed groups keep the primary ma..."](https://github.com/useautumn/autumn/commit/838f7e4bc0f8c186d967d68d181000b25042b1d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57010928)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)

<!-- /greptile_comment -->