### PR TITLE
perf(logging): compact check and track responses

### DIFF
--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -5,13 +5,13 @@ import { addExtrasToLogs } from "@/utils/logging/addContextToLogs.js";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
 
 const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
-	// "/v1/balances.track",
-	// "/v1/balances.check",
-	// "/v1/check",
-	// "/v1/track",
-	// "/v1/customers.get_or_create",
-	// "/v1/entities.get",
+	"/v1/balances.track",
+	"/v1/balances.check",
+	"/v1/check",
+	"/v1/track",
 ]);
+
+const SLOW_REQUEST_BODY_THRESHOLD_MS = 500;
 
 // Event pages run to megabytes each, dwarfing every other route's ingest.
 const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
@@ -19,13 +19,65 @@ const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
 	"/v1/events.list",
 ]);
 
-const SUCCESS_REQUEST_LOG_SAMPLE_RATE = Number.parseFloat(
-	process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ?? "0",
+const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = Number.parseFloat(
+	process.env.AXIOM_SUCCESS_RESPONSE_BODY_SAMPLE_RATE ??
+		process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ??
+		"0.01",
 );
 
-const shouldSampleSuccessLog = () =>
-	SUCCESS_REQUEST_LOG_SAMPLE_RATE > 0 &&
-	Math.random() < Math.min(SUCCESS_REQUEST_LOG_SAMPLE_RATE, 1);
+const shouldSampleSuccessResponseBody = () =>
+	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
+	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
+
+const COMPACT_RESPONSE_FIELDS = new Set([
+	"allowed",
+	"code",
+	"feature_id",
+	"required_balance",
+	"value",
+]);
+const COMPACT_BALANCE_FIELDS = new Set([
+	"feature_id",
+	"plan_id",
+	"usage",
+	"granted",
+	"remaining",
+	"current_balance",
+	"unlimited",
+	"overage_allowed",
+	"next_reset_at",
+]);
+
+const compactFields = ({
+	value,
+	fields,
+}: {
+	value: Record<string, unknown>;
+	fields: Set<string>;
+}) =>
+	Object.fromEntries(
+		Object.entries(value).filter(([field]) => fields.has(field)),
+	);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const compactHighVolumeResponseBody = (
+	responseBody: Record<string, unknown>,
+) => {
+	const compactResponseBody = compactFields({
+		value: responseBody,
+		fields: COMPACT_RESPONSE_FIELDS,
+	});
+	if (responseBody.balance === null) compactResponseBody.balance = null;
+	if (isRecord(responseBody.balance)) {
+		compactResponseBody.balance = compactFields({
+			value: responseBody.balance,
+			fields: COMPACT_BALANCE_FIELDS,
+		});
+	}
+	return compactResponseBody;
+};
 
 export const logRequestResult = async ({
 	ctx,
@@ -51,20 +103,24 @@ export const logRequestResult = async ({
 		const isHighVolumeSuccess =
 			isSuccess && HIGH_VOLUME_SUCCESS_ROUTES.has(c.req.path);
 
-		if (isHighVolumeSuccess && !shouldSampleSuccessLog()) {
-			return;
-		}
-
 		ctx.logger = addExtrasToLogs({
 			logger: ctx.logger,
 			extras: ctx.extraLogs,
 		});
 
-		const skipResponseBody =
+		const excludeResponseBody =
 			isSuccess && RESPONSE_BODY_EXCLUDED_ROUTES.has(c.req.path);
+		const compactResponseBody =
+			isHighVolumeSuccess &&
+			durationMs < SLOW_REQUEST_BODY_THRESHOLD_MS &&
+			!shouldSampleSuccessResponseBody();
 
-		let finalResponseBody = skipResponseBody ? null : responseBody;
-		if (finalResponseBody === undefined && c.req.path.includes("/v1")) {
+		let finalResponseBody = excludeResponseBody ? null : responseBody;
+		if (
+			!excludeResponseBody &&
+			finalResponseBody === undefined &&
+			c.req.path.includes("/v1")
+		) {
 			const contentType = c.res.headers.get("content-type");
 			if (contentType?.includes("application/json")) {
 				try {
@@ -73,6 +129,10 @@ export const logRequestResult = async ({
 					finalResponseBody = null;
 				}
 			}
+		}
+
+		if (compactResponseBody && isRecord(finalResponseBody)) {
+			finalResponseBody = compactHighVolumeResponseBody(finalResponseBody);
 		}
 
 		const log = isSuccess ? ctx.logger.info : ctx.logger.warn;

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -47,6 +47,19 @@ const COMPACT_BALANCE_FIELDS = new Set([
 	"overage_allowed",
 	"next_reset_at",
 ]);
+const COMPACT_DEDUCTION_FIELDS = new Set([
+	"balance_id",
+	"feature_id",
+	"plan_id",
+	"reset",
+	"value",
+]);
+const COMPACT_FLAG_FIELDS = new Set([
+	"id",
+	"feature_id",
+	"plan_id",
+	"expires_at",
+]);
 
 const compactFields = ({
 	value,
@@ -74,6 +87,37 @@ const compactHighVolumeResponseBody = (
 		compactResponseBody.balance = compactFields({
 			value: responseBody.balance,
 			fields: COMPACT_BALANCE_FIELDS,
+		});
+	}
+	if (isRecord(responseBody.balances)) {
+		const balances: Record<string, Record<string, unknown> | null> = {};
+		for (const [featureId, balance] of Object.entries(responseBody.balances)) {
+			if (balance === null) {
+				balances[featureId] = null;
+			} else if (isRecord(balance)) {
+				balances[featureId] = compactFields({
+					value: balance,
+					fields: COMPACT_BALANCE_FIELDS,
+				});
+			}
+		}
+		compactResponseBody.balances = balances;
+	}
+	if (Array.isArray(responseBody.deductions)) {
+		compactResponseBody.deductions = responseBody.deductions
+			.filter(isRecord)
+			.map((deduction) =>
+				compactFields({
+					value: deduction,
+					fields: COMPACT_DEDUCTION_FIELDS,
+				}),
+			);
+	}
+	if (responseBody.flag === null) compactResponseBody.flag = null;
+	if (isRecord(responseBody.flag)) {
+		compactResponseBody.flag = compactFields({
+			value: responseBody.flag,
+			fields: COMPACT_FLAG_FIELDS,
 		});
 	}
 	return compactResponseBody;

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -12,6 +12,7 @@ const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
 ]);
 
 const SLOW_REQUEST_BODY_THRESHOLD_MS = 500;
+const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = 0.01;
 
 // Event pages run to megabytes each, dwarfing every other route's ingest.
 const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
@@ -19,15 +20,8 @@ const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
 	"/v1/events.list",
 ]);
 
-const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = Number.parseFloat(
-	process.env.AXIOM_SUCCESS_RESPONSE_BODY_SAMPLE_RATE ??
-		process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ??
-		"0.01",
-);
-
 const shouldSampleSuccessResponseBody = () =>
-	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
-	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
+	Math.random() < SUCCESS_RESPONSE_BODY_SAMPLE_RATE;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -29,96 +29,36 @@ const shouldSampleSuccessResponseBody = () =>
 	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
 	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
 
-const COMPACT_RESPONSE_FIELDS = new Set([
-	"allowed",
-	"code",
-	"feature_id",
-	"required_balance",
-	"value",
-]);
-const COMPACT_BALANCE_FIELDS = new Set([
-	"feature_id",
-	"plan_id",
-	"usage",
-	"granted",
-	"remaining",
-	"current_balance",
-	"unlimited",
-	"overage_allowed",
-	"next_reset_at",
-]);
-const COMPACT_DEDUCTION_FIELDS = new Set([
-	"balance_id",
-	"feature_id",
-	"plan_id",
-	"reset",
-	"value",
-]);
-const COMPACT_FLAG_FIELDS = new Set([
-	"id",
-	"feature_id",
-	"plan_id",
-	"expires_at",
-]);
-
-const compactFields = ({
-	value,
-	fields,
-}: {
-	value: Record<string, unknown>;
-	fields: Set<string>;
-}) =>
-	Object.fromEntries(
-		Object.entries(value).filter(([field]) => fields.has(field)),
-	);
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stripLargeFields = (value: unknown) => {
+	if (!isRecord(value)) return value;
+	const compactValue = { ...value };
+	delete compactValue.breakdown;
+	delete compactValue.feature;
+	delete compactValue.rollovers;
+	return compactValue;
+};
 
 const compactHighVolumeResponseBody = (
 	responseBody: Record<string, unknown>,
 ) => {
-	const compactResponseBody = compactFields({
-		value: responseBody,
-		fields: COMPACT_RESPONSE_FIELDS,
-	});
-	if (responseBody.balance === null) compactResponseBody.balance = null;
-	if (isRecord(responseBody.balance)) {
-		compactResponseBody.balance = compactFields({
-			value: responseBody.balance,
-			fields: COMPACT_BALANCE_FIELDS,
-		});
+	const compactResponseBody = { ...responseBody };
+	delete compactResponseBody.preview;
+	if ("balance" in compactResponseBody) {
+		compactResponseBody.balance = stripLargeFields(responseBody.balance);
 	}
 	if (isRecord(responseBody.balances)) {
-		const balances: Record<string, Record<string, unknown> | null> = {};
-		for (const [featureId, balance] of Object.entries(responseBody.balances)) {
-			if (balance === null) {
-				balances[featureId] = null;
-			} else if (isRecord(balance)) {
-				balances[featureId] = compactFields({
-					value: balance,
-					fields: COMPACT_BALANCE_FIELDS,
-				});
-			}
-		}
-		compactResponseBody.balances = balances;
+		compactResponseBody.balances = Object.fromEntries(
+			Object.entries(responseBody.balances).map(([featureId, balance]) => [
+				featureId,
+				stripLargeFields(balance),
+			]),
+		);
 	}
-	if (Array.isArray(responseBody.deductions)) {
-		compactResponseBody.deductions = responseBody.deductions
-			.filter(isRecord)
-			.map((deduction) =>
-				compactFields({
-					value: deduction,
-					fields: COMPACT_DEDUCTION_FIELDS,
-				}),
-			);
-	}
-	if (responseBody.flag === null) compactResponseBody.flag = null;
-	if (isRecord(responseBody.flag)) {
-		compactResponseBody.flag = compactFields({
-			value: responseBody.flag,
-			fields: COMPACT_FLAG_FIELDS,
-		});
+	if ("flag" in compactResponseBody) {
+		compactResponseBody.flag = stripLargeFields(responseBody.flag);
 	}
 	return compactResponseBody;
 };

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -251,19 +251,27 @@ describe("logRequestResult", () => {
 	test("keeps compact multi-feature track diagnostics", async () => {
 		spyOn(Math, "random").mockReturnValue(0.5);
 		const responseBody = {
+			customer_id: "cus_123",
+			event_name: "api_call",
 			value: 45.67,
 			balance: null,
 			balances: {
 				action1: {
+					object: "balance",
 					feature_id: "action1",
 					current_balance: 154.33,
 					usage: 45.67,
+					max_purchase: null,
+					feature: { id: "action1", name: "Action 1" },
 					breakdown: [{ id: "cus_ent_action1" }],
+					rollovers: [{ id: "rollover_action1" }],
 				},
 				action3: {
+					object: "balance",
 					feature_id: "action3",
 					current_balance: 104.33,
 					usage: 45.67,
+					max_purchase: null,
 					breakdown: [{ id: "cus_ent_action3" }],
 				},
 			},
@@ -274,15 +282,15 @@ describe("logRequestResult", () => {
 					plan_id: "free",
 					reset: null,
 					value: 45.67,
-					unexpected: "drop-me",
 				},
 			],
 			flag: {
+				object: "flag",
 				id: "cus_ent_flag",
 				feature_id: "premium",
 				plan_id: "free",
 				expires_at: null,
-				unexpected: "drop-me",
+				feature: { id: "premium", name: "Premium" },
 			},
 		};
 		const { captured } = await captureJsonResponse({
@@ -295,18 +303,24 @@ describe("logRequestResult", () => {
 			statusCode: 200,
 			durationMs: 10,
 			res: {
+				customer_id: "cus_123",
+				event_name: "api_call",
 				value: 45.67,
 				balance: null,
 				balances: {
 					action1: {
+						object: "balance",
 						feature_id: "action1",
 						current_balance: 154.33,
 						usage: 45.67,
+						max_purchase: null,
 					},
 					action3: {
+						object: "balance",
 						feature_id: "action3",
 						current_balance: 104.33,
 						usage: 45.67,
+						max_purchase: null,
 					},
 				},
 				deductions: [
@@ -319,6 +333,7 @@ describe("logRequestResult", () => {
 					},
 				],
 				flag: {
+					object: "flag",
 					id: "cus_ent_flag",
 					feature_id: "premium",
 					plan_id: "free",

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { Context } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { logRequestResult } from "@/honoMiddlewares/requestLogging/logRequestResult.js";
@@ -47,18 +47,55 @@ const mergeLoggedObjects = (args: unknown[]) =>
 		),
 	);
 
+const captureJsonResponse = async ({
+	path,
+	durationMs,
+	responseBody,
+}: {
+	path: string;
+	durationMs: number;
+	responseBody: Record<string, unknown>;
+}) => {
+	const captured: CapturedLog[] = [];
+	let cloneCount = 0;
+	const ctx = {
+		timestamp: 123,
+		logger: createCapturingLogger({ captured }),
+		extraLogs: {},
+		org: { slug: "test-org" },
+	} as unknown as AutumnContext;
+	const c = {
+		req: { path },
+		res: {
+			status: 200,
+			headers: new Headers({ "content-type": "application/json" }),
+			clone: () => {
+				cloneCount++;
+				return { json: async () => responseBody };
+			},
+		},
+	} as unknown as Context<HonoEnv>;
+
+	await logRequestResult({ ctx, c, durationMs });
+	return { captured, cloneCount };
+};
+
+afterEach(() => {
+	mock.restore();
+});
+
 describe("logRequestResult", () => {
 	test("logs the request body without rebinding request metadata", async () => {
 		const captured: CapturedLog[] = [];
 		const requestLogContext: LogRequestContext = {
 			id: "req_123",
 			method: "POST",
-			url: "https://api.useautumn.com/v1/check",
+			url: "https://api.useautumn.com/v1/customers.get",
 			timestamp: 123,
 			customer_id: "cus_123",
 			query: {},
 			body: { feature_id: "messages" },
-			name: "POST /v1/check",
+			name: "POST /v1/customers.get",
 		};
 		const internalRequestContext = {
 			id: requestLogContext.id,
@@ -80,7 +117,7 @@ describe("logRequestResult", () => {
 			org: { slug: "test-org" },
 		} as unknown as AutumnContext;
 		const c = {
-			req: { path: "/v1/check" },
+			req: { path: "/v1/customers.get" },
 			res: {
 				status: 200,
 				headers: new Headers({ "content-type": "application/json" }),
@@ -172,7 +209,78 @@ describe("logRequestResult", () => {
 		});
 	});
 
-	test("still reads and logs successful JSON response bodies when not supplied", async () => {
+	test("compacts an unsampled fast high-volume response", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = {
+			allowed: true,
+			required_balance: 1,
+			preview: { scenario: "upgrade" },
+			balance: {
+				feature_id: "messages",
+				remaining: 90,
+				usage: 10,
+				granted: 100,
+				overage_allowed: false,
+				breakdown: [{ id: "cus_ent_123", remaining: 90 }],
+			},
+		};
+		const { captured, cloneCount } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(cloneCount).toBe(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: {
+				allowed: true,
+				required_balance: 1,
+				balance: {
+					feature_id: "messages",
+					remaining: 90,
+					usage: 10,
+					granted: 100,
+					overage_allowed: false,
+				},
+			},
+		});
+	});
+
+	test("keeps a sampled fast high-volume response in full", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const responseBody = { allowed: true, balance: { remaining: 90 } };
+		const { captured } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: responseBody,
+		});
+	});
+
+	test("keeps a slow high-volume response in full", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = { allowed: true, balance: { remaining: 90 } };
+		const { captured } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 500,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 500,
+			res: responseBody,
+		});
+	});
+
+	test("still reads and logs successful JSON response bodies for other routes", async () => {
 		const captured: CapturedLog[] = [];
 		const responseBody = { allowed: true, balance: 90 };
 		let cloneCount = 0;
@@ -183,7 +291,7 @@ describe("logRequestResult", () => {
 			org: { slug: "test-org" },
 		} as unknown as AutumnContext;
 		const c = {
-			req: { path: "/v1/check" },
+			req: { path: "/v1/customers.get" },
 			res: {
 				status: 200,
 				headers: new Headers({ "content-type": "application/json" }),

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -248,6 +248,86 @@ describe("logRequestResult", () => {
 		});
 	});
 
+	test("keeps compact multi-feature track diagnostics", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = {
+			value: 45.67,
+			balance: null,
+			balances: {
+				action1: {
+					feature_id: "action1",
+					current_balance: 154.33,
+					usage: 45.67,
+					breakdown: [{ id: "cus_ent_action1" }],
+				},
+				action3: {
+					feature_id: "action3",
+					current_balance: 104.33,
+					usage: 45.67,
+					breakdown: [{ id: "cus_ent_action3" }],
+				},
+			},
+			deductions: [
+				{
+					balance_id: "cus_ent_action1",
+					feature_id: "action1",
+					plan_id: "free",
+					reset: null,
+					value: 45.67,
+					unexpected: "drop-me",
+				},
+			],
+			flag: {
+				id: "cus_ent_flag",
+				feature_id: "premium",
+				plan_id: "free",
+				expires_at: null,
+				unexpected: "drop-me",
+			},
+		};
+		const { captured } = await captureJsonResponse({
+			path: "/v1/track",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: {
+				value: 45.67,
+				balance: null,
+				balances: {
+					action1: {
+						feature_id: "action1",
+						current_balance: 154.33,
+						usage: 45.67,
+					},
+					action3: {
+						feature_id: "action3",
+						current_balance: 104.33,
+						usage: 45.67,
+					},
+				},
+				deductions: [
+					{
+						balance_id: "cus_ent_action1",
+						feature_id: "action1",
+						plan_id: "free",
+						reset: null,
+						value: 45.67,
+					},
+				],
+				flag: {
+					id: "cus_ent_flag",
+					feature_id: "premium",
+					plan_id: "free",
+					expires_at: null,
+				},
+			},
+		});
+	});
+
 	test("keeps a sampled fast high-volume response in full", async () => {
 		spyOn(Math, "random").mockReturnValue(0);
 		const responseBody = { allowed: true, balance: { remaining: 90 } };


### PR DESCRIPTION
## Summary
- keep a terminal record for every check and track request
- retain full response bodies for a 1% fast-success sample, all non-2xx responses, and all responses taking at least 500 ms
- compact other fast-success bodies to an explicit allowlist of decision and core balance fields

## Why
Axiom currently receives full check and track response bodies at high volume. This preserves product visibility while removing large preview and balance breakdown payloads from the common path.

## Verification
- focused logRequestResult unit tests: 10 passed
- server typecheck: passed
- Biome check: passed
- commit hooks: knip and server typecheck passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compacts successful check, track, and balances response bodies before logging so Axiom ingest drops large preview, breakdown, feature, and rollover payloads while terminal records stay informative. Previously fast successes on these routes were sampled away entirely; now every one is logged, with full bodies kept for a 1% sample, responses taking ≥500 ms, or non-2xx responses.

- Fast successes keep decision, balance, deduction, and flag fields; the full-body sample rate is fixed at 0.01, replacing the `AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE` gate.
- Covers `/v1/check`, `/v1/track`, `/v1/balances.check`, and `/v1/balances.track`.
- Unit tests cover compaction, sampling, slow, and multi-feature paths.

<sup>Written for commit 44fcd5f0ae9431e8ac3b76bbf0bfd0c5257158f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces logging volume for high-traffic check and track endpoints while retaining useful diagnostics and complete responses for exceptional cases.

- **Improvements:** Logs every terminal check and track result, compacting fast successful responses while preserving balances, deductions, flags, and core decision fields.
- **Improvements:** Retains full response bodies for sampled requests, slow requests, and non-success responses.
- **Bug fixes:** Restores the balance, deduction, and flag diagnostics omitted by the earlier compaction implementation.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/requestLogging/logRequestResult.ts | Adds selective response compaction and sampling while retaining full bodies for slow, sampled, and unsuccessful requests. |
| server/tests/unit/logging/logRequestResult.test.ts | Verifies compact, sampled, slow, multi-feature, and ordinary-route logging behavior. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Check or track response] --> B{Successful and high volume?}
  B -- No --> F[Log full response]
  B -- Yes --> C{Slow or sampled?}
  C -- Yes --> F
  C -- No --> D[Remove preview and large nested fields]
  D --> E[Log compact terminal response]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(logging): fix response sample r..."](https://github.com/useautumn/autumn/commit/44fcd5f0ae9431e8ac3b76bbf0bfd0c5257158f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57461168)</sub>

<!-- /greptile_comment -->