### PR TITLE
ci: post shipped fallback after five minutes

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   notify-shipped:
@@ -23,6 +24,9 @@ jobs:
       (github.event.changes.body &&
       !contains(github.event.changes.body.from || '', '<!-- This is an auto-generated description by cubic. -->') &&
       !contains(github.event.changes.body.from || '', '<!-- greptile_comment -->')))
+    concurrency:
+      group: shipped-summary-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
 
     steps:
@@ -32,10 +36,11 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-          SLACK_SHIPPED_WEBHOOK_URL: ${{ secrets.SLACK_SHIPPED_WEBHOOK_URL }}
+          DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
+          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
         run: |
-          if [ -z "$SLACK_SHIPPED_WEBHOOK_URL" ]; then
-            echo "::error::SLACK_SHIPPED_WEBHOOK_URL is not configured"
+          if [ -z "$DEPLOY_URL" ] || [ -z "$DEPLOY_SECRET" ]; then
+            echo "::error::DEPLOY_URL and DEPLOY_SECRET must be configured"
             exit 1
           fi
 
@@ -81,15 +86,86 @@ jobs:
             -e 's/>/\&gt;/g')
           printf -v SLACK_MESSAGE '*%s* :rocket:\n<%s|PR #%s>\n\n%s' \
             "$route_label" "$PR_URL" "$PR_NUMBER" "$slack_summary"
-          export SLACK_MESSAGE
+          export PR_URL SLACK_MESSAGE
 
-          node -e 'process.stdout.write(JSON.stringify({ text: process.env.SLACK_MESSAGE }))' \
-            > "$RUNNER_TEMP/slack-payload.json"
+          node -e 'process.stdout.write(JSON.stringify({ pullRequestUrl: process.env.PR_URL, text: process.env.SLACK_MESSAGE }))' \
+            > "$RUNNER_TEMP/shipped-summary-payload.json"
 
           curl --silent --show-error --fail-with-body --retry 3 --retry-all-errors \
+            --request POST \
             --header "Content-Type: application/json" \
-            --data-binary @"$RUNNER_TEMP/slack-payload.json" \
-            "$SLACK_SHIPPED_WEBHOOK_URL"
+            --header "x-deploy-secret: $DEPLOY_SECRET" \
+            --data-binary @"$RUNNER_TEMP/shipped-summary-payload.json" \
+            "$DEPLOY_URL/api/shipped/summary"
+
+  wait-for-summary:
+    name: Wait for a PR summary
+    if: >-
+      github.event.action == 'opened' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait for a PR summary
+        run: sleep 300
+
+  notify-without-summary:
+    name: Notify without summary
+    needs: wait-for-summary
+    if: >-
+      github.event.action == 'opened' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    concurrency:
+      group: shipped-summary-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post fallback to shipped
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
+          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [ -z "$DEPLOY_URL" ] || [ -z "$DEPLOY_SECRET" ]; then
+            echo "::error::DEPLOY_URL and DEPLOY_SECRET must be configured"
+            exit 1
+          fi
+
+          pr_body=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.body // ""')
+          case "$pr_body" in
+            *'<!-- This is an auto-generated description by cubic. -->'* | *'<!-- greptile_comment -->'*)
+              echo "A shipped message has already been posted"
+              exit 0
+              ;;
+          esac
+
+          if [ "$PR_HEAD_REF" = "dev" ]; then
+            route_label="dev2main"
+          else
+            slack_head_ref=$(printf '%s' "$PR_HEAD_REF" | sed \
+              -e 's/&/\&amp;/g' \
+              -e 's/</\&lt;/g' \
+              -e 's/>/\&gt;/g')
+            route_label="$slack_head_ref → main"
+          fi
+
+          printf -v SLACK_MESSAGE '*%s* :rocket:\n<%s|PR #%s>' \
+            "$route_label" "$PR_URL" "$PR_NUMBER"
+          export PR_URL SLACK_MESSAGE
+
+          node -e 'process.stdout.write(JSON.stringify({ pullRequestUrl: process.env.PR_URL, text: process.env.SLACK_MESSAGE }))' \
+            > "$RUNNER_TEMP/shipped-summary-payload.json"
+
+          curl --silent --show-error --fail-with-body --retry 3 --retry-all-errors \
+            --request POST \
+            --header "Content-Type: application/json" \
+            --header "x-deploy-secret: $DEPLOY_SECRET" \
+            --data-binary @"$RUNNER_TEMP/shipped-summary-payload.json" \
+            "$DEPLOY_URL/api/shipped/summary"
 
   notify-merged:
     name: Reply when merged


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes shipped summaries through the deployment service and adds a summary-less fallback after five minutes. The fallback currently mistakes the presence of a summary marker for successful notification delivery.

- **[Improvements]** Sends summary and fallback payloads through the authenticated shipped-summary endpoint.
- **[Improvements]** Adds serialized, per-PR notification jobs and a five-minute wait before posting a fallback.
- **[Bug fixes]** Adds pull-request read permission so the fallback can inspect the latest PR body.
</details>


<h3>Confidence Score: 4/5</h3>

The notification fallback should be fixed before merging because a failed summary delivery can still leave the PR with no shipped notification.

The fallback checks only for a marker in the PR body, although the normal notification can fail after that marker is present, causing both delivery paths to produce no message.

**Files Needing Attention:** .github/workflows/post-cubic-summary.yml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/post-cubic-summary.yml | Adds deployment-backed summary delivery and a timed fallback, but the fallback can skip when the original delivery failed after adding a body marker. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/post-cubic-summary.yml:139-144
**Marker masks failed delivery**

When a summary marker is added but extraction or the deployment request fails, this fallback treats the marker as proof of delivery and exits, causing the PR to receive no shipped notification.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: post shipped fallback after five min..."](https://github.com/useautumn/autumn/commit/133f9614c73156ef5955f3bea350d4e481433748) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57058712)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->