### PR TITLE
feat: org-level default net terms for invoice-mode billing

### DIFF
--- a/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
+++ b/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
@@ -30,7 +30,11 @@ export const setupInvoiceModeContext = async ({
 		enableProductImmediately: params.invoice_mode.enable_plan_immediately,
 		footer: template?.footer,
 		memo: template?.memo,
-		daysUntilDue: net_terms_days ?? template?.net_terms_days,
+		daysUntilDue:
+			net_terms_days ??
+			template?.net_terms_days ??
+			ctx.org.config.default_net_terms_days ??
+			undefined,
 		paymentMethodTypes: ctx.org.config.allowed_payment_methods ?? undefined,
 	};
 };

--- a/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
+++ b/server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts
@@ -33,7 +33,7 @@ export const setupInvoiceModeContext = async ({
 		daysUntilDue:
 			net_terms_days ??
 			template?.net_terms_days ??
-			ctx.org.config.default_net_terms_days ??
+			ctx.org.config.default_invoice_net_terms_days ??
 			undefined,
 		paymentMethodTypes: ctx.org.config.allowed_payment_methods ?? undefined,
 	};

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -90,7 +90,9 @@ export const createStripeSub2 = async ({
 
 			add_invoice_items: invoiceItems,
 			collection_method: invoiceOnly ? "send_invoice" : "charge_automatically",
-			days_until_due: invoiceOnly ? 30 : undefined,
+			days_until_due: invoiceOnly
+				? (org.config.default_net_terms_days ?? 30)
+				: undefined,
 			billing_cycle_anchor: billingCycleAnchorUnix
 				? Math.floor(billingCycleAnchorUnix / 1000)
 				: undefined,

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/createStripeSub2.ts
@@ -91,7 +91,7 @@ export const createStripeSub2 = async ({
 			add_invoice_items: invoiceItems,
 			collection_method: invoiceOnly ? "send_invoice" : "charge_automatically",
 			days_until_due: invoiceOnly
-				? (org.config.default_net_terms_days ?? 30)
+				? (org.config.default_invoice_net_terms_days ?? 30)
 				: undefined,
 			billing_cycle_anchor: billingCycleAnchorUnix
 				? Math.floor(billingCycleAnchorUnix / 1000)

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -151,7 +151,9 @@ export const handleOneOffFunction = async ({
 		currency: orgToCurrency({ org }),
 		discounts: rewards ? rewards.map((r) => ({ coupon: r.id })) : undefined,
 		collection_method: attachParams.invoiceOnly ? "send_invoice" : undefined,
-		days_until_due: attachParams.invoiceOnly ? 30 : undefined,
+		days_until_due: attachParams.invoiceOnly
+			? (org.config.default_net_terms_days ?? 30)
+			: undefined,
 		...(shouldMemo ? { description: invoiceMemo } : {}),
 		...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
 	});

--- a/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
+++ b/server/src/internal/customers/attach/attachFunctions/addProductFlow/handleOneOffFunction.ts
@@ -152,7 +152,7 @@ export const handleOneOffFunction = async ({
 		discounts: rewards ? rewards.map((r) => ({ coupon: r.id })) : undefined,
 		collection_method: attachParams.invoiceOnly ? "send_invoice" : undefined,
 		days_until_due: attachParams.invoiceOnly
-			? (org.config.default_net_terms_days ?? 30)
+			? (org.config.default_invoice_net_terms_days ?? 30)
 			: undefined,
 		...(shouldMemo ? { description: invoiceMemo } : {}),
 		...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),

--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -80,7 +80,7 @@ export const updateStripeSub2 = async ({
 		add_invoice_items: itemSet.invoiceItems,
 		...(invoiceOnly && {
 			collection_method: "send_invoice",
-			days_until_due: 30,
+			days_until_due: attachParams.org.config.default_net_terms_days ?? 30,
 		}),
 		payment_behavior: "error_if_incomplete",
 

--- a/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
+++ b/server/src/internal/customers/attach/attachFunctions/upgradeFlow/updateStripeSub2.ts
@@ -80,7 +80,8 @@ export const updateStripeSub2 = async ({
 		add_invoice_items: itemSet.invoiceItems,
 		...(invoiceOnly && {
 			collection_method: "send_invoice",
-			days_until_due: attachParams.org.config.default_net_terms_days ?? 30,
+			days_until_due:
+				attachParams.org.config.default_invoice_net_terms_days ?? 30,
 		}),
 		payment_behavior: "error_if_incomplete",
 

--- a/server/tests/integration/billing/attach/invoice/invoice-mode-default-net-terms.test.ts
+++ b/server/tests/integration/billing/attach/invoice/invoice-mode-default-net-terms.test.ts
@@ -1,9 +1,9 @@
 /**
- * Regression coverage for org-level `default_net_terms_days` on invoice-mode
+ * Regression coverage for org-level `default_invoice_net_terms_days` on invoice-mode
  * attaches.
  *
  * Contract under test:
- *   - `org.config.default_net_terms_days` is applied as `days_until_due` on
+ *   - `org.config.default_invoice_net_terms_days` is applied as `days_until_due` on
  *     invoice-mode (send_invoice) subscription creation.
  *   - It is also applied to the standalone invoice a one-off attach creates.
  *   - Unset config keeps the historical 30-day due window, so existing orgs
@@ -39,7 +39,7 @@ test.concurrent(
 			setup: [
 				s.platform.create({
 					configOverrides: {
-						default_net_terms_days: ORG_DEFAULT_NET_TERMS_DAYS,
+						default_invoice_net_terms_days: ORG_DEFAULT_NET_TERMS_DAYS,
 					},
 					setupDefaultFeatures: true,
 				}),
@@ -92,7 +92,7 @@ test.concurrent(
 			setup: [
 				s.platform.create({
 					configOverrides: {
-						default_net_terms_days: ORG_DEFAULT_NET_TERMS_DAYS,
+						default_invoice_net_terms_days: ORG_DEFAULT_NET_TERMS_DAYS,
 					},
 					setupDefaultFeatures: true,
 				}),

--- a/server/tests/integration/billing/attach/invoice/invoice-mode-default-net-terms.test.ts
+++ b/server/tests/integration/billing/attach/invoice/invoice-mode-default-net-terms.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression coverage for org-level `default_net_terms_days` on invoice-mode
+ * attaches.
+ *
+ * Contract under test:
+ *   - `org.config.default_net_terms_days` is applied as `days_until_due` on
+ *     invoice-mode (send_invoice) subscription creation.
+ *   - It is also applied to the standalone invoice a one-off attach creates.
+ *   - Unset config keeps the historical 30-day due window, so existing orgs
+ *     see no behavior change.
+ */
+
+import { expect, test } from "bun:test";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+
+const ORG_DEFAULT_NET_TERMS_DAYS = 45;
+const HARDCODED_NET_TERMS_DAYS = 30;
+const SECONDS_PER_DAY = 86_400;
+
+// ═══════════════════════════════════════════════════════════════════
+// TEST 1: org default lands on the invoice-mode subscription
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-mode net terms: subscription uses the org default")}`,
+	async () => {
+		const customerId = "invoice-net-terms-subscription";
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: {
+						default_net_terms_days: ORG_DEFAULT_NET_TERMS_DAYS,
+					},
+					setupDefaultFeatures: true,
+				}),
+				s.customer({ testClock: false }),
+				s.products({ list: [pro] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					invoice: true,
+					enableProductImmediately: true,
+					finalizeInvoice: true,
+				}),
+			],
+		});
+
+		const subscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: customer?.processor?.id ?? "",
+			limit: 1,
+		});
+		const subscription = subscriptions.data[0];
+
+		expect(subscription).toBeDefined();
+		expect(subscription.collection_method).toBe("send_invoice");
+		expect(subscription.days_until_due).toBe(ORG_DEFAULT_NET_TERMS_DAYS);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// TEST 2: org default lands on a one-off attach's standalone invoice
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-mode net terms: one-off invoice uses the org default")}`,
+	async () => {
+		const customerId = "invoice-net-terms-one-off";
+		const oneOff = products.oneOff({
+			id: "one-off-credits",
+			items: [
+				items.oneOffMessages({
+					includedUsage: 0,
+					billingUnits: 100,
+					price: 10,
+				}),
+			],
+		});
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [
+				s.platform.create({
+					configOverrides: {
+						default_net_terms_days: ORG_DEFAULT_NET_TERMS_DAYS,
+					},
+					setupDefaultFeatures: true,
+				}),
+				s.customer({ testClock: false }),
+				s.products({ list: [oneOff] }),
+			],
+			actions: [
+				s.billing.attach({
+					productId: oneOff.id,
+					options: [{ feature_id: TestFeature.Messages, quantity: 100 }],
+					invoice: true,
+					enableProductImmediately: true,
+					finalizeInvoice: false,
+				}),
+			],
+		});
+
+		const invoices = await ctx.stripeCli.invoices.list({
+			customer: customer?.processor?.id ?? "",
+			limit: 1,
+		});
+		const invoice = invoices.data[0];
+
+		expect(invoice).toBeDefined();
+		expect(invoice.collection_method).toBe("send_invoice");
+		// Stripe resolves days_until_due into an absolute due_date at creation.
+		expect(invoice.due_date).not.toBeNull();
+		const dueInDays = Math.round(
+			((invoice.due_date ?? 0) - invoice.created) / SECONDS_PER_DAY,
+		);
+		expect(dueInDays).toBe(ORG_DEFAULT_NET_TERMS_DAYS);
+	},
+);
+
+// ═══════════════════════════════════════════════════════════════════
+// TEST 3: unset org config keeps the 30-day due window
+// ═══════════════════════════════════════════════════════════════════
+
+test.concurrent(
+	`${chalk.yellowBright("invoice-mode net terms: unset org config keeps 30 days")}`,
+	async () => {
+		const customerId = "invoice-net-terms-unset";
+		const pro = products.pro({
+			id: "pro",
+			items: [items.monthlyMessages({ includedUsage: 100 })],
+		});
+
+		const { ctx, customer } = await initScenario({
+			customerId,
+			setup: [s.customer({ testClock: false }), s.products({ list: [pro] })],
+			actions: [
+				s.billing.attach({
+					productId: pro.id,
+					invoice: true,
+					finalizeInvoice: true,
+				}),
+			],
+		});
+
+		const subscriptions = await ctx.stripeCli.subscriptions.list({
+			customer: customer?.processor?.id ?? "",
+			limit: 1,
+		});
+		const subscription = subscriptions.data[0];
+
+		expect(subscription).toBeDefined();
+		expect(subscription.collection_method).toBe("send_invoice");
+		expect(subscription.days_until_due).toBe(HARDCODED_NET_TERMS_DAYS);
+	},
+);

--- a/server/tests/unit/billing/setup-invoice-mode-context.test.ts
+++ b/server/tests/unit/billing/setup-invoice-mode-context.test.ts
@@ -4,25 +4,73 @@ import { OrgConfigSchema } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupInvoiceModeContext } from "@/internal/billing/v2/setup/setupInvoiceModeContext";
 
+const TEMPLATE_ID = "tmpl_1";
+
+/** Stands in for the `select().from().where().limit()` chain
+ *  `InvoiceTemplateService.getById` runs. */
+const makeDb = ({
+	template,
+}: {
+	template?: { net_terms_days: number | null };
+}) => {
+	const rows = template
+		? [
+				{
+					internal_id: "it_1",
+					id: TEMPLATE_ID,
+					name: "Template",
+					footer: null,
+					memo: null,
+					net_terms_days: template.net_terms_days,
+					created_at: 0,
+				},
+			]
+		: [];
+	const chain = {
+		select: () => chain,
+		from: () => chain,
+		where: () => chain,
+		limit: async () => rows,
+	};
+	return chain;
+};
+
 const makeCtx = ({
 	allowedPaymentMethods,
+	defaultNetTermsDays,
+	template,
 }: {
 	allowedPaymentMethods?: InvoicePaymentMethod[] | null;
+	defaultNetTermsDays?: number | null;
+	template?: { net_terms_days: number | null };
 }) =>
 	({
-		db: {},
+		db: makeDb({ template }),
 		org: {
 			id: "org_123",
-			config: { allowed_payment_methods: allowedPaymentMethods },
+			config: {
+				allowed_payment_methods: allowedPaymentMethods,
+				default_net_terms_days: defaultNetTermsDays,
+			},
 		},
 	}) as unknown as AutumnContext;
 
-const makeParams = ({ enabled = true }: { enabled?: boolean }) =>
+const makeParams = ({
+	enabled = true,
+	netTermsDays,
+	invoiceTemplateId,
+}: {
+	enabled?: boolean;
+	netTermsDays?: number;
+	invoiceTemplateId?: string;
+}) =>
 	({
 		invoice_mode: {
 			enabled,
 			enable_plan_immediately: false,
 			finalize: true,
+			net_terms_days: netTermsDays,
+			invoice_template_id: invoiceTemplateId,
 		},
 	}) as unknown as AttachParamsV1;
 
@@ -58,6 +106,59 @@ describe("setupInvoiceModeContext payment method types", () => {
 	});
 });
 
+describe("setupInvoiceModeContext net terms", () => {
+	test("falls back to the org default when request and template are silent", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({ defaultNetTermsDays: 45 }),
+			params: makeParams({}),
+		});
+
+		expect(invoiceMode?.daysUntilDue).toBe(45);
+	});
+
+	test("request net terms beat the org default", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({ defaultNetTermsDays: 45 }),
+			params: makeParams({ netTermsDays: 7 }),
+		});
+
+		expect(invoiceMode?.daysUntilDue).toBe(7);
+	});
+
+	test("template net terms beat the org default", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({
+				defaultNetTermsDays: 45,
+				template: { net_terms_days: 14 },
+			}),
+			params: makeParams({ invoiceTemplateId: TEMPLATE_ID }),
+		});
+
+		expect(invoiceMode?.daysUntilDue).toBe(14);
+	});
+
+	test("a template without net terms falls through to the org default", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({
+				defaultNetTermsDays: 45,
+				template: { net_terms_days: null },
+			}),
+			params: makeParams({ invoiceTemplateId: TEMPLATE_ID }),
+		});
+
+		expect(invoiceMode?.daysUntilDue).toBe(45);
+	});
+
+	test("stays undefined when no org default is configured", async () => {
+		const invoiceMode = await setupInvoiceModeContext({
+			ctx: makeCtx({ defaultNetTermsDays: null }),
+			params: makeParams({}),
+		});
+
+		expect(invoiceMode?.daysUntilDue).toBeUndefined();
+	});
+});
+
 describe("allowed_payment_methods org config schema", () => {
 	test("rejects an empty array but allows null or omitted", () => {
 		expect(
@@ -72,5 +173,28 @@ describe("allowed_payment_methods org config schema", () => {
 			OrgConfigSchema.parse({ allowed_payment_methods: ["card"] })
 				.allowed_payment_methods,
 		).toEqual(["card"]);
+	});
+});
+
+describe("default_net_terms_days org config schema", () => {
+	test("rejects zero, negative and fractional values but allows null or omitted", () => {
+		expect(
+			OrgConfigSchema.safeParse({ default_net_terms_days: 0 }).success,
+		).toBe(false);
+		expect(
+			OrgConfigSchema.safeParse({ default_net_terms_days: -1 }).success,
+		).toBe(false);
+		expect(
+			OrgConfigSchema.safeParse({ default_net_terms_days: 1.5 }).success,
+		).toBe(false);
+		expect(
+			OrgConfigSchema.parse({ default_net_terms_days: null })
+				.default_net_terms_days,
+		).toBeNull();
+		expect(OrgConfigSchema.parse({}).default_net_terms_days).toBeUndefined();
+		expect(
+			OrgConfigSchema.parse({ default_net_terms_days: 45 })
+				.default_net_terms_days,
+		).toBe(45);
 	});
 });

--- a/server/tests/unit/billing/setup-invoice-mode-context.test.ts
+++ b/server/tests/unit/billing/setup-invoice-mode-context.test.ts
@@ -50,7 +50,7 @@ const makeCtx = ({
 			id: "org_123",
 			config: {
 				allowed_payment_methods: allowedPaymentMethods,
-				default_net_terms_days: defaultNetTermsDays,
+				default_invoice_net_terms_days: defaultNetTermsDays,
 			},
 		},
 	}) as unknown as AutumnContext;
@@ -176,25 +176,28 @@ describe("allowed_payment_methods org config schema", () => {
 	});
 });
 
-describe("default_net_terms_days org config schema", () => {
+describe("default_invoice_net_terms_days org config schema", () => {
 	test("rejects zero, negative and fractional values but allows null or omitted", () => {
 		expect(
-			OrgConfigSchema.safeParse({ default_net_terms_days: 0 }).success,
+			OrgConfigSchema.safeParse({ default_invoice_net_terms_days: 0 }).success,
 		).toBe(false);
 		expect(
-			OrgConfigSchema.safeParse({ default_net_terms_days: -1 }).success,
+			OrgConfigSchema.safeParse({ default_invoice_net_terms_days: -1 }).success,
 		).toBe(false);
 		expect(
-			OrgConfigSchema.safeParse({ default_net_terms_days: 1.5 }).success,
+			OrgConfigSchema.safeParse({ default_invoice_net_terms_days: 1.5 })
+				.success,
 		).toBe(false);
 		expect(
-			OrgConfigSchema.parse({ default_net_terms_days: null })
-				.default_net_terms_days,
+			OrgConfigSchema.parse({ default_invoice_net_terms_days: null })
+				.default_invoice_net_terms_days,
 		).toBeNull();
-		expect(OrgConfigSchema.parse({}).default_net_terms_days).toBeUndefined();
 		expect(
-			OrgConfigSchema.parse({ default_net_terms_days: 45 })
-				.default_net_terms_days,
+			OrgConfigSchema.parse({}).default_invoice_net_terms_days,
+		).toBeUndefined();
+		expect(
+			OrgConfigSchema.parse({ default_invoice_net_terms_days: 45 })
+				.default_invoice_net_terms_days,
 		).toBe(45);
 	});
 });

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -64,6 +64,9 @@ export const OrgConfigSchema = z.object({
 
 	// Unset/null = Stripe's own invoice settings apply; never add a default.
 	allowed_payment_methods: z.array(InvoicePaymentMethodSchema).min(1).nullish(),
+
+	// Unset/null = downstream 30-day fallback applies; never add a default.
+	default_net_terms_days: z.number().int().positive().nullish(),
 });
 
 export type OrgConfig = z.infer<typeof OrgConfigSchema>;

--- a/shared/models/orgModels/orgConfig.ts
+++ b/shared/models/orgModels/orgConfig.ts
@@ -66,7 +66,7 @@ export const OrgConfigSchema = z.object({
 	allowed_payment_methods: z.array(InvoicePaymentMethodSchema).min(1).nullish(),
 
 	// Unset/null = downstream 30-day fallback applies; never add a default.
-	default_net_terms_days: z.number().int().positive().nullish(),
+	default_invoice_net_terms_days: z.number().int().positive().nullish(),
 });
 
 export type OrgConfig = z.infer<typeof OrgConfigSchema>;

--- a/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
+++ b/vite/src/components/forms/shared/InvoiceSettingsSection.tsx
@@ -17,17 +17,19 @@ const NO_TEMPLATE_VALUE = "none";
 
 export interface InvoiceSettings {
 	templateId: string | null;
-	netTermsDays: number;
+	netTermsDays: number | null;
 }
 
 export function InvoiceSettingsSection({
 	value,
 	onChange,
 	disabled,
+	defaultNetTermsDays,
 }: {
 	value: InvoiceSettings;
 	onChange: (value: InvoiceSettings) => void;
 	disabled?: boolean;
+	defaultNetTermsDays?: number;
 }) {
 	const { templates } = useInvoiceTemplatesQuery();
 	const hasTemplates = templates.length > 0;
@@ -80,7 +82,11 @@ export function InvoiceSettingsSection({
 						<Input
 							type="number"
 							min={1}
-							value={String(value.netTermsDays)}
+							value={String(
+								value.netTermsDays ??
+									defaultNetTermsDays ??
+									DEFAULT_NET_TERMS_DAYS,
+							)}
 							onChange={(e) => {
 								const parsed = Number.parseInt(e.target.value, 10);
 								onChange({

--- a/vite/src/components/forms/shared/SendInvoiceStage.tsx
+++ b/vite/src/components/forms/shared/SendInvoiceStage.tsx
@@ -143,7 +143,7 @@ export function SendInvoiceStage({
 	const [enableImmediately, setEnableImmediately] = useState(true);
 	const [invoiceSettings, setInvoiceSettings] = useState<InvoiceSettings>({
 		templateId: null,
-		netTermsDays: org?.config?.default_net_terms_days ?? DEFAULT_NET_TERMS_DAYS,
+		netTermsDays: null,
 	});
 	const [completedInvoiceUrl, setCompletedInvoiceUrl] = useState<string | null>(
 		null,
@@ -177,15 +177,18 @@ export function SendInvoiceStage({
 
 	const buildSubmitParams = (
 		finalizeInvoice: boolean,
-	): SendInvoiceSubmitParams => ({
-		enableProductImmediately: enableImmediately,
-		finalizeInvoice,
-		invoiceTemplateId: invoiceSettings.templateId ?? undefined,
-		netTermsDays:
-			invoiceSettings.netTermsDays > 0
-				? invoiceSettings.netTermsDays
-				: undefined,
-	});
+	): SendInvoiceSubmitParams => {
+		const resolvedNetTermsDays =
+			invoiceSettings.netTermsDays ??
+			org?.config?.default_net_terms_days ??
+			DEFAULT_NET_TERMS_DAYS;
+		return {
+			enableProductImmediately: enableImmediately,
+			finalizeInvoice,
+			invoiceTemplateId: invoiceSettings.templateId ?? undefined,
+			netTermsDays: resolvedNetTermsDays > 0 ? resolvedNetTermsDays : undefined,
+		};
+	};
 
 	const handleDraft = async () => {
 		setActiveAction("draft");
@@ -311,6 +314,7 @@ export function SendInvoiceStage({
 				value={invoiceSettings}
 				onChange={setInvoiceSettings}
 				disabled={needsEmail}
+				defaultNetTermsDays={org?.config?.default_net_terms_days}
 			/>
 
 			<PreviewSection previewQuery={previewQuery} />

--- a/vite/src/components/forms/shared/SendInvoiceStage.tsx
+++ b/vite/src/components/forms/shared/SendInvoiceStage.tsx
@@ -180,7 +180,7 @@ export function SendInvoiceStage({
 	): SendInvoiceSubmitParams => {
 		const resolvedNetTermsDays =
 			invoiceSettings.netTermsDays ??
-			org?.config?.default_net_terms_days ??
+			org?.config?.default_invoice_net_terms_days ??
 			DEFAULT_NET_TERMS_DAYS;
 		return {
 			enableProductImmediately: enableImmediately,
@@ -314,7 +314,7 @@ export function SendInvoiceStage({
 				value={invoiceSettings}
 				onChange={setInvoiceSettings}
 				disabled={needsEmail}
-				defaultNetTermsDays={org?.config?.default_net_terms_days}
+				defaultNetTermsDays={org?.config?.default_invoice_net_terms_days}
 			/>
 
 			<PreviewSection previewQuery={previewQuery} />

--- a/vite/src/components/forms/shared/SendInvoiceStage.tsx
+++ b/vite/src/components/forms/shared/SendInvoiceStage.tsx
@@ -9,6 +9,7 @@ import {
 	SheetHeader,
 	SheetSection,
 } from "@/components/v2/sheets/SharedSheetComponents";
+import { useOrg } from "@/hooks/common/useOrg";
 import { useAxiosInstance } from "@/services/useAxiosInstance";
 import { getStripeInvoiceLink } from "@/utils/linkUtils";
 import { useCusQuery } from "@/views/customers/customer/hooks/useCusQuery";
@@ -133,6 +134,7 @@ export function SendInvoiceStage({
 	scheduledStartDate?: number | null;
 }) {
 	const { customer, refetch } = useCusQuery();
+	const { org } = useOrg();
 	const axiosInstance = useAxiosInstance();
 
 	const [emailValue, setEmailValue] = useState("");
@@ -141,7 +143,7 @@ export function SendInvoiceStage({
 	const [enableImmediately, setEnableImmediately] = useState(true);
 	const [invoiceSettings, setInvoiceSettings] = useState<InvoiceSettings>({
 		templateId: null,
-		netTermsDays: DEFAULT_NET_TERMS_DAYS,
+		netTermsDays: org?.config?.default_net_terms_days ?? DEFAULT_NET_TERMS_DAYS,
 	});
 	const [completedInvoiceUrl, setCompletedInvoiceUrl] = useState<string | null>(
 		null,

--- a/vite/src/views/settings/sections/InvoicesSection.tsx
+++ b/vite/src/views/settings/sections/InvoicesSection.tsx
@@ -1,5 +1,6 @@
 import { SettingsSection } from "../SettingsSection";
 import { AllowedPaymentMethodsSubsection } from "./components/AllowedPaymentMethodsSubsection";
+import { DefaultNetTermsSubsection } from "./components/DefaultNetTermsSubsection";
 import { InvoiceTemplatesSubsection } from "./components/InvoiceTemplatesSubsection";
 
 export const InvoicesSection = () => {
@@ -10,6 +11,7 @@ export const InvoicesSection = () => {
 		>
 			<InvoiceTemplatesSubsection />
 			<AllowedPaymentMethodsSubsection />
+			<DefaultNetTermsSubsection />
 		</SettingsSection>
 	);
 };

--- a/vite/src/views/settings/sections/components/DefaultNetTermsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/DefaultNetTermsSubsection.tsx
@@ -1,0 +1,71 @@
+import { Input } from "@autumn/ui";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useOrg } from "@/hooks/common/useOrg";
+import { useAxiosInstance } from "@/services/useAxiosInstance";
+
+export const DefaultNetTermsSubsection = () => {
+	const { org, mutate: refetchOrg } = useOrg();
+	const axiosInstance = useAxiosInstance();
+	const [draft, setDraft] = useState<string | null>(null);
+
+	const { mutate, isPending, variables } = useMutation({
+		mutationFn: async (days: number | null) => {
+			await axiosInstance.patch("/organization/config", {
+				default_net_terms_days: days,
+			});
+		},
+		onSuccess: async () => {
+			await refetchOrg();
+			toast.success("Default net payment terms saved");
+		},
+		onError: () => toast.error("Failed to update default net payment terms"),
+	});
+
+	// While a save is in flight, reflect the value being saved.
+	const savedDays =
+		(isPending ? variables : org?.config?.default_net_terms_days) ?? null;
+	const inputValue = draft ?? (savedDays === null ? "" : String(savedDays));
+
+	const commit = () => {
+		if (draft === null) return;
+		const trimmed = draft.trim();
+		setDraft(null);
+
+		if (trimmed === "") {
+			if (savedDays !== null) mutate(null);
+			return;
+		}
+		const parsed = Number.parseInt(trimmed, 10);
+		if (Number.isNaN(parsed) || parsed < 1) return;
+		if (parsed !== savedDays) mutate(parsed);
+	};
+
+	return (
+		<div className="flex items-center justify-between gap-4">
+			<div className="flex flex-col gap-0.5">
+				<span className="text-sm font-medium">Net payment terms</span>
+				<span className="text-xs text-muted-foreground">
+					{savedDays === null
+						? "Unset — invoices Autumn creates are due 30 days after they're sent"
+						: "Used when neither the request nor the invoice template sets its own terms"}
+				</span>
+			</div>
+			<Input
+				type="number"
+				min={1}
+				placeholder="30"
+				aria-label="Default net payment terms in days"
+				className="w-24 shrink-0"
+				value={inputValue}
+				disabled={isPending}
+				onChange={(event) => setDraft(event.target.value)}
+				onBlur={commit}
+				onKeyDown={(event) => {
+					if (event.key === "Enter") event.currentTarget.blur();
+				}}
+			/>
+		</div>
+	);
+};

--- a/vite/src/views/settings/sections/components/DefaultNetTermsSubsection.tsx
+++ b/vite/src/views/settings/sections/components/DefaultNetTermsSubsection.tsx
@@ -13,7 +13,7 @@ export const DefaultNetTermsSubsection = () => {
 	const { mutate, isPending, variables } = useMutation({
 		mutationFn: async (days: number | null) => {
 			await axiosInstance.patch("/organization/config", {
-				default_net_terms_days: days,
+				default_invoice_net_terms_days: days,
 			});
 		},
 		onSuccess: async () => {
@@ -25,7 +25,8 @@ export const DefaultNetTermsSubsection = () => {
 
 	// While a save is in flight, reflect the value being saved.
 	const savedDays =
-		(isPending ? variables : org?.config?.default_net_terms_days) ?? null;
+		(isPending ? variables : org?.config?.default_invoice_net_terms_days) ??
+		null;
 	const inputValue = draft ?? (savedDays === null ? "" : String(savedDays));
 
 	const commit = () => {


### PR DESCRIPTION
## What

Adds a `default_net_terms_days` org setting that fills in `days_until_due` on invoice-mode billing when neither the request nor the invoice template specifies net terms.

Precedence: request `net_terms_days` → invoice template `net_terms_days` → org default → 30 (unchanged hardcoded fallback).

## Changes

- `shared/models/orgModels/orgConfig.ts` — new `default_net_terms_days` (positive int, nullish, no default). Lives in the `organizations.config` jsonb, and `PATCH /organization/config` derives valid keys from the schema, so no migration or route change.
- `server/src/internal/billing/v2/setup/setupInvoiceModeContext.ts` — org default appended to the `daysUntilDue` fallback chain. Covers attach, multi-attach, update-subscription, schedules, and plan migrations.
- V1 legacy attach parity: `createStripeSub2.ts`, `handleOneOffFunction.ts`, `updateStripeSub2.ts` now use the org default instead of hardcoded 30.
- Dashboard: new "Net payment terms" subsection under Settings → Invoices; the send-invoice form seeds its net terms from the org default instead of the hardcoded 30.

## Behavior note

A template with blank net terms previously fell through to the hardcoded 30; once an org sets a default, such templates inherit the org default instead. Orgs that never set the field see no change.

## Tests

- Unit: 5 new precedence cases + schema validation in `setup-invoice-mode-context.test.ts` (green).
- Integration: new `invoice-mode-default-net-terms.test.ts` (subscription + one-off + unset-config cases), patterned on `invoice-mode-allowed-payment-methods.test.ts`.
- Verified live on the EC2 sandbox: org default of 28 prefilled the send-invoice form and landed as `days_until_due` (invoice due exactly created + 28d in Stripe).