### PR TITLE
release

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -29,6 +29,9 @@ const MAX_IDLE_RETRIES = 20;
 /** Each idle window is 2 minutes, so this bounds a quiet turn at ~6 minutes
  * before leaf answers with whatever it has. */
 const MAX_IDLE_RESYNCS = 3;
+/** Settle before the caller's own wall-clock backstop, so a turn eve never
+ * resumes is answered by leaf rather than killed mid-recovery. */
+const MAX_QUIET_MS = ms.minutes(2.5);
 /** The ceiling on a single turn however busy it looks: a stream that dribbles
  * one event per idle window would otherwise reset the resync budget forever. */
 const MAX_TURN_DURATION_MS = ms.minutes(15);
@@ -167,6 +170,7 @@ const settleExhaustedTurn = ({
 		event: "leaf.eve_turn_abandoned",
 		data: {
 			has_partial_text: Boolean(partialText),
+			quiet_ms: activity.msSinceActivity(),
 			session_id: session.sessionId,
 			stream_index: session.state.streamIndex,
 			turn_ms: activity.msSinceStart(),
@@ -285,7 +289,10 @@ export const consumeAgentTurn = async ({
 				});
 			}
 
-			if (activity.msSinceStart() >= MAX_TURN_DURATION_MS) {
+			const quietTooLong =
+				activity.activeChildren() === 0 &&
+				activity.msSinceActivity() >= MAX_QUIET_MS;
+			if (activity.msSinceStart() >= MAX_TURN_DURATION_MS || quietTooLong) {
 				return settleExhaustedTurn({ activity, logger, turn });
 			}
 

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
@@ -33,6 +33,7 @@ import { catalogPlanNeedingDecision } from "../../resolveCatalogDecision/catalog
 export type EveTurnOutcome =
 	| { kind: "answered"; catalogDecision?: CatalogPlanPreview; text: string }
 	| { kind: "parked"; question?: PendingQuestion; text: string }
+	| { kind: "deferred" }
 	| { kind: "silent" }
 	| { kind: "stopped"; stopReason: RunStopReason; text: string }
 	| { approval: AgentApprovalRequest; kind: "suspended"; text: string }
@@ -315,6 +316,14 @@ const reduceInputRequest = ({
 	};
 };
 
+/** Eve parks holding the message when a delivery answers a subagent's park:
+ * the responses route to the child and the message lands on a parent with no
+ * pending batch, so the turn starts, receives and completes without working. */
+const turnDeferredItsInput = (progress: EveTurnProgress) =>
+	progress.turnStarted &&
+	progress.toolLabels.size === 0 &&
+	progress.subagentChildSessionIds.size === 0;
+
 const reduceTerminalEvent = ({
 	event,
 	progress,
@@ -335,7 +344,7 @@ const reduceTerminalEvent = ({
 		],
 		outcome: eveTurnProducedOutput({ catalogDecision, text })
 			? { catalogDecision, kind: "answered", text }
-			: { kind: "silent" },
+			: { kind: turnDeferredItsInput(progress) ? "deferred" : "silent" },
 		progress,
 	};
 };

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -4,6 +4,7 @@ import type {
 	AgentTurnContext,
 	AgentTurnParams,
 } from "../../domain/agentTurnContext.js";
+import { postEveMessage } from "../../eve/client.js";
 import type { EveAuthContext, EveSessionRef } from "../../eve/types.js";
 import {
 	generateThreadTitle,
@@ -119,11 +120,38 @@ export const runAgentTurn = async ({
 			});
 			return startFresh();
 		});
-		const outcome = await consume(session).catch(async (error) => {
+		let outcome = await consume(session).catch(async (error) => {
 			await recoverLostSession({ ctx, error, existingSession, session });
 			session = await startFresh();
 			return consume(session);
 		});
+		if (outcome.kind === "deferred") {
+			logger.warn("Eve parked holding the message; redelivering", {
+				event: "leaf.eve_deferred_input_redelivered",
+				data: {
+					session_id: session.sessionId,
+					stream_index: session.state.streamIndex,
+				},
+			});
+			await postEveMessage({
+				auth: { ...auth, orgInstructions: prepared.orgContext?.instructions },
+				message: buildAgentTurnMessage({
+					env,
+					isAdminInstall: isInternalAutumnSlackProvider({
+						provider: thread.provider,
+					}),
+					newSession: false,
+					orgSlug: org.slug,
+					params,
+				}),
+				session,
+			});
+			const redelivered = await consume(session);
+			// One redelivery is the fix; a second park is eve failing to consume
+			// its own deferred input, and must not read as a fresh deferral.
+			outcome =
+				redelivered.kind === "deferred" ? { kind: "silent" } : redelivered;
+		}
 		const result = await resolveAgentTurnOutcome({
 			env,
 			logger,

--- a/apps/leaf/tests/evals/agent/mcp/attach-approval.eval.ts
+++ b/apps/leaf/tests/evals/agent/mcp/attach-approval.eval.ts
@@ -60,13 +60,14 @@ initEval<EvalMetadata>({
 	cases: [
 		{
 			name: "destructive attach waits for approval",
+			// No confirm turn: a second message races the card it would confirm,
+			// withdrawing the gate the approval is meant to answer.
 			conversation: [
 				user({
 					message:
 						"Please attach the Pro plan to Atlas Labs. Preview it first, then attach it after approval.",
 				}),
-				user({ message: "Looks good, attach it." }),
-				approve(),
+				approve({ optional: false }),
 			],
 			expect: [
 				tools.called({

--- a/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
+++ b/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
@@ -1,0 +1,272 @@
+/**
+ * The parent-quiet cap in consumeAgentTurn: a turn with NO live child that has
+ * been silent past MAX_QUIET_MS (2.5 min) settles on the clock, not after the
+ * MAX_IDLE_RESYNCS (3) budget is spent.
+ *
+ * The existing idle-stream-recovery suite cannot see this: its mock stream
+ * never advances any clock, so msSinceActivity() is always ~0 and the resync
+ * budget always wins. Here the mock stream advances a FAKE clock between
+ * passes, so quiet time grows without real waiting, and the two paths settle
+ * at different pass counts with different quiet_ms.
+ *
+ * Discriminating signal (per-pass advance = 80s):
+ *  - with the quiet cap: settles after 2 parent passes, quiet_ms ~160_000
+ *  - without it:         settles after 4 parent passes, quiet_ms ~320_000
+ */
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	setSystemTime,
+	test,
+} from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { EveEvent } from "../../../src/internal/agentRuntime/eve/eveEventSchemas.js";
+import type { EveSessionRef } from "../../../src/internal/agentRuntime/eve/types.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/env.js", () => ({ env: {} }));
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+class MockEveStreamDisconnectedError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveStreamDisconnectedError";
+	}
+}
+class MockEveStreamIdleTimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveStreamIdleTimeoutError";
+	}
+}
+
+const TURN_START = new Date("2026-08-26T10:00:00Z");
+const QUIET_CAP_MS = 150_000;
+const PASS_ADVANCE_MS = 80_000;
+
+let nowMs = TURN_START.getTime();
+const advanceClock = (byMs: number) => {
+	nowMs += byMs;
+	setSystemTime(new Date(nowMs));
+};
+
+type StreamPass = { events: EveEvent[]; thenThrow?: "idle" | "disconnect" };
+
+let streamPasses: StreamPass[] = [];
+let childEvents: EveEvent[] = [];
+let childKeepsStreaming = true;
+let parentStreamCalls = 0;
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/client.js",
+	factory: () => ({
+		EveSessionDeadError: class extends Error {},
+		EveStreamDisconnectedError: MockEveStreamDisconnectedError,
+		EveStreamIdleTimeoutError: MockEveStreamIdleTimeoutError,
+		fastForwardEveStreamIndex: async () => undefined,
+		isEveTransportLost: (error: unknown) =>
+			error instanceof MockEveStreamDisconnectedError ||
+			error instanceof MockEveStreamIdleTimeoutError,
+		resyncEveStreamIndex: async () => undefined,
+		streamEveEvents: async function* ({ session }: { session: EveSessionRef }) {
+			if (session.sessionId.startsWith("wrun_child")) {
+				for (const event of childEvents) {
+					yield event;
+					await new Promise((resolve) => setTimeout(resolve, 1));
+				}
+				if (childKeepsStreaming) await new Promise(() => undefined);
+				throw new MockEveStreamIdleTimeoutError("child idle");
+			}
+			const pass = streamPasses[
+				Math.min(parentStreamCalls, streamPasses.length - 1)
+			] ?? { events: [] };
+			parentStreamCalls += 1;
+			for (const event of pass.events) yield event;
+			// A real idle window burns wall-clock before it throws.
+			advanceClock(PASS_ADVANCE_MS);
+			if (pass.thenThrow === "idle") {
+				throw new MockEveStreamIdleTimeoutError("Eve stream idle timeout");
+			}
+			if (pass.thenThrow === "disconnect") {
+				throw new MockEveStreamDisconnectedError("socket closed");
+			}
+		},
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/sessionState.js",
+	factory: () => ({
+		advanceStreamCursor: (session: EveSessionRef) => {
+			session.state.streamIndex += 1;
+		},
+		saveEveSessionState: async () => undefined,
+		statusAfterTerminalEvent: (eventType: string) =>
+			eventType === "session.completed" ? "completed" : "waiting",
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/repo.js",
+	factory: () => ({ deleteEveSession: async () => undefined }),
+});
+
+const { consumeAgentTurn } = await import(
+	"../../../src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.js"
+);
+
+const event = (partial: Record<string, unknown>) =>
+	partial as unknown as EveEvent;
+
+const session = (): EveSessionRef => ({
+	env: AppEnv.Sandbox,
+	newSession: false,
+	sessionId: "eve_session_1",
+	state: {
+		version: 1,
+		continuationToken: "token_1",
+		streamIndex: 33,
+		status: "running",
+		lastEventAt: 0,
+		pendingRequests: [],
+	},
+	threadKey: "sandbox:slack:T1:C1:thread_1",
+});
+
+type AbandonedLog = { quiet_ms: number; turn_ms: number };
+
+const consumeAndCaptureAbandon = async () => {
+	const abandoned: AbandonedLog[] = [];
+	const logger = {
+		error: (
+			_message: string,
+			meta?: { event?: string; data?: AbandonedLog },
+		) => {
+			if (meta?.event === "leaf.eve_turn_abandoned" && meta.data) {
+				abandoned.push(meta.data);
+			}
+		},
+		info: () => {},
+		warn: () => {},
+	};
+	const outcome = await consumeAgentTurn({
+		auth: {} as never,
+		env: AppEnv.Sandbox,
+		logger: logger as never,
+		onAction: async () => undefined,
+		orgId: "org_1",
+		session: session(),
+		token: "t",
+	} as never);
+	return { abandoned, outcome };
+};
+
+// Nine idle passes: far more than either exit path needs, so the pass count at
+// settle time is decided purely by which condition fired.
+const nineQuietPasses = (first: EveEvent[]): StreamPass[] => [
+	{ events: first, thenThrow: "idle" },
+	...Array.from({ length: 8 }, () => ({
+		events: [] as EveEvent[],
+		thenThrow: "idle" as const,
+	})),
+];
+
+describe("a parent quiet past the cap settles on the clock", () => {
+	beforeEach(() => {
+		parentStreamCalls = 0;
+		childEvents = [];
+		childKeepsStreaming = false;
+		nowMs = TURN_START.getTime();
+		setSystemTime(TURN_START);
+	});
+
+	afterEach(() => {
+		setSystemTime();
+	});
+
+	test("settles at the quiet cap, before the idle-resync budget is spent", async () => {
+		streamPasses = nineQuietPasses([
+			event({ type: "turn.started" }),
+			event({
+				finishReason: "stop",
+				message: "Partial answer so far.",
+				type: "message.completed",
+			}),
+		]);
+
+		const { abandoned, outcome } = await consumeAndCaptureAbandon();
+
+		expect(outcome).toMatchObject({
+			kind: "answered",
+			text: "Partial answer so far.",
+		});
+		expect(abandoned).toHaveLength(1);
+
+		// The quiet cap fires the pass after quiet time crosses 150s. Spending
+		// the 3-resync budget instead takes two more passes and >= 320s quiet.
+		expect(parentStreamCalls).toBe(2);
+
+		const [log] = abandoned;
+		expect(log.quiet_ms).toBeGreaterThanOrEqual(QUIET_CAP_MS);
+		expect(log.quiet_ms).toBeLessThan(QUIET_CAP_MS + PASS_ADVANCE_MS);
+	});
+
+	test("a live child suppresses the quiet cap even when the parent is silent", async () => {
+		// Same silent parent, but a child relay is still streaming: the turn is
+		// working, so neither the quiet cap nor the resync budget may settle it.
+		childKeepsStreaming = true;
+		childEvents = Array.from({ length: 3 }, () =>
+			event({
+				actions: [{ toolName: "autumn__previewAttach" }],
+				type: "actions.requested",
+			}),
+		);
+		streamPasses = [
+			{
+				events: [
+					event({ type: "turn.started" }),
+					event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
+				],
+				thenThrow: "idle",
+			},
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{
+				events: [
+					event({
+						finishReason: "stop",
+						message: "Done after a long delegation.",
+						type: "message.completed",
+					}),
+					event({ type: "session.waiting" }),
+				],
+			},
+		];
+
+		const { abandoned, outcome } = await consumeAndCaptureAbandon();
+
+		expect(abandoned).toHaveLength(0);
+		expect(outcome).toMatchObject({
+			kind: "answered",
+			text: "Done after a long delegation.",
+		});
+		// Six quiet passes at 80s each is well past the 150s cap, proving the
+		// live child — not a short clock — is what kept the turn alive.
+		expect(parentStreamCalls).toBeGreaterThan(5);
+	});
+});

--- a/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
+++ b/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Withdrawing a subagent's approval card drops the user's message.
+ *
+ * eve's routeDeliverPayload (execution/subagent-hitl-proxy.js) splits one POST:
+ * an inputResponse for a PROXIED child request goes to the child, and every
+ * other field -- including `message` -- goes to the parent. The parent has no
+ * pending batch of its own, so resolvePendingInput returns deferredMessage and
+ * parks, stashing the message in eve.runtime.deferredStepInput. It emits only
+ * turn.started / message.received / turn.completed / session.waiting and then
+ * waits for a delivery that never comes.
+ *
+ * Prod 2026-08-27 wrun_01M11DJD2N6N0BC04TQRDE3CGD: stream advanced 32 -> 37 on
+ * exactly that no-op batch, then silence to abandonment at 8m06s.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { AppEnv } from "@autumn/shared";
+import type { EveEvent } from "../../../src/internal/agentRuntime/eve/eveEventSchemas.js";
+import type { EveSessionRef } from "../../../src/internal/agentRuntime/eve/types.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+mock.module("../../../src/lib/env.js", () => ({ env: {} }));
+mock.module("../../../src/lib/db.js", () => ({ db: {} }));
+
+const mockLeafModule = ({
+	factory,
+	specifier,
+}: {
+	factory: () => Record<string, unknown>;
+	specifier: string;
+}) => mockModuleWithRestore({ baseUrl: import.meta.url, factory, specifier });
+
+class MockEveStreamIdleTimeoutError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "EveStreamIdleTimeoutError";
+	}
+}
+
+let parentPasses: EveEvent[][] = [];
+let parentStreamCalls = 0;
+let repostedMessages: unknown[] = [];
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/client.js",
+	factory: () => ({
+		EveSessionDeadError: class extends Error {},
+		EveStreamDisconnectedError: class extends Error {},
+		EveStreamIdleTimeoutError: MockEveStreamIdleTimeoutError,
+		fastForwardEveStreamIndex: async () => undefined,
+		isEveTransportLost: (error: unknown) =>
+			error instanceof MockEveStreamIdleTimeoutError,
+		postEveMessage: async ({ message }: { message?: unknown }) => {
+			repostedMessages.push(message);
+			return { continuationToken: "token_2", sessionId: "eve_session_1" };
+		},
+		resyncEveStreamIndex: async () => undefined,
+		streamEveEvents: async function* () {
+			const events = parentPasses[parentStreamCalls] ?? [];
+			parentStreamCalls += 1;
+			for (const event of events) yield event;
+			// Nothing more ever arrives on a parked session.
+			throw new MockEveStreamIdleTimeoutError("Eve stream idle timeout");
+		},
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/sessionState.js",
+	factory: () => ({
+		advanceStreamCursor: (session: EveSessionRef) => {
+			session.state.streamIndex += 1;
+		},
+		saveEveSessionState: async () => undefined,
+		statusAfterTerminalEvent: (eventType: string) =>
+			eventType === "session.completed" ? "completed" : "waiting",
+	}),
+});
+
+await mockLeafModule({
+	specifier: "../../../src/internal/agentRuntime/eve/repo.js",
+	factory: () => ({ deleteEveSession: async () => undefined }),
+});
+
+const { consumeAgentTurn } = await import(
+	"../../../src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.js"
+);
+
+const event = (partial: Record<string, unknown>) =>
+	partial as unknown as EveEvent;
+
+const session = (): EveSessionRef => ({
+	env: AppEnv.Sandbox,
+	newSession: false,
+	sessionId: "eve_session_1",
+	state: {
+		version: 1,
+		continuationToken: "token_1",
+		streamIndex: 32,
+		status: "running",
+		lastEventAt: 0,
+		pendingRequests: [],
+	},
+	threadKey: "sandbox:slack:T1:C1:thread_1",
+});
+
+const consume = () =>
+	consumeAgentTurn({
+		auth: {} as never,
+		env: AppEnv.Sandbox,
+		logger: { error: () => {}, info: () => {}, warn: () => {} } as never,
+		onAction: async () => undefined,
+		orgId: "org_1",
+		session: session(),
+		token: "t",
+	} as never);
+
+describe("a withdrawal that eve defers is redelivered", () => {
+	beforeEach(() => {
+		parentStreamCalls = 0;
+		repostedMessages = [];
+	});
+
+	test("the parked no-op turn does not silently swallow the message", async () => {
+		// Exactly what eve emits for a deferred message: a turn that starts,
+		// receives, completes and parks without ever doing any work.
+		parentPasses = [
+			[
+				event({ type: "turn.started" }),
+				event({ type: "message.received" }),
+				event({ type: "turn.completed" }),
+				event({ type: "session.waiting" }),
+			],
+		];
+
+		const outcome = await consume();
+
+		// A bare park after a withdrawal means the message is sitting in eve's
+		// deferredStepInput. Leaf must redeliver it rather than report silence.
+		expect(outcome).not.toMatchObject({ kind: "silent" });
+	});
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes three agent-turn reliability issues: silent turns now answer before the caller's timeout kills them, withdrawing a subagent's approval card no longer drops the user's message, and the attach-approval eval no longer races its own confirm card.

- Silent turns with no active child settle after 2.5 quiet minutes rather than spending the full resync budget and getting killed mid-recovery by the 3m20s caller backstop.
- A live child subagent suppresses the quiet cap, so long delegations are unaffected.
- Abandoned-turn logs now record `quiet_ms`.
- Turns that park without running any tool or subagent are classed `deferred`, and leaf reposts the message once so eve consumes its own deferred input; a second park reads as silent to avoid looping.
- The attach-approval eval drops its confirm turn, which could withdraw the pending approval before its card rendered; a missing approval card is now a hard failure.

<sup>Written for commit 5c9c0d929c87683e08ea93319e3dde945413d858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release improves recovery for quiet and deferred Eve agent turns and updates approval-related coverage.
- **Bug fixes:** Detects a parked turn that retained the user's input and redelivers the message once.
- **Improvements:** Adds a 2.5-minute inactivity backstop for turns without active child agents.
- **Improvements:** Adds regression tests for deferred-message recovery, quiet-turn limits, and approval behavior.
</details>


<h3>Confidence Score: 4/5</h3>

The deferred-message recovery should be fixed before merging because it can consume the wrong Eve session after a repost.

The normal delivery path adopts Eve's returned session ID and continuation token, while the new recovery path discards both and immediately streams using stale session state.

**Files Needing Attention:** apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts | Adds a bounded inactivity timeout while exempting turns with active child agents. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts | Introduces a deferred outcome for completed turns that started without producing output or tracked work. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts | Redelivers deferred input once, but fails to adopt the session state returned by the repost. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consume Eve turn] --> B{Outcome deferred?}
    B -- No --> C[Resolve normal outcome]
    B -- Yes --> D[Post original message again]
    D --> E[Adopt returned session state]
    E --> F[Consume redelivered turn]
    F --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts:136-149
**Repost keeps stale session**

If Eve rotates the continuation token or re-homes the session while accepting this repost, the returned session state is discarded and `consume` streams from the old session, causing the redelivered response to be missed or a later delivery to use a stale token. Adopt and persist the returned session state here as the normal message-delivery path does.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #3101 from useautumn/..."](https://github.com/useautumn/autumn/commit/5c9c0d929c87683e08ea93319e3dde945413d858) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57469721)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->