### PR TITLE
Fix dev tab title and blue sandbox favicon in local dev

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -423,6 +423,7 @@ async function startDev() {
 			SLACK_REDIRECT_URI,
 			DISCORD_BOT_URL: process.env.DISCORD_BOT_URL ?? LOCAL_CHAT_URL,
 			VITE_APP_ENV: viteAppEnv,
+			VITE_WORKTREE_NUM: String(worktreeNum),
 			...(useLocalAuthUrls && {
 				CLIENT_URL: localUrl(process.env.CLIENT_URL, LOCAL_CLIENT_URL),
 				VITE_BACKEND_URL: localUrl(

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -12,15 +12,11 @@ const sandboxFaviconHref = (color: string) =>
 		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
-declare const __APP_ENV__: string;
-
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
 	const color =
-		env === AppEnv.Sandbox && __APP_ENV__ !== "dev"
-			? (activeSandbox?.color ?? "blue")
-			: undefined;
+		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -12,11 +12,15 @@ const sandboxFaviconHref = (color: string) =>
 		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
+declare const __APP_ENV__: string;
+
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
 	const color =
-		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
+		env === AppEnv.Sandbox && __APP_ENV__ !== "dev"
+			? (activeSandbox?.color ?? "blue")
+			: undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -7,16 +7,24 @@ import { useEnv } from "@/utils/envUtils";
 const AUTUMN_MARK =
 	"M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z";
 
+// Matches --color-sandbox in packages/ui/src/styles/index.css, the brand
+// blue used by SandboxBanner when no sandbox-specific tag color is set.
+const DEFAULT_SANDBOX_FAVICON_COLOR = "#0f9bff";
+
 const sandboxFaviconHref = (color: string) =>
 	`data:image/svg+xml,${encodeURIComponent(
-		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
+		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${color}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
 	const color =
-		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
+		env === AppEnv.Sandbox
+			? activeSandbox?.color
+				? sandboxColorValue(activeSandbox.color)
+				: DEFAULT_SANDBOX_FAVICON_COLOR
+			: undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/main.tsx
+++ b/vite/src/main.tsx
@@ -13,12 +13,13 @@ Sentry.init({
 });
 
 declare const __APP_ENV__: string;
+declare const __WORKTREE_NUM__: string;
 if (__APP_ENV__ === "prod") {
 	document.title = "Autumn (P)";
 } else if (__APP_ENV__ === "staging") {
 	document.title = "Autumn (S)";
 } else if (__APP_ENV__ === "dev") {
-	document.title = "Autumn (Dev)";
+	document.title = `Autumn (wt${__WORKTREE_NUM__})`;
 }
 
 const queryClient = new QueryClient({

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -53,6 +53,7 @@ function printPortlessUrl(): Plugin {
 export default defineConfig({
 	define: {
 		__APP_ENV__: JSON.stringify(process.env.VITE_APP_ENV || ""),
+		__WORKTREE_NUM__: JSON.stringify(process.env.VITE_WORKTREE_NUM || "1"),
 	},
 	esbuild: {
 		pure: ["console.log"],


### PR DESCRIPTION
In local dev the tab always showed "Autumn (Dev)" and a blue favicon (the sandbox indicator, since local dev defaults to the sandbox route), regardless of which worktree you're on.

- Title now reads `Autumn (wtX)` using the worktree number (`wt1` for canonical), instead of a fixed "Autumn (Dev)". Wired via `VITE_WORKTREE_NUM` from `scripts/dev.ts` → `__WORKTREE_NUM__` vite define.
- `SandboxFavicon` no longer paints the blue sandbox icon when `__APP_ENV__ === "dev"`, so local dev keeps the normal white favicon. Production/staging sandbox favicon behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local dev tab title so it shows the current worktree number (`Autumn (wtX)`, with `wt1` for canonical) instead of the fixed `Autumn (Dev)`. Also makes the sandbox favicon's default color match the brand blue (`#0f9bff`) when no sandbox-specific color is set.

- Dev servers started without the worktree-aware launcher fall back to `wt1`.

<sup>Written for commit eb3a9797660504675bc8013b4b2cddd4474a27e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes local development tabs identify their worktree and aligns the default sandbox favicon with the shared sandbox brand color.
- **[Bug fixes, Improvements]** Pass the launcher’s worktree number into Vite and display it in the development tab title.
- **[Improvements]** Use the shared sandbox blue as the default generated sandbox favicon color while preserving configured sandbox colors.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/dev.ts | Passes the resolved worktree number to the Vite development process. |
| vite/src/main.tsx | Replaces the fixed development title with a worktree-aware title. |
| vite/vite.config.ts | Exposes the worktree value as a compile-time constant. |
| vite/src/components/general/SandboxFavicon.tsx | Aligns the default sandbox favicon color with the shared sandbox theme and retains color canonicalization. |

<sub>Reviews (4): Last reviewed commit: ["Match default sandbox favicon to the rea..."](https://github.com/useautumn/autumn/commit/eb3a9797660504675bc8013b4b2cddd4474a27e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57172858)</sub>

<!-- /greptile_comment -->