### PR TITLE
Gate graduated credit checks on fundable balances

### DIFF
--- a/server/src/internal/balances/check/getCheckResponseV2.ts
+++ b/server/src/internal/balances/check/getCheckResponseV2.ts
@@ -31,11 +31,12 @@ export const getCheckResponseV2 = async ({
 		evaluationApiSubject,
 	} = checkData;
 
+	let creditRateFundable = true;
 	if (
 		featureToUse.type === FeatureType.CreditSystem &&
 		featureToUse.id !== originalFeature.id
 	) {
-		requiredBalance = getCreditRateRequiredBalance({
+		const creditRateRequiredBalance = getCreditRateRequiredBalance({
 			fullSubject: checkData.fullSubject,
 			sourceFeature: originalFeature,
 			creditSystem: featureToUse,
@@ -43,6 +44,8 @@ export const getCheckResponseV2 = async ({
 			reverseOrder: ctx.org.config?.reverse_deduction_order,
 			inStatuses: orgToInStatuses({ org: ctx.org }),
 		});
+		requiredBalance = creditRateRequiredBalance.requiredBalance;
+		creditRateFundable = creditRateRequiredBalance.fundable;
 	}
 
 	if (!evaluationApiBalance && !evaluationApiFlag) {
@@ -59,7 +62,8 @@ export const getCheckResponseV2 = async ({
 	const allowed = evaluationApiFlag
 		? true
 		: evaluationApiBalance
-			? apiBalanceToAllowed({
+			? creditRateFundable &&
+				apiBalanceToAllowed({
 					apiBalance: evaluationApiBalance,
 					apiSubject: evaluationApiSubject,
 					feature: featureToUse,

--- a/server/src/internal/balances/check/runCheckWithTrackV2.ts
+++ b/server/src/internal/balances/check/runCheckWithTrackV2.ts
@@ -109,7 +109,7 @@ export const runCheckWithTrackV2 = async ({
 					amount: requiredBalance,
 					reverseOrder: ctx.org.config?.reverse_deduction_order,
 					inStatuses: orgToInStatuses({ org: ctx.org }),
-				})
+				}).requiredBalance
 			: requiredBalance;
 
 	const featureDeductions = getTrackFeatureDeductions({

--- a/server/src/internal/features/creditSystemUtils.ts
+++ b/server/src/internal/features/creditSystemUtils.ts
@@ -356,6 +356,12 @@ const getCreditRateFundedUnits = ({
 	return lowerBound;
 };
 
+export type CreditRateRequiredBalance = {
+	requiredBalance: number;
+	/** False when the active graduated credit entitlements cannot fund every requested unit. */
+	fundable: boolean;
+};
+
 export const getCreditRateRequiredBalance = ({
 	fullSubject,
 	sourceFeature,
@@ -370,17 +376,20 @@ export const getCreditRateRequiredBalance = ({
 	amount: number;
 	reverseOrder?: boolean;
 	inStatuses?: CusProductStatus[];
-}): number => {
+}): CreditRateRequiredBalance => {
 	const schemaItem = getCreditSchemaItem({
 		featureId: sourceFeature.id,
 		creditSystem,
 	});
 	if (schemaItem?.tier_behavior !== "graduated") {
-		return featureToCreditSystem({
-			featureId: sourceFeature.id,
-			creditSystem,
-			amount,
-		});
+		return {
+			requiredBalance: featureToCreditSystem({
+				featureId: sourceFeature.id,
+				creditSystem,
+				amount,
+			}),
+			fundable: true,
+		};
 	}
 
 	const customerEntitlements = fullSubjectToCustomerEntitlements({
@@ -390,11 +399,14 @@ export const getCreditRateRequiredBalance = ({
 		inStatuses,
 	});
 	if (customerEntitlements.length === 0) {
-		return featureToCreditSystem({
-			featureId: sourceFeature.id,
-			creditSystem,
-			amount,
-		});
+		return {
+			requiredBalance: featureToCreditSystem({
+				featureId: sourceFeature.id,
+				creditSystem,
+				amount,
+			}),
+			fundable: true,
+		};
 	}
 
 	let remainingUnits = new Decimal(amount);
@@ -431,19 +443,24 @@ export const getCreditRateRequiredBalance = ({
 		finalUsage = currentUsage + fundedUnits;
 		finalCreditSystem = entitlementCreditSystem;
 
-		if (remainingUnits.lte(1e-10)) return requiredCredits.toNumber();
+		if (remainingUnits.lte(1e-10)) {
+			return { requiredBalance: requiredCredits.toNumber(), fundable: true };
+		}
 	}
 
-	return requiredCredits
-		.add(
-			featureToCreditSystem({
-				featureId: sourceFeature.id,
-				creditSystem: finalCreditSystem,
-				amount: remainingUnits.toNumber(),
-				currentUsage: finalUsage,
-			}),
-		)
-		.toNumber();
+	return {
+		requiredBalance: requiredCredits
+			.add(
+				featureToCreditSystem({
+					featureId: sourceFeature.id,
+					creditSystem: finalCreditSystem,
+					amount: remainingUnits.toNumber(),
+					currentUsage: finalUsage,
+				}),
+			)
+			.toNumber(),
+		fundable: remainingUnits.lte(1e-10),
+	};
 };
 
 export const featureToCreditSystem = ({

--- a/server/tests/unit/features/get-credit-cost.test.ts
+++ b/server/tests/unit/features/get-credit-cost.test.ts
@@ -195,86 +195,115 @@ describe("getCreditRateRequiredBalance — flat rate cards", () => {
 				creditSystem: flatCreditFeature,
 				amount: 167.33,
 			}),
-		).toBe(
-			getCreditCost({
+		).toEqual({
+			requiredBalance: getCreditCost({
 				featureId: sourceFeature.id,
 				creditSystem: flatCreditFeature,
 				amount: 167.33,
 			}),
-		);
+			fundable: true,
+		});
 	});
 });
 
+const makeGraduatedCustomerEntitlement = ({
+	id,
+	balance,
+	currentUsage,
+}: {
+	id: string;
+	balance: number;
+	currentUsage: number;
+}) => ({
+	id,
+	balance,
+	additional_balance: 0,
+	rollovers: [],
+	usage_attribution: {
+		[sourceFeature.internal_id]: {
+			units: currentUsage,
+			credits: getCreditCost({
+				featureId: sourceFeature.id,
+				creditSystem: graduatedCreditFeature,
+				amount: currentUsage,
+			}),
+		},
+	},
+	entitlement: {
+		feature: graduatedCreditFeature,
+		allowance_type: AllowanceType.Fixed,
+		entity_feature_id: null,
+		interval: null,
+		interval_count: 1,
+	},
+});
+
+const makeGraduatedFullSubject = ({
+	entitlements,
+}: {
+	entitlements: Array<{ id: string; balance: number; currentUsage: number }>;
+}) =>
+	({
+		subjectType: "customer",
+		entity: null,
+		customer_products: entitlements.map((entitlement) => ({
+			status: "active",
+			customer_entitlements: [makeGraduatedCustomerEntitlement(entitlement)],
+		})),
+		extra_customer_entitlements: [],
+		pooled_customer_entitlements: [],
+	}) as unknown as FullSubject;
+
 describe("getCreditCost — graduated rate cards", () => {
 	test("rates a check across each entitlement's independent tier position", () => {
-		const makeCustomerEntitlement = ({
-			id,
-			balance,
-			currentUsage,
-		}: {
-			id: string;
-			balance: number;
-			currentUsage: number;
-		}) => ({
-			id,
-			balance,
-			additional_balance: 0,
-			rollovers: [],
-			usage_attribution: {
-				[sourceFeature.internal_id]: {
-					units: currentUsage,
-					credits: getCreditCost({
-						featureId: sourceFeature.id,
-						creditSystem: graduatedCreditFeature,
-						amount: currentUsage,
-					}),
-				},
-			},
-			entitlement: {
-				feature: graduatedCreditFeature,
-				allowance_type: AllowanceType.Fixed,
-				entity_feature_id: null,
-				interval: null,
-				interval_count: 1,
-			},
-		});
-		const fullSubject = {
-			subjectType: "customer",
-			entity: null,
-			customer_products: [
-				{
-					status: "active",
-					customer_entitlements: [
-						makeCustomerEntitlement({
-							id: "base_credits",
-							balance: 0.5,
-							currentUsage: 9_950,
-						}),
-					],
-				},
-				{
-					status: "active",
-					customer_entitlements: [
-						makeCustomerEntitlement({
-							id: "addon_credits",
-							balance: 0.9,
-							currentUsage: 0,
-						}),
-					],
-				},
+		const fullSubject = makeGraduatedFullSubject({
+			entitlements: [
+				{ id: "base_credits", balance: 0.5, currentUsage: 9_950 },
+				{ id: "addon_credits", balance: 0.9, currentUsage: 0 },
 			],
-			extra_customer_entitlements: [],
-			pooled_customer_entitlements: [],
-		} as unknown as FullSubject;
+		});
 
-		expect(
-			getCreditRateRequiredBalance({
-				fullSubject,
-				sourceFeature,
-				creditSystem: graduatedCreditFeature,
-				amount: 100,
-			}),
-		).toBeCloseTo(1, 10);
+		const requiredBalance = getCreditRateRequiredBalance({
+			fullSubject,
+			sourceFeature,
+			creditSystem: graduatedCreditFeature,
+			amount: 100,
+		});
+		expect(requiredBalance.requiredBalance).toBeCloseTo(1, 10);
+		expect(requiredBalance.fundable).toBe(true);
+	});
+
+	test("flags exhausted graduated entitlements as unfundable", () => {
+		const fullSubject = makeGraduatedFullSubject({
+			entitlements: [
+				{ id: "base_credits", balance: 0, currentUsage: 10_000 },
+				{ id: "addon_credits", balance: 0, currentUsage: 0 },
+			],
+		});
+
+		const requiredBalance = getCreditRateRequiredBalance({
+			fullSubject,
+			sourceFeature,
+			creditSystem: graduatedCreditFeature,
+			amount: 100,
+		});
+		expect(requiredBalance.requiredBalance).toBeCloseTo(1, 10);
+		expect(requiredBalance.fundable).toBe(false);
+	});
+
+	test("flags a partially fundable graduated check as unfundable", () => {
+		const fullSubject = makeGraduatedFullSubject({
+			entitlements: [{ id: "base_credits", balance: 0.5, currentUsage: 9_950 }],
+		});
+
+		const requiredBalance = getCreditRateRequiredBalance({
+			fullSubject,
+			sourceFeature,
+			creditSystem: graduatedCreditFeature,
+			amount: 100,
+		});
+		expect(requiredBalance.requiredBalance).toBeCloseTo(0.9, 10);
+		expect(requiredBalance.fundable).toBe(false);
 	});
 
 	test("charges the marginal cost when usage crosses one tier", () => {


### PR DESCRIPTION
## Summary

- `/check` for a graduated invoice-credit source feature rated `required_balance` per entitlement but derived `allowed` from the generic balance evaluator, where an uncapped usage-priced credit item always allows via overage - so exhausted graduated credits still returned `allowed: true`.
- `getCreditRateRequiredBalance` now returns `{ requiredBalance, fundable }`; `getCheckResponseV2` gates `allowed` on `fundable` for the graduated branch only. Flat invoice-credit, legacy credit systems, and the lock/track path (whose `allowed` comes from the real deduction) are unchanged.

## Why

The base-plan plus add-on scenario (100-credit base drained by 10k tracked units, 0-credit add-on) must return `allowed: false` with `required_balance` rated from the add-on's own tier position. No customer state could produce `false` before this change.

## Testing

- server unit: 19/19 `get-credit-cost.test.ts` (3 new/updated fundability cases), 173 across `tests/unit/features` + `tests/unit/balances`; `bun ts` and scoped Biome clean.
- Integration: `track-graduated-credit-system` 'check rates each credit entitlement from its own tier position' failed `Expected: false, Received: true` before the fix and passes after, against a local server on latest dev (deduction, spill, and rating confirmed correct pre-fix - the funding gate was the only defect).
- `bun tw` evidence: the test failed in both cloud runs on dev `c2d174a`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `/check` for graduated invoice-credit sources so exhausted credits now return `allowed: false` instead of slipping through the uncapped-overage evaluator. `getCreditRateRequiredBalance` now returns a `fundable` flag alongside `requiredBalance`, and the check response gates on that flag for the graduated branch only; flat invoice-credit, legacy credit systems, and the lock/track path behave as before.

<sup>Written for commit 9fca6e41b36f6e83e4b1a5c7fb2b88a52cec00ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes graduated credit checks so access is denied when the customer's active balances cannot fund every requested unit.

- **Bug fixes, API changes:** Adds a `fundable` result to graduated credit-rate calculations and uses it when producing non-tracking `/check` responses.
- **Improvements:** Keeps check-and-track responses based on the actual deduction result while adapting them to the new calculation shape.
- **Improvements:** Adds unit coverage for fully funded, exhausted, and partially funded graduated balances.
</details>


<h3>Confidence Score: 4/5</h3>

The unlimited graduated-credit case should be fixed before merging because customers with unlimited access can now receive a denied check.

The new precondition derives fundability from a helper that represents unlimited entitlements as zero, overriding an API balance that the established evaluator explicitly accepts as unlimited.

**Files Needing Attention:** server/src/internal/balances/check/getCheckResponseV2.ts and server/src/internal/features/creditSystemUtils.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/balances/check/getCheckResponseV2.ts | Applies the graduated-credit funding gate to non-tracking checks, but incorrectly overrides unlimited balance semantics. |
| server/src/internal/features/creditSystemUtils.ts | Returns required credit cost and full-request fundability; its finite-balance loop does not account for unlimited entitlements. |
| server/src/internal/balances/check/runCheckWithTrackV2.ts | Adapts the check-and-track path to use the required-balance field while continuing to derive access from the actual deduction. |
| server/tests/unit/features/get-credit-cost.test.ts | Adds useful finite-balance fundability tests but omits the supported unlimited-entitlement state. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[/check request/] --> B[Select source feature or linked credit system]
  B --> C{Graduated linked credit system?}
  C -- No --> D[Use generic balance evaluator]
  C -- Yes --> E[Rate units across active credit entitlements]
  E --> F[Calculate required balance and fundable]
  F --> G{Fundable and evaluator allows?}
  G -- Yes --> H[allowed: true]
  G -- No --> I[allowed: false]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/balances/check/getCheckResponseV2.ts:65
**Unlimited credits become unfundable**

When a non-tracking check uses a graduated credit system with an unlimited entitlement, the fundability calculation reads that entitlement as zero available credits and this new gate returns `allowed: false`, even though the balance evaluator accepts the unlimited balance.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: gate graduated credit checks on fun..."](https://github.com/useautumn/autumn/commit/9fca6e41b36f6e83e4b1a5c7fb2b88a52cec00ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57139420)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Event metering, balances, and insights](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/event-metering-and-insights.md)

<!-- /greptile_comment -->