### PR TITLE
Fix legacy credit schema compatibility

### DIFF
--- a/shared/api/features/apiFeatureV1.ts
+++ b/shared/api/features/apiFeatureV1.ts
@@ -4,7 +4,7 @@ import {
 	ProviderMarkupsSchema,
 } from "../../models/featureModels/featureConfig/creditConfig";
 import { FeatureType } from "../../models/featureModels/featureEnums";
-import { ApiCreditSchemaItemSchema } from "./creditRateCard.js";
+import { ApiCreditSchemaResponseItemSchema } from "./creditRateCard.js";
 
 export const ApiFeatureV1Schema = z.object({
 	id: z.string().meta({
@@ -29,7 +29,7 @@ export const ApiFeatureV1Schema = z.object({
 		description:
 			"Event names that trigger this feature's balance. Allows multiple features to respond to a single event.",
 	}),
-	credit_schema: z.array(ApiCreditSchemaItemSchema).optional().meta({
+	credit_schema: z.array(ApiCreditSchemaResponseItemSchema).optional().meta({
 		description:
 			"For classic credit systems: maps metered features to flat or graduated credit costs.",
 	}),

--- a/shared/api/features/creditRateCard.test.ts
+++ b/shared/api/features/creditRateCard.test.ts
@@ -92,6 +92,24 @@ describe("credit rate-card feature API schemas", () => {
 		]);
 	});
 
+	test("rejects empty metered feature IDs in create and update requests", () => {
+		expect(
+			CreateFeatureV2ParamsSchema.safeParse({
+				feature_id: "credits",
+				name: "Credits",
+				type: FeatureType.CreditSystem,
+				credit_schema: [{ metered_feature_id: "", credit_cost: 0 }],
+			}).success,
+		).toBe(false);
+
+		expect(
+			UpdateFeatureV2ParamsSchema.safeParse({
+				feature_id: "credits",
+				credit_schema: [{ metered_feature_id: "", credit_cost: 0 }],
+			}).success,
+		).toBe(false);
+	});
+
 	test("supports partial rate-card updates", () => {
 		const result = UpdateFeatureV2ParamsSchema.parse({
 			feature_id: "credits",

--- a/shared/api/features/creditRateCard.test.ts
+++ b/shared/api/features/creditRateCard.test.ts
@@ -77,6 +77,21 @@ describe("credit rate-card feature API schemas", () => {
 		expect(result.credit_schema).toHaveLength(2);
 	});
 
+	test("accepts legacy response rates with an empty metered feature ID", () => {
+		const result = ApiFeatureV1Schema.parse({
+			id: "credits",
+			name: "Credits",
+			type: FeatureType.CreditSystem,
+			consumable: true,
+			credit_schema: [{ metered_feature_id: "", credit_cost: 0 }],
+			archived: false,
+		});
+
+		expect(result.credit_schema).toEqual([
+			{ metered_feature_id: "", credit_cost: 0 },
+		]);
+	});
+
 	test("supports partial rate-card updates", () => {
 		const result = UpdateFeatureV2ParamsSchema.parse({
 			feature_id: "credits",

--- a/shared/api/features/creditRateCard.ts
+++ b/shared/api/features/creditRateCard.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 
 const ApiCreditSchemaItemBaseSchema = z.object({
-	metered_feature_id: z.string().meta({
+	metered_feature_id: z.string().nonempty().meta({
 		description:
 			"ID of the metered feature that draws from this credit system.",
 	}),
@@ -74,6 +74,16 @@ export const ApiGraduatedCreditSchemaItemSchema =
 export const ApiCreditSchemaItemSchema = z.union([
 	ApiFlatCreditSchemaItemSchema,
 	ApiGraduatedCreditSchemaItemSchema,
+]);
+
+const ApiLegacyFlatCreditSchemaItemSchema =
+	ApiFlatCreditSchemaItemSchema.extend({
+		metered_feature_id: z.literal(""),
+	});
+
+export const ApiCreditSchemaResponseItemSchema = z.union([
+	ApiCreditSchemaItemSchema,
+	ApiLegacyFlatCreditSchemaItemSchema,
 ]);
 
 export type ApiCreditSchemaItem = z.infer<typeof ApiCreditSchemaItemSchema>;

--- a/shared/api/features/creditRateCard.ts
+++ b/shared/api/features/creditRateCard.ts
@@ -1,7 +1,7 @@
 import { z } from "zod/v4";
 
 const ApiCreditSchemaItemBaseSchema = z.object({
-	metered_feature_id: z.string().nonempty().meta({
+	metered_feature_id: z.string().meta({
 		description:
 			"ID of the metered feature that draws from this credit system.",
 	}),


### PR DESCRIPTION
## Summary

- allow legacy flat credit schema entries with an empty metered feature ID to pass V1 API response validation
- keep create, update, and pricing-agent request validation strict
- add regression coverage for both compatibility boundaries

## Production issue

Production contains legacy credit_schema entries with an empty metered_feature_id that were accepted by the previous z.string() schema. The new credit rate-card API schema required that value to be non-empty, so customer response hydration failed with a Zod error even when no new rate card had been configured.

The compatibility allowance is limited to ApiFeatureV1Schema responses. It does not change rating, balance deductions, attribution, invoicing, or database state.

## Verification

- both regressions observed failing for their expected reasons before their production changes
- bun test api/features/creditRateCard.test.ts: 8 passed
- server bun ts: passed
- Biome on all three changed files: passed
- commit hook knip check: passed





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores compatibility with legacy credit-schema responses while preserving strict validation for all new configuration inputs.
- **[Bug fixes] [API changes]** Allows V1 feature responses to include legacy flat credit entries whose metered feature ID is empty.
- **[Improvements]** Keeps create, update, and pricing-agent inputs restricted to non-empty metered feature IDs.
- **[Improvements]** Adds regression tests covering both the compatible response boundary and strict request boundaries.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported permissive write validation is fixed while legacy compatibility is confined to response validation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/features/creditRateCard.ts | Separates the strict request schema from a legacy-compatible flat response schema without weakening write validation. |
| shared/api/features/apiFeatureV1.ts | Uses the response-only compatibility schema for V1 feature credit-schema output. |
| shared/api/features/creditRateCard.test.ts | Verifies that legacy responses succeed while create and update requests with empty IDs remain rejected. |

<sub>Reviews (4): Last reviewed commit: ["Keep credit rate card writes strict"](https://github.com/useautumn/autumn/commit/ae74c1ae4e6b386565aec991f7330e6c8a8f515b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57076975)</sub>

<!-- /greptile_comment -->