### PR TITLE
Gate credit rate card UI to admins

### DIFF
--- a/vite/src/views/products/features/credit-systems/components/ClassicCreditSchema.tsx
+++ b/vite/src/views/products/features/credit-systems/components/ClassicCreditSchema.tsx
@@ -1,6 +1,7 @@
 import type { CreditSchemaItem, Feature } from "@autumn/shared";
 import { FormLabel, IconButton, Switch } from "@autumn/ui";
 import { PlusIcon } from "@phosphor-icons/react";
+import { useAdmin } from "@/views/admin/hooks/useAdmin";
 import { useCreditSchema } from "../hooks/useCreditSchema";
 import type { CreditSystemFormInstance } from "../hooks/useCreditSystemForm";
 import { CreditRateCardRow } from "./CreditRateCardRow";
@@ -10,6 +11,7 @@ interface ClassicCreditSchemaProps {
 }
 
 export function ClassicCreditSchema({ form }: ClassicCreditSchemaProps) {
+	const { isAdmin } = useAdmin();
 	const {
 		schema,
 		schemaKeys,
@@ -23,19 +25,21 @@ export function ClassicCreditSchema({ form }: ClassicCreditSchemaProps) {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="flex items-center justify-between gap-4">
-				<div className="flex flex-col gap-0.5">
-					<span className="text-sm font-medium">Invoice credits</span>
-					<span className="text-xs text-muted-foreground">
-						Itemize usage of this credit system as credits on the invoice.
-					</span>
+			{isAdmin && (
+				<div className="flex items-center justify-between gap-4">
+					<div className="flex flex-col gap-0.5">
+						<span className="text-sm font-medium">Invoice credits</span>
+						<span className="text-xs text-muted-foreground">
+							Itemize usage of this credit system as credits on the invoice.
+						</span>
+					</div>
+					<Switch
+						aria-label="Invoice credits"
+						checked={invoiceCredit}
+						onCheckedChange={setInvoiceCredit}
+					/>
 				</div>
-				<Switch
-					aria-label="Invoice credits"
-					checked={invoiceCredit}
-					onCheckedChange={setInvoiceCredit}
-				/>
-			</div>
+			)}
 
 			<div className="flex flex-col gap-2">
 				<FormLabel>Rate card</FormLabel>
@@ -58,6 +62,7 @@ export function ClassicCreditSchema({ form }: ClassicCreditSchemaProps) {
 							allFeatures={allSchemaCandidateFeatures}
 							onChange={(next) => setSchemaItem({ index, item: next })}
 							onRemove={() => removeSchemaItem(index)}
+							showRateCardControls={isAdmin}
 						/>
 					);
 				})}

--- a/vite/src/views/products/features/credit-systems/components/CreditRateCardRow.tsx
+++ b/vite/src/views/products/features/credit-systems/components/CreditRateCardRow.tsx
@@ -5,7 +5,6 @@ import {
 	isAiCreditSystem,
 } from "@autumn/shared";
 import { GroupedTabButton, IconButton } from "@autumn/ui";
-import { WarningCircleIcon } from "@phosphor-icons/react";
 import { X } from "lucide-react";
 import {
 	isGraduated,
@@ -27,6 +26,7 @@ interface CreditRateCardRowProps {
 	allFeatures: Feature[];
 	onChange: (item: CreditSchemaItem) => void;
 	onRemove: () => void;
+	showRateCardControls: boolean;
 }
 
 export function CreditRateCardRow({
@@ -35,6 +35,7 @@ export function CreditRateCardRow({
 	allFeatures,
 	onChange,
 	onRemove,
+	showRateCardControls,
 }: CreditRateCardRowProps) {
 	const selectedFeature = allFeatures.find(
 		(f: Feature) => f.id === item.metered_feature_id,
@@ -72,46 +73,46 @@ export function CreditRateCardRow({
 				/>
 			</div>
 
-			<div className="flex items-center gap-2">
-				<span className="text-tertiary-foreground text-xs shrink-0 w-14">
-					per
-				</span>
-				{isAiChild && (
-					<span className="text-tertiary-foreground text-xs">$</span>
-				)}
-				<CreditNumberInput
-					ariaLabel="Billing units"
-					className="w-26 shrink-0"
-					placeholder="eg. 100"
-					value={item.feature_amount}
-					onValueChange={(feature_amount) =>
-						onChange({ ...item, feature_amount })
-					}
-				/>
-				<span className="text-tertiary-foreground text-xs truncate">
-					{unitName}
-				</span>
-				<GroupedTabButton
-					className="ml-auto shrink-0"
-					value={rateTypeOf(item)}
-					onValueChange={(rateType) =>
-						onChange(
-							setRateType({ item, rateType: rateType as "flat" | "graduated" }),
-						)
-					}
-					options={RATE_TYPE_OPTIONS}
-				/>
-			</div>
+			{showRateCardControls && (
+				<div className="flex items-center gap-2">
+					<span className="text-tertiary-foreground text-xs shrink-0 w-14">
+						per
+					</span>
+					{isAiChild && (
+						<span className="text-tertiary-foreground text-xs">$</span>
+					)}
+					<CreditNumberInput
+						ariaLabel="Billing units"
+						className="w-26 shrink-0"
+						placeholder="eg. 100"
+						value={item.feature_amount}
+						onValueChange={(feature_amount) =>
+							onChange({ ...item, feature_amount })
+						}
+					/>
+					<span className="text-tertiary-foreground text-xs truncate">
+						{unitName}
+					</span>
+					<GroupedTabButton
+						className="ml-auto shrink-0"
+						value={rateTypeOf(item)}
+						onValueChange={(rateType) =>
+							onChange(
+								setRateType({
+									item,
+									rateType: rateType as "flat" | "graduated",
+								}),
+							)
+						}
+						options={RATE_TYPE_OPTIONS}
+					/>
+				</div>
+			)}
 
 			{isGraduated(item) ? (
-				<>
+				showRateCardControls ? (
 					<CreditTierRows item={item} onChange={onChange} />
-					<div className="flex items-center gap-1.5 text-amber-500 text-xs">
-						<WarningCircleIcon size={12} />
-						Tiered rating is not live yet — tracking usage for this feature will
-						be rejected.
-					</div>
-				</>
+				) : null
 			) : (
 				<div className="flex items-center gap-2">
 					<span className="text-tertiary-foreground text-xs shrink-0 w-14">

--- a/vite/tests/credit-rate-card-admin-gate.test.tsx
+++ b/vite/tests/credit-rate-card-admin-gate.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import {
+	type CreditSchemaItem,
+	type Feature,
+	FeatureType,
+	FeatureUsageType,
+} from "@autumn/shared";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CreditRateCardRow } from "../src/views/products/features/credit-systems/components/CreditRateCardRow";
+
+const feature = {
+	id: "feature_a",
+	name: "Feature A",
+	type: FeatureType.Metered,
+	config: { usage_type: FeatureUsageType.Single },
+} as Feature;
+
+const renderRateCardRow = ({
+	item,
+	showRateCardControls,
+}: {
+	item: CreditSchemaItem;
+	showRateCardControls: boolean;
+}) =>
+	renderToStaticMarkup(
+		<CreditRateCardRow
+			item={item}
+			availableFeatures={[feature]}
+			allFeatures={[feature]}
+			onChange={() => {}}
+			onRemove={() => {}}
+			showRateCardControls={showRateCardControls}
+		/>,
+	);
+
+test("non-admins retain flat credit costs without rate-card controls", () => {
+	const html = renderRateCardRow({
+		item: {
+			metered_feature_id: feature.id,
+			feature_amount: 100,
+			credit_amount: 1,
+		},
+		showRateCardControls: false,
+	});
+
+	expect(html).not.toContain('aria-label="Billing units"');
+	expect(html).not.toContain(">Tiered<");
+	expect(html).toContain('aria-label="Credit cost"');
+});
+
+test("admins can edit billing units and graduated tiers without a stale warning", () => {
+	const html = renderRateCardRow({
+		item: {
+			metered_feature_id: feature.id,
+			feature_amount: 100,
+			tier_behavior: "graduated",
+			tiers: [{ to: "inf", credit_amount: 1 }],
+		},
+		showRateCardControls: true,
+	});
+
+	expect(html).toContain('aria-label="Billing units"');
+	expect(html).toContain(">Tiered<");
+	expect(html).not.toContain("Tiered rating is not live yet");
+});


### PR DESCRIPTION
## Cubic summary

Keeps the enterprise credit rate-card rollout hidden from non-admin dashboard users while preserving the existing flat credit-system editor.

## What changed

- Only Autumn admins see the Invoice credits switch.
- Only Autumn admins see billing units and flat/tiered rate controls.
- Non-admins can still edit the original flat credit cost.
- Removes the stale orange warning that said tiered rating was not live.
- Leaves API and backend behavior unchanged.

## Verification

- Vite typecheck passed.
- All 530 Vite unit tests passed.
- Root typecheck passed across 12 packages.
- React Doctor reported no findings in the changed files.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Keeps the enterprise credit rate-card controls hidden from non-admin dashboard users while preserving the original flat credit-cost editor.

- **Bug fixes:** Shows invoice-credit, billing-unit, rate-type, and tier controls only to Autumn admins.
- **Improvements:** Removes the outdated warning that tiered rating is not live.
- **Improvements:** Adds coverage confirming the admin and non-admin versions of the editor.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intended admin-only controls correctly gated and the non-admin flat editor preserved.

All component callers provide the new required property, role gating fails closed, and the added tests cover the principal admin and non-admin rendering paths without revealing a concrete regression.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/features/credit-systems/components/ClassicCreditSchema.tsx | Uses the existing admin state to gate invoice-credit and advanced rate-card controls while leaving schema-row management available. |
| vite/src/views/products/features/credit-systems/components/CreditRateCardRow.tsx | Conditionally renders billing units, rate type, and graduated tiers while retaining the flat credit-cost input for non-admins. |
| vite/tests/credit-rate-card-admin-gate.test.tsx | Verifies that non-admins retain flat credit-cost editing and admins receive the advanced rate-card controls without the stale warning. |

<sub>Reviews (1): Last reviewed commit: ["gate credit rate card UI to admins"](https://github.com/useautumn/autumn/commit/ff64df72e46be573b3d7d07809eac8edd981628f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57061491)</sub>

<!-- /greptile_comment -->