### PR TITLE
feat(catalog-v2): stamp plan processors and fan out to variants

### DIFF
--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct.ts
@@ -1,0 +1,43 @@
+import type { ApiPlanProcessors, Product } from "@autumn/shared";
+
+const processorsEqual = ({
+	left,
+	right,
+}: {
+	left: Product["processor"];
+	right: Product["processor"];
+}): boolean =>
+	(left?.id ?? null) === (right?.id ?? null) &&
+	JSON.stringify(left?.additional_ids ?? []) ===
+		JSON.stringify(right?.additional_ids ?? []);
+
+/** Stamp `plan.processors.stripe` onto `product.processor`. Omit keeps. */
+export const applyPlanProcessorsToProduct = ({
+	product,
+	processors,
+}: {
+	product: Product;
+	processors?: ApiPlanProcessors;
+}): { product: Product; changed: boolean } => {
+	if (processors?.stripe === undefined) {
+		return { product, changed: false };
+	}
+
+	const next: Product = {
+		...product,
+		processor: {
+			type: "stripe",
+			id: processors.stripe.product_id,
+			...(processors.stripe.additional_product_ids?.length
+				? { additional_ids: processors.stripe.additional_product_ids }
+				: {}),
+		},
+	};
+	return {
+		product: next,
+		changed: !processorsEqual({
+			left: product.processor,
+			right: next.processor,
+		}),
+	};
+};

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan.ts
@@ -8,6 +8,7 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import type { ProductDetailsPlan } from "@/internal/catalogV2/actions/updateCatalog/types/upsertProductPlan";
 import { isExistingRowPromote } from "@/internal/catalogV2/actions/updateCatalog/utils/productStateUtils/isExistingRowPromote";
+import { applyPlanProcessorsToProduct } from "./applyPlanProcessorsToProduct";
 import { diffProductDetails } from "./diffProductDetails";
 import { initProductRow } from "./initProductRow";
 import { planParamsToProductRowPatch } from "./planParamsToProductRowPatch";
@@ -75,7 +76,7 @@ export const computeProductDetailsPlan = ({
 	) {
 		patch.is_default = true;
 	}
-	const next: Product = {
+	const patched: Product = {
 		...currentFullProduct,
 		...patch,
 		...(baseInternalProductId !== undefined
@@ -85,13 +86,22 @@ export const computeProductDetailsPlan = ({
 				}
 			: {}),
 	};
+	const { product: next, changed: processorChanged } =
+		applyPlanProcessorsToProduct({
+			product: patched,
+			processors: planParams.processors,
+		});
 	const previousAttributes = diffProductDetails({
 		current: currentFullProduct,
 		next,
 	});
-	if (isEmptyObject(previousAttributes)) {
+	if (isEmptyObject(previousAttributes) && !processorChanged) {
 		return { changed: false, product: currentFullProduct };
 	}
 
-	return { changed: true, product: next, previousAttributes };
+	return {
+		changed: true,
+		product: next,
+		...(isEmptyObject(previousAttributes) ? {} : { previousAttributes }),
+	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/initProductRow.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/initProductRow.ts
@@ -5,6 +5,7 @@ import {
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { generateId } from "@/utils/genUtils.js";
+import { applyPlanProcessorsToProduct } from "./applyPlanProcessorsToProduct";
 import { planParamsToProductRowPatch } from "./planParamsToProductRowPatch";
 
 /**
@@ -35,7 +36,7 @@ export const initProductRow = ({
 			current: base,
 		});
 		const willBeActive = planParams.active === true;
-		return {
+		const cloned = {
 			...base,
 			...patch,
 			version,
@@ -52,11 +53,15 @@ export const initProductRow = ({
 			base_internal_product_id:
 				baseInternalProductId ?? base.base_internal_product_id ?? null,
 		};
+		return applyPlanProcessorsToProduct({
+			product: cloned,
+			processors: planParams.processors,
+		}).product;
 	}
 
 	const patch = planParamsToProductRowPatch({ planParams, current: null });
 
-	return {
+	const created = {
 		id: planParams.plan_id,
 		name: patch.name ?? planParams.plan_id,
 		description: patch.description ?? null,
@@ -89,4 +94,8 @@ export const initProductRow = ({
 		usage_alerts: patch.usage_alerts ?? null,
 		overage_allowed: patch.overage_allowed ?? null,
 	};
+	return applyPlanProcessorsToProduct({
+		product: created,
+		processors: planParams.processors,
+	}).product;
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/creates/initVariantPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/creates/initVariantPlanParams.ts
@@ -85,5 +85,8 @@ export const initVariantPlanParams = ({
 			: {}),
 		metadata: baseFullProduct.metadata,
 		...(licenses.length > 0 ? { licenses } : {}),
+		...(variant.processors !== undefined
+			? { processors: variant.processors }
+			: {}),
 	};
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/editDiff/variantSettingsPlanParams.ts
@@ -3,6 +3,7 @@ import {
 	billingControlsFromColumns,
 	type Product,
 	productDetailFieldIsSame,
+	productToPlanProcessors,
 	type UpdateCatalogPlanParams,
 } from "@autumn/shared";
 
@@ -14,6 +15,7 @@ type VariantSettingsPlanParams = Pick<
 	| "config"
 	| "metadata"
 	| "billing_controls"
+	| "processors"
 >;
 
 const settingsChanged = ({
@@ -59,6 +61,17 @@ export const variantSettingsPlanParams = ({
 		)
 	) {
 		patch.billing_controls = billingControlsFromColumns(next);
+	}
+
+	const currentProcessors = productToPlanProcessors({ product: current });
+	const nextProcessors = productToPlanProcessors({ product: next });
+	if (
+		(currentProcessors?.stripe?.product_id ?? null) !==
+			(nextProcessors?.stripe?.product_id ?? null) ||
+		JSON.stringify(currentProcessors?.stripe?.additional_product_ids ?? []) !==
+			JSON.stringify(nextProcessors?.stripe?.additional_product_ids ?? [])
+	) {
+		if (nextProcessors) patch.processors = nextProcessors;
 	}
 
 	return patch;

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/deriveVariantEdits.ts
@@ -63,7 +63,8 @@ const buildVariantEditIntent = ({
 		!editDiff &&
 		!hasSettings &&
 		newBasePointer === undefined &&
-		target.archived === undefined
+		target.archived === undefined &&
+		target.processors === undefined
 	) {
 		return undefined;
 	}
@@ -74,7 +75,11 @@ const buildVariantEditIntent = ({
 		target.version ===
 			activeVersionForPlan({ planId: target.planId, productStatesContext });
 	const pointerIsOnlyChange =
-		!target.follow && !editDiff && !hasSettings && repointToNewBase;
+		!target.follow &&
+		!editDiff &&
+		!hasSettings &&
+		target.processors === undefined &&
+		repointToNewBase;
 
 	return {
 		productKey: { planId: target.planId, version: target.version },
@@ -83,6 +88,9 @@ const buildVariantEditIntent = ({
 			version: target.version,
 			...settingsPatch,
 			...(target.archived !== undefined ? { archived: target.archived } : {}),
+			...(target.processors !== undefined
+				? { processors: target.processors }
+				: {}),
 		},
 		source: pointerIsOnlyChange ? "repoint" : "variant_propagation",
 		...(editDiff ? { editDiff } : {}),

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/resolveVariantEditTargets.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/resolveVariantEditTargets.ts
@@ -12,6 +12,7 @@ export type VariantEditTarget = {
 	follow: boolean;
 	customize?: CatalogVariantParams["customize"];
 	archived?: boolean;
+	processors?: CatalogVariantParams["processors"];
 };
 
 type TargetSourceArgs = {
@@ -69,7 +70,12 @@ const targetsFromDeclaredCustomize = ({
 	productStatesContext,
 }: TargetSourceArgs): VariantEditTarget[] =>
 	(upsert.declaredVariants ?? []).flatMap((variant) => {
-		if (!variant.customize && variant.archived === undefined) return [];
+		if (
+			!variant.customize &&
+			variant.archived === undefined &&
+			variant.processors === undefined
+		)
+			return [];
 		return targetVersionsFor({
 			planId: variant.variant_plan_id,
 			version: variant.version,
@@ -82,6 +88,9 @@ const targetsFromDeclaredCustomize = ({
 			...(variant.customize ? { customize: variant.customize } : {}),
 			...(variant.archived !== undefined
 				? { archived: variant.archived }
+				: {}),
+			...(variant.processors !== undefined
+				? { processors: variant.processors }
 				: {}),
 		}));
 	});
@@ -127,6 +136,7 @@ const mergeTargets = ({
 		current.follow ||= target.follow;
 		if (target.customize !== undefined) current.customize = target.customize;
 		if (target.archived !== undefined) current.archived = target.archived;
+		if (target.processors !== undefined) current.processors = target.processors;
 	}
 	return [...byKey.values()];
 };

--- a/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
+++ b/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
@@ -126,6 +126,12 @@ export const deriveVariantMints = ({
 		const newVersionSlug =
 			declaredVariant?.new_version_slug ?? propagateTarget?.new_version_slug;
 		mintedPlanIds.add(planId);
+		const declaredProcessors = (upsert.declaredVariants ?? []).find(
+			(variant) =>
+				variant.variant_plan_id === planId &&
+				(variant.version === undefined || variant.version === active.version) &&
+				variant.processors !== undefined,
+		)?.processors;
 		intents.push({
 			productKey: { planId, version },
 			planParams: {
@@ -135,6 +141,9 @@ export const deriveVariantMints = ({
 				...(intent.planParams.active === true ? { active: true } : {}),
 				...(newVersionSlug ? { new_version_slug: newVersionSlug } : {}),
 				...settingsPatch,
+				...(declaredProcessors !== undefined
+					? { processors: declaredProcessors }
+					: {}),
 			},
 			source: "variant_propagation",
 			...(editDiff ? { editDiff } : {}),

--- a/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
+++ b/server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts
@@ -49,6 +49,7 @@ export const applyProductDetailsUpdate = async ({
 			usage_alerts: product.usage_alerts,
 			overage_allowed: product.overage_allowed,
 			base_internal_product_id: product.base_internal_product_id,
+			processor: product.processor,
 		},
 	});
 

--- a/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
+++ b/server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts
@@ -12,7 +12,9 @@ import {
 	getProductItemDisplay,
 	itemToBillingInterval,
 	itemToBillingIntervalCount,
+	priceConfigToPriceProcessors,
 	productItemsToPlanItemsV1,
+	productToPlanProcessors,
 	productV2ToBasePrice,
 	productV2ToFeatureItems,
 	sortProductItems,
@@ -109,6 +111,9 @@ export async function getPlanResponse({
 
 	// 4. Extract base price using existing helper
 	const basePriceItem = productV2ToBasePrice({ product: productV2 as any });
+	const basePriceProcessors = priceConfigToPriceProcessors({
+		config: basePriceItem?.price_config,
+	});
 	const basePrice: ApiPlanV1["price"] | null = basePriceItem
 		? {
 				amount: basePriceItem.price,
@@ -126,6 +131,7 @@ export async function getPlanResponse({
 					features,
 					currency,
 				}),
+				...(basePriceProcessors ? { processors: basePriceProcessors } : {}),
 			}
 		: null;
 
@@ -174,6 +180,9 @@ export async function getPlanResponse({
 		: undefined;
 
 	// 9. Build Plan response
+	const planProcessors = productToPlanProcessors({
+		product,
+	});
 	const plan = {
 		id: product.id,
 		name: product.name || "",
@@ -200,6 +209,7 @@ export async function getPlanResponse({
 		metadata: product.metadata ?? {},
 
 		customer_eligibility: customerEligibility,
+		...(planProcessors ? { processors: planProcessors } : {}),
 	} satisfies ApiPlanV1;
 
 	// 10. Graph edges: up-link to the base plan, down-links to variants.

--- a/server/tests/integration/catalog-v2/plans/CASES.md
+++ b/server/tests/integration/catalog-v2/plans/CASES.md
@@ -43,6 +43,9 @@ plans/
     update-plan-free-trial.test.ts
     stripe-reuse.test.ts
     stripe-reuse-mint.test.ts
+  processors/
+    get-echo.test.ts
+    utils/expectPlanProcessors.ts
   versions/
     plan-versions.test.ts
     new-version-mint.test.ts
@@ -1372,3 +1375,35 @@ overrides the target per variant; unnamed targets fall back to `v{n}`.
 | variant target following in place → existing row's slug untouched | `versions/version-identity-propagate-slug.test.ts` |
 | target slug another version of that target holds → `DuplicateVersionSlug` | `versions/version-identity-propagate-slug.test.ts` |
 | `license_parents[].new_version_slug` with `new_version` → names the parent's minted row | `versions/version-identity-propagate-slug.test.ts` |
+
+## 27. Processors GET echo — `processors/`
+
+`catalogV2.get` maps existing Stripe ids onto `processors.stripe`. Price
+processors expose `price_id` only — Stripe product is inferred from the
+price. Currency echo waits for price stamp.
+
+| Case | Status |
+|---|---|
+| Paid + Stripe init → GET plan `product_id` / price `price_id` match DB | ✓ `processors/get-echo.test.ts` |
+| Free plan omits `processors` | ✓ `processors/get-echo.test.ts` |
+| `create_in_stripe: false` omits `processors` | ✓ `processors/get-echo.test.ts` |
+| Mapper: V2 prepaid id wins over V1; omit when unset | ✓ unit `catalogV2/processors-echo.test.ts` |
+
+## 28. Plan processor stamp + variant fan-out
+
+`plans[].processors.stripe` stamps `product.processor`. Omit keeps. Not a
+product-detail key — processor-only updates still persist. Base stamp fans
+out to latest variants (same path as description/group). `variants[].processors`
+or a direct `plans[]` entry for the variant overrides the base.
+
+Price processors, Stripe retrieve, and init-skip are later.
+
+| Case | Status |
+|---|---|
+| Stamp `product_id` onto the plan row | ✓ unit `computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts` |
+| Omit / same id is a no-op | ✓ unit `computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts` |
+| Processor is not a `PRODUCT_DETAIL_KEYS` field | ✓ unit `computeProductDetailsPlan/diffProductDetails.test.ts` |
+| Base processor change fans out to latest variant | ✓ unit `variants/derive-variant-intents.test.ts` |
+| `variants[].processors` overrides the base | ✓ unit `variants/derive-variant-intents.test.ts` |
+| Variant create copies `variants[].processors` | ✓ unit `variants/derive-variant-intents.test.ts` |
+| Direct variant `plans[]` entry overrides (first claim wins) | existing `claimNewIntents` — no extra path |

--- a/server/tests/integration/catalog-v2/plans/processors/get-echo.test.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/get-echo.test.ts
@@ -1,0 +1,184 @@
+/**
+ * catalogV2.get echoes Stripe product/price ids as `processors.stripe`.
+ *
+ * Contract:
+ *   New fields:  plan.processors.stripe.{product_id, additional_product_ids?}
+ *                price.processors.stripe.{price_id}
+ *                items[].price.processors.stripe.{price_id}
+ *   Behaviors:   paid + Stripe init → GET matches product.processor / price.config
+ *                free plan / create_in_stripe:false → processors omitted
+ *
+ * Red (current): processors is not on ApiPlanV1 / GET
+ * Green (after): GET echoes existing DB stripe ids; omit when unset
+ */
+
+import { expect, test } from "bun:test";
+import {
+	type ApiPlanExpandedV1,
+	BillingInterval,
+	BillingMethod,
+	type FullProduct,
+} from "@autumn/shared";
+import {
+	findBasePrice,
+	findFeaturePrice,
+	stripeConfigValue,
+} from "@tests/integration/utils/expectStripePriceResources.js";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { initScenario } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import type { AutumnInt } from "@/external/autumn/autumnCli.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { uniqueTestId } from "../../utils/uniqueTestId.js";
+import { deleteDbPlans } from "../utils/expectCatalogPlans.js";
+import { expectApiPlanProcessorsCorrect } from "./utils/expectPlanProcessors.js";
+
+const getFull = async ({
+	ctx,
+	planId,
+}: {
+	ctx: AutumnContext;
+	planId: string;
+}): Promise<FullProduct> =>
+	ProductService.getFull({
+		db: ctx.db,
+		idOrInternalId: planId,
+		orgId: ctx.org.id,
+		env: ctx.env,
+	});
+
+const getApiPlan = async ({
+	autumn,
+	planId,
+}: {
+	autumn: AutumnInt;
+	planId: string;
+}): Promise<ApiPlanExpandedV1> => {
+	const catalog = await autumn.catalogV2.get({ include_archived: true });
+	const plan = catalog.plans.find((row) => row.id === planId);
+	expect(plan, `GET catalog plan ${planId}`).toBeDefined();
+	return plan!;
+};
+
+const prepaidMessagesItem = {
+	feature_id: TestFeature.Messages,
+	included: 0,
+	price: {
+		amount: 10,
+		interval: BillingInterval.Month,
+		billing_method: BillingMethod.Prepaid,
+		billing_units: 100,
+	},
+};
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors get: paid plan echoes stripe product and price ids")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_get_paid");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Processors Get Paid",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [prepaidMessagesItem],
+					},
+				],
+			});
+
+			const db = await getFull({ ctx, planId });
+			const api = await getApiPlan({ autumn: autumnV2_3, planId });
+			const base = findBasePrice({ product: db });
+			const prepaid = findFeaturePrice({
+				product: db,
+				featureId: TestFeature.Messages,
+			});
+			const prepaidPriceId =
+				stripeConfigValue({
+					price: prepaid,
+					field: "stripe_prepaid_price_v2_id",
+				}) ?? stripeConfigValue({ price: prepaid, field: "stripe_price_id" });
+
+			expect(db.processor?.id, "db processor minted").toMatch(/^prod_/);
+			expectApiPlanProcessorsCorrect({
+				plan: api,
+				stripe: { product_id: db.processor?.id ?? "" },
+				basePriceId: stripeConfigValue({
+					price: base,
+					field: "stripe_price_id",
+				}),
+				items: {
+					[TestFeature.Messages]: prepaidPriceId,
+				},
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors get: free plan omits processors")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_get_free");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Processors Get Free",
+						items: [{ feature_id: TestFeature.Dashboard }],
+					},
+				],
+			});
+
+			const api = await getApiPlan({ autumn: autumnV2_3, planId });
+			expect(api.price, "free plan price").toBeNull();
+			expectApiPlanProcessorsCorrect({
+				plan: api,
+				stripe: null,
+				items: { [TestFeature.Dashboard]: null },
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("catalogV2 processors get: create_in_stripe false omits processors")}`,
+	async () => {
+		const { autumnV2_3, ctx } = await initScenario({ setup: [], actions: [] });
+		const planId = uniqueTestId("cv2_proc_get_skip");
+		await deleteDbPlans({ ctx, planIds: [planId] });
+		try {
+			await autumnV2_3.catalogV2.update({
+				plans: [
+					{
+						plan_id: planId,
+						name: "Processors Get Skip",
+						price: { amount: 20, interval: BillingInterval.Month },
+						items: [prepaidMessagesItem],
+						create_in_stripe: false,
+					},
+				],
+			});
+
+			const api = await getApiPlan({ autumn: autumnV2_3, planId });
+			expectApiPlanProcessorsCorrect({
+				plan: api,
+				stripe: null,
+				basePriceId: null,
+				items: { [TestFeature.Messages]: null },
+			});
+		} finally {
+			await deleteDbPlans({ ctx, planIds: [planId] });
+		}
+	},
+);

--- a/server/tests/integration/catalog-v2/plans/processors/utils/expectPlanProcessors.ts
+++ b/server/tests/integration/catalog-v2/plans/processors/utils/expectPlanProcessors.ts
@@ -1,0 +1,54 @@
+import { expect } from "bun:test";
+import type { ApiPlanV1 } from "@autumn/shared";
+
+/**
+ * API-side processors asserts via catalogV2.get.
+ * Omit a field to skip. Pass `null` on `stripe` / a price slot to assert omitted.
+ */
+export const expectApiPlanProcessorsCorrect = ({
+	plan,
+	stripe,
+	basePriceId,
+	items,
+}: {
+	plan: ApiPlanV1;
+	stripe?: { product_id: string } | null;
+	basePriceId?: string | null;
+	items?: Record<string, string | null>;
+}) => {
+	if (stripe === null) {
+		expect(plan.processors, "plan processors omitted").toBeUndefined();
+	} else if (stripe !== undefined) {
+		expect(plan.processors?.stripe?.product_id, "plan product_id").toBe(
+			stripe.product_id,
+		);
+	}
+
+	if (basePriceId === null) {
+		expect(plan.price?.processors, "base processors omitted").toBeUndefined();
+	} else if (basePriceId !== undefined) {
+		expect(
+			plan.price?.processors?.stripe?.price_id,
+			"base price_id",
+		).toBe(basePriceId);
+	}
+
+	if (items === undefined) return;
+	for (const [featureId, expectedPriceId] of Object.entries(items)) {
+		const item = plan.items.find(
+			(candidate) => candidate.feature_id === featureId,
+		);
+		expect(item, `missing item ${featureId}`).toBeDefined();
+		if (expectedPriceId === null) {
+			expect(
+				item?.price?.processors,
+				`${featureId} processors omitted`,
+			).toBeUndefined();
+			continue;
+		}
+		expect(
+			item?.price?.processors?.stripe?.price_id,
+			`${featureId} price_id`,
+		).toBe(expectedPriceId);
+	}
+};

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/applyPlanProcessorsToProduct.test.ts
@@ -1,0 +1,59 @@
+/**
+ * applyPlanProcessorsToProduct — stamp plan.processors.stripe onto product.processor.
+ *
+ * Omit / processors.stripe omitted → keep. Object → set. Same id → unchanged.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Product } from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/db/products";
+import { applyPlanProcessorsToProduct } from "@/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/applyPlanProcessorsToProduct";
+
+const row = (overrides: Partial<Product> = {}): Product =>
+	({ ...products.create({ id: "pro" }), ...overrides }) as Product;
+
+describe("applyPlanProcessorsToProduct", () => {
+	test("omit keeps the existing processor", () => {
+		const product = row({
+			processor: { type: "stripe", id: "prod_existing" },
+		});
+		expect(applyPlanProcessorsToProduct({ product })).toEqual({
+			product,
+			changed: false,
+		});
+		expect(
+			applyPlanProcessorsToProduct({ product, processors: {} }),
+		).toEqual({ product, changed: false });
+	});
+
+	test("stripe object stamps id and additional ids", () => {
+		const product = row({ processor: null });
+		const { product: next, changed } = applyPlanProcessorsToProduct({
+			product,
+			processors: {
+				stripe: {
+					product_id: "prod_abc",
+					additional_product_ids: ["prod_alias"],
+				},
+			},
+		});
+		expect(changed).toBe(true);
+		expect(next.processor).toEqual({
+			type: "stripe",
+			id: "prod_abc",
+			additional_ids: ["prod_alias"],
+		});
+	});
+
+	test("same id is not a change", () => {
+		const product = row({
+			processor: { type: "stripe", id: "prod_abc" },
+		});
+		expect(
+			applyPlanProcessorsToProduct({
+				product,
+				processors: { stripe: { product_id: "prod_abc" } },
+			}),
+		).toEqual({ product, changed: false });
+	});
+});

--- a/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
+++ b/server/tests/unit/catalogV2/computeProductDetailsPlan/diffProductDetails.test.ts
@@ -85,4 +85,14 @@ describe("productDetailsAreSame / diffProductDetails", () => {
 			true,
 		);
 	});
+
+	test("processor is not a product-detail key", () => {
+		const current = row({ processor: { type: "stripe", id: "prod_old" } });
+		const next = row({ processor: { type: "stripe", id: "prod_new" } });
+		expect(productDetailsAreSame({ product1: current, product2: next })).toBe(
+			true,
+		);
+		expect(diffProductDetails({ current, next })).toEqual({});
+	});
 });
+

--- a/server/tests/unit/catalogV2/processors-echo.test.ts
+++ b/server/tests/unit/catalogV2/processors-echo.test.ts
@@ -1,0 +1,85 @@
+/**
+ * productToPlanProcessors / priceConfigToPriceProcessors — GET echo mappers.
+ *
+ * Contract:
+ *   plan processor.id → processors.stripe.product_id
+ *   prepaid V2 id wins over V1 for price_id
+ *   omit the object when no stripe price id is set
+ *
+ * Red (current): mappers do not exist
+ * Green (after): mapping table above
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	priceConfigToPriceProcessors,
+	productToPlanProcessors,
+} from "@autumn/shared";
+
+describe("productToPlanProcessors", () => {
+	test("maps processor id and additional ids", () => {
+		expect(
+			productToPlanProcessors({
+				product: {
+					processor: {
+						type: "stripe",
+						id: "prod_abc",
+						additional_ids: ["prod_alias"],
+					},
+				},
+			}),
+		).toEqual({
+			stripe: {
+				product_id: "prod_abc",
+				additional_product_ids: ["prod_alias"],
+			},
+		});
+	});
+
+	test("omits when processor is missing", () => {
+		expect(
+			productToPlanProcessors({ product: { processor: null } }),
+		).toBeUndefined();
+		expect(
+			productToPlanProcessors({
+				product: { processor: { type: "stripe", id: "" } },
+			}),
+		).toBeUndefined();
+	});
+});
+
+describe("priceConfigToPriceProcessors", () => {
+	test("prepaid V2 id wins over V1", () => {
+		expect(
+			priceConfigToPriceProcessors({
+				config: {
+					stripe_product_id: "prod_price",
+					stripe_price_id: "price_v1",
+					stripe_prepaid_price_v2_id: "price_v2",
+				},
+			}),
+		).toEqual({
+			stripe: { price_id: "price_v2" },
+		});
+	});
+
+	test("falls back to stripe_price_id when V2 is unset", () => {
+		expect(
+			priceConfigToPriceProcessors({
+				config: { stripe_price_id: "price_v1" },
+			}),
+		).toEqual({
+			stripe: { price_id: "price_v1" },
+		});
+	});
+
+	test("omits when no stripe price id is set", () => {
+		expect(priceConfigToPriceProcessors({ config: {} })).toBeUndefined();
+		expect(priceConfigToPriceProcessors({ config: null })).toBeUndefined();
+		expect(
+			priceConfigToPriceProcessors({
+				config: { stripe_product_id: "prod_price" },
+			}),
+		).toBeUndefined();
+	});
+});

--- a/server/tests/unit/catalogV2/variants/derive-variant-intents.test.ts
+++ b/server/tests/unit/catalogV2/variants/derive-variant-intents.test.ts
@@ -364,4 +364,165 @@ describe("deriveVariantIntents", () => {
 		expect(mint).toBeDefined();
 		expect(mint?.planParams.active).toBe(true);
 	});
+
+	test("processor change fans out to latest variant", () => {
+		const current = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+		const next = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_new" },
+		};
+		const variant = {
+			...baseProduct,
+			id: "team-eu",
+			internal_id: "internal_team-eu",
+			base_internal_product_id: baseProduct.internal_id,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+
+		const intents = deriveVariantIntents({
+			intent: {
+				productKey: { planId: "team", version: 1 },
+				planParams: {
+					plan_id: "team",
+					version: 1,
+					processors: { stripe: { product_id: "prod_new" } },
+				},
+				source: "direct",
+			},
+			upsert: {
+				row: {
+					planId: "team",
+					version: 1,
+					op: "update",
+					source: "direct",
+					versioning: "existing",
+					currentFullProduct: current,
+					baseFullProduct: null,
+					nextFullProduct: next,
+				},
+				state: { hasCustomers: false, planHadLiveVersions: true },
+			} as UpsertProductPlan,
+			projectedProductStatesContext: {
+				...emptyStates({ planIds: ["team", "team-eu"] }),
+				versionsByPlanId: {
+					team: [next],
+					"team-eu": [variant],
+				},
+			},
+		});
+
+		expect(intents).toHaveLength(1);
+		expect(intents[0]?.source).toBe("variant_propagation");
+		expect(intents[0]?.planParams.processors).toEqual({
+			stripe: { product_id: "prod_new" },
+		});
+	});
+
+	test("variants[].processors overrides base fan-out", () => {
+		const current = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+		const next = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_new" },
+		};
+		const variant = {
+			...baseProduct,
+			id: "team-eu",
+			internal_id: "internal_team-eu",
+			base_internal_product_id: baseProduct.internal_id,
+			processor: { type: "stripe", id: "prod_old" },
+		};
+
+		const intents = deriveVariantIntents({
+			intent: {
+				productKey: { planId: "team", version: 1 },
+				planParams: {
+					plan_id: "team",
+					version: 1,
+					processors: { stripe: { product_id: "prod_new" } },
+				},
+				source: "direct",
+			},
+			upsert: {
+				row: {
+					planId: "team",
+					version: 1,
+					op: "update",
+					source: "direct",
+					versioning: "existing",
+					currentFullProduct: current,
+					baseFullProduct: null,
+					nextFullProduct: next,
+				},
+				declaredVariants: [
+					{
+						variant_plan_id: "team-eu",
+						processors: { stripe: { product_id: "prod_eu" } },
+					},
+				],
+				state: { hasCustomers: false, planHadLiveVersions: true },
+			} as UpsertProductPlan,
+			projectedProductStatesContext: {
+				...emptyStates({ planIds: ["team", "team-eu"] }),
+				versionsByPlanId: {
+					team: [next],
+					"team-eu": [variant],
+				},
+			},
+		});
+
+		expect(intents).toHaveLength(1);
+		expect(intents[0]?.planParams.processors).toEqual({
+			stripe: { product_id: "prod_eu" },
+		});
+	});
+
+	test("variant_link create copies variants[].processors onto planParams", () => {
+		const next = {
+			...baseProduct,
+			processor: { type: "stripe", id: "prod_base" },
+		};
+		const intents = deriveVariantIntents({
+			intent: {
+				productKey: { planId: "team", version: 1 },
+				planParams: { plan_id: "team", version: 1 },
+				source: "direct",
+			},
+			upsert: {
+				row: {
+					planId: "team",
+					version: 1,
+					op: "none",
+					source: "direct",
+					versioning: "existing",
+					currentFullProduct: next,
+					baseFullProduct: null,
+					nextFullProduct: next,
+				},
+				declaredVariants: [
+					{
+						variant_plan_id: "team-eu",
+						name: "Team EU",
+						processors: { stripe: { product_id: "prod_eu" } },
+					},
+				],
+				state: { hasCustomers: false, planHadLiveVersions: true },
+			} as UpsertProductPlan,
+			projectedProductStatesContext: emptyStates({
+				planIds: ["team", "team-eu"],
+			}),
+		});
+
+		expect(intents).toHaveLength(1);
+		expect(intents[0]?.source).toBe("variant_link");
+		expect(intents[0]?.planParams.processors).toEqual({
+			stripe: { product_id: "prod_eu" },
+		});
+	});
 });
+

--- a/server/tests/unit/catalogV2/variants/variant-models.test.ts
+++ b/server/tests/unit/catalogV2/variants/variant-models.test.ts
@@ -138,4 +138,15 @@ previous_version_slug: null,
 		});
 		expect(parsed).not.toHaveProperty("versioning");
 	});
+
+	test("variants[] accepts processors", () => {
+		const parsed = CatalogVariantParamsSchema.parse({
+			variant_plan_id: "team-eu",
+			processors: { stripe: { product_id: "prod_eu" } },
+		});
+		expect(parsed.processors).toEqual({
+			stripe: { product_id: "prod_eu" },
+		});
+	});
 });
+

--- a/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogPlanParams.ts
@@ -1,5 +1,6 @@
 import { FreeTrialParamsV1Schema } from "@api/common/freeTrial/freeTrialParamsV1.js";
 import { BasePriceParamsSchema } from "@api/products/components/basePrice/basePrice.js";
+import { ApiPlanProcessorsSchema } from "@api/products/components/processors.js";
 import { PlanLicenseParamsSchema } from "@api/products/crud/licenses/planLicenseParams.js";
 import { MigrationParamsSchema } from "@api/products/crud/migrationParams.js";
 import { CreatePlanItemParamsV1Schema } from "@api/products/items/crud/createPlanItemParamsV1.js";
@@ -49,6 +50,10 @@ export const UpdateCatalogPlanParamsSchema = z.object({
 	active: z.boolean().optional().meta({
 		description:
 			"Take the active pointer. On `new_version`, omit to mint a draft; `true` promotes the minted row immediately.",
+	}),
+	processors: ApiPlanProcessorsSchema.optional().meta({
+		description:
+			"Payment processors this plan is connected to. Omit to keep.",
 	}),
 	price: BasePriceParamsSchema.nullable().optional().meta({
 		description:

--- a/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
+++ b/shared/api/catalogV2/planUpdate/params/catalogVariantParams.ts
@@ -1,4 +1,5 @@
 import { CustomizePlanV1Schema } from "@api/billing/common/customizePlan/customizePlanV1.js";
+import { ApiPlanProcessorsSchema } from "@api/products/components/processors.js";
 import { idRegex } from "@utils/utils.js";
 import { z } from "zod/v4";
 
@@ -33,6 +34,10 @@ export const CatalogVariantParamsSchema = z.object({
 	new_version_slug: z.string().nonempty().regex(idRegex).optional().meta({
 		description:
 			"Slug for the row this variant mints. Omit to inherit the base's `new_version_slug`, then `v{n}`. Ignored when this entry resolves to an existing row.",
+	}),
+	processors: ApiPlanProcessorsSchema.optional().meta({
+		description:
+			"Overrides the base plan's processors for this variant. Omit to inherit when the base processors change.",
 	}),
 	base_variant_id: CatalogBaseVariantIdSchema.meta({
 		description:

--- a/shared/api/products/apiPlanV1.ts
+++ b/shared/api/products/apiPlanV1.ts
@@ -9,6 +9,10 @@ import { ApiFreeTrialV2Schema } from "./components/apiFreeTrialV2.js";
 import { CustomerEligibilitySchema } from "./components/customerEligibility.js";
 import { DisplaySchema } from "./components/display.js";
 import {
+	ApiPlanProcessorsSchema,
+	ApiPriceProcessorsSchema,
+} from "./components/processors.js";
+import {
 	API_PLAN_ITEM_PREPAID_EXAMPLE,
 	API_PLAN_ITEM_USAGE_BASED_EXAMPLE,
 	ApiPlanItemV1Schema,
@@ -132,6 +136,10 @@ export const ApiPlanV1Schema = z.object({
 			display: DisplaySchema.optional().meta({
 				description: "Display text for showing this price in pricing pages.",
 			}),
+			processors: ApiPriceProcessorsSchema.optional().meta({
+				description:
+					"Payment processors this base price is connected to. Omitted when unset.",
+			}),
 		})
 		.nullable()
 		.meta({
@@ -141,6 +149,10 @@ export const ApiPlanV1Schema = z.object({
 	items: z.array(ApiPlanItemV1Schema).meta({
 		description:
 			"Feature configurations included in this plan. Each item defines included units, pricing, and reset behavior for a feature.",
+	}),
+	processors: ApiPlanProcessorsSchema.optional().meta({
+		description:
+			"Payment processors this plan is connected to. Omitted when unset.",
 	}),
 	free_trial: ApiFreeTrialV2Schema.optional().meta({
 		description:

--- a/shared/api/products/components/processors.ts
+++ b/shared/api/products/components/processors.ts
@@ -1,0 +1,36 @@
+import { z } from "zod/v4";
+
+/** Stripe connection on a plan — the Stripe Product. */
+export const ApiStripePlanProcessorSchema = z.object({
+	product_id: z.string().meta({
+		description: "Stripe product ID this plan is billed under.",
+	}),
+	additional_product_ids: z.array(z.string()).optional().meta({
+		description: "Extra Stripe product IDs aliased to this plan.",
+	}),
+});
+
+/** Stripe connection on a price — the Stripe Price. Product is inferred from it. */
+export const ApiStripePriceProcessorSchema = z.object({
+	price_id: z.string().meta({
+		description:
+			"Stripe price ID. For prepaid with included > 0 this is the V2 price.",
+	}),
+});
+
+export const ApiPlanProcessorsSchema = z.object({
+	stripe: ApiStripePlanProcessorSchema.optional(),
+});
+
+export const ApiPriceProcessorsSchema = z.object({
+	stripe: ApiStripePriceProcessorSchema.optional(),
+});
+
+export type ApiStripePlanProcessor = z.infer<
+	typeof ApiStripePlanProcessorSchema
+>;
+export type ApiStripePriceProcessor = z.infer<
+	typeof ApiStripePriceProcessorSchema
+>;
+export type ApiPlanProcessors = z.infer<typeof ApiPlanProcessorsSchema>;
+export type ApiPriceProcessors = z.infer<typeof ApiPriceProcessorsSchema>;

--- a/shared/api/products/index.ts
+++ b/shared/api/products/index.ts
@@ -7,6 +7,7 @@ export * from "./components/apiFreeTrialV2";
 export * from "./components/basePrice/basePriceToProductItem";
 export * from "./components/billingMethod";
 export * from "./components/display";
+export * from "./components/processors";
 export * from "./components/planChange/index";
 export * from "./components/planExpand";
 export * from "./crud/index";

--- a/shared/api/products/items/apiPlanItemV1.ts
+++ b/shared/api/products/items/apiPlanItemV1.ts
@@ -6,6 +6,7 @@ import {
 } from "@api/products/components/additionalCurrencies.js";
 import { BillingMethod } from "@api/products/components/billingMethod.js";
 import { DisplaySchema } from "@api/products/components/display.js";
+import { ApiPriceProcessorsSchema } from "@api/products/components/processors.js";
 import { RolloverExpiryDurationType } from "@models/productModels/durationTypes/rolloverExpiryDurationType.js";
 import { BillingInterval } from "@models/productModels/intervals/billingInterval.js";
 import { ResetInterval } from "@models/productModels/intervals/resetInterval.js";
@@ -126,6 +127,10 @@ export const ApiPlanItemV1Schema = z
 				max_purchase: z.number().nullable().meta({
 					description:
 						"Maximum units a customer can purchase beyond included. E.g. if included=100 and max_purchase=300, customer can use up to 400 total before usage is capped. Null for no limit.",
+				}),
+				processors: ApiPriceProcessorsSchema.optional().meta({
+					description:
+						"Payment processors this item price is connected to. Omitted when unset.",
 				}),
 			})
 			.nullable()

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -56,6 +56,7 @@ export * from "./productUtils/classifyProduct/isProductPaidAndRecurring";
 export * from "./productUtils/compareProduct/productDetailsAreSame";
 export * from "./productUtils/convertProduct/productKey";
 export * from "./productUtils/convertProduct/productToEffectivePrices";
+export * from "./productUtils/convertProduct/productToPlanProcessors";
 export * from "./productUtils/convertProduct/productToProductKey";
 export * from "./productUtils/convertProduct/productToReplacementKey";
 // Product utils

--- a/shared/utils/productUtils/convertProduct/productToPlanProcessors.ts
+++ b/shared/utils/productUtils/convertProduct/productToPlanProcessors.ts
@@ -1,0 +1,19 @@
+import type { ApiPlanProcessors } from "@api/products/components/processors";
+import type { Product } from "@models/productModels/productModels";
+
+export const productToPlanProcessors = ({
+	product,
+}: {
+	product: Pick<Product, "processor">;
+}): ApiPlanProcessors | undefined => {
+	const processor = product.processor;
+	if (!processor?.id) return undefined;
+	return {
+		stripe: {
+			product_id: processor.id,
+			...(processor.additional_ids?.length
+				? { additional_product_ids: processor.additional_ids }
+				: {}),
+		},
+	};
+};

--- a/shared/utils/productUtils/priceUtils/convertPrice/priceConfigToPriceProcessors.ts
+++ b/shared/utils/productUtils/priceUtils/convertPrice/priceConfigToPriceProcessors.ts
@@ -1,0 +1,18 @@
+import type { ApiPriceProcessors } from "@api/products/components/processors";
+
+type StripePriceConfigSlots = {
+	stripe_product_id?: string | null;
+	stripe_price_id?: string | null;
+	stripe_prepaid_price_v2_id?: string | null;
+} | null;
+
+export const priceConfigToPriceProcessors = ({
+	config,
+}: {
+	config?: StripePriceConfigSlots;
+}): ApiPriceProcessors | undefined => {
+	const priceId =
+		config?.stripe_prepaid_price_v2_id || config?.stripe_price_id || undefined;
+	if (!priceId) return undefined;
+	return { stripe: { price_id: priceId } };
+};

--- a/shared/utils/productUtils/priceUtils/index.ts
+++ b/shared/utils/productUtils/priceUtils/index.ts
@@ -7,6 +7,7 @@ export * from "./classifyPrice/priceIsTieredOneOff.js";
 export * from "./classifyPriceUtils.js";
 export * from "./comparePrice/pricesAreSame.js";
 export * from "./convertAmountUtils.js";
+export * from "./convertPrice/priceConfigToPriceProcessors.js";
 export * from "./convertPrice/priceToStripeTiersMode.js";
 export * from "./convertPriceUtils.js";
 export * from "./findPrice/findPriceByFeatureId.js";

--- a/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemV1.ts
+++ b/shared/utils/productV2Utils/productItemUtils/convertProductItem/productItemToPlanItemV1.ts
@@ -1,4 +1,5 @@
 import { PlanExpand } from "@api/products/components/planExpand.js";
+import { priceConfigToPriceProcessors } from "@utils/productUtils/priceUtils/convertPrice/priceConfigToPriceProcessors.js";
 import {
 	type ApiPlanItemV1,
 	ApiPlanItemV1Schema,
@@ -106,6 +107,10 @@ const itemToPlanFeaturePrice = ({
 		});
 	}
 
+	const processors = priceConfigToPriceProcessors({
+		config: item.price_config,
+	});
+
 	return {
 		amount: price ?? undefined,
 		additional_currencies: additionalCurrencies,
@@ -121,6 +126,7 @@ const itemToPlanFeaturePrice = ({
 		billing_units: item.billing_units ?? 1,
 		billing_method: billingMethod,
 		max_purchase: maxPurchase,
+		...(processors ? { processors } : {}),
 	};
 };
 


### PR DESCRIPTION
## Summary
- Accept `plans[].processors.stripe` (and `variants[].processors`) on `catalogV2.update`, stamp onto `product.processor`, and echo them on GET as `processors.stripe`.
- Fan the base Stripe product id out to latest variants via the existing settings path. A variant's own processors (from `variants[]` or a direct `plans[]` entry) override the base; omit keeps.

Price processors, Stripe retrieve/validate, and init-skip are out of this PR.

## Test plan
- [ ] Unit: `UNIT_TESTS=1 bun test tests/unit/catalogV2/processors-echo.test.ts tests/unit/catalogV2/computeProductDetailsPlan tests/unit/catalogV2/variants` (already green locally)
- [ ] Integration (needs server): `bun t tests/integration/catalog-v2/plans/processors --headless`
  - GET echo on a paid plan / free plan / `create_in_stripe: false`
  - Stamp `product_id` on Team → Team EU `processor.id` matches
  - `variants[].processors` or a direct variant `plans[]` entry overrides the base
  - Omit leaves the existing processor


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `processors.stripe` to `catalogV2.update` and GET so plans can set and echo their Stripe product and price ids.

**Behavior**
- `plans[].processors.stripe` and `variants[].processors` stamp `product.processor`; omitting keeps the current value.
- Base processor changes propagate to latest variants, with `variants[].processors` or a direct `plans[]` entry overriding the base.
- GET returns plan and price `processors.stripe` from the DB; free plans and `create_in_stripe: false` omit them.

**Out of scope**
- Price processor stamping, Stripe retrieve/validate, and init-skip.

<sup>Written for commit 4769d9fa391b6325b547c0c172a54dc0b8f7c0a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Stripe processor mappings to catalog plan inputs and responses, persists plan-level mappings, and propagates base mappings to variants.
- **[API changes]** Accept and return plan, base-price, and item-price Stripe processor identifiers.
- **[Improvements]** Persist processor-only plan changes and carry processor mappings through plan creation and cloning.
- **[Improvements]** Fan base processor changes out to variants while allowing explicit variant overrides.
- **[Bug fixes]** Preserve processor mappings in catalog response conversion.
</details>


<h3>Confidence Score: 4/5</h3>

The PR should not merge until processors-only variant overrides correctly mint a new variant version during a base new-version update.

A processors-only variant declaration currently bypasses variant mint selection, allowing the existing customer-bearing variant row to receive a processor change that should have been isolated to a new version.

**Files Needing Attention:** server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts | Copies processor overrides into variant mints but fails to select variants declared only with processors, causing existing rows to be edited under new-version updates. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/edits/resolveVariantEditTargets.ts | Adds processors to variant edit targets and correctly gives explicit variant declarations precedence within the edit lane. |
| server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeProductDetailsPlan/computeProductDetailsPlan.ts | Correctly recognizes processor-only changes even though processor is outside the ordinary product-detail diff. |
| server/src/internal/catalogV2/execute/executeUpsertProducts/applyProductDetailsUpdate.ts | Persists the computed processor mapping during product-detail updates. |
| server/src/internal/products/productUtils/productResponseUtils/getPlanResponse.ts | Adds plan and price processor identifiers to catalog responses using the new conversion helpers. |
| shared/api/products/components/processors.ts | Defines the new Stripe plan and price processor API schemas. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[catalogV2.update processors] --> Base[Stamp base product.processor]
  Base --> Persist[Persist product row]
  Base --> Variants[Resolve variant targets]
  Variants --> Override{Variant override?}
  Override -->|Yes| Own[Use variant processor]
  Override -->|No| Inherit[Use base processor]
  Persist --> Get[catalogV2.get]
  Own --> Get
  Inherit --> Get
  Get --> Response[processors.stripe response]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts`, line 53-56 ([link](https://github.com/useautumn/autumn/blob/4769d9fa391b6325b547c0c172a54dc0b8f7c0a0/server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts#L53-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Processor overrides skip minting**

   When a base plan uses `new_version` and an existing customer-bearing variant declares only `variants[].processors`, `mintablePlanIds` skips that variant and the edit lane changes its existing row instead, causing customers on the old version to receive the new processor mapping.

   **Knowledge Base Used:** [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts
   Line: 53-56
   
   Comment:
   **Processor overrides skip minting**
   
   When a base plan uses `new_version` and an existing customer-bearing variant declares only `variants[].processors`, `mintablePlanIds` skips that variant and the edit lane changes its existing row instead, causing customers on the old version to receive the new processor mapping.
   
   
   
   **Knowledge Base Used:** [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/catalogV2/actions/updateCatalog/compute/computeUpsertProductsPlan/computeVariantPlan/mints/deriveVariantMints.ts:53-56
**Processor overrides skip minting**

When a base plan uses `new_version` and an existing customer-bearing variant declares only `variants[].processors`, `mintablePlanIds` skips that variant and the edit lane changes its existing row instead, causing customers on the old version to receive the new processor mapping.

```suggestion
	for (const variant of upsert.declaredVariants ?? []) {
		if (
			(!variant.customize && variant.processors === undefined) ||
			variant.version !== undefined
		)
			continue;
		planIds.add(variant.variant_plan_id);
	}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(catalog-v2): stamp plan processors ..."](https://github.com/useautumn/autumn/commit/4769d9fa391b6325b547c0c172a54dc0b8f7c0a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57170865)</sub>

**Context used:**

- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->