### PR TITLE
Approve resumes eve natively; the SYSTEM NOTE release is gone

### DIFF
--- a/.github/workflows/leaf-unit-tests.yml
+++ b/.github/workflows/leaf-unit-tests.yml
@@ -1,0 +1,63 @@
+name: Leaf Unit Tests
+
+on:
+  pull_request:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: leaf-unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Check changed files
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      leaf: ${{ steps.filter.outputs.leaf }}
+    steps:
+      # paths-filter diffs via the API on pull_request but needs a local repo on push.
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check changed files
+        id: filter
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050
+        with:
+          filters: |
+            leaf:
+              - "apps/leaf/**"
+              - "shared/**"
+              - "packages/**"
+              - "package.json"
+              - "bun.lock"
+              - ".github/workflows/leaf-unit-tests.yml"
+
+  unit-tests:
+    name: Unit Tests
+    needs: changes
+    if: needs.changes.outputs.leaf == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # The suite is hermetic: db/env modules are mocked and the script's env
+      # values are placeholders, so no Postgres or API server is needed.
+      - name: Run unit tests
+        run: bun run test
+        working-directory: apps/leaf

--- a/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/consumeResumedAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/consumeResumedAgentTurn.ts
@@ -142,6 +142,7 @@ export const consumeResumedAgentTurn = async ({
 	const expectedWrites = (expectedToolNames ?? []).map((toolName) => ({
 		normalized: normalizeToolName(toolName),
 		reserved: false,
+		result: undefined as unknown,
 		status: "pending" as "applied" | "failed" | "pending",
 		toolName,
 	}));
@@ -187,6 +188,8 @@ export const consumeResumedAgentTurn = async ({
 		const step = index >= 0 ? expectedWrites[index] : undefined;
 		if (step) {
 			step.status = isFailedActionResult(event) ? "failed" : "applied";
+			const output = event.result?.output;
+			step.result = parsedResultText(output) ?? output;
 		}
 	};
 	try {
@@ -326,7 +329,8 @@ export const consumeResumedAgentTurn = async ({
 			});
 		}
 	}
-	const writes = expectedWrites.map(({ status, toolName }) => ({
+	const writes = expectedWrites.map(({ result, status, toolName }) => ({
+		result,
 		status,
 		toolName,
 	}));

--- a/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/submitAgentInput.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/submitAgentInput.ts
@@ -15,7 +15,6 @@ export const submitAgentInput = async ({
 	session,
 	siblingOptionIdFor,
 	siblingRequestIds,
-	suppressSiblingWithheldNote,
 }: {
 	approveSiblings?: boolean;
 	auth: EveAuthContext;
@@ -28,7 +27,6 @@ export const submitAgentInput = async ({
 	session: EveSessionRef;
 	siblingOptionIdFor?: (siblingRequestId: string) => string | undefined;
 	siblingRequestIds?: ReadonlyArray<string>;
-	suppressSiblingWithheldNote?: boolean;
 }) => {
 	await answerEveInput({
 		approveSiblings,
@@ -39,7 +37,6 @@ export const submitAgentInput = async ({
 		session,
 		siblingOptionIdFor,
 		siblingRequestIds,
-		suppressSiblingWithheldNote,
 	});
 	await saveEveSessionState({ orgId, session });
 	return consumeResumedAgentTurn({

--- a/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/types.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/types.ts
@@ -8,6 +8,7 @@ export type ResumedAgentTurn = Readonly<{
 	chainedSiblingRequestIds: ReadonlyArray<string>;
 	approvedWriteFailed: boolean;
 	writes: ReadonlyArray<{
+		result?: unknown;
 		status: "applied" | "failed" | "pending";
 		toolName: string;
 	}>;

--- a/apps/leaf/src/internal/agentRuntime/eve/client.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/client.ts
@@ -173,7 +173,6 @@ export const postEveInputResponse = async ({
 	session,
 	siblingOptionIdFor,
 	siblingRequestIds,
-	suppressSiblingWithheldNote,
 }: {
 	approveSiblings?: boolean;
 	auth: EveAuthContext;
@@ -183,7 +182,6 @@ export const postEveInputResponse = async ({
 	session: EveSessionRef;
 	siblingOptionIdFor?: (siblingRequestId: string) => string | undefined;
 	siblingRequestIds?: ReadonlyArray<string>;
-	suppressSiblingWithheldNote?: boolean;
 }) => {
 	const siblings = [...new Set(siblingRequestIds ?? [])].filter(
 		(siblingRequestId) => siblingRequestId && siblingRequestId !== requestId,
@@ -204,7 +202,7 @@ export const postEveInputResponse = async ({
 					})),
 				],
 				message:
-					siblings.length && !approveSiblings && !suppressSiblingWithheldNote
+					siblings.length && !approveSiblings
 						? [note, SIBLING_WITHHELD_NOTE].filter(Boolean).join("\n\n")
 						: note,
 			}),

--- a/apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts
+++ b/apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts
@@ -1,29 +1,15 @@
 import type { ChatApproval, ChatApprovalWrite } from "@autumn/shared";
 import { db } from "../../../lib/db.js";
-import { errorMessage } from "../../../lib/errorMessage.js";
 import { logger } from "../../../lib/logger.js";
-import {
-	normalizeToolName,
-	toolLabel,
-} from "../../agentRuntime/tools/toolPolicy.js";
 import { executeAutumnMcpTool } from "../../autumnMcp/client.js";
 import { getOrgInstallationToken } from "../../installations/actions/getOrgInstallationToken.js";
-import { denyOptionOf } from "../domain/approvalRecord.js";
 import { chatApprovalRepo } from "../repos/chatApprovalRepo.js";
 import { chatApprovalWritesRepo } from "../repos/chatApprovalWritesRepo.js";
 import type { ApprovalRunResult, ApprovalWriteOutcome } from "../types.js";
-import { withWritePreviews } from "../utils/fetchApprovalPreview.js";
-import { previewMoneyFactsDrifted } from "../utils/previewMoneyFacts.js";
-import { writeToPreviewTool } from "../utils/toolRegistry.js";
-import { isSameToolRequest, publicToolArgs } from "../utils/toolRequest.js";
 import {
 	classifyWriteExecution,
 	type WriteExecutionOutcome,
 } from "../utils/writeExecutionResult.js";
-import { submitApprovalInput } from "./submitApprovalInput.js";
-
-const DRIFT_MESSAGE =
-	"Prices changed since this card was shown — nothing was applied. Review the updated preview and approve again.";
 
 /** Runs one gated write and classifies the result — a throw is a terminal
  * `unknown` (never blindly retried against a billing API). */
@@ -52,81 +38,6 @@ const runWrite = async ({
 type ExecutedWrite = {
 	outcome: WriteExecutionOutcome | { status: "skipped" };
 	write: ChatApprovalWrite;
-};
-
-/** Re-previews every write and compares money facts against what the card
- * showed. Fail closed: an unfetchable preview counts as drifted. */
-const detectPreviewDrift = async ({
-	env,
-	writes,
-	token,
-}: {
-	env: ChatApproval["env"];
-	writes: ReadonlyArray<ChatApprovalWrite>;
-	token: string;
-}) => {
-	const checkable = writes.filter(
-		(write) => write.preview && writeToPreviewTool(write.tool_name),
-	);
-	if (!checkable.length) return { drifted: false } as const;
-	const fresh = await withWritePreviews({
-		env,
-		getToken: async () => token,
-		logger,
-		writes: checkable.map((write) => ({
-			input: write.tool_args,
-			requestId: write.request_id ?? "",
-			toolName: write.tool_name,
-		})),
-	});
-	const reason = checkable
-		.map((write, index) => {
-			const verdict = previewMoneyFactsDrifted({
-				current: fresh[index]?.preview,
-				stored: write.preview,
-			});
-			return verdict.drifted ? verdict.reason : undefined;
-		})
-		.find(Boolean);
-	if (!reason) return { drifted: false } as const;
-	return {
-		drifted: true,
-		reason,
-		refresh: async () => {
-			await Promise.all(
-				checkable.map((write, index) =>
-					setWritePreviewEverywhere({
-						preview: fresh[index]?.preview,
-						write,
-					}),
-				),
-			);
-		},
-	} as const;
-};
-
-/** The primary write is mirrored on the parent row for card rendering, so a
- * refreshed preview must land on both copies or they drift apart. */
-const setWritePreviewEverywhere = async ({
-	preview,
-	write,
-}: {
-	preview: unknown;
-	write: ChatApprovalWrite;
-}) => {
-	await chatApprovalWritesRepo.setPreview({
-		approvalId: write.approval_id,
-		db,
-		preview,
-		writeId: write.id,
-	});
-	if (write.position === 0) {
-		await chatApprovalRepo.setPreview({
-			approvalId: write.approval_id,
-			db,
-			preview,
-		});
-	}
 };
 
 const executeWrites = async ({
@@ -173,31 +84,6 @@ const executeWrites = async ({
 	return executed;
 };
 
-const outcomeNote = ({
-	executed,
-}: {
-	executed: ReadonlyArray<ExecutedWrite>;
-}) => {
-	const lines = executed.map(({ outcome, write }) => {
-		const label = `${toolLabel(write.tool_name)} (${write.tool_name})`;
-		if (outcome.status === "applied") return `- ${label}: applied`;
-		if (outcome.status === "skipped") {
-			return `- ${label}: NOT applied (skipped after an earlier failure)`;
-		}
-		return `- ${label}: ${outcome.status} — ${outcome.detail}`;
-	});
-	const allApplied = executed.every(
-		({ outcome }) => outcome.status === "applied",
-	);
-	return [
-		"SYSTEM NOTE — the deny responses on this batch are PROCEDURAL, not real denials: the user APPROVED the card and the system has already executed the writes directly. The denies only release the paused tool calls.",
-		"Your subagent saw only the procedural denials and may report these writes as denied or failed — that report is WRONG and must be ignored. This note is the ground truth:",
-		allApplied ? "Every write below is APPLIED and live:" : "Actual outcomes:",
-		...lines,
-		"Do NOT re-issue any of these writes, do NOT re-delegate to verify, and NEVER describe an applied write as denied or rejected. The approval card in the thread already shows these outcomes — do not reply; end your turn silently.",
-	].join("\n");
-};
-
 const stepOutcomes = (
 	executed: ReadonlyArray<ExecutedWrite>,
 ): ApprovalWriteOutcome[] =>
@@ -206,15 +92,13 @@ const stepOutcomes = (
 		toolName: write.tool_name,
 	}));
 
-/** Deterministic approve: runs the stored writes, resumes eve as notification
- * only — outcomes are ground truth, the model's text is never surfaced. */
+/** Dead-session fallback: the eve session that parked these writes is gone,
+ * so the stored writes run directly — the card is the only outcome surface. */
 export const executeApprovalWrites = async ({
 	approval,
-	onResumed,
 	providerUserId,
 }: {
 	approval: ChatApproval;
-	onResumed?: (result: ApprovalRunResult) => Promise<void> | void;
 	providerUserId: string;
 }): Promise<ApprovalRunResult | undefined> => {
 	const writes = await chatApprovalWritesRepo.list({
@@ -229,28 +113,6 @@ export const executeApprovalWrites = async ({
 		provider: approval.provider,
 		workspaceId: approval.workspace_id,
 	});
-
-	const drift = await detectPreviewDrift({
-		env: approval.env,
-		writes,
-		token: accessToken,
-	});
-	if (drift.drifted) {
-		// Release first: the preview writers are pending-guarded, so the fresh
-		// previews can only land once the row is back in pending.
-		await chatApprovalRepo.release({
-			approvalId: approval.id,
-			db,
-			providerUserId,
-		});
-		await drift.refresh();
-		logger.info("Approval drifted; card refreshed instead of executing", {
-			event: "leaf.approval_drift_refreshed",
-			approval_id: approval.id,
-			data: { reason: drift.reason },
-		});
-		return { drifted: true, message: DRIFT_MESSAGE };
-	}
 
 	const executed = await executeWrites({
 		env: approval.env,
@@ -270,7 +132,7 @@ export const executeApprovalWrites = async ({
 		providerUserId,
 		status: allApplied ? "approved" : "failed",
 	});
-	logger.info("Executed approved writes", {
+	logger.info("Executed approved writes without an eve session", {
 		event: "leaf.approval_writes_executed",
 		approval_id: approval.id,
 		data: {
@@ -279,44 +141,6 @@ export const executeApprovalWrites = async ({
 				tool: write.tool_name,
 			})),
 		},
-	});
-
-	// Notification only, fired async — execution is already durable and the
-	// card must not wait on a model turn; failures (even session-gone) only log.
-	const notifyEve = async () => {
-		const appliedArgs = executed
-			.filter(({ outcome }) => outcome.status === "applied")
-			.map(({ write }) => ({
-				toolArgs: write.tool_args,
-				toolName: write.tool_name,
-			}));
-		const resumed = await submitApprovalInput({
-			approval,
-			note: outcomeNote({ executed }),
-			optionId: denyOptionOf(approval),
-			providerUserId,
-			shouldAbsorbChained: ({ input, toolName }) =>
-				appliedArgs.some(
-					(applied) =>
-						normalizeToolName(applied.toolName) ===
-							normalizeToolName(toolName) &&
-						isSameToolRequest(
-							publicToolArgs(applied.toolArgs),
-							publicToolArgs(input ?? {}),
-						),
-				)
-					? "This write was already applied by the system when the user approved — do not re-issue it and do not reply; the card already confirms it."
-					: undefined,
-			suppressSiblingWithheldNote: true,
-		});
-		await onResumed?.(resumed);
-	};
-	void notifyEve().catch((error) => {
-		logger.warn("Could not notify eve after executing approved writes", {
-			event: "leaf.approval_notify_failed",
-			approval_id: approval.id,
-			data: { error: errorMessage(error) },
-		});
 	});
 
 	if (!allApplied) {

--- a/apps/leaf/src/internal/approvals/actions/guardApprovalDrift.ts
+++ b/apps/leaf/src/internal/approvals/actions/guardApprovalDrift.ts
@@ -1,0 +1,134 @@
+import type { ChatApproval, ChatApprovalWrite } from "@autumn/shared";
+import { db } from "../../../lib/db.js";
+import { logger } from "../../../lib/logger.js";
+import { getOrgInstallationToken } from "../../installations/actions/getOrgInstallationToken.js";
+import { chatApprovalRepo } from "../repos/chatApprovalRepo.js";
+import { chatApprovalWritesRepo } from "../repos/chatApprovalWritesRepo.js";
+import { withWritePreviews } from "../utils/fetchApprovalPreview.js";
+import { previewMoneyFactsDrifted } from "../utils/previewMoneyFacts.js";
+import { writeToPreviewTool } from "../utils/toolRegistry.js";
+
+const DRIFT_MESSAGE =
+	"Prices changed since this card was shown — nothing was applied. Review the updated preview and approve again.";
+
+/** Re-previews every write and compares money facts against what the card
+ * showed. Fail closed: an unfetchable preview counts as drifted. */
+const detectPreviewDrift = async ({
+	env,
+	writes,
+	token,
+}: {
+	env: ChatApproval["env"];
+	writes: ReadonlyArray<ChatApprovalWrite>;
+	token: string;
+}) => {
+	const checkable = writes.filter(
+		(write) => write.preview && writeToPreviewTool(write.tool_name),
+	);
+	if (!checkable.length) return { drifted: false } as const;
+	const fresh = await withWritePreviews({
+		env,
+		getToken: async () => token,
+		logger,
+		writes: checkable.map((write) => ({
+			input: write.tool_args,
+			requestId: write.request_id ?? "",
+			toolName: write.tool_name,
+		})),
+	});
+	const reason = checkable
+		.map((write, index) => {
+			const verdict = previewMoneyFactsDrifted({
+				current: fresh[index]?.preview,
+				stored: write.preview,
+			});
+			return verdict.drifted ? verdict.reason : undefined;
+		})
+		.find(Boolean);
+	if (!reason) return { drifted: false } as const;
+	return {
+		drifted: true,
+		reason,
+		refresh: async () => {
+			await Promise.all(
+				checkable.map((write, index) =>
+					setWritePreviewEverywhere({
+						preview: fresh[index]?.preview,
+						write,
+					}),
+				),
+			);
+		},
+	} as const;
+};
+
+/** The primary write is mirrored on the parent row for card rendering, so a
+ * refreshed preview must land on both copies or they drift apart. */
+const setWritePreviewEverywhere = async ({
+	preview,
+	write,
+}: {
+	preview: unknown;
+	write: ChatApprovalWrite;
+}) => {
+	await chatApprovalWritesRepo.setPreview({
+		approvalId: write.approval_id,
+		db,
+		preview,
+		writeId: write.id,
+	});
+	if (write.position === 0) {
+		await chatApprovalRepo.setPreview({
+			approvalId: write.approval_id,
+			db,
+			preview,
+		});
+	}
+};
+
+/** Pre-resume money guard: a drifted card is released back to pending with
+ * fresh previews instead of resuming — nothing executes. */
+export const guardApprovalDrift = async ({
+	approval,
+	providerUserId,
+}: {
+	approval: ChatApproval;
+	providerUserId: string;
+}): Promise<{ drifted: true; message: string } | undefined> => {
+	const writes = await chatApprovalWritesRepo.list({
+		approvalId: approval.id,
+		db,
+	});
+	const checkable = writes.some(
+		(write) => write.preview && writeToPreviewTool(write.tool_name),
+	);
+	if (!checkable) return undefined;
+
+	const { accessToken } = await getOrgInstallationToken({
+		env: approval.env,
+		orgId: approval.org_id,
+		provider: approval.provider,
+		workspaceId: approval.workspace_id,
+	});
+	const drift = await detectPreviewDrift({
+		env: approval.env,
+		writes,
+		token: accessToken,
+	});
+	if (!drift.drifted) return undefined;
+
+	// Release first: the preview writers are pending-guarded, so the fresh
+	// previews can only land once the row is back in pending.
+	await chatApprovalRepo.release({
+		approvalId: approval.id,
+		db,
+		providerUserId,
+	});
+	await drift.refresh();
+	logger.info("Approval drifted; card refreshed instead of executing", {
+		event: "leaf.approval_drift_refreshed",
+		approval_id: approval.id,
+		data: { reason: drift.reason },
+	});
+	return { drifted: true, message: DRIFT_MESSAGE };
+};

--- a/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
@@ -1,6 +1,5 @@
 import type { ChatApproval } from "@autumn/shared";
 import { db } from "../../../lib/db.js";
-import { env } from "../../../lib/env.js";
 import { logger } from "../../../lib/logger.js";
 import { APPROVAL_SESSION_GONE_MESSAGE } from "../../../ui/messages.js";
 import { EveSessionGoneError } from "../../agentRuntime/eve/client.js";
@@ -13,6 +12,7 @@ import { chatApprovalRepo } from "../repos/chatApprovalRepo.js";
 import type { ApprovalRunResult, SubmittedApprovalResult } from "../types.js";
 import { approvalErrorResult } from "../utils/approvalErrors.js";
 import { executeApprovalWrites } from "./executeApprovalWrites.js";
+import { guardApprovalDrift } from "./guardApprovalDrift.js";
 import { resumeApproval } from "./resumeApproval.js";
 
 const dropEveSession = async ({ approval }: { approval: ChatApproval }) => {
@@ -54,22 +54,33 @@ const releaseClaim = async ({
 	}
 };
 
-/** Slack-surface-only: the dashboard shows a group's primary write alone, so
- * it must never execute the whole group. */
-const approvalExecutorEnabled = ({ provider }: { provider: string }) => {
-	const flag =
-		env.LEAF_APPROVAL_EXECUTOR ??
-		(process.env.NODE_ENV === "production" ? "0" : "1");
-	return flag === "1" && surfaceRendersGroup(provider);
+/** The eve session is gone, so the deterministic executor is the only way to
+ * honor the approval — Slack-surface-only, since only a surface that rendered
+ * the whole group may execute it. */
+const executeWithoutSession = async ({
+	approval,
+	providerUserId,
+}: {
+	approval: ChatApproval;
+	providerUserId: string;
+}): Promise<ApprovalRunResult | undefined> => {
+	if (!surfaceRendersGroup(approval.provider ?? "")) return undefined;
+	try {
+		return await executeApprovalWrites({ approval, providerUserId });
+	} catch (error) {
+		logger.error("[chat] Dead-session write execution failed", error, {
+			event: "leaf.approval_executor_failed",
+			approval_id: approval.id,
+		});
+		return undefined;
+	}
 };
 
 export const resolveApproval = async ({
 	approval,
-	onResumed,
 	providerUserId,
 }: {
 	approval: ChatApproval;
-	onResumed?: (result: ApprovalRunResult) => Promise<void> | void;
 	onProgress?: (statusLine: string) => void;
 	providerUserId: string;
 }): Promise<ApprovalRunResult> => {
@@ -84,19 +95,15 @@ export const resolveApproval = async ({
 		);
 	}
 
-	if (approvalExecutorEnabled({ provider: approval.provider ?? "" })) {
+	if (surfaceRendersGroup(approval.provider ?? "")) {
 		try {
-			const executed = await executeApprovalWrites({
-				approval,
-				onResumed,
-				providerUserId,
-			});
-			if (executed) return executed;
+			const drifted = await guardApprovalDrift({ approval, providerUserId });
+			if (drifted) return drifted;
 		} catch (error) {
-			// Nothing has executed when this throws (token mint / step listing),
-			// so releasing the claim is safe.
-			logger.error("[chat] Approval executor failed before executing", error, {
-				event: "leaf.approval_executor_failed",
+			// Nothing has executed when the guard throws (token mint / preview
+			// fetch), so releasing the claim is safe.
+			logger.error("[chat] Approval drift guard failed", error, {
+				event: "leaf.approval_drift_guard_failed",
 				approval_id: approval.id,
 			});
 			await releaseClaim({ approval, providerUserId });
@@ -112,19 +119,24 @@ export const resolveApproval = async ({
 		});
 	} catch (error) {
 		if (error instanceof EveSessionGoneError) {
-			// Eve lost the session this card belongs to; no retry can run it, and
-			// leaving it pending would block the thread behind a dead card.
+			// Eve lost the session this card belongs to; the deterministic
+			// executor still honors the approval from the stored writes.
 			logger.error("[chat] Approval session is gone", error, {
 				event: "leaf.approval_session_gone",
 				approval_id: approval.id,
 			});
+			await dropEveSession({ approval });
+			const executed = await executeWithoutSession({
+				approval,
+				providerUserId,
+			});
+			if (executed) return executed;
 			await chatApprovalRepo.finalize({
 				approvalId: approval.id,
 				db,
 				providerUserId,
 				status: "failed",
 			});
-			await dropEveSession({ approval });
 			return {
 				error: true,
 				message: APPROVAL_SESSION_GONE_MESSAGE,

--- a/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
+++ b/apps/leaf/src/internal/approvals/actions/resolveApproval.ts
@@ -54,9 +54,9 @@ const releaseClaim = async ({
 	}
 };
 
-/** The eve session is gone, so the deterministic executor is the only way to
- * honor the approval — Slack-surface-only, since only a surface that rendered
- * the whole group may execute it. */
+/** Dead-session fallback, reached only after guardApprovalDrift passed in this
+ * same resolve — Slack-only, since only a surface that rendered the group may
+ * execute it. */
 const executeWithoutSession = async ({
 	approval,
 	providerUserId,

--- a/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
+++ b/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
@@ -8,6 +8,7 @@ import {
 import { submitAgentInput } from "../../agentRuntime/actions/submitAgentInput/submitAgentInput.js";
 import type { ResumedAgentTurn } from "../../agentRuntime/actions/submitAgentInput/types.js";
 import { getEveSessionBySessionId } from "../../agentRuntime/eve/repo.js";
+import { rawErrorShapeText } from "../../autumnMcp/errorResult.js";
 import {
 	approvalAuthContext,
 	childSessionIdsOf,
@@ -161,10 +162,19 @@ export const submitApprovalInput = async ({
 		expectExecution &&
 		(deferredEmptyTurn || (settled && approvedWriteUnverified && !text));
 	if (expectExecution && approvedWriteFailed) {
+		const failedWrite = writes.find((write) => write.status === "failed");
 		logger.error("Approved Eve action failed", undefined, {
 			event: "leaf.eve_approval_failed",
 			approval_id: approval.id,
-			data: approvalLogData,
+			data: {
+				...approvalLogData,
+				failed_tool: failedWrite?.toolName,
+				failure: rawErrorShapeText(failedWrite?.result),
+				writes: writes.map((write) => ({
+					status: write.status,
+					tool: write.toolName,
+				})),
+			},
 		});
 		return {
 			chainedApprovalId,

--- a/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
+++ b/apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts
@@ -1,4 +1,4 @@
-import type { ChatApproval } from "@autumn/shared";
+import type { ChatApproval, ChatApprovalWrite } from "@autumn/shared";
 import { db } from "../../../lib/db.js";
 import { logger } from "../../../lib/logger.js";
 import {
@@ -6,8 +6,7 @@ import {
 	APPROVAL_NOT_EXECUTED_MESSAGE,
 } from "../../../ui/messages.js";
 import { submitAgentInput } from "../../agentRuntime/actions/submitAgentInput/submitAgentInput.js";
-import { postEveInputResponse } from "../../agentRuntime/eve/client.js";
-import { approvalOptionIds } from "../../agentRuntime/eve/events.js";
+import type { ResumedAgentTurn } from "../../agentRuntime/actions/submitAgentInput/types.js";
 import { getEveSessionBySessionId } from "../../agentRuntime/eve/repo.js";
 import {
 	approvalAuthContext,
@@ -21,27 +20,43 @@ import { chatApprovalWritesRepo } from "../repos/chatApprovalWritesRepo.js";
 import type { SubmittedApprovalResult } from "../types.js";
 import { createChainedApproval } from "./createChainedApproval.js";
 
-/** Answers the park in eve and consumes the resumed turn; re-issued duplicates
- * of already-applied writes can be absorbed instead of carded again. */
+/** Write rows and resume outcomes share execution order — position 0 is the
+ * primary, then the withheld siblings. Steps without evidence stay pending. */
+const persistWriteOutcomes = async ({
+	writeRows,
+	writes,
+}: {
+	writeRows: ReadonlyArray<ChatApprovalWrite>;
+	writes: ResumedAgentTurn["writes"];
+}) => {
+	await Promise.all(
+		writeRows.map((row, index) => {
+			const outcome = writes[index];
+			if (!outcome || outcome.status === "pending") return undefined;
+			return chatApprovalWritesRepo.setStatus({
+				db,
+				result: outcome.result,
+				status: outcome.status,
+				writeId: row.id,
+			});
+		}),
+	);
+};
+
+/** Answers the park in eve and consumes the resumed turn; the write outcomes
+ * eve streams back are persisted onto the approval's write rows. */
 export const submitApprovalInput = async ({
 	approval,
 	expectExecution,
 	note,
 	optionId,
 	providerUserId,
-	shouldAbsorbChained,
-	suppressSiblingWithheldNote,
 }: {
 	approval: ChatApproval;
 	expectExecution?: boolean;
 	note?: string;
 	optionId: string;
 	providerUserId: string;
-	shouldAbsorbChained?: (chained: {
-		input?: Record<string, unknown>;
-		toolName: string;
-	}) => string | undefined;
-	suppressSiblingWithheldNote?: boolean;
 }): Promise<SubmittedApprovalResult> => {
 	if (!(approval.run_id && approval.tool_call_id)) {
 		logger.warn("Approval is missing Eve session state", {
@@ -97,7 +112,6 @@ export const submitApprovalInput = async ({
 		approvedWriteFailed,
 		approvedWriteUnverified,
 		chained,
-		chainedSiblingRequestIds,
 		chainedWithheld,
 		deferredEmptyTurn,
 		writes,
@@ -119,45 +133,30 @@ export const submitApprovalInput = async ({
 		session,
 		siblingOptionIdFor: siblingDenyOptionFor(writeRows),
 		siblingRequestIds,
-		suppressSiblingWithheldNote,
 	});
-	const absorbNote =
-		chained && !chainedWithheld?.length
-			? shouldAbsorbChained?.({
-					input: chained.input,
-					toolName: chained.toolName,
-				})
-			: undefined;
-	if (chained && absorbNote) {
-		// A re-issued duplicate of a write the system just applied — deny it in
-		// eve with the reason instead of asking the user again.
-		await postEveInputResponse({
-			auth,
-			note: absorbNote,
-			optionId: approvalOptionIds({ options: chained.options }).deny,
-			requestId: chained.requestId,
-			session,
-			siblingRequestIds: chainedSiblingRequestIds,
-		});
-		logger.info("Absorbed duplicate re-issued write", {
-			event: "leaf.approval_duplicate_absorbed",
-			approval_id: approval.id,
-			data: { tool: chained.toolName },
-		});
+	if (expectExecution && writeRows.length) {
+		try {
+			await persistWriteOutcomes({ writeRows, writes });
+		} catch (error) {
+			logger.warn("Could not persist approval write outcomes", {
+				event: "leaf.approval_write_outcomes_persist_failed",
+				approval_id: approval.id,
+				error,
+			});
+		}
 	}
-	const chainedApprovalId =
-		chained && !absorbNote
-			? await createChainedApproval({
-					auth,
-					chained,
-					providerUserId,
-					sessionId: session.sessionId,
-					withheld: chainedWithheld,
-				})
-			: undefined;
+	const chainedApprovalId = chained
+		? await createChainedApproval({
+				auth,
+				chained,
+				providerUserId,
+				sessionId: session.sessionId,
+				withheld: chainedWithheld,
+			})
+		: undefined;
 	// Eve may execute the approved call before the resumed stream opens, so a
 	// turn that did real work without echoing the result still counts as run.
-	const settled = !((chained && !absorbNote) || question);
+	const settled = !(chained || question);
 	const notExecuted =
 		expectExecution &&
 		(deferredEmptyTurn || (settled && approvedWriteUnverified && !text));

--- a/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
+++ b/apps/leaf/src/internal/approvals/surfaces/slack/decide.ts
@@ -447,9 +447,6 @@ export const handleApprovalActionWithDeps = async ({
 		try {
 			result = await deps.resolveApproval({
 				approval: claimed,
-				onResumed: async (resumed) => {
-					await surfaceResumedOutcome({ resumed });
-				},
 				onProgress: (line) => {
 					statusText = line;
 					editor.requestEdit();

--- a/apps/leaf/src/internal/approvals/types.ts
+++ b/apps/leaf/src/internal/approvals/types.ts
@@ -61,7 +61,6 @@ export type ApprovalAuthorization =
 export type ApprovalActionDeps = {
 	resolveApproval: (input: {
 		approval: ChatApproval;
-		onResumed?: (result: ApprovalRunResult) => Promise<void> | void;
 		onProgress?: (statusLine: string) => void;
 		providerUserId: string;
 	}) => Promise<ApprovalRunResult>;

--- a/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
+++ b/apps/leaf/src/internal/approvals/utils/approvalDisplay.ts
@@ -4,7 +4,10 @@ import {
 	parsePreviewPayload,
 } from "@autumn/render";
 import type { AppEnv } from "@autumn/shared";
+import { errorMessage } from "../../../lib/errorMessage.js";
+import { logger } from "../../../lib/logger.js";
 import { executeAutumnMcpTool } from "../../autumnMcp/client.js";
+import { autumnMcpErrorText } from "../../autumnMcp/errorResult.js";
 
 const text = (value: unknown) =>
 	typeof value === "string" && value.trim() ? value.trim() : null;
@@ -122,11 +125,28 @@ export const resolveApprovalDisplay = async ({
 		customerId || planIds.length || needsFeatures ? getToken() : null;
 	const fetchRecord = (toolName: string, request: Record<string, unknown>) =>
 		token
-			?.then((value) =>
-				executeTool({ env, token: value, toolName, args: { request } }),
-			)
-			.then(parsePreviewPayload)
-			.catch(() => null);
+			?.then(async (value) => {
+				const result = await executeTool({
+					env,
+					token: value,
+					toolName,
+					args: { request },
+				});
+				const errorText = autumnMcpErrorText(result);
+				if (errorText) throw new Error(errorText);
+				return parsePreviewPayload(result);
+			})
+			.catch((error) => {
+				logger.warn("Approval display lookup failed", {
+					event: "leaf.approval_display_fetch_failed",
+					data: {
+						error: errorMessage(error).slice(0, 300),
+						request,
+						tool: toolName,
+					},
+				});
+				return null;
+			});
 	const [customer, features, plans] = await Promise.all([
 		customerId
 			? fetchRecord("getCustomer", {

--- a/apps/leaf/src/lib/env.ts
+++ b/apps/leaf/src/lib/env.ts
@@ -24,7 +24,6 @@ const envSchema = z
 			.transform((value) => value === "true" || value === "1"),
 		EVE_INTERNAL_AUTH_TOKEN: optionalString,
 		EVE_SERVER_URL: z.string().url().default("http://127.0.0.1:3999"),
-		LEAF_APPROVAL_EXECUTOR: z.string().optional(),
 		MCP_OAUTH_ENVIRONMENT: z.enum(["live", "sandbox"]).default("sandbox"),
 		PORT: z.coerce.number().int().positive().default(3099),
 		SLACK_CLIENT_ID: z.string().min(1),

--- a/apps/leaf/tests/e2e/approveFlow.e2e.ts
+++ b/apps/leaf/tests/e2e/approveFlow.e2e.ts
@@ -1,8 +1,9 @@
 /**
- * The deterministic executor: approve executes the stored writes directly —
- * fast, exactly-once, drift-guarded — and eve is only notified.
+ * The approve flow: approve resumes eve, which executes the parked writes
+ * itself; outcomes stream back onto the write rows. Drift is guarded
+ * pre-resume — a drifted card refreshes instead of executing.
  *
- *   bun tests/e2e/approveExecutor.e2e.ts
+ *   bun tests/e2e/approveFlow.e2e.ts
  */
 import { AppEnv, chatApprovals, chatApprovalWrites } from "@autumn/shared";
 import { eq } from "drizzle-orm";
@@ -98,16 +99,6 @@ const customerHasLaunch = async (customerId: string) =>
 		}),
 	).includes("launch");
 
-const requireApplied = (label: string, result: unknown) => {
-	const text = JSON.stringify(result);
-	if (text.includes('"isError":true') || text.includes("errorMessage")) {
-		throw new Error(`${label} failed: ${text.slice(0, 300)}`);
-	}
-	if (text.includes("payment_url")) {
-		throw new Error(`${label} redirected to checkout instead of applying`);
-	}
-};
-
 const approval = await parkGroupedAttach();
 
 // Concurrent double-click: the SQL claim admits exactly one.
@@ -122,23 +113,20 @@ check(
 
 const claimed = claimA ?? claimB;
 if (!claimed) throw new Error("no claim won");
-let resumedOutcome: Record<string, unknown> | undefined;
-const startedAt = Date.now();
 const result = await resolveApproval({
 	approval: claimed,
-	onResumed: (resumed) => {
-		resumedOutcome = resumed as Record<string, unknown>;
-	},
 	providerUserId,
 });
-const durationMs = Date.now() - startedAt;
 
 check(
-	"approve executed deterministically",
+	"approve resumed eve and applied",
 	!("drifted" in result) && !("error" in result),
 	JSON.stringify(result).slice(0, 200),
 );
-check("approve→applied is fast", durationMs < 60_000, `${durationMs}ms total`);
+check(
+	"resumed turn did not chain a new card",
+	!("chainedApprovalId" in result && result.chainedApprovalId),
+);
 check(
 	"both customers received the plan (bulk)",
 	(await customerHasLaunch(customerA)) && (await customerHasLaunch(customerB)),
@@ -150,24 +138,19 @@ const writes = await db
 	.where(eq(chatApprovalWrites.approval_id, approval.id))
 	.orderBy(chatApprovalWrites.position);
 check(
-	"every write row is applied",
+	"every write row is applied from stream evidence",
 	writes.length === 2 && writes.every((write) => write.status === "applied"),
 	writes.map((write) => write.status).join(","),
+);
+check(
+	"write rows carry the streamed results",
+	writes.every((write) => write.result != null),
 );
 const [finalRow] = await db
 	.select()
 	.from(chatApprovals)
 	.where(eq(chatApprovals.id, approval.id));
 check("row finalized approved", finalRow?.status === "approved");
-
-// The eve notification resolves async, off the approve critical path. The
-// model's text is never surfaced; only chained parks/questions would be.
-await new Promise((resolve) => setTimeout(resolve, 45_000));
-check(
-	"async resume settled without re-issued writes",
-	resumedOutcome !== undefined && !resumedOutcome.chainedApprovalId,
-	JSON.stringify(resumedOutcome ?? {}).slice(0, 140),
-);
 
 // Re-click after apply: the claim refuses a decided row.
 const reclaim = await chatApprovalRepo.claim({

--- a/apps/leaf/tests/e2e/staleIdRename.e2e.ts
+++ b/apps/leaf/tests/e2e/staleIdRename.e2e.ts
@@ -1,0 +1,127 @@
+/**
+ * Root-fix validation: after an approved id rename, a follow-up write in the
+ * SAME thread must target the NEW id — the transcript now records the rename
+ * as a real tool result instead of a procedural deny + SYSTEM NOTE.
+ *
+ *   bun tests/e2e/staleIdRename.e2e.ts
+ */
+import { AppEnv } from "@autumn/shared";
+import { createApproval } from "../../src/internal/approvals/actions/createApproval.js";
+import { resolveApproval } from "../../src/internal/approvals/actions/resolveApproval.js";
+import { chatApprovalRepo } from "../../src/internal/approvals/repos/chatApprovalRepo.js";
+import { executeAutumnMcpTool } from "../../src/internal/autumnMcp/client.js";
+import { getInstallationOAuthAccessToken } from "../../src/internal/installations/actions/getInstallationOAuthAccessToken.js";
+import { db } from "../../src/lib/db.js";
+import { logger } from "../../src/lib/logger.js";
+import { runSlackAgentTurn } from "../../src/providers/slack/actions/runSlackAgentTurn.js";
+import type { SlackChatInstallation } from "../../src/providers/slack/domain/slackAgentTurn.js";
+import { findInstallationWithOrg } from "../../src/providers/slack/installations.js";
+
+const WORKSPACE_ID = process.env.E2E_SLACK_WORKSPACE ?? "T07NPTDCU69";
+const results: Array<{ name: string; ok: boolean }> = [];
+const check = (name: string, ok: boolean, detail?: string) => {
+	results.push({ name, ok });
+	console.log(`${ok ? "✅" : "❌"} ${name}${detail ? ` — ${detail}` : ""}`);
+};
+
+const installation = (await findInstallationWithOrg(
+	"slack",
+	WORKSPACE_ID,
+)) as SlackChatInstallation | null;
+if (!installation) throw new Error(`No slack installation for ${WORKSPACE_ID}`);
+const providerUserId = installation.installed_by_provider_user_id ?? "";
+const token = await getInstallationOAuthAccessToken({
+	env: AppEnv.Sandbox,
+	installation,
+	orgId: installation.org_id,
+});
+
+const tag = Date.now().toString(36);
+const oldId = `stale-${tag}-a`;
+const newId = `stale-${tag}-renamed`;
+await executeAutumnMcpTool({
+	args: {
+		intent: "stale id validation",
+		request: { customer_id: oldId, email: `${oldId}@example.com` },
+	},
+	env: AppEnv.Sandbox,
+	token,
+	toolName: "getOrCreateCustomer",
+});
+
+const threadId = `stale-${tag}`;
+const runTurn = (text: string) =>
+	runSlackAgentTurn({
+		channelId: threadId,
+		installation,
+		logger,
+		onAction: () => {},
+		onApprovalsSuperseded: () => {},
+		onReasoning: () => {},
+		onThinking: () => {},
+		providerUserId,
+		text,
+		threadId,
+	});
+
+const renameTurn = await runTurn(
+	`Change the id of customer ${oldId} to ${newId}.`,
+);
+if (renameTurn.kind !== "approval") {
+	throw new Error(`rename turn kind ${renameTurn.kind}`);
+}
+const renameArgs = JSON.stringify(renameTurn.approval.toolArgs);
+check("rename write targets the old id", renameArgs.includes(oldId));
+
+const created = await createApproval({
+	channelId: threadId,
+	env: AppEnv.Sandbox,
+	getToken: async () => token,
+	logger,
+	orgId: installation.org_id,
+	provider: installation.provider,
+	providerUserId,
+	turn: {
+		approval: renameTurn.approval,
+		sessionId: renameTurn.sessionId,
+	} as never,
+	workspaceId: installation.workspace_id,
+});
+if (!created) throw new Error("no rename approval created");
+const claimed = await chatApprovalRepo.claim({
+	approvalId: created.approvalId,
+	db,
+	providerUserId,
+});
+if (!claimed) throw new Error("rename claim failed");
+const resolved = await resolveApproval({ approval: claimed, providerUserId });
+check(
+	"rename approve applied via eve",
+	!("drifted" in resolved) && !("error" in resolved),
+	JSON.stringify(resolved).slice(0, 160),
+);
+
+const oldGone = JSON.stringify(
+	await executeAutumnMcpTool({
+		args: { intent: "verify", request: { customer_id: oldId } },
+		env: AppEnv.Sandbox,
+		token,
+		toolName: "getCustomer",
+	}),
+).includes("customer_not_found");
+check("old id no longer resolves", oldGone);
+
+const followUpTurn = await runTurn(
+	"now update this customer's name to Validation Check",
+);
+if (followUpTurn.kind !== "approval") {
+	throw new Error(`follow-up turn kind ${followUpTurn.kind}`);
+}
+const followUpArgs = JSON.stringify(followUpTurn.approval.toolArgs);
+check(
+	"follow-up write targets the NEW id",
+	followUpArgs.includes(newId) && !followUpArgs.includes(`"${oldId}"`),
+	followUpArgs.slice(0, 300),
+);
+
+process.exit(results.every((entry) => entry.ok) ? 0 : 1);

--- a/apps/leaf/tests/unit/approvals/resolveApproval.test.ts
+++ b/apps/leaf/tests/unit/approvals/resolveApproval.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { AppEnv, type ChatApproval } from "@autumn/shared";
 import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
@@ -28,12 +28,39 @@ await mockLeafModule({
 	}),
 });
 
+let resumeBehavior: () => Promise<unknown> = async () => ({});
 await mockLeafModule({
 	specifier: "../../../src/internal/approvals/actions/resumeApproval.js",
 	factory: () => ({
-		resumeApproval: async () => {
-			throw new Error("eve stream disconnected");
+		resumeApproval: () => resumeBehavior(),
+	}),
+});
+
+let driftBehavior: () => Promise<unknown> = async () => undefined;
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/actions/guardApprovalDrift.js",
+	factory: () => ({
+		guardApprovalDrift: () => driftBehavior(),
+	}),
+});
+
+const executorCalls: string[] = [];
+let executorBehavior: () => Promise<unknown> = async () => undefined;
+await mockLeafModule({
+	specifier: "../../../src/internal/approvals/actions/executeApprovalWrites.js",
+	factory: () => ({
+		executeApprovalWrites: ({ approval }: { approval: ChatApproval }) => {
+			executorCalls.push(approval.id);
+			return executorBehavior();
 		},
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/repo.js",
+	factory: () => ({
+		deleteEveSession: async () => {},
+		getEveSessionBySessionId: async () => undefined,
 	}),
 });
 
@@ -44,25 +71,41 @@ await mockLeafModule({
 	}),
 });
 
+const { EveSessionGoneError } = await import(
+	"../../../src/internal/agentRuntime/eve/client.js"
+);
 const { resolveApproval } = await import(
 	"../../../src/internal/approvals/actions/resolveApproval.js"
 );
 
-const approval = () =>
+const approval = (overrides: Partial<ChatApproval> = {}) =>
 	({
 		env: AppEnv.Sandbox,
 		harness: "eve",
 		id: "a_1",
 		org_id: "org_1",
+		provider: "slack",
+		run_id: "eve_session_1",
 		tool_name: "autumn__attach",
+		...overrides,
 	}) as unknown as ChatApproval;
+
+beforeEach(() => {
+	repoCalls.length = 0;
+	executorCalls.length = 0;
+	resumeBehavior = async () => ({ result: {}, text: "", writes: [] });
+	driftBehavior = async () => undefined;
+	executorBehavior = async () => undefined;
+});
 
 // Claiming moves the row pending→running. A retryable failure deliberately
 // skips finalize so the user can retry — but without releasing the claim the
 // row stays running forever and the card can never be clicked again.
 describe("resolveApproval releases the claim it could not finalize", () => {
 	test("returns the row to pending when the resume fails retryably", async () => {
-		repoCalls.length = 0;
+		resumeBehavior = async () => {
+			throw new Error("eve stream disconnected");
+		};
 
 		const result = await resolveApproval({
 			approval: approval(),
@@ -71,5 +114,111 @@ describe("resolveApproval releases the claim it could not finalize", () => {
 
 		expect(result).toMatchObject({ error: true, retryable: true });
 		expect(repoCalls).toEqual(["release"]);
+	});
+});
+
+describe("resolveApproval drift guard", () => {
+	test("a drifted card returns without resuming or finalizing", async () => {
+		driftBehavior = async () => ({ drifted: true, message: "drifted" });
+		let resumed = false;
+		resumeBehavior = async () => {
+			resumed = true;
+			return {};
+		};
+
+		const result = await resolveApproval({
+			approval: approval(),
+			providerUserId: "U1",
+		});
+
+		expect(result).toMatchObject({ drifted: true });
+		expect(resumed).toBe(false);
+		expect(repoCalls).toEqual([]);
+	});
+
+	test("a thrown guard releases the claim retryably", async () => {
+		driftBehavior = async () => {
+			throw new Error("preview fetch failed");
+		};
+
+		const result = await resolveApproval({
+			approval: approval(),
+			providerUserId: "U1",
+		});
+
+		expect(result).toMatchObject({ error: true, retryable: true });
+		expect(repoCalls).toEqual(["release"]);
+	});
+
+	test("the dashboard surface skips the guard", async () => {
+		let guarded = false;
+		driftBehavior = async () => {
+			guarded = true;
+			return undefined;
+		};
+
+		const result = await resolveApproval({
+			approval: approval({ provider: "web" } as Partial<ChatApproval>),
+			providerUserId: "U1",
+		});
+
+		expect(guarded).toBe(false);
+		expect(result).toMatchObject({ result: {} });
+	});
+});
+
+describe("resolveApproval dead-session fallback", () => {
+	test("a gone session executes the stored writes deterministically", async () => {
+		resumeBehavior = async () => {
+			throw new EveSessionGoneError("session gone");
+		};
+		executorBehavior = async () => ({
+			result: {},
+			text: "",
+			toolName: "autumn__attach",
+			writes: [{ status: "applied", toolName: "autumn__attach" }],
+		});
+
+		const result = await resolveApproval({
+			approval: approval(),
+			providerUserId: "U1",
+		});
+
+		expect(executorCalls).toEqual(["a_1"]);
+		expect(result).toMatchObject({
+			writes: [{ status: "applied", toolName: "autumn__attach" }],
+		});
+		expect(repoCalls).toEqual([]);
+	});
+
+	test("a gone session without stored writes finalizes failed", async () => {
+		resumeBehavior = async () => {
+			throw new EveSessionGoneError("session gone");
+		};
+
+		const result = await resolveApproval({
+			approval: approval(),
+			providerUserId: "U1",
+		});
+
+		expect(executorCalls).toEqual(["a_1"]);
+		expect(result).toMatchObject({ error: true, retryable: false });
+		expect(repoCalls).toEqual(["finalize"]);
+	});
+
+	test("the dashboard surface never executes the group", async () => {
+		resumeBehavior = async () => {
+			throw new EveSessionGoneError("session gone");
+		};
+		executorBehavior = async () => ({ result: {}, text: "", writes: [] });
+
+		const result = await resolveApproval({
+			approval: approval({ provider: "web" } as Partial<ChatApproval>),
+			providerUserId: "U1",
+		});
+
+		expect(executorCalls).toEqual([]);
+		expect(result).toMatchObject({ error: true, retryable: false });
+		expect(repoCalls).toEqual(["finalize"]);
 	});
 });

--- a/apps/leaf/tests/unit/harness/resume-eve-approval.test.ts
+++ b/apps/leaf/tests/unit/harness/resume-eve-approval.test.ts
@@ -9,14 +9,30 @@ import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 // stubbing them is what makes every module below importable, hence restorable.
 mock.module("../../../src/lib/env.js", () => ({ env: {} }));
 mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+let writeRows: unknown[] = [];
+const writeStatusUpdates: Array<{
+	result?: unknown;
+	status: string;
+	writeId: string;
+}> = [];
 mock.module(
 	"../../../src/internal/approvals/repos/chatApprovalWritesRepo.js",
 	() => ({
 		chatApprovalWritesRepo: {
 			insert: async () => undefined,
-			list: async () => [],
+			list: async () => writeRows,
 			setPreview: async () => true,
-			setStatus: async () => undefined,
+			setStatus: async (input: {
+				result?: unknown;
+				status: string;
+				writeId: string;
+			}) => {
+				writeStatusUpdates.push({
+					result: input.result,
+					status: input.status,
+					writeId: input.writeId,
+				});
+			},
 		},
 	}),
 );
@@ -958,5 +974,118 @@ describe("delegated writes are verified on the child stream", () => {
 
 		expect(result).toMatchObject({ error: true, retryable: true });
 		expect(loggedEvents).toEqual(["leaf.eve_approval_not_executed"]);
+	});
+});
+
+describe("approved write outcomes persist onto the write rows", () => {
+	beforeEach(() => {
+		streamedEvents = EMPTY_TURN;
+		streamedEventsBySession = {};
+		idleTimeoutSessionIds = [];
+		postedResponses.length = 0;
+		loggedEvents.length = 0;
+		writeStatusUpdates.length = 0;
+		writeRows = [
+			{
+				deny_option_id: "deny",
+				id: "w_1",
+				position: 0,
+				request_id: "req_1",
+				tool_args: {},
+				tool_name: "autumn__updateCustomer",
+			},
+			{
+				deny_option_id: "deny",
+				id: "w_2",
+				position: 1,
+				request_id: "req_2",
+				tool_args: {},
+				tool_name: "autumn__attach",
+			},
+		];
+		session = {
+			env: AppEnv.Sandbox,
+			newSession: false,
+			sessionId: "eve_session_1",
+			state: {
+				version: 1,
+				continuationToken: "token_1",
+				streamIndex: 4,
+				status: "waiting",
+				lastEventAt: 0,
+				pendingRequests: [],
+			},
+			threadKey: "sandbox:slack:T1:C1:thread_1",
+		};
+	});
+
+	test("streamed results land on their rows in execution order", async () => {
+		streamedEvents = [
+			{ type: "turn.started" },
+			{
+				result: {
+					callId: "c1",
+					output: { ok: true },
+					toolName: "autumn__updateCustomer",
+				},
+				status: "completed",
+				type: "action.result",
+			},
+			{
+				result: {
+					callId: "c2",
+					output: { error: "Plan not found" },
+					toolName: "autumn__attach",
+				},
+				status: "error",
+				type: "action.result",
+			},
+			{ type: "session.waiting" },
+		];
+
+		await resumeApproval({
+			approval: groupedApproval(),
+			providerUserId: "U1",
+		});
+
+		expect(writeStatusUpdates).toEqual([
+			{ result: { ok: true }, status: "applied", writeId: "w_1" },
+			{ result: { error: "Plan not found" }, status: "failed", writeId: "w_2" },
+		]);
+	});
+
+	test("a write without stream evidence stays pending", async () => {
+		streamedEvents = [
+			{ type: "turn.started" },
+			{
+				result: {
+					callId: "c1",
+					output: { ok: true },
+					toolName: "autumn__updateCustomer",
+				},
+				status: "completed",
+				type: "action.result",
+			},
+			{ type: "session.waiting" },
+		];
+
+		await resumeApproval({
+			approval: groupedApproval(),
+			providerUserId: "U1",
+		});
+
+		expect(writeStatusUpdates).toEqual([
+			{ result: { ok: true }, status: "applied", writeId: "w_1" },
+		]);
+	});
+
+	test("a deny persists nothing", async () => {
+		writeRows = [writeRows[0] as never];
+		await discardApproval({
+			approval: approval(),
+			providerUserId: "U1",
+		});
+
+		expect(writeStatusUpdates).toEqual([]);
 	});
 });

--- a/apps/leaf/tests/unit/harness/resume-stream-reconnect.test.ts
+++ b/apps/leaf/tests/unit/harness/resume-stream-reconnect.test.ts
@@ -195,7 +195,7 @@ describe("consumeResumedAgentTurn stream resilience", () => {
 		expect(result.approvedWriteFailed).toBe(false);
 		expect(result.approvedWriteUnverified).toBe(false);
 		expect(result.writes).toEqual([
-			{ status: "applied", toolName: "autumn__attach" },
+			{ result: { ok: true }, status: "applied", toolName: "autumn__attach" },
 		]);
 		expect(result.text).toBe("Attached the plan.");
 	});
@@ -248,7 +248,7 @@ describe("consumeResumedAgentTurn stream resilience", () => {
 		expect(result.approvedWriteFailed).toBe(false);
 		expect(result.approvedWriteUnverified).toBe(false);
 		expect(result.writes).toEqual([
-			{ status: "applied", toolName: "autumn__attach" },
+			{ result: { ok: true }, status: "applied", toolName: "autumn__attach" },
 		]);
 	});
 
@@ -265,7 +265,7 @@ describe("consumeResumedAgentTurn stream resilience", () => {
 		expect(result.approvedWriteFailed).toBe(false);
 		expect(result.approvedWriteUnverified).toBe(false);
 		expect(result.writes).toEqual([
-			{ status: "applied", toolName: "autumn__attach" },
+			{ result: { ok: true }, status: "applied", toolName: "autumn__attach" },
 		]);
 	});
 });


### PR DESCRIPTION
## Problem

Approving a Slack card in dev ran the deterministic executor, then released the parked eve tool calls with a **procedural deny + "SYSTEM NOTE"** telling the model the denies weren't real. Eve's contract makes that unfixable:

- the deny reason is hardcoded ("Tool execution was denied.") — no custom reason or result can ride along
- for subagent-parked writes the decision routes to the **child** session but any note routes to the **parent**, deferred a full turn

So the child recorded a bald deny for a write that actually ran, and the orchestrator later received an out-of-band note claiming it was applied — exactly the shape of a prompt injection, which the model correctly refused, telling the user an applied write "was denied".

## Fix

Approve is now **eve-native everywhere** (prod already behaved this way — `LEAF_APPROVAL_EXECUTOR` defaulted off): the approve resumes eve, which replays the exact parked call synchronously, so the child's transcript records a real tool result. The injection-shaped release path is deleted.

- `resolveApproval` — flag branch removed; live session → always `resumeApproval`
- **drift guard hoisted pre-resume** (`guardApprovalDrift`, Slack surfaces): a drifted card releases back to pending with fresh previews and nothing executes — Slack prod gains drift protection it never had
- `executeApprovalWrites` stripped to the **dead-session fallback** (`EveSessionGoneError`, Slack-only): the stored writes still honor the approval when eve lost the session; the deny+SYSTEM-NOTE notify is gone
- **write outcomes persist from stream evidence**: `consumeResumedAgentTurn` captures each write's `action.result` output and `submitApprovalInput` lands status+result on `chat_approval_writes` in position order
- pruned now-dead machinery: `LEAF_APPROVAL_EXECUTOR`, `onResumed` chain, `shouldAbsorbChained` absorb block, `suppressSiblingWithheldNote`

## Validation

- `tsc` clean, biome clean, 480/480 leaf unit tests on this branch (new coverage: drift-guard branches, dead-session fallback ×3, write-outcome persistence ×3)
- Live e2e against the local stack (`tests/e2e/approveFlow.e2e.ts`, renamed from `approveExecutor`): grouped 2-write approve resumed eve → both applied, rows persisted with streamed results, finalized, re-click refused; tampered preview → drift refused pre-resume, row released, nothing executed
- `eveSlack.e2e.ts` ×2: approve / supersede / deny / discard scenarios all pass (S5 ask_question + S6 image fail identically pre-change — model nondeterminism and the known upstream eve image bug)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes Slack approval execution resume Eve directly and retains deterministic execution only when the parked Eve session has disappeared.

- **[Bug fixes, Improvements]** Resume approved Eve calls natively so their real tool results appear in the session transcript.
- **[Bug fixes, Improvements]** Check Slack approval previews for pricing drift before resuming execution.
- **[Improvements]** Persist streamed write results and statuses on individual approval-write records.
- **[Improvements]** Add Leaf unit-test CI and expand approval-flow coverage.
</details>


<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until the dead-session fallback revalidates pricing immediately before executing stored writes.

A pricing change can occur during the asynchronous Eve resume attempt; if Eve then reports that the session is gone, the fallback executes the previously stored arguments without checking that they still match the approved preview.

**Files Needing Attention:** apps/leaf/src/internal/approvals/actions/resolveApproval.ts, apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/approvals/actions/resolveApproval.ts | Routes approvals through the drift guard and Eve resume, with direct stored-write execution after a missing-session response. |
| apps/leaf/src/internal/approvals/actions/guardApprovalDrift.ts | Extracts Slack preview revalidation and refresh behavior into a pre-resume guard. |
| apps/leaf/src/internal/approvals/actions/executeApprovalWrites.ts | Narrows deterministic write execution to the dead-session fallback. |
| apps/leaf/src/internal/approvals/actions/submitApprovalInput.ts | Persists streamed write outcomes and removes the procedural deny-and-notify path. |
| apps/leaf/src/internal/agentRuntime/actions/submitAgentInput/consumeResumedAgentTurn.ts | Captures each approved write's streamed result alongside its execution status. |
| .github/workflows/leaf-unit-tests.yml | Adds path-filtered Leaf unit tests for pull requests and pushes to dev. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[User approves Slack card] --> B[Claim approval]
  B --> C[Check preview drift]
  C -->|Drift detected| D[Release approval and refresh previews]
  C -->|No drift| E[Resume parked Eve call]
  E -->|Session available| F[Eve executes writes]
  F --> G[Persist streamed outcomes]
  E -->|Session gone| H[Execute stored writes directly]
  G --> I[Finalize approval]
  H --> I
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: 🐛 approval lookups and failures lo..."](https://github.com/useautumn/autumn/commit/fc0fe63db27bf9102373459ce45b4e4b296e86aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57036633)</sub>

**Context used:**

- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)

<!-- /greptile_comment -->