### PR TITLE
Release

### DIFF
--- a/apps/leaf/package.json
+++ b/apps/leaf/package.json
@@ -42,7 +42,7 @@
 		"chat": "^4.31.0",
 		"date-fns": "^4.1.0",
 		"drizzle-orm": "catalog:",
-		"eve": "^0.16.2",
+		"eve": "0.16.2",
 		"hono": "4.12.27",
 		"lru-cache": "^11.2.7",
 		"postgres": "catalog:",

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -219,6 +219,7 @@ const outcomeForExhaustedRetries = async ({
 
 export const consumeAgentTurn = async ({
 	auth,
+	deadlineAt,
 	env,
 	logger,
 	onAction,
@@ -231,6 +232,7 @@ export const consumeAgentTurn = async ({
 	token,
 }: {
 	auth: EveAuthContext;
+	deadlineAt?: number;
 	env: AppEnv;
 	logger: AutumnLogger;
 	onAction?: EveEventContext["onAction"];
@@ -292,7 +294,13 @@ export const consumeAgentTurn = async ({
 			const quietTooLong =
 				activity.activeChildren() === 0 &&
 				activity.msSinceActivity() >= MAX_QUIET_MS;
-			if (activity.msSinceStart() >= MAX_TURN_DURATION_MS || quietTooLong) {
+			const deadlineReached =
+				deadlineAt !== undefined && Date.now() >= deadlineAt;
+			if (
+				activity.msSinceStart() >= MAX_TURN_DURATION_MS ||
+				quietTooLong ||
+				deadlineReached
+			) {
 				return settleExhaustedTurn({ activity, logger, turn });
 			}
 

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
@@ -44,6 +44,7 @@ export type EveTurnProgress = Readonly<{
 	lastPreview?: CapturedPreview;
 	pendingText: string;
 	reasoningStreamId?: string;
+	sawToolActivity: boolean;
 	subagentChildSessionIds: ReadonlySet<string>;
 	subagentStartedAtByCallId: ReadonlyMap<string, number>;
 	toolInputs: ReadonlyMap<string, Record<string, unknown>>;
@@ -72,6 +73,7 @@ export type EveTurnTransition = Readonly<{
 export const createEveTurnProgress = (): EveTurnProgress => ({
 	finalText: "",
 	pendingText: "",
+	sawToolActivity: false,
 	subagentChildSessionIds: new Set(),
 	subagentStartedAtByCallId: new Map(),
 	toolInputs: new Map(),
@@ -149,7 +151,15 @@ const reduceRequestedActions = ({
 		toolLabels.set(action.callId, label);
 		if (action.input) toolInputs.set(action.callId, action.input);
 	}
-	return { effects, progress: { ...progress, toolInputs, toolLabels } };
+	return {
+		effects,
+		progress: {
+			...progress,
+			sawToolActivity: progress.sawToolActivity || event.actions.length > 0,
+			toolInputs,
+			toolLabels,
+		},
+	};
 };
 
 const reduceActionResult = ({
@@ -321,7 +331,7 @@ const reduceInputRequest = ({
  * pending batch, so the turn starts, receives and completes without working. */
 const turnDeferredItsInput = (progress: EveTurnProgress) =>
 	progress.turnStarted &&
-	progress.toolLabels.size === 0 &&
+	!progress.sawToolActivity &&
 	progress.subagentChildSessionIds.size === 0;
 
 const reduceTerminalEvent = ({

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -91,6 +91,7 @@ export const runAgentTurn = async ({
 		run?.resolveSessionId(session.sessionId);
 		return consumeAgentTurn({
 			auth,
+			deadlineAt: ctx.deadlineAt,
 			env,
 			logger,
 			onAction,

--- a/apps/leaf/src/internal/agentRuntime/domain/agentTurnContext.ts
+++ b/apps/leaf/src/internal/agentRuntime/domain/agentTurnContext.ts
@@ -31,6 +31,7 @@ export type AgentActionProgress = Readonly<{
 }>;
 
 export type AgentTurnContext = Readonly<{
+	deadlineAt?: number;
 	eveSession?: EveSessionRef;
 	env: AppEnv;
 	id: string;

--- a/apps/leaf/src/internal/agentRuntime/eve/eveEventSchemas.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/eveEventSchemas.ts
@@ -129,6 +129,8 @@ const eveEventSchema = eveEventEnvelopeSchema.transform((envelope) => {
 			return event({ schema: messageAppendedSchema, type: envelope.type });
 		case "message.completed":
 			return event({ schema: messageCompletedSchema, type: envelope.type });
+		case "step.failed":
+			return event({ schema: failureSchema, type: envelope.type });
 		case "turn.failed":
 			return event({ schema: failureSchema, type: envelope.type });
 		case "session.failed":

--- a/apps/leaf/src/providers/slack/setup/setupSlackAgentTurn.ts
+++ b/apps/leaf/src/providers/slack/setup/setupSlackAgentTurn.ts
@@ -1,9 +1,11 @@
+import { ms } from "@autumn/shared";
 import type {
 	AgentTurnContext,
 	AgentTurnParams,
 } from "../../../internal/agentRuntime/domain/agentTurnContext.js";
 import { findEveSessionForThread } from "../../../internal/agentRuntime/eve/repo.js";
 import { getInstallationOAuthAccessToken } from "../../../internal/installations/actions/getInstallationOAuthAccessToken.js";
+import { MESSAGE_TIMEOUT_MS } from "../../../lib/chatAgentConfig.js";
 import { db } from "../../../lib/db.js";
 import { logger as rootLogger } from "../../../lib/logger.js";
 import type { SlackAgentTurnParams } from "../domain/slackAgentTurn.js";
@@ -11,6 +13,8 @@ import { prepareAttachmentMessage } from "./prepareAttachments.js";
 import { resolveSlackAdminOrgContext } from "./resolveSlackAdminOrg.js";
 import { resolveSlackCallerAuth } from "./resolveSlackCallerAuth.js";
 import { getDefaultChatEnv, selectChatEnv } from "./selectChatEnv.js";
+
+const SETTLE_BEFORE_BACKSTOP_MS = ms.seconds(30);
 
 export const setupSlackAgentTurn = async ({
 	agentRunId,
@@ -132,6 +136,7 @@ export const setupSlackAgentTurn = async ({
 	});
 	const context: AgentTurnContext = {
 		autumnUserId,
+		deadlineAt: Date.now() + MESSAGE_TIMEOUT_MS - SETTLE_BEFORE_BACKSTOP_MS,
 		env,
 		eveSession: existingSession,
 		id: agentRunId ?? crypto.randomUUID(),

--- a/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
+++ b/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
@@ -223,6 +223,56 @@ describe("a parent quiet past the cap settles on the clock", () => {
 		expect(log.quiet_ms).toBeLessThan(QUIET_CAP_MS + PASS_ADVANCE_MS);
 	});
 
+	test("a caller deadline settles the turn before its own backstop", async () => {
+		// A live child suppresses the quiet cap, so without a deadline the turn
+		// runs to the 15 min ceiling -- long past the caller's 3m20s wall.
+		childKeepsStreaming = true;
+		childEvents = Array.from({ length: 3 }, () =>
+			event({
+				actions: [{ toolName: "autumn__previewAttach" }],
+				type: "actions.requested",
+			}),
+		);
+		streamPasses = nineQuietPasses([
+			event({ type: "turn.started" }),
+			event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
+			event({
+				finishReason: "stop",
+				message: "Partial answer so far.",
+				type: "message.completed",
+			}),
+		]);
+
+		const abandoned: AbandonedLog[] = [];
+		const logger = {
+			error: (
+				_message: string,
+				meta?: { event?: string; data?: AbandonedLog },
+			) => {
+				if (meta?.event === "leaf.eve_turn_abandoned" && meta.data) {
+					abandoned.push(meta.data);
+				}
+			},
+			info: () => {},
+			warn: () => {},
+		};
+		const outcome = await consumeAgentTurn({
+			auth: {} as never,
+			// Two passes of virtual clock, so the third crosses it.
+			deadlineAt: TURN_START.getTime() + 2 * PASS_ADVANCE_MS,
+			env: AppEnv.Sandbox,
+			logger: logger as never,
+			onAction: async () => undefined,
+			orgId: "org_1",
+			session: session(),
+			token: "t",
+		} as never);
+
+		expect(outcome).toMatchObject({ kind: "answered" });
+		expect(abandoned).toHaveLength(1);
+		expect(parentStreamCalls).toBeLessThan(5);
+	});
+
 	test("a live child suppresses the quiet cap even when the parent is silent", async () => {
 		// Same silent parent, but a child relay is still streaming: the turn is
 		// working, so neither the quiet cap nor the resync budget may settle it.

--- a/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
+++ b/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
@@ -121,6 +121,31 @@ describe("a withdrawal that eve defers is redelivered", () => {
 		repostedMessages = [];
 	});
 
+	test("a parked turn that ran tools is not mistaken for a deferral", async () => {
+		// toolLabels is cleared as each result lands, so a completed tool call
+		// used to leave the map empty and read as a deferred message.
+		parentPasses = [
+			[
+				event({ type: "turn.started" }),
+				event({
+					actions: [{ callId: "c1", toolName: "autumn__getCustomer" }],
+					type: "actions.requested",
+				}),
+				event({
+					result: { callId: "c1", toolName: "autumn__getCustomer" },
+					status: "ok",
+					type: "action.result",
+				}),
+				event({ type: "session.waiting" }),
+			],
+		];
+
+		const outcome = await consume();
+
+		expect(outcome).toMatchObject({ kind: "silent" });
+		expect(repostedMessages).toHaveLength(0);
+	});
+
 	test("the parked no-op turn does not silently swallow the message", async () => {
 		// Exactly what eve emits for a deferred message: a turn that starts,
 		// receives, completes and parks without ever doing any work.

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -423,6 +423,7 @@ async function startDev() {
 			SLACK_REDIRECT_URI,
 			DISCORD_BOT_URL: process.env.DISCORD_BOT_URL ?? LOCAL_CHAT_URL,
 			VITE_APP_ENV: viteAppEnv,
+			VITE_WORKTREE_NUM: String(worktreeNum),
 			...(useLocalAuthUrls && {
 				CLIENT_URL: localUrl(process.env.CLIENT_URL, LOCAL_CLIENT_URL),
 				VITE_BACKEND_URL: localUrl(

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -5,13 +5,13 @@ import { addExtrasToLogs } from "@/utils/logging/addContextToLogs.js";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
 
 const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
-	// "/v1/balances.track",
-	// "/v1/balances.check",
-	// "/v1/check",
-	// "/v1/track",
-	// "/v1/customers.get_or_create",
-	// "/v1/entities.get",
+	"/v1/balances.track",
+	"/v1/balances.check",
+	"/v1/check",
+	"/v1/track",
 ]);
+
+const SLOW_REQUEST_BODY_THRESHOLD_MS = 500;
 
 // Event pages run to megabytes each, dwarfing every other route's ingest.
 const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
@@ -19,13 +19,65 @@ const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
 	"/v1/events.list",
 ]);
 
-const SUCCESS_REQUEST_LOG_SAMPLE_RATE = Number.parseFloat(
-	process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ?? "0",
+const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = Number.parseFloat(
+	process.env.AXIOM_SUCCESS_RESPONSE_BODY_SAMPLE_RATE ??
+		process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ??
+		"0.01",
 );
 
-const shouldSampleSuccessLog = () =>
-	SUCCESS_REQUEST_LOG_SAMPLE_RATE > 0 &&
-	Math.random() < Math.min(SUCCESS_REQUEST_LOG_SAMPLE_RATE, 1);
+const shouldSampleSuccessResponseBody = () =>
+	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
+	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
+
+const COMPACT_RESPONSE_FIELDS = new Set([
+	"allowed",
+	"code",
+	"feature_id",
+	"required_balance",
+	"value",
+]);
+const COMPACT_BALANCE_FIELDS = new Set([
+	"feature_id",
+	"plan_id",
+	"usage",
+	"granted",
+	"remaining",
+	"current_balance",
+	"unlimited",
+	"overage_allowed",
+	"next_reset_at",
+]);
+
+const compactFields = ({
+	value,
+	fields,
+}: {
+	value: Record<string, unknown>;
+	fields: Set<string>;
+}) =>
+	Object.fromEntries(
+		Object.entries(value).filter(([field]) => fields.has(field)),
+	);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const compactHighVolumeResponseBody = (
+	responseBody: Record<string, unknown>,
+) => {
+	const compactResponseBody = compactFields({
+		value: responseBody,
+		fields: COMPACT_RESPONSE_FIELDS,
+	});
+	if (responseBody.balance === null) compactResponseBody.balance = null;
+	if (isRecord(responseBody.balance)) {
+		compactResponseBody.balance = compactFields({
+			value: responseBody.balance,
+			fields: COMPACT_BALANCE_FIELDS,
+		});
+	}
+	return compactResponseBody;
+};
 
 export const logRequestResult = async ({
 	ctx,
@@ -51,20 +103,24 @@ export const logRequestResult = async ({
 		const isHighVolumeSuccess =
 			isSuccess && HIGH_VOLUME_SUCCESS_ROUTES.has(c.req.path);
 
-		if (isHighVolumeSuccess && !shouldSampleSuccessLog()) {
-			return;
-		}
-
 		ctx.logger = addExtrasToLogs({
 			logger: ctx.logger,
 			extras: ctx.extraLogs,
 		});
 
-		const skipResponseBody =
+		const excludeResponseBody =
 			isSuccess && RESPONSE_BODY_EXCLUDED_ROUTES.has(c.req.path);
+		const compactResponseBody =
+			isHighVolumeSuccess &&
+			durationMs < SLOW_REQUEST_BODY_THRESHOLD_MS &&
+			!shouldSampleSuccessResponseBody();
 
-		let finalResponseBody = skipResponseBody ? null : responseBody;
-		if (finalResponseBody === undefined && c.req.path.includes("/v1")) {
+		let finalResponseBody = excludeResponseBody ? null : responseBody;
+		if (
+			!excludeResponseBody &&
+			finalResponseBody === undefined &&
+			c.req.path.includes("/v1")
+		) {
 			const contentType = c.res.headers.get("content-type");
 			if (contentType?.includes("application/json")) {
 				try {
@@ -73,6 +129,10 @@ export const logRequestResult = async ({
 					finalResponseBody = null;
 				}
 			}
+		}
+
+		if (compactResponseBody && isRecord(finalResponseBody)) {
+			finalResponseBody = compactHighVolumeResponseBody(finalResponseBody);
 		}
 
 		const log = isSuccess ? ctx.logger.info : ctx.logger.warn;

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -47,6 +47,19 @@ const COMPACT_BALANCE_FIELDS = new Set([
 	"overage_allowed",
 	"next_reset_at",
 ]);
+const COMPACT_DEDUCTION_FIELDS = new Set([
+	"balance_id",
+	"feature_id",
+	"plan_id",
+	"reset",
+	"value",
+]);
+const COMPACT_FLAG_FIELDS = new Set([
+	"id",
+	"feature_id",
+	"plan_id",
+	"expires_at",
+]);
 
 const compactFields = ({
 	value,
@@ -74,6 +87,37 @@ const compactHighVolumeResponseBody = (
 		compactResponseBody.balance = compactFields({
 			value: responseBody.balance,
 			fields: COMPACT_BALANCE_FIELDS,
+		});
+	}
+	if (isRecord(responseBody.balances)) {
+		const balances: Record<string, Record<string, unknown> | null> = {};
+		for (const [featureId, balance] of Object.entries(responseBody.balances)) {
+			if (balance === null) {
+				balances[featureId] = null;
+			} else if (isRecord(balance)) {
+				balances[featureId] = compactFields({
+					value: balance,
+					fields: COMPACT_BALANCE_FIELDS,
+				});
+			}
+		}
+		compactResponseBody.balances = balances;
+	}
+	if (Array.isArray(responseBody.deductions)) {
+		compactResponseBody.deductions = responseBody.deductions
+			.filter(isRecord)
+			.map((deduction) =>
+				compactFields({
+					value: deduction,
+					fields: COMPACT_DEDUCTION_FIELDS,
+				}),
+			);
+	}
+	if (responseBody.flag === null) compactResponseBody.flag = null;
+	if (isRecord(responseBody.flag)) {
+		compactResponseBody.flag = compactFields({
+			value: responseBody.flag,
+			fields: COMPACT_FLAG_FIELDS,
 		});
 	}
 	return compactResponseBody;

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -12,6 +12,7 @@ const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
 ]);
 
 const SLOW_REQUEST_BODY_THRESHOLD_MS = 500;
+const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = 0.01;
 
 // Event pages run to megabytes each, dwarfing every other route's ingest.
 const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
@@ -19,15 +20,8 @@ const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
 	"/v1/events.list",
 ]);
 
-const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = Number.parseFloat(
-	process.env.AXIOM_SUCCESS_RESPONSE_BODY_SAMPLE_RATE ??
-		process.env.AXIOM_SUCCESS_REQUEST_LOG_SAMPLE_RATE ??
-		"0.01",
-);
-
 const shouldSampleSuccessResponseBody = () =>
-	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
-	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
+	Math.random() < SUCCESS_RESPONSE_BODY_SAMPLE_RATE;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -29,96 +29,36 @@ const shouldSampleSuccessResponseBody = () =>
 	SUCCESS_RESPONSE_BODY_SAMPLE_RATE > 0 &&
 	Math.random() < Math.min(SUCCESS_RESPONSE_BODY_SAMPLE_RATE, 1);
 
-const COMPACT_RESPONSE_FIELDS = new Set([
-	"allowed",
-	"code",
-	"feature_id",
-	"required_balance",
-	"value",
-]);
-const COMPACT_BALANCE_FIELDS = new Set([
-	"feature_id",
-	"plan_id",
-	"usage",
-	"granted",
-	"remaining",
-	"current_balance",
-	"unlimited",
-	"overage_allowed",
-	"next_reset_at",
-]);
-const COMPACT_DEDUCTION_FIELDS = new Set([
-	"balance_id",
-	"feature_id",
-	"plan_id",
-	"reset",
-	"value",
-]);
-const COMPACT_FLAG_FIELDS = new Set([
-	"id",
-	"feature_id",
-	"plan_id",
-	"expires_at",
-]);
-
-const compactFields = ({
-	value,
-	fields,
-}: {
-	value: Record<string, unknown>;
-	fields: Set<string>;
-}) =>
-	Object.fromEntries(
-		Object.entries(value).filter(([field]) => fields.has(field)),
-	);
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stripLargeFields = (value: unknown) => {
+	if (!isRecord(value)) return value;
+	const compactValue = { ...value };
+	delete compactValue.breakdown;
+	delete compactValue.feature;
+	delete compactValue.rollovers;
+	return compactValue;
+};
 
 const compactHighVolumeResponseBody = (
 	responseBody: Record<string, unknown>,
 ) => {
-	const compactResponseBody = compactFields({
-		value: responseBody,
-		fields: COMPACT_RESPONSE_FIELDS,
-	});
-	if (responseBody.balance === null) compactResponseBody.balance = null;
-	if (isRecord(responseBody.balance)) {
-		compactResponseBody.balance = compactFields({
-			value: responseBody.balance,
-			fields: COMPACT_BALANCE_FIELDS,
-		});
+	const compactResponseBody = { ...responseBody };
+	delete compactResponseBody.preview;
+	if ("balance" in compactResponseBody) {
+		compactResponseBody.balance = stripLargeFields(responseBody.balance);
 	}
 	if (isRecord(responseBody.balances)) {
-		const balances: Record<string, Record<string, unknown> | null> = {};
-		for (const [featureId, balance] of Object.entries(responseBody.balances)) {
-			if (balance === null) {
-				balances[featureId] = null;
-			} else if (isRecord(balance)) {
-				balances[featureId] = compactFields({
-					value: balance,
-					fields: COMPACT_BALANCE_FIELDS,
-				});
-			}
-		}
-		compactResponseBody.balances = balances;
+		compactResponseBody.balances = Object.fromEntries(
+			Object.entries(responseBody.balances).map(([featureId, balance]) => [
+				featureId,
+				stripLargeFields(balance),
+			]),
+		);
 	}
-	if (Array.isArray(responseBody.deductions)) {
-		compactResponseBody.deductions = responseBody.deductions
-			.filter(isRecord)
-			.map((deduction) =>
-				compactFields({
-					value: deduction,
-					fields: COMPACT_DEDUCTION_FIELDS,
-				}),
-			);
-	}
-	if (responseBody.flag === null) compactResponseBody.flag = null;
-	if (isRecord(responseBody.flag)) {
-		compactResponseBody.flag = compactFields({
-			value: responseBody.flag,
-			fields: COMPACT_FLAG_FIELDS,
-		});
+	if ("flag" in compactResponseBody) {
+		compactResponseBody.flag = stripLargeFields(responseBody.flag);
 	}
 	return compactResponseBody;
 };

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -251,19 +251,27 @@ describe("logRequestResult", () => {
 	test("keeps compact multi-feature track diagnostics", async () => {
 		spyOn(Math, "random").mockReturnValue(0.5);
 		const responseBody = {
+			customer_id: "cus_123",
+			event_name: "api_call",
 			value: 45.67,
 			balance: null,
 			balances: {
 				action1: {
+					object: "balance",
 					feature_id: "action1",
 					current_balance: 154.33,
 					usage: 45.67,
+					max_purchase: null,
+					feature: { id: "action1", name: "Action 1" },
 					breakdown: [{ id: "cus_ent_action1" }],
+					rollovers: [{ id: "rollover_action1" }],
 				},
 				action3: {
+					object: "balance",
 					feature_id: "action3",
 					current_balance: 104.33,
 					usage: 45.67,
+					max_purchase: null,
 					breakdown: [{ id: "cus_ent_action3" }],
 				},
 			},
@@ -274,15 +282,15 @@ describe("logRequestResult", () => {
 					plan_id: "free",
 					reset: null,
 					value: 45.67,
-					unexpected: "drop-me",
 				},
 			],
 			flag: {
+				object: "flag",
 				id: "cus_ent_flag",
 				feature_id: "premium",
 				plan_id: "free",
 				expires_at: null,
-				unexpected: "drop-me",
+				feature: { id: "premium", name: "Premium" },
 			},
 		};
 		const { captured } = await captureJsonResponse({
@@ -295,18 +303,24 @@ describe("logRequestResult", () => {
 			statusCode: 200,
 			durationMs: 10,
 			res: {
+				customer_id: "cus_123",
+				event_name: "api_call",
 				value: 45.67,
 				balance: null,
 				balances: {
 					action1: {
+						object: "balance",
 						feature_id: "action1",
 						current_balance: 154.33,
 						usage: 45.67,
+						max_purchase: null,
 					},
 					action3: {
+						object: "balance",
 						feature_id: "action3",
 						current_balance: 104.33,
 						usage: 45.67,
+						max_purchase: null,
 					},
 				},
 				deductions: [
@@ -319,6 +333,7 @@ describe("logRequestResult", () => {
 					},
 				],
 				flag: {
+					object: "flag",
 					id: "cus_ent_flag",
 					feature_id: "premium",
 					plan_id: "free",

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { Context } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { logRequestResult } from "@/honoMiddlewares/requestLogging/logRequestResult.js";
@@ -47,18 +47,55 @@ const mergeLoggedObjects = (args: unknown[]) =>
 		),
 	);
 
+const captureJsonResponse = async ({
+	path,
+	durationMs,
+	responseBody,
+}: {
+	path: string;
+	durationMs: number;
+	responseBody: Record<string, unknown>;
+}) => {
+	const captured: CapturedLog[] = [];
+	let cloneCount = 0;
+	const ctx = {
+		timestamp: 123,
+		logger: createCapturingLogger({ captured }),
+		extraLogs: {},
+		org: { slug: "test-org" },
+	} as unknown as AutumnContext;
+	const c = {
+		req: { path },
+		res: {
+			status: 200,
+			headers: new Headers({ "content-type": "application/json" }),
+			clone: () => {
+				cloneCount++;
+				return { json: async () => responseBody };
+			},
+		},
+	} as unknown as Context<HonoEnv>;
+
+	await logRequestResult({ ctx, c, durationMs });
+	return { captured, cloneCount };
+};
+
+afterEach(() => {
+	mock.restore();
+});
+
 describe("logRequestResult", () => {
 	test("logs the request body without rebinding request metadata", async () => {
 		const captured: CapturedLog[] = [];
 		const requestLogContext: LogRequestContext = {
 			id: "req_123",
 			method: "POST",
-			url: "https://api.useautumn.com/v1/check",
+			url: "https://api.useautumn.com/v1/customers.get",
 			timestamp: 123,
 			customer_id: "cus_123",
 			query: {},
 			body: { feature_id: "messages" },
-			name: "POST /v1/check",
+			name: "POST /v1/customers.get",
 		};
 		const internalRequestContext = {
 			id: requestLogContext.id,
@@ -80,7 +117,7 @@ describe("logRequestResult", () => {
 			org: { slug: "test-org" },
 		} as unknown as AutumnContext;
 		const c = {
-			req: { path: "/v1/check" },
+			req: { path: "/v1/customers.get" },
 			res: {
 				status: 200,
 				headers: new Headers({ "content-type": "application/json" }),
@@ -172,7 +209,78 @@ describe("logRequestResult", () => {
 		});
 	});
 
-	test("still reads and logs successful JSON response bodies when not supplied", async () => {
+	test("compacts an unsampled fast high-volume response", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = {
+			allowed: true,
+			required_balance: 1,
+			preview: { scenario: "upgrade" },
+			balance: {
+				feature_id: "messages",
+				remaining: 90,
+				usage: 10,
+				granted: 100,
+				overage_allowed: false,
+				breakdown: [{ id: "cus_ent_123", remaining: 90 }],
+			},
+		};
+		const { captured, cloneCount } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(cloneCount).toBe(1);
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: {
+				allowed: true,
+				required_balance: 1,
+				balance: {
+					feature_id: "messages",
+					remaining: 90,
+					usage: 10,
+					granted: 100,
+					overage_allowed: false,
+				},
+			},
+		});
+	});
+
+	test("keeps a sampled fast high-volume response in full", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const responseBody = { allowed: true, balance: { remaining: 90 } };
+		const { captured } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: responseBody,
+		});
+	});
+
+	test("keeps a slow high-volume response in full", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = { allowed: true, balance: { remaining: 90 } };
+		const { captured } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 500,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 500,
+			res: responseBody,
+		});
+	});
+
+	test("still reads and logs successful JSON response bodies for other routes", async () => {
 		const captured: CapturedLog[] = [];
 		const responseBody = { allowed: true, balance: 90 };
 		let cloneCount = 0;
@@ -183,7 +291,7 @@ describe("logRequestResult", () => {
 			org: { slug: "test-org" },
 		} as unknown as AutumnContext;
 		const c = {
-			req: { path: "/v1/check" },
+			req: { path: "/v1/customers.get" },
 			res: {
 				status: 200,
 				headers: new Headers({ "content-type": "application/json" }),

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -248,6 +248,86 @@ describe("logRequestResult", () => {
 		});
 	});
 
+	test("keeps compact multi-feature track diagnostics", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = {
+			value: 45.67,
+			balance: null,
+			balances: {
+				action1: {
+					feature_id: "action1",
+					current_balance: 154.33,
+					usage: 45.67,
+					breakdown: [{ id: "cus_ent_action1" }],
+				},
+				action3: {
+					feature_id: "action3",
+					current_balance: 104.33,
+					usage: 45.67,
+					breakdown: [{ id: "cus_ent_action3" }],
+				},
+			},
+			deductions: [
+				{
+					balance_id: "cus_ent_action1",
+					feature_id: "action1",
+					plan_id: "free",
+					reset: null,
+					value: 45.67,
+					unexpected: "drop-me",
+				},
+			],
+			flag: {
+				id: "cus_ent_flag",
+				feature_id: "premium",
+				plan_id: "free",
+				expires_at: null,
+				unexpected: "drop-me",
+			},
+		};
+		const { captured } = await captureJsonResponse({
+			path: "/v1/track",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: {
+				value: 45.67,
+				balance: null,
+				balances: {
+					action1: {
+						feature_id: "action1",
+						current_balance: 154.33,
+						usage: 45.67,
+					},
+					action3: {
+						feature_id: "action3",
+						current_balance: 104.33,
+						usage: 45.67,
+					},
+				},
+				deductions: [
+					{
+						balance_id: "cus_ent_action1",
+						feature_id: "action1",
+						plan_id: "free",
+						reset: null,
+						value: 45.67,
+					},
+				],
+				flag: {
+					id: "cus_ent_flag",
+					feature_id: "premium",
+					plan_id: "free",
+					expires_at: null,
+				},
+			},
+		});
+	});
+
 	test("keeps a sampled fast high-volume response in full", async () => {
 		spyOn(Math, "random").mockReturnValue(0);
 		const responseBody = { allowed: true, balance: { remaining: 90 } };

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -12,15 +12,11 @@ const sandboxFaviconHref = (color: string) =>
 		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
-declare const __APP_ENV__: string;
-
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
 	const color =
-		env === AppEnv.Sandbox && __APP_ENV__ !== "dev"
-			? (activeSandbox?.color ?? "blue")
-			: undefined;
+		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -12,11 +12,15 @@ const sandboxFaviconHref = (color: string) =>
 		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
+declare const __APP_ENV__: string;
+
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
 	const color =
-		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
+		env === AppEnv.Sandbox && __APP_ENV__ !== "dev"
+			? (activeSandbox?.color ?? "blue")
+			: undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/components/general/SandboxFavicon.tsx
+++ b/vite/src/components/general/SandboxFavicon.tsx
@@ -7,16 +7,24 @@ import { useEnv } from "@/utils/envUtils";
 const AUTUMN_MARK =
 	"M10.7139 9.06887C9.77726 11.211 8.84052 13.3532 7.90386 15.4953C8.63795 16.4465 9.37205 17.3984 10.1061 18.3496C12.2827 15.537 14.4599 12.7244 16.637 9.91183L9.27077 22.9514C12.9161 20.7518 16.5615 18.5529 20.2069 16.3534V4.85034L10.7139 9.06887Z";
 
+// Matches --color-sandbox in packages/ui/src/styles/index.css, the brand
+// blue used by SandboxBanner when no sandbox-specific tag color is set.
+const DEFAULT_SANDBOX_FAVICON_COLOR = "#0f9bff";
+
 const sandboxFaviconHref = (color: string) =>
 	`data:image/svg+xml,${encodeURIComponent(
-		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${sandboxColorValue(color)}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
+		`<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg"><rect width="28" height="28" rx="6" fill="${color}"/><path d="${AUTUMN_MARK}" fill="black"/></svg>`,
 	)}`;
 
 export const SandboxFavicon = () => {
 	const env = useEnv();
 	const activeSandbox = useActiveSandbox();
 	const color =
-		env === AppEnv.Sandbox ? (activeSandbox?.color ?? "blue") : undefined;
+		env === AppEnv.Sandbox
+			? activeSandbox?.color
+				? sandboxColorValue(activeSandbox.color)
+				: DEFAULT_SANDBOX_FAVICON_COLOR
+			: undefined;
 
 	useEffect(() => {
 		if (!color) return;

--- a/vite/src/main.tsx
+++ b/vite/src/main.tsx
@@ -13,12 +13,13 @@ Sentry.init({
 });
 
 declare const __APP_ENV__: string;
+declare const __WORKTREE_NUM__: string;
 if (__APP_ENV__ === "prod") {
 	document.title = "Autumn (P)";
 } else if (__APP_ENV__ === "staging") {
 	document.title = "Autumn (S)";
 } else if (__APP_ENV__ === "dev") {
-	document.title = "Autumn (Dev)";
+	document.title = `Autumn (wt${__WORKTREE_NUM__})`;
 }
 
 const queryClient = new QueryClient({

--- a/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
+++ b/vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx
@@ -38,15 +38,22 @@ export function BillingUnits() {
 		capitalize: false,
 	});
 
+	const hasMultipleTiers = (item.tiers?.length ?? 0) > 1;
+
 	return (
-		<div className="flex min-w-0 overflow-hidden">
+		<div
+			className={cn(
+				"flex min-w-0 overflow-hidden",
+				hasMultipleTiers && "shrink-0",
+			)}
+		>
 			<Popover open={open} onOpenChange={setOpen}>
 				<PopoverTrigger asChild>
 					<Button
 						variant="muted"
 						className={cn(
 							"min-w-0 max-w-full justify-start overflow-hidden text-tertiary-foreground",
-							item.tiers?.length && item.tiers.length > 1 && "max-w-20",
+							hasMultipleTiers && "max-w-20",
 						)}
 					>
 						<span className="min-w-0 truncate text-xs">

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -53,6 +53,7 @@ function printPortlessUrl(): Plugin {
 export default defineConfig({
 	define: {
 		__APP_ENV__: JSON.stringify(process.env.VITE_APP_ENV || ""),
+		__WORKTREE_NUM__: JSON.stringify(process.env.VITE_WORKTREE_NUM || "1"),
 	},
 	esbuild: {
 		pure: ["console.log"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release to `dev` bundling dashboard presentation fixes, reduced request-log volume for high-traffic routes, and Slack agent-turn fixes. The dashboard changes label each local worktree's tab with its number (e.g., `wt3`), match the sandbox favicon to brand blue `#0f9bff`, and stop the per-unit billing selector from collapsing in graduated tiers.

**Logging**
- Fast success bodies for `/v1/balances.track`, `/v1/balances.check`, `/v1/check`, and `/v1/track` are compacted in logs, dropping heavy fields like `breakdown`, `feature`, `rollovers`, and `preview` while keeping balances and deductions; responses ≥500ms and a 1% sample stay in full.

**Slack agent turns**
- Turns settle when the caller's deadline passes instead of running to their own longer budgets, so a Slack user gets whatever text arrived rather than a raw timeout when the outer 3m20s wall hits.
- A turn that ran tools is no longer read as a deferred message, preventing duplicate delivery.
- `step.failed` events parse with the failure shape instead of falling through as unknown.
- `eve` is pinned to exact `0.16.2` so stream-protocol behavior can't drift across patches.

<sup>Written for commit d4457a4fec7aba01582024ac5a46f671fe0c0765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The release combines Leaf turn-lifecycle fixes, more compact request logs, and small dashboard development and layout improvements.
- **[Bug fixes]** Leaf now settles Slack agent turns before the caller timeout and correctly distinguishes completed tool activity from a deferred no-op turn.
- **[Improvements]** Fast successful check and track responses retain compact diagnostics in logs, while slow and sampled responses remain complete.
- **[Bug fixes, Improvements]** Sandbox favicon coloring, worktree-specific development tab titles, and graduated-tier billing-unit layout are corrected.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts | Adds caller-deadline handling so agent turns settle before the Slack request backstop. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts | Persists whether any tool activity occurred so completed calls are not mistaken for deferred no-op turns. |
| server/src/honoMiddlewares/requestLogging/logRequestResult.ts | Compacts common high-volume success responses while retaining complete slow and sampled responses. |
| vite/src/components/general/SandboxFavicon.tsx | Resolves sandbox colors to valid brand hex values before generating the favicon. |
| vite/src/views/products/plan/components/edit-plan-feature/BillingUnits.tsx | Prevents the billing-unit selector from shrinking in multi-tier rows. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Slack[Slack agent request] --> Setup[Create turn context]
  Setup --> Deadline[Set deadline before caller backstop]
  Deadline --> Consume[Consume Eve events]
  Consume -->|Completes normally| Outcome[Return final outcome]
  Consume -->|Deadline reached| Settle[Settle with partial text or unreachable message]
  Settle --> Outcome
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge pull request #3106 from useautumn/..."](https://github.com/useautumn/autumn/commit/d4457a4fec7aba01582024ac5a46f671fe0c0765) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57475288)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->