### PR TITLE
Fix atmn graduated credit schema support

### DIFF
--- a/packages/atmn/src/commands/push/push.ts
+++ b/packages/atmn/src/commands/push/push.ts
@@ -429,10 +429,23 @@ function normalizeFeatureForCompare(f: Feature): Record<string, unknown> {
 	if (f.creditSchema && f.creditSchema.length > 0) {
 		result.creditSchema = [...f.creditSchema]
 			.sort((a, b) => a.meteredFeatureId.localeCompare(b.meteredFeatureId))
-			.map((cs) => ({
-				meteredFeatureId: cs.meteredFeatureId,
-				creditCost: cs.creditCost,
-			}));
+			.map((creditSchemaItem) => {
+				const base = {
+					meteredFeatureId: creditSchemaItem.meteredFeatureId,
+					...(creditSchemaItem.billingUnits !== undefined &&
+						creditSchemaItem.billingUnits !== 1 && {
+							billingUnits: creditSchemaItem.billingUnits,
+						}),
+				};
+
+				return creditSchemaItem.tierBehavior === "graduated"
+					? {
+							...base,
+							tierBehavior: creditSchemaItem.tierBehavior,
+							tiers: creditSchemaItem.tiers,
+						}
+					: { ...base, creditCost: creditSchemaItem.creditCost };
+			});
 	}
 
 	if (f.type === "ai_credit_system") {

--- a/packages/atmn/src/commands/test-diff/command.ts
+++ b/packages/atmn/src/commands/test-diff/command.ts
@@ -39,10 +39,23 @@ function normalizeFeatureForCompare(f: Feature): Rec {
 	if (f.creditSchema && f.creditSchema.length > 0) {
 		result.creditSchema = [...f.creditSchema]
 			.sort((a, b) => a.meteredFeatureId.localeCompare(b.meteredFeatureId))
-			.map((cs) => ({
-				meteredFeatureId: cs.meteredFeatureId,
-				creditCost: cs.creditCost,
-			}));
+			.map((creditSchemaItem) => {
+				const base = {
+					meteredFeatureId: creditSchemaItem.meteredFeatureId,
+					...(creditSchemaItem.billingUnits !== undefined &&
+						creditSchemaItem.billingUnits !== 1 && {
+							billingUnits: creditSchemaItem.billingUnits,
+						}),
+				};
+
+				return creditSchemaItem.tierBehavior === "graduated"
+					? {
+							...base,
+							tierBehavior: creditSchemaItem.tierBehavior,
+							tiers: creditSchemaItem.tiers,
+						}
+					: { ...base, creditCost: creditSchemaItem.creditCost };
+			});
 	}
 	return result;
 }

--- a/packages/atmn/src/compose/models/featureModels.ts
+++ b/packages/atmn/src/compose/models/featureModels.ts
@@ -4,6 +4,36 @@
 
 import { z } from "zod/v4";
 
+export const CreditTierSchema = z.object({
+	to: z.union([z.number(), z.literal("inf")]),
+	creditCost: z.number(),
+});
+
+const CreditSchemaItemBaseSchema = z.object({
+	meteredFeatureId: z.string(),
+	billingUnits: z.number().optional(),
+});
+
+export const FlatCreditSchemaItemSchema = CreditSchemaItemBaseSchema.extend({
+	creditCost: z.number(),
+	tierBehavior: z.never().optional(),
+	tiers: z.never().optional(),
+});
+
+export const GraduatedCreditSchemaItemSchema =
+	CreditSchemaItemBaseSchema.extend({
+		creditCost: z.never().optional(),
+		tierBehavior: z.literal("graduated"),
+		tiers: z.array(CreditTierSchema),
+	});
+
+export const CreditSchemaItemSchema = z.union([
+	FlatCreditSchemaItemSchema,
+	GraduatedCreditSchemaItemSchema,
+]);
+
+export type CreditSchemaItem = z.infer<typeof CreditSchemaItemSchema>;
+
 export const FeatureSchema = z.object({
 	id: z.string().meta({
 		description:
@@ -17,23 +47,10 @@ export const FeatureSchema = z.object({
 		description:
 			"Event names that trigger this feature's balance. Allows multiple features to respond to a single event.",
 	}),
-	creditSchema: z
-		.array(
-			z.object({
-				metered_feature_id: z.string().meta({
-					description:
-						"ID of the metered feature that draws from this credit system.",
-				}),
-				credit_cost: z.number().meta({
-					description: "Credits consumed per unit of the metered feature.",
-				}),
-			}),
-		)
-		.optional()
-		.meta({
-			description:
-				"For credit_system features: maps metered features to their credit costs.",
-		}),
+	creditSchema: z.array(CreditSchemaItemSchema).optional().meta({
+		description:
+			"For credit_system features: maps metered features to flat or graduated credit costs.",
+	}),
 	archived: z.boolean().meta({
 		description:
 			"Whether the feature is archived and hidden from the dashboard.",
@@ -51,10 +68,7 @@ type FeatureBase = {
 	/** Event names that trigger this feature */
 	eventNames?: string[];
 	/** Credit schema for credit_system features */
-	creditSchema?: Array<{
-		meteredFeatureId: string;
-		creditCost: number;
-	}>;
+	creditSchema?: CreditSchemaItem[];
 };
 
 /** Boolean feature - no consumable field allowed */
@@ -76,10 +90,7 @@ export type CreditSystemFeature = FeatureBase & {
 	/** Credit systems are always consumable */
 	consumable?: true;
 	/** Required: defines how credits map to metered features */
-	creditSchema: Array<{
-		meteredFeatureId: string;
-		creditCost: number;
-	}>;
+	creditSchema: CreditSchemaItem[];
 };
 
 export type ModelMarkupEntry = {

--- a/packages/atmn/src/lib/transforms/apiToSdk/Transformer.test.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/Transformer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { transformFeatureToApi } from "../sdkToApi/feature.js";
 import { transformApiFeature } from "./feature.js";
 import { transformApiPlan } from "./plan.js";
 import { createTransformer } from "./Transformer.js";
@@ -68,6 +69,45 @@ describe("Transformer", () => {
 				expect(result.consumable).toBe(true);
 				expect(result.creditSchema).toHaveLength(1);
 			}
+		});
+
+		test("graduated credit system round trip", () => {
+			const apiFeature = {
+				id: "credits",
+				name: "Credits",
+				type: "credit_system",
+				consumable: true,
+				archived: false,
+				credit_schema: [
+					{
+						metered_feature_id: "api_calls",
+						billing_units: 100,
+						tier_behavior: "graduated" as const,
+						tiers: [
+							{ to: 10_000, credit_cost: 1 },
+							{ to: "inf" as const, credit_cost: 0.5 },
+						],
+					},
+				],
+			};
+
+			const feature = transformApiFeature(apiFeature);
+
+			expect(feature.type).toBe("credit_system");
+			if (feature.type === "credit_system") {
+				expect(feature.creditSchema[0]).toEqual({
+					meteredFeatureId: "api_calls",
+					billingUnits: 100,
+					tierBehavior: "graduated",
+					tiers: [
+						{ to: 10_000, creditCost: 1 },
+						{ to: "inf", creditCost: 0.5 },
+					],
+				});
+			}
+			expect(transformFeatureToApi(feature).credit_schema).toEqual(
+				apiFeature.credit_schema,
+			);
 		});
 
 		test("ai_credit_system", () => {

--- a/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
+++ b/packages/atmn/src/lib/transforms/apiToSdk/feature.ts
@@ -1,16 +1,38 @@
-import type { Feature, ModelMarkupEntry } from "../../../compose/models/featureModels.js";
+import type {
+	CreditSchemaItem,
+	Feature,
+	ModelMarkupEntry,
+} from "../../../compose/models/featureModels.js";
 import type { ApiFeature } from "../../api/types/feature.js";
 import { createTransformer } from "./Transformer.js";
 
 type RawApiFeature = Omit<ApiFeature, "type"> & { type: string };
 
-function mapCreditSchema(
-	api: RawApiFeature,
-): Array<{ meteredFeatureId: string; creditCost: number }> {
-	return (api.credit_schema ?? []).map((cs) => ({
-		meteredFeatureId: cs.metered_feature_id,
-		creditCost: cs.credit_cost,
-	}));
+function mapCreditSchema(api: RawApiFeature): CreditSchemaItem[] {
+	return (api.credit_schema ?? []).map((creditSchemaItem) => {
+		const base = {
+			meteredFeatureId: creditSchemaItem.metered_feature_id,
+			...(creditSchemaItem.billing_units !== undefined && {
+				billingUnits: creditSchemaItem.billing_units,
+			}),
+		};
+
+		if (creditSchemaItem.tier_behavior === "graduated") {
+			return {
+				...base,
+				tierBehavior: "graduated",
+				tiers: creditSchemaItem.tiers.map((tier) => ({
+					to: tier.to,
+					creditCost: tier.credit_cost,
+				})),
+			};
+		}
+
+		return {
+			...base,
+			creditCost: creditSchemaItem.credit_cost,
+		};
+	});
 }
 
 function mapModelMarkups(api: RawApiFeature): Record<string, ModelMarkupEntry> | undefined {

--- a/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
+++ b/packages/atmn/src/lib/transforms/sdkToApi/feature.ts
@@ -1,4 +1,5 @@
 import type { Feature } from "../../../compose/models/index.js";
+import type { ApiFeature } from "../../api/types/feature.js";
 
 export interface ApiFeatureParams {
 	id: string;
@@ -7,10 +8,7 @@ export interface ApiFeatureParams {
 	consumable?: boolean;
 	archived?: boolean;
 	event_names?: string[];
-	credit_schema?: Array<{
-		metered_feature_id: string;
-		credit_cost: number;
-	}>;
+	credit_schema?: ApiFeature["credit_schema"];
 	model_markups?: Record<string, {
 		markup?: number;
 		input_cost?: number;
@@ -40,10 +38,30 @@ export function transformFeatureToApi(feature: Feature): ApiFeatureParams {
 	}
 
 	if (feature.type === "credit_system" && feature.creditSchema) {
-		base.credit_schema = feature.creditSchema.map((entry) => ({
-			metered_feature_id: entry.meteredFeatureId,
-			credit_cost: entry.creditCost,
-		}));
+		base.credit_schema = feature.creditSchema.map((creditSchemaItem) => {
+			const baseItem = {
+				metered_feature_id: creditSchemaItem.meteredFeatureId,
+				...(creditSchemaItem.billingUnits !== undefined && {
+					billing_units: creditSchemaItem.billingUnits,
+				}),
+			};
+
+			if (creditSchemaItem.tierBehavior === "graduated") {
+				return {
+					...baseItem,
+					tier_behavior: "graduated" as const,
+					tiers: creditSchemaItem.tiers.map((tier) => ({
+						to: tier.to,
+						credit_cost: tier.creditCost,
+					})),
+				};
+			}
+
+			return {
+				...baseItem,
+				credit_cost: creditSchemaItem.creditCost,
+			};
+		});
 	}
 
 	if (feature.type === "ai_credit_system") {

--- a/packages/atmn/src/views/react/features/components/FeatureSheet.tsx
+++ b/packages/atmn/src/views/react/features/components/FeatureSheet.tsx
@@ -103,7 +103,7 @@ export function FeatureSheet({
 				feature.credit_schema &&
 				feature.credit_schema.length > 0 && (
 					<SheetSection title="Credit Schema">
-						{feature.credit_schema.map((item: { metered_feature_id: string; credit_cost: number }, index: number) => (
+						{feature.credit_schema.map((item, index) => (
 							<Box key={item.metered_feature_id} flexDirection="column">
 								<Text>
 									<Text color="gray">{index + 1}. </Text>
@@ -111,8 +111,16 @@ export function FeatureSheet({
 								</Text>
 								<Box paddingLeft={2}>
 									<Text>
-										<Text color="gray">Credit Cost: </Text>
-										<Text color="cyan">{item.credit_cost}</Text>
+										<Text color="gray">
+											{item.tier_behavior === "graduated"
+												? "Pricing: "
+												: "Credit Cost: "}
+										</Text>
+										<Text color="cyan">
+											{item.tier_behavior === "graduated"
+												? `${item.tiers.length} graduated tiers`
+												: item.credit_cost}
+										</Text>
 									</Text>
 								</Box>
 							</Box>


### PR DESCRIPTION
## Cubic summary

Fixes the release typecheck by teaching atmn to model and preserve both flat and graduated credit-schema entries instead of assuming every entry has a top-level credit cost.

## What changed

- Adds flat and graduated credit-schema variants to the atmn feature model.
- Preserves billing units and graduated tiers through API-to-SDK and SDK-to-API transforms.
- Includes the complete rate-card shape in push and test-diff comparisons.
- Displays graduated entries safely in the feature sheet.
- Adds a graduated API-to-SDK-to-API round-trip regression test.

## Verification

- Root bun ts: 12 of 12 packages passed.
- Focused transformer test: 14 passed, 0 failed.
- Full atmn test command: 72 passed; live CLI cases could not initialize without UNIT_TEST_AUTUMN_SECRET_KEY.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extends atmn’s credit-schema model and conversion paths so graduated pricing survives pull, comparison, display, and push operations.
- **[Bug fixes, API changes]** Models flat and graduated credit-schema entries, including billing units and tier data.
- **[Bug fixes]** Preserves complete graduated pricing across API-to-SDK and SDK-to-API transformations.
- **[Bug fixes, Improvements]** Compares graduated rate-card details during push and test-diff operations.
- **[Improvements]** Displays graduated entries safely and adds a round-trip regression test.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failures identified.

The flat and graduated schema variants remain aligned across modeling, transformation, comparison, display, and the added round-trip regression test.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/atmn/src/compose/models/featureModels.ts | Adds distinct flat and graduated credit-schema models with billing-unit and tier support. |
| packages/atmn/src/lib/transforms/apiToSdk/feature.ts | Preserves API billing units and graduated tiers in the SDK representation. |
| packages/atmn/src/lib/transforms/sdkToApi/feature.ts | Serializes both flat and graduated SDK entries back into the API contract. |
| packages/atmn/src/commands/push/push.ts | Includes graduated rate-card details in feature change detection while respecting the billing-unit default. |
| packages/atmn/src/commands/test-diff/command.ts | Aligns test-diff normalization with push comparison behavior. |
| packages/atmn/src/views/react/features/components/FeatureSheet.tsx | Renders a graduated-tier summary instead of assuming every entry has a flat credit cost. |
| packages/atmn/src/lib/transforms/apiToSdk/Transformer.test.ts | Covers a graduated API-to-SDK-to-API round trip. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  API[API credit_schema] --> A[API-to-SDK transform]
  A --> Model[Flat or graduated SDK model]
  Model --> Compare[Push and test-diff comparison]
  Model --> View[Feature sheet]
  Model --> B[SDK-to-API transform]
  B --> API
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix atmn graduated credit schema support"](https://github.com/useautumn/autumn/commit/99f3762c37c0c8ad486547f557bc9aacfd8a80e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57058003)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
- Knowledge Base — [Product surfaces and developer integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/product-surfaces-and-integrations.md)

<!-- /greptile_comment -->