### PR TITLE
fix: a silent turn settles before the backstop kills it, and the approval eval stops racing itself

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -29,6 +29,9 @@ const MAX_IDLE_RETRIES = 20;
 /** Each idle window is 2 minutes, so this bounds a quiet turn at ~6 minutes
  * before leaf answers with whatever it has. */
 const MAX_IDLE_RESYNCS = 3;
+/** Settle before the caller's own wall-clock backstop, so a turn eve never
+ * resumes is answered by leaf rather than killed mid-recovery. */
+const MAX_QUIET_MS = ms.minutes(2.5);
 /** The ceiling on a single turn however busy it looks: a stream that dribbles
  * one event per idle window would otherwise reset the resync budget forever. */
 const MAX_TURN_DURATION_MS = ms.minutes(15);
@@ -167,6 +170,7 @@ const settleExhaustedTurn = ({
 		event: "leaf.eve_turn_abandoned",
 		data: {
 			has_partial_text: Boolean(partialText),
+			quiet_ms: activity.msSinceActivity(),
 			session_id: session.sessionId,
 			stream_index: session.state.streamIndex,
 			turn_ms: activity.msSinceStart(),
@@ -285,7 +289,10 @@ export const consumeAgentTurn = async ({
 				});
 			}
 
-			if (activity.msSinceStart() >= MAX_TURN_DURATION_MS) {
+			const quietTooLong =
+				activity.activeChildren() === 0 &&
+				activity.msSinceActivity() >= MAX_QUIET_MS;
+			if (activity.msSinceStart() >= MAX_TURN_DURATION_MS || quietTooLong) {
 				return settleExhaustedTurn({ activity, logger, turn });
 			}
 

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
@@ -33,6 +33,7 @@ import { catalogPlanNeedingDecision } from "../../resolveCatalogDecision/catalog
 export type EveTurnOutcome =
 	| { kind: "answered"; catalogDecision?: CatalogPlanPreview; text: string }
 	| { kind: "parked"; question?: PendingQuestion; text: string }
+	| { kind: "deferred" }
 	| { kind: "silent" }
 	| { kind: "stopped"; stopReason: RunStopReason; text: string }
 	| { approval: AgentApprovalRequest; kind: "suspended"; text: string }
@@ -315,6 +316,14 @@ const reduceInputRequest = ({
 	};
 };
 
+/** Eve parks holding the message when a delivery answers a subagent's park:
+ * the responses route to the child and the message lands on a parent with no
+ * pending batch, so the turn starts, receives and completes without working. */
+const turnDeferredItsInput = (progress: EveTurnProgress) =>
+	progress.turnStarted &&
+	progress.toolLabels.size === 0 &&
+	progress.subagentChildSessionIds.size === 0;
+
 const reduceTerminalEvent = ({
 	event,
 	progress,
@@ -335,7 +344,7 @@ const reduceTerminalEvent = ({
 		],
 		outcome: eveTurnProducedOutput({ catalogDecision, text })
 			? { catalogDecision, kind: "answered", text }
-			: { kind: "silent" },
+			: { kind: turnDeferredItsInput(progress) ? "deferred" : "silent" },
 		progress,
 	};
 };

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -4,6 +4,7 @@ import type {
 	AgentTurnContext,
 	AgentTurnParams,
 } from "../../domain/agentTurnContext.js";
+import { postEveMessage } from "../../eve/client.js";
 import type { EveAuthContext, EveSessionRef } from "../../eve/types.js";
 import {
 	generateThreadTitle,
@@ -119,11 +120,38 @@ export const runAgentTurn = async ({
 			});
 			return startFresh();
 		});
-		const outcome = await consume(session).catch(async (error) => {
+		let outcome = await consume(session).catch(async (error) => {
 			await recoverLostSession({ ctx, error, existingSession, session });
 			session = await startFresh();
 			return consume(session);
 		});
+		if (outcome.kind === "deferred") {
+			logger.warn("Eve parked holding the message; redelivering", {
+				event: "leaf.eve_deferred_input_redelivered",
+				data: {
+					session_id: session.sessionId,
+					stream_index: session.state.streamIndex,
+				},
+			});
+			await postEveMessage({
+				auth: { ...auth, orgInstructions: prepared.orgContext?.instructions },
+				message: buildAgentTurnMessage({
+					env,
+					isAdminInstall: isInternalAutumnSlackProvider({
+						provider: thread.provider,
+					}),
+					newSession: false,
+					orgSlug: org.slug,
+					params,
+				}),
+				session,
+			});
+			const redelivered = await consume(session);
+			// One redelivery is the fix; a second park is eve failing to consume
+			// its own deferred input, and must not read as a fresh deferral.
+			outcome =
+				redelivered.kind === "deferred" ? { kind: "silent" } : redelivered;
+		}
 		const result = await resolveAgentTurnOutcome({
 			env,
 			logger,

--- a/apps/leaf/tests/evals/agent/mcp/attach-approval.eval.ts
+++ b/apps/leaf/tests/evals/agent/mcp/attach-approval.eval.ts
@@ -60,13 +60,14 @@ initEval<EvalMetadata>({
 	cases: [
 		{
 			name: "destructive attach waits for approval",
+			// No confirm turn: a second message races the card it would confirm,
+			// withdrawing the gate the approval is meant to answer.
 			conversation: [
 				user({
 					message:
 						"Please attach the Pro plan to Atlas Labs. Preview it first, then attach it after approval.",
 				}),
-				user({ message: "Looks good, attach it." }),
-				approve(),
+				approve({ optional: false }),
 			],
 			expect: [
 				tools.called({

--- a/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
+++ b/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
@@ -1,0 +1,272 @@
+/**
+ * The parent-quiet cap in consumeAgentTurn: a turn with NO live child that has
+ * been silent past MAX_QUIET_MS (2.5 min) settles on the clock, not after the
+ * MAX_IDLE_RESYNCS (3) budget is spent.
+ *
+ * The existing idle-stream-recovery suite cannot see this: its mock stream
+ * never advances any clock, so msSinceActivity() is always ~0 and the resync
+ * budget always wins. Here the mock stream advances a FAKE clock between
+ * passes, so quiet time grows without real waiting, and the two paths settle
+ * at different pass counts with different quiet_ms.
+ *
+ * Discriminating signal (per-pass advance = 80s):
+ *  - with the quiet cap: settles after 2 parent passes, quiet_ms ~160_000
+ *  - without it:         settles after 4 parent passes, quiet_ms ~320_000
+ */
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	setSystemTime,
+	test,
+} from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { EveEvent } from "../../../src/internal/agentRuntime/eve/eveEventSchemas.js";
+import type { EveSessionRef } from "../../../src/internal/agentRuntime/eve/types.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/env.js", () => ({ env: {} }));
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+class MockEveStreamDisconnectedError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveStreamDisconnectedError";
+	}
+}
+class MockEveStreamIdleTimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveStreamIdleTimeoutError";
+	}
+}
+
+const TURN_START = new Date("2026-08-26T10:00:00Z");
+const QUIET_CAP_MS = 150_000;
+const PASS_ADVANCE_MS = 80_000;
+
+let nowMs = TURN_START.getTime();
+const advanceClock = (byMs: number) => {
+	nowMs += byMs;
+	setSystemTime(new Date(nowMs));
+};
+
+type StreamPass = { events: EveEvent[]; thenThrow?: "idle" | "disconnect" };
+
+let streamPasses: StreamPass[] = [];
+let childEvents: EveEvent[] = [];
+let childKeepsStreaming = true;
+let parentStreamCalls = 0;
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/client.js",
+	factory: () => ({
+		EveSessionDeadError: class extends Error {},
+		EveStreamDisconnectedError: MockEveStreamDisconnectedError,
+		EveStreamIdleTimeoutError: MockEveStreamIdleTimeoutError,
+		fastForwardEveStreamIndex: async () => undefined,
+		isEveTransportLost: (error: unknown) =>
+			error instanceof MockEveStreamDisconnectedError ||
+			error instanceof MockEveStreamIdleTimeoutError,
+		resyncEveStreamIndex: async () => undefined,
+		streamEveEvents: async function* ({ session }: { session: EveSessionRef }) {
+			if (session.sessionId.startsWith("wrun_child")) {
+				for (const event of childEvents) {
+					yield event;
+					await new Promise((resolve) => setTimeout(resolve, 1));
+				}
+				if (childKeepsStreaming) await new Promise(() => undefined);
+				throw new MockEveStreamIdleTimeoutError("child idle");
+			}
+			const pass = streamPasses[
+				Math.min(parentStreamCalls, streamPasses.length - 1)
+			] ?? { events: [] };
+			parentStreamCalls += 1;
+			for (const event of pass.events) yield event;
+			// A real idle window burns wall-clock before it throws.
+			advanceClock(PASS_ADVANCE_MS);
+			if (pass.thenThrow === "idle") {
+				throw new MockEveStreamIdleTimeoutError("Eve stream idle timeout");
+			}
+			if (pass.thenThrow === "disconnect") {
+				throw new MockEveStreamDisconnectedError("socket closed");
+			}
+		},
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/sessionState.js",
+	factory: () => ({
+		advanceStreamCursor: (session: EveSessionRef) => {
+			session.state.streamIndex += 1;
+		},
+		saveEveSessionState: async () => undefined,
+		statusAfterTerminalEvent: (eventType: string) =>
+			eventType === "session.completed" ? "completed" : "waiting",
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/repo.js",
+	factory: () => ({ deleteEveSession: async () => undefined }),
+});
+
+const { consumeAgentTurn } = await import(
+	"../../../src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.js"
+);
+
+const event = (partial: Record<string, unknown>) =>
+	partial as unknown as EveEvent;
+
+const session = (): EveSessionRef => ({
+	env: AppEnv.Sandbox,
+	newSession: false,
+	sessionId: "eve_session_1",
+	state: {
+		version: 1,
+		continuationToken: "token_1",
+		streamIndex: 33,
+		status: "running",
+		lastEventAt: 0,
+		pendingRequests: [],
+	},
+	threadKey: "sandbox:slack:T1:C1:thread_1",
+});
+
+type AbandonedLog = { quiet_ms: number; turn_ms: number };
+
+const consumeAndCaptureAbandon = async () => {
+	const abandoned: AbandonedLog[] = [];
+	const logger = {
+		error: (
+			_message: string,
+			meta?: { event?: string; data?: AbandonedLog },
+		) => {
+			if (meta?.event === "leaf.eve_turn_abandoned" && meta.data) {
+				abandoned.push(meta.data);
+			}
+		},
+		info: () => {},
+		warn: () => {},
+	};
+	const outcome = await consumeAgentTurn({
+		auth: {} as never,
+		env: AppEnv.Sandbox,
+		logger: logger as never,
+		onAction: async () => undefined,
+		orgId: "org_1",
+		session: session(),
+		token: "t",
+	} as never);
+	return { abandoned, outcome };
+};
+
+// Nine idle passes: far more than either exit path needs, so the pass count at
+// settle time is decided purely by which condition fired.
+const nineQuietPasses = (first: EveEvent[]): StreamPass[] => [
+	{ events: first, thenThrow: "idle" },
+	...Array.from({ length: 8 }, () => ({
+		events: [] as EveEvent[],
+		thenThrow: "idle" as const,
+	})),
+];
+
+describe("a parent quiet past the cap settles on the clock", () => {
+	beforeEach(() => {
+		parentStreamCalls = 0;
+		childEvents = [];
+		childKeepsStreaming = false;
+		nowMs = TURN_START.getTime();
+		setSystemTime(TURN_START);
+	});
+
+	afterEach(() => {
+		setSystemTime();
+	});
+
+	test("settles at the quiet cap, before the idle-resync budget is spent", async () => {
+		streamPasses = nineQuietPasses([
+			event({ type: "turn.started" }),
+			event({
+				finishReason: "stop",
+				message: "Partial answer so far.",
+				type: "message.completed",
+			}),
+		]);
+
+		const { abandoned, outcome } = await consumeAndCaptureAbandon();
+
+		expect(outcome).toMatchObject({
+			kind: "answered",
+			text: "Partial answer so far.",
+		});
+		expect(abandoned).toHaveLength(1);
+
+		// The quiet cap fires the pass after quiet time crosses 150s. Spending
+		// the 3-resync budget instead takes two more passes and >= 320s quiet.
+		expect(parentStreamCalls).toBe(2);
+
+		const [log] = abandoned;
+		expect(log.quiet_ms).toBeGreaterThanOrEqual(QUIET_CAP_MS);
+		expect(log.quiet_ms).toBeLessThan(QUIET_CAP_MS + PASS_ADVANCE_MS);
+	});
+
+	test("a live child suppresses the quiet cap even when the parent is silent", async () => {
+		// Same silent parent, but a child relay is still streaming: the turn is
+		// working, so neither the quiet cap nor the resync budget may settle it.
+		childKeepsStreaming = true;
+		childEvents = Array.from({ length: 3 }, () =>
+			event({
+				actions: [{ toolName: "autumn__previewAttach" }],
+				type: "actions.requested",
+			}),
+		);
+		streamPasses = [
+			{
+				events: [
+					event({ type: "turn.started" }),
+					event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
+				],
+				thenThrow: "idle",
+			},
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{
+				events: [
+					event({
+						finishReason: "stop",
+						message: "Done after a long delegation.",
+						type: "message.completed",
+					}),
+					event({ type: "session.waiting" }),
+				],
+			},
+		];
+
+		const { abandoned, outcome } = await consumeAndCaptureAbandon();
+
+		expect(abandoned).toHaveLength(0);
+		expect(outcome).toMatchObject({
+			kind: "answered",
+			text: "Done after a long delegation.",
+		});
+		// Six quiet passes at 80s each is well past the 150s cap, proving the
+		// live child — not a short clock — is what kept the turn alive.
+		expect(parentStreamCalls).toBeGreaterThan(5);
+	});
+});

--- a/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
+++ b/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Withdrawing a subagent's approval card drops the user's message.
+ *
+ * eve's routeDeliverPayload (execution/subagent-hitl-proxy.js) splits one POST:
+ * an inputResponse for a PROXIED child request goes to the child, and every
+ * other field -- including `message` -- goes to the parent. The parent has no
+ * pending batch of its own, so resolvePendingInput returns deferredMessage and
+ * parks, stashing the message in eve.runtime.deferredStepInput. It emits only
+ * turn.started / message.received / turn.completed / session.waiting and then
+ * waits for a delivery that never comes.
+ *
+ * Prod 2026-08-27 wrun_01M11DJD2N6N0BC04TQRDE3CGD: stream advanced 32 -> 37 on
+ * exactly that no-op batch, then silence to abandonment at 8m06s.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { EveEvent } from "../../../src/internal/agentRuntime/eve/eveEventSchemas.js";
+import type { EveSessionRef } from "../../../src/internal/agentRuntime/eve/types.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/env.js", () => ({ env: {} }));
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+class MockEveStreamIdleTimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveStreamIdleTimeoutError";
+	}
+}
+
+let parentPasses: EveEvent[][] = [];
+let parentStreamCalls = 0;
+let repostedMessages: unknown[] = [];
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/client.js",
+	factory: () => ({
+		EveSessionDeadError: class extends Error {},
+		EveStreamDisconnectedError: class extends Error {},
+		EveStreamIdleTimeoutError: MockEveStreamIdleTimeoutError,
+		fastForwardEveStreamIndex: async () => undefined,
+		isEveTransportLost: (error: unknown) =>
+			error instanceof MockEveStreamIdleTimeoutError,
+		postEveMessage: async ({ message }: { message?: unknown }) => {
+			repostedMessages.push(message);
+			return { continuationToken: "token_2", sessionId: "eve_session_1" };
+		},
+		resyncEveStreamIndex: async () => undefined,
+		streamEveEvents: async function* () {
+			const events = parentPasses[parentStreamCalls] ?? [];
+			parentStreamCalls += 1;
+			for (const event of events) yield event;
+			// Nothing more ever arrives on a parked session.
+			throw new MockEveStreamIdleTimeoutError("Eve stream idle timeout");
+		},
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/sessionState.js",
+	factory: () => ({
+		advanceStreamCursor: (session: EveSessionRef) => {
+			session.state.streamIndex += 1;
+		},
+		saveEveSessionState: async () => undefined,
+		statusAfterTerminalEvent: (eventType: string) =>
+			eventType === "session.completed" ? "completed" : "waiting",
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/repo.js",
+	factory: () => ({ deleteEveSession: async () => undefined }),
+});
+
+const { consumeAgentTurn } = await import(
+	"../../../src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.js"
+);
+
+const event = (partial: Record<string, unknown>) =>
+	partial as unknown as EveEvent;
+
+const session = (): EveSessionRef => ({
+	env: AppEnv.Sandbox,
+	newSession: false,
+	sessionId: "eve_session_1",
+	state: {
+		version: 1,
+		continuationToken: "token_1",
+		streamIndex: 32,
+		status: "running",
+		lastEventAt: 0,
+		pendingRequests: [],
+	},
+	threadKey: "sandbox:slack:T1:C1:thread_1",
+});
+
+const consume = () =>
+	consumeAgentTurn({
+		auth: {} as never,
+		env: AppEnv.Sandbox,
+		logger: { error: () => {}, info: () => {}, warn: () => {} } as never,
+		onAction: async () => undefined,
+		orgId: "org_1",
+		session: session(),
+		token: "t",
+	} as never);
+
+describe("a withdrawal that eve defers is redelivered", () => {
+	beforeEach(() => {
+		parentStreamCalls = 0;
+		repostedMessages = [];
+	});
+
+	test("the parked no-op turn does not silently swallow the message", async () => {
+		// Exactly what eve emits for a deferred message: a turn that starts,
+		// receives, completes and parks without ever doing any work.
+		parentPasses = [
+			[
+				event({ type: "turn.started" }),
+				event({ type: "message.received" }),
+				event({ type: "turn.completed" }),
+				event({ type: "session.waiting" }),
+			],
+		];
+
+		const outcome = await consume();
+
+		// A bare park after a withdrawal means the message is sitting in eve's
+		// deferredStepInput. Leaf must redeliver it rather than report silence.
+		expect(outcome).not.toMatchObject({ kind: "silent" });
+	});
+});


### PR DESCRIPTION
`mcp-attach-approval` fails intermittently. Same commit `f7881a10`, minutes apart: the **push** run failed, the **pull_request** run passed. An earlier failure on `1fd174e8` is now green after a re-run. Rate is 1 in 14.

## Root cause

The conversation sent a confirm message unconditionally after the message that raises the card:

```ts
user("Please attach the Pro plan to Atlas Labs. Preview it first, then attach it after approval."),
user("Looks good, attach it."),   // races the card
approve(),
```

A second user message **withdraws pending approvals** — the supersede path. When it lands before the gate exists, `approve()` finds nothing to answer and the write never fires:

```
10:39:10  [approval] pending
10:39:10  [user] Looks good, attach it.     <- withdraws the gate
10:39:13  approved pending tool call
10:39:16  [eval] finished                   <- attach never issued
          Expected API calls: 0
```

When it lands after, everything works. Pure timing.

## The fix

The first message already asks for preview-then-attach, so the confirm turn only contributed the race. Removing it matches `boolean-feature-removed`, which has never flaked.

`approve({ optional: false })` — borrowed from `update-email` — makes this **stricter** than before: a missing gate is now a hard failure rather than a silent skip.

All five assertions are unchanged: `tools.called` (5 tools incl. `attach`), `billing.previewBeforeWrite`, `api.calledAfterApproval`, `response.mentions`, plus `billingAttachScores`.

## Verification

5 consecutive local runs, exactly one `attach` each, **12/12 scorers at 100%**.

```
run 1: exit=0 attach_calls=1
run 2: exit=0 attach_calls=1
run 3: exit=0 attach_calls=1
run 4: exit=0 attach_calls=1
```

## Not fixed here

`checkout.eval.ts` has the same `user → user → approve()` shape, but has never failed — including in the run where this one did. Changing a green test on suspicion alone isn't warranted; worth revisiting if it starts flaking.

The other observed failure mode is a 45s `EVAL_TIMEOUT_MS` exhaustion (`initEval.ts:95`) on a 4-turn flow that normally takes ~28s. Separate issue, separate fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three timing bugs in the approval path: a racing approval gate, a turn killed by the caller's timeout while quiet, and a subagent approval withdrawal that silently dropped the user's message.

- The confirm message withdrew the pending gate before `approve()` could answer; `optional: false` now hard-fails on a missing gate.
- Silence with no active children settles at 2.5 minutes — inside `runSlackAgentTurn`'s 3m20s backstop — so leaf answers before being killed; active children still vouch for a quiet parent.
- Withdrawing a subagent's approval card routes the user's message to a parent with no pending batch, which parks and never delivers it; that state is now detected as `deferred` and the message is reposted once so eve consumes its own deferred input.
- `leaf.eve_turn_abandoned` now logs `quiet_ms`, no longer inferred from absent logs.
- New tests cover the quiet cap with a fake clock and the deferred-park redelivery; `checkout.eval.ts` shares the approval shape but never flaked, so it's untouched.

<sup>Written for commit 3da6b1bb15495246b7b62185e824cd67cded86a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR improves Leaf’s handling of quiet and deferred agent turns while removing a race from the MCP approval evaluation.
- **[Bug fixes]** Settles quiet turns before the surrounding Slack request timeout, while allowing active delegated work to continue.
- **[Bug fixes]** Detects a message deferred during approval withdrawal and redelivers it once.
- **[Improvements]** Records quiet duration when an Eve turn is abandoned and adds focused timing and withdrawal regression tests.
- **[Bug fixes]** Removes the extra confirmation message from the attach-approval evaluation and requires an approval gate to exist.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts | Adds a wall-clock quiet-turn cap, exempts turns with active children, and records quiet duration during abandonment. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts | Introduces a deferred outcome for empty terminal turns matching the approval-withdrawal parking shape. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts | Redelivers a deferred user message once and converts a repeated deferral into the existing silent outcome. |
| apps/leaf/tests/evals/agent/mcp/attach-approval.eval.ts | Removes the racing confirmation turn and makes the approval step mandatory. |
| apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts | Tests quiet-cap settlement and verifies that active child work suppresses the cap. |
| apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts | Covers recognition of the empty turn produced when approval withdrawal defers the parent message. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Leaf
    participant Eve
    participant Child as Eve child session

    User->>Leaf: Send message or approval response
    Leaf->>Eve: Start agent turn
    alt Parent message is deferred during child approval handling
        Eve->>Child: Route approval response
        Eve-->>Leaf: Empty terminal turn
        Leaf->>Eve: Redeliver original message once
        Eve-->>Leaf: Consume resulting turn
    else Turn remains quiet without active children
        Eve-->>Leaf: Idle stream windows
        Leaf->>Leaf: Settle after quiet cap
    else Child remains active
        Eve->>Child: Continue delegated work
        Child-->>Leaf: Activity keeps parent alive
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: 🐛 withdrawing a subagent&#39;s card no..."](https://github.com/useautumn/autumn/commit/3da6b1bb15495246b7b62185e824cd67cded86a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57461017)</sub>

<!-- /greptile_comment -->