### PR TITLE
Fix invoice credit rate card regressions

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts
@@ -61,13 +61,31 @@ const validateProjectedInvoiceCreditPrices = ({
 };
 
 const validateProjectedInvoiceCreditPooling = ({
+	catalogContext,
 	updateCatalogPlan,
 }: {
+	catalogContext: UpdateCatalogContext;
 	updateCatalogPlan: UpdateCatalogPlan;
 }): void => {
-	for (const updateFeaturePlan of updateCatalogPlan.updateFeatures) {
+	const projectedPlanIds = new Set(
+		Object.keys(catalogContext.productStatesContext.versionsByPlanId),
+	);
+	const validationCatalogPlan = {
+		...updateCatalogPlan,
+		projected: {
+			...updateCatalogPlan.projected,
+			products: [
+				...catalogContext.invoiceCreditProducts.filter(
+					(product) => !projectedPlanIds.has(product.id),
+				),
+				...updateCatalogPlan.projected.products,
+			],
+		},
+	};
+
+	for (const updateFeaturePlan of validationCatalogPlan.updateFeatures) {
 		const { next: feature } = updateFeaturePlan;
-		const hasPooledPlanItem = updateCatalogPlan.projected.products.some(
+		const hasPooledPlanItem = validationCatalogPlan.projected.products.some(
 			(product) =>
 				product.entitlements.some(
 					(entitlement) =>
@@ -83,14 +101,17 @@ const validateProjectedInvoiceCreditPooling = ({
 			feature,
 			usageBased: planItemsForFeatureAreUsageBased({
 				internalFeatureId: feature.internal_id,
-				updateCatalogPlan,
+				updateCatalogPlan: validationCatalogPlan,
 			}),
 		});
-		validateProjectedInvoiceCreditPrices({ feature, updateCatalogPlan });
+		validateProjectedInvoiceCreditPrices({
+			feature,
+			updateCatalogPlan: validationCatalogPlan,
+		});
 	}
 
-	for (const feature of updateCatalogPlan.insertFeatures) {
-		const hasPooledPlanItem = updateCatalogPlan.projected.products.some(
+	for (const feature of validationCatalogPlan.insertFeatures) {
+		const hasPooledPlanItem = validationCatalogPlan.projected.products.some(
 			(product) =>
 				product.entitlements.some(
 					(entitlement) =>
@@ -103,10 +124,13 @@ const validateProjectedInvoiceCreditPooling = ({
 			feature,
 			usageBased: planItemsForFeatureAreUsageBased({
 				internalFeatureId: feature.internal_id,
-				updateCatalogPlan,
+				updateCatalogPlan: validationCatalogPlan,
 			}),
 		});
-		validateProjectedInvoiceCreditPrices({ feature, updateCatalogPlan });
+		validateProjectedInvoiceCreditPrices({
+			feature,
+			updateCatalogPlan: validationCatalogPlan,
+		});
 	}
 };
 
@@ -123,7 +147,7 @@ export const handleUpdateCatalogErrors = async ({
 	params: UpdateCatalogParams;
 }): Promise<void> => {
 	handleUpdateFeatureErrors({ ctx, catalogContext, updateCatalogPlan });
-	validateProjectedInvoiceCreditPooling({ updateCatalogPlan });
+	validateProjectedInvoiceCreditPooling({ catalogContext, updateCatalogPlan });
 	handleRemoveFeatureErrors({ updateCatalogPlan });
 	handleRemovePlanErrors({
 		updateCatalogPlan,

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupInvoiceCreditProducts.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupInvoiceCreditProducts.ts
@@ -1,0 +1,60 @@
+import {
+	entitlements,
+	type FullProduct,
+	products,
+	type UpdateCatalogParams,
+} from "@autumn/shared";
+import { and, eq, inArray } from "drizzle-orm";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { ProductService } from "@/internal/products/ProductService.js";
+
+/**
+ * Loads every persisted plan version that references a feature being enabled
+ * for invoice credits. Catalog validation overlays same-call plan changes on
+ * these rows so feature-only updates and atomic feature/plan updates both see
+ * the final catalog state.
+ */
+export const setupInvoiceCreditProducts = async ({
+	ctx,
+	params,
+}: {
+	ctx: AutumnContext;
+	params: UpdateCatalogParams;
+}): Promise<FullProduct[]> => {
+	const internalFeatureIds = params.features.flatMap((entry) => {
+		if (entry.invoice_credit !== true) return [];
+		const feature = ctx.features.find(
+			(candidate) => candidate.id === entry.feature_id,
+		);
+		return feature?.internal_id ? [feature.internal_id] : [];
+	});
+
+	if (internalFeatureIds.length === 0) return [];
+
+	const referencedPlans = await ctx.db
+		.selectDistinct({ planId: products.id })
+		.from(entitlements)
+		.innerJoin(
+			products,
+			eq(entitlements.internal_product_id, products.internal_id),
+		)
+		.where(
+			and(
+				inArray(entitlements.internal_feature_id, internalFeatureIds),
+				eq(products.org_id, ctx.org.id),
+				eq(products.env, ctx.env),
+			),
+		);
+
+	const planIds = referencedPlans.map(({ planId }) => planId);
+	if (planIds.length === 0) return [];
+
+	return ProductService.listFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		inIds: planIds,
+		returnAll: true,
+		skipCache: true,
+	});
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext.ts
@@ -3,6 +3,7 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { setupFeatureUsagePersisted } from "@/internal/catalogV2/actions/updateCatalog/setup/preview/setupFeatureUsagePersisted";
 import { setupPlanUsagePersisted } from "@/internal/catalogV2/actions/updateCatalog/setup/preview/setupPlanUsagePersisted";
 import { setupFeatureStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupFeatureStatesContext";
+import { setupInvoiceCreditProducts } from "@/internal/catalogV2/actions/updateCatalog/setup/setupInvoiceCreditProducts";
 import { setupLicenseStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupLicenseStatesContext";
 import { setupProductStatesContext } from "@/internal/catalogV2/actions/updateCatalog/setup/setupProductStatesContext";
 import {
@@ -22,6 +23,12 @@ export const setupUpdateCatalogContext = async ({
 	preview?: boolean;
 	phases: CatalogPhases;
 }): Promise<UpdateCatalogContext> => {
+	const invoiceCreditProductsPromise = timeCatalogPhase({
+		ctx,
+		phases,
+		phase: "invoice_credit_products",
+		run: () => setupInvoiceCreditProducts({ ctx, params }),
+	});
 	const [featureStatesContext, productStatesContext, featureUsagePersisted] =
 		await Promise.all([
 			timeCatalogPhase({
@@ -40,6 +47,7 @@ export const setupUpdateCatalogContext = async ({
 					})
 				: undefined,
 		]);
+	const invoiceCreditProducts = await invoiceCreditProductsPromise;
 
 	// License refs + plan-usage samples both need loaded product internal ids.
 	const [licenseStatesContext, planUsagePersisted] = await Promise.all([
@@ -63,6 +71,7 @@ export const setupUpdateCatalogContext = async ({
 	return {
 		featureStatesContext,
 		productStatesContext,
+		invoiceCreditProducts,
 		licenseStatesContext,
 		previewContext: preview
 			? {

--- a/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/updateCatalogContext.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/updateCatalogContext.ts
@@ -1,3 +1,4 @@
+import type { FullProduct } from "@autumn/shared";
 import type { FeatureState } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/featureState";
 import type { LicenseStatesContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/licenseStatesContext";
 import type { PreviewCatalogContext } from "@/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/previewCatalogContext";
@@ -8,6 +9,8 @@ export interface UpdateCatalogContext {
 	/** Dependency + rewrite overflow flags, keyed by feature id. */
 	featureStatesContext: Record<string, FeatureState>;
 	productStatesContext: ProductStatesContext;
+	/** Persisted plan versions referencing a feature being enabled for invoice credits. */
+	invoiceCreditProducts: FullProduct[];
 	licenseStatesContext: LicenseStatesContext;
 	/** Present iff the action ran with preview: true. */
 	previewContext?: PreviewCatalogContext;

--- a/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
+++ b/server/tests/integration/balances/reset/get-customer-reset-rollovers.test.ts
@@ -155,7 +155,7 @@ test.concurrent(`${chalk.yellowBright("lazy reset rollover (cache): caps rollove
 });
 
 test.concurrent(
-	`${chalk.yellowBright("invoice-credit cached reset: clears prior attribution and rates new-cycle rollover usage from zero")}`,
+	`${chalk.yellowBright("invoice-credit cached renewal: clears prior attribution and rates new-cycle rollover usage from zero")}`,
 	async () => {
 		const tieredCreditsItem = items.consumable({
 			featureId: TestFeature.TieredCredits,
@@ -176,37 +176,24 @@ test.concurrent(
 		const { customerId, autumnV2_3, ctx } = await initScenario({
 			customerId: "invoice-credit-reset-rollover",
 			setup: [
-				s.customer({ paymentMethod: "success", testClock: false }),
+				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [product] }),
 			],
-			actions: [s.billing.attach({ productId: product.id })],
+			actions: [
+				s.billing.attach({ productId: product.id }),
+				s.track({
+					featureId: TestFeature.TieredAction,
+					value: 5_000,
+					timeout: 2_000,
+				}),
+				s.advanceToNextInvoice({ withPause: true }),
+			],
 		});
 		const sourceInternalFeatureId = ctx.features.find(
 			(feature) => feature.id === TestFeature.TieredAction,
 		)?.internal_id;
 		expect(sourceInternalFeatureId).toBeDefined();
 
-		await autumnV2_3.track({
-			customer_id: customerId,
-			feature_id: TestFeature.TieredAction,
-			value: 5_000,
-		});
-		await timeout(2_000);
-		const beforeReset = await findCustomerEntitlement({
-			ctx,
-			customerId,
-			featureId: TestFeature.TieredCredits,
-		});
-		expect(beforeReset?.usage_attribution?.[sourceInternalFeatureId!]).toEqual({
-			units: 5_000,
-			credits: 50,
-		});
-
-		await expireCusEntForReset({
-			ctx,
-			customerId,
-			featureId: TestFeature.TieredCredits,
-		});
 		const afterReset =
 			await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
 		expect(afterReset.balances[TestFeature.TieredCredits].remaining).toBe(
@@ -262,23 +249,20 @@ test.concurrent(
 		const { customerId, autumnV2_3, ctx } = await initScenario({
 			customerId: "invoice-credit-postgres-rollover",
 			setup: [
-				s.customer({ paymentMethod: "success", testClock: false }),
+				s.customer({ paymentMethod: "success" }),
 				s.products({ list: [product] }),
 			],
-			actions: [s.billing.attach({ productId: product.id })],
+			actions: [
+				s.billing.attach({ productId: product.id }),
+				s.track({
+					featureId: TestFeature.TieredAction,
+					value: 5_000,
+					timeout: 2_000,
+				}),
+				s.advanceToNextInvoice({ withPause: true }),
+			],
 		});
 
-		await autumnV2_3.track({
-			customer_id: customerId,
-			feature_id: TestFeature.TieredAction,
-			value: 5_000,
-		});
-		await timeout(2_000);
-		await expireCusEntForReset({
-			ctx,
-			customerId,
-			featureId: TestFeature.TieredCredits,
-		});
 		await autumnV2_3.customers.get<ApiCustomerV5>(customerId, {
 			skip_cache: "true",
 		});

--- a/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
+++ b/server/tests/integration/balances/track/basic/track-graduated-credit-system.test.ts
@@ -88,7 +88,7 @@ test.concurrent(
 		const addOnProduct = makeCreditProduct({
 			id: "graduated-credit-multiple-addon",
 			isAddOn: true,
-			creditAllowance: 0.9,
+			creditAllowance: 0,
 		});
 		const { autumnV2_3 } = await initScenario({
 			customerId,

--- a/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
+++ b/server/tests/integration/balances/update/invoice-credit-mutation-guards.test.ts
@@ -98,11 +98,6 @@ test.concurrent(
 			feature_id: TestFeature.InvoiceCredits,
 			next_reset_at: nextResetAt,
 		});
-		await autumnV2.balances.update({
-			customer_id: customerId,
-			feature_id: TestFeature.InvoiceCredits,
-			expires_at: nextResetAt + 24 * 60 * 60 * 1000,
-		});
 
 		const customer = await autumnV2.customers.get<ApiCustomer>(customerId);
 		expect(customer.balances[TestFeature.InvoiceCredits]).toMatchObject({

--- a/server/tests/integration/catalog-v2/features/credit-rate-card.test.ts
+++ b/server/tests/integration/catalog-v2/features/credit-rate-card.test.ts
@@ -374,7 +374,6 @@ test.concurrent(
 								included: 100,
 								pooled: true,
 								reset: { interval: ResetInterval.Month },
-								price: usagePrice,
 							},
 						],
 					},


### PR DESCRIPTION
## Summary

- Validate invoice-credit feature changes against persisted plans and changes made in the same catalog request.
- Allow valid atomic catalog transitions while rejecting pooled or invalidly priced invoice-credit plans.
- Correct the invoice-credit regression fixtures for Stripe renewal and valid graduated pricing.

## Why

Feature-only catalog updates could miss existing plans that referenced the feature. Changes that updated a feature and its plans together also needed validation against the final projected catalog state, rather than stale persisted state.

## Testing

- `cd server && bun ts`
- Full cloud suite running: `bun tw all --ref=og/fix-credit-rate-card-regressions --max=50 --provider=modal --no-dashboard` (`mt9wvxu0-lnmvf3`)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes invoice-credit catalog validation by combining persisted plans with plans projected by the current atomic request.
- **Bug fixes:** Loads persisted plan versions that reference a feature being enabled for invoice credits.
- **Bug fixes, Improvements:** Validates pricing, pooling, and usage-based requirements against the final projected catalog while allowing valid atomic feature-and-plan transitions.
- **Bug fixes:** Updates balance and catalog regression fixtures for Stripe renewal and graduated invoice-credit pricing.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the persisted-plan overlay preserves the complete final state for request-touched plans and validates relevant untouched versions.

The new query is scoped to the current organization and environment, and the overlay replaces persisted plan families only when the catalog projection already contains their complete post-request state; no actionable failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/setup/setupInvoiceCreditProducts.ts | Loads all live persisted versions of plan families referencing features being enabled for invoice credits, scoped by organization and environment. |
| server/src/internal/catalogV2/actions/updateCatalog/errors/handleUpdateCatalogErrors.ts | Overlays persisted plans with the complete projected state of request-touched plans before enforcing invoice-credit constraints. |
| server/src/internal/catalogV2/actions/updateCatalog/setup/setupUpdateCatalogContext.ts | Adds the persisted invoice-credit plan lookup to catalog-context setup and runs it alongside the existing setup work. |
| server/src/internal/catalogV2/actions/updateCatalog/types/updateCatalogContext/updateCatalogContext.ts | Extends the update context with the persisted plans needed by invoice-credit validation. |
| server/tests/integration/catalog-v2/features/credit-rate-card.test.ts | Corrects the pooled-plan regression fixture so it isolates pooling validation from invalid pricing. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Catalog update request] --> Persisted[Load persisted plans referencing enabled feature]
  Request --> Projection[Project feature and plan changes]
  Persisted --> Overlay[Overlay projected plans by plan ID]
  Projection --> Overlay
  Overlay --> Validate[Validate pooling, usage pricing, and credit rate]
  Validate --> Apply[Apply valid catalog transition]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix invoice credit regression tests"](https://github.com/useautumn/autumn/commit/961e3413925d8caddc9f05053d760846d18f8f3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57026420)</sub>

<!-- /greptile_comment -->