### PR TITLE
ci: post shipped PRs immediately

### DIFF
--- a/.github/workflows/post-cubic-summary.yml
+++ b/.github/workflows/post-cubic-summary.yml
@@ -98,20 +98,8 @@ jobs:
             --data-binary @"$RUNNER_TEMP/shipped-summary-payload.json" \
             "$DEPLOY_URL/api/shipped/summary"
 
-  wait-for-summary:
-    name: Wait for a PR summary
-    if: >-
-      github.event.action == 'opened' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Wait for a PR summary
-        run: sleep 300
-
   notify-without-summary:
-    name: Notify without summary
-    needs: wait-for-summary
+    name: Post PR to shipped
     if: >-
       github.event.action == 'opened' &&
       github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Post main-target PRs to #shipped immediately, then update the same Slack message when Cubic or Greptile adds a summary.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This workflow now posts eligible PRs to the shipped Slack channel immediately and relies on later summary events to update the same message.
- **Improvements:** Removes the five-minute wait before posting a newly opened internal PR.
- **Improvements:** Renames the fallback notification job to reflect that it immediately posts the PR.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed workflow.

The change only removes the initial notification delay; existing marker checks still prevent the fallback path from posting when a summary is already present, and later summary events remain routed through the same per-PR shipped-summary endpoint.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/post-cubic-summary.yml | Removes the five-minute delay before the initial shipped notification while preserving summary-marker guards and per-PR workflow serialization. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant PR as Pull Request
  participant GH as GitHub Actions
  participant API as Shipped API
  participant Slack
  PR->>GH: PR opened
  GH->>API: Post PR immediately
  API->>Slack: Create shipped message
  PR->>GH: Summary added later
  GH->>API: Post summary for PR URL
  API->>Slack: Update existing message
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: post shipped PRs immediately"](https://github.com/useautumn/autumn/commit/774b39081824fbc77b5ff6d1f07d2f50b9859293) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57069669)</sub>

<!-- /greptile_comment -->