### PR TITLE
fix(dashboard): stop per-unit selector collapsing in graduated tier rows

### DIFF
--- a/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
@@ -38,15 +38,22 @@ export function BillingUnits() {
 		capitalize: false,
 	});
 
+	const hasMultipleTiers = (item.tiers?.length ?? 0) > 1;
+
 	return (
-		<div className="flex min-w-0 overflow-hidden">
+		<div
+			className={cn(
+				"flex min-w-0 overflow-hidden",
+				hasMultipleTiers && "shrink-0",
+			)}
+		>
 			<Popover open={open} onOpenChange={setOpen}>
 				<PopoverTrigger asChild>
 					<Button
 						variant="muted"
 						className={cn(
 							"min-w-0 max-w-full justify-start overflow-hidden text-tertiary-foreground",
-							item.tiers?.length && item.tiers.length > 1 && "max-w-20",
+							hasMultipleTiers && "max-w-20",
 						)}
 					>
 						<span className="min-w-0 truncate text-xs">


### PR DESCRIPTION
In graduated pricing tier rows, the "per <unit>" selector was crushed to an unreadable sliver (rendered as a clipped "pe"). The row's only two flex children without shrink protection were the tier amount input (whose base `Input` is `w-full`, so it starts oversized) and the `BillingUnits` wrapper (no width floor), so flex shrink collapsed the latter.

Fix: give the `BillingUnits` wrapper `shrink-0` when the item has multiple tiers, so the button's existing `max-w-20` cap bounds it and the amount input becomes the sole flexing element.

Gated to multi-tier rows deliberately: in single-tier mode the button is `max-w-full` (no real cap), so an unconditional `shrink-0` would let a long feature name push "Add Tier" out of the fixed-width sheet. Single-tier layout is byte-identical.

Checks: pinned Biome clean, `bun run ts` in `vite/` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the per-unit selector collapsing to a clipped "pe" in graduated tier rows by preventing flex shrink on the `BillingUnits` wrapper when multiple tiers exist.

- The fix is scoped to multi-tier rows so single-tier layout stays byte-identical.

<sup>Written for commit 8a19810e75945a5b5c6c6c5b0bfbede10c93e935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

