### PR TITLE
fix: use canonical blue for default sandbox favicon

### DIFF
--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -6,20 +6,21 @@ import { useEnv } from "@/utils/envUtils";
 
 const AUTUMN_MARK =
 	"M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z";
+const DEFAULT_SANDBOX_FAVICON_COLOR = "#0f9bff";
 
-const sandboxFaviconHref = (color: string) =>
+export const sandboxFaviconHref = (color?: string) =>
 	`data:image/svg+xml,${encodeURIComponent(
-		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
+		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${color ? sandboxColorValue(color) : DEFAULT_SANDBOX_FAVICON_COLOR}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
-	const color =
-		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
+	const isSandbox = env === AppEnv.Sandbox;
+	const color = activeSandbox?.color;
 
 	useEffect(() => {
-		if (!color) return;
+		if (!isSandbox) return;
 
 		const favicon = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
 		if (!favicon) return;
@@ -31,7 +32,7 @@ export const SandboxFavicon = () => {
 			if (originalHref) favicon.setAttribute("href", originalHref);
 			else favicon.removeAttribute("href");
 		};
-	}, [color]);
+	}, [color, isSandbox]);
 
 	return null;
 };

--- a/vite/tests/components/general/sandbox-favicon.test.ts
+++ b/vite/tests/components/general/sandbox-favicon.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { sandboxFaviconHref } from "@/components/general/SandboxFavicon";
+
+const faviconSvg = (color?: string) =>
+	decodeURIComponent(sandboxFaviconHref(color).split(",")[1]);
+
+describe("sandboxFaviconHref", () => {
+	test("uses the canonical blue only for the default sandbox", () => {
+		expect(faviconSvg()).toContain('fill="#0f9bff"');
+		expect(faviconSvg("blue")).toContain('fill="#2b7fff"');
+	});
+});


### PR DESCRIPTION
## Summary

- use the canonical lighter sandbox blue for the default sandbox favicon
- preserve configured colours for named sandboxes
- add focused coverage for both default and named blue favicons

## Verification

- bun test tests/components/general/sandbox-favicon.test.ts tests/hooks/sandbox/sandboxDisplay.test.ts
- bunx biome check vite/src/components/general/SandboxFavicon.tsx vite/tests/components/general/sandbox-favicon.test.ts
- bun ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses the canonical lighter sandbox blue for the default sandbox favicon instead of the named `blue` color, while preserving configured colors for named sandboxes. Adds focused coverage for both default and named blue favicons.

<sup>Written for commit a459fb658bf8d54304dd97888b01cc96e89d354b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR updates the default sandbox favicon to use the canonical lighter blue while retaining the configured color for named sandboxes.
- **[Bug fixes]** Use `#0f9bff` when a sandbox has no configured favicon color.
- **[Improvements]** Preserve named sandbox colors through the existing color mapping.
- **[Improvements]** Add focused tests distinguishing the default favicon from the named blue favicon.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intended default and configured favicon colors handled distinctly.

The favicon remains limited to fixed color values, environment transitions retain the existing cleanup behavior, and the added test directly covers the intended color distinction.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/components/general/SandboxFavicon.tsx | Separates sandbox-environment detection from the optional configured color so the canonical default blue is used only when no color is configured. |
| vite/tests/components/general/sandbox-favicon.test.ts | Verifies that the default sandbox favicon uses the lighter canonical blue while a named blue sandbox retains its configured blue. |

<sub>Reviews (1): Last reviewed commit: ["fix: use canonical blue for default sand..."](https://github.com/useautumn/autumn/commit/a459fb658bf8d54304dd97888b01cc96e89d354b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57473192)</sub>

<!-- /greptile_comment -->