### PR TITLE
fix: a completed turn is never mistaken for a deferred message

### DIFF
--- a/apps/leaf/package.json
+++ b/apps/leaf/package.json
@@ -42,7 +42,7 @@
 		"chat": "^4.31.0",
 		"date-fns": "^4.1.0",
 		"drizzle-orm": "catalog:",
-		"eve": "^0.16.2",
+		"eve": "0.16.2",
 		"hono": "4.12.27",
 		"lru-cache": "^11.2.7",
 		"postgres": "catalog:",

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -219,6 +219,7 @@ const outcomeForExhaustedRetries = async ({
 
 export const consumeAgentTurn = async ({
 	auth,
+	deadlineAt,
 	env,
 	logger,
 	onAction,
@@ -231,6 +232,7 @@ export const consumeAgentTurn = async ({
 	token,
 }: {
 	auth: EveAuthContext;
+	deadlineAt?: number;
 	env: AppEnv;
 	logger: AutumnLogger;
 	onAction?: EveEventContext["onAction"];
@@ -292,7 +294,13 @@ export const consumeAgentTurn = async ({
 			const quietTooLong =
 				activity.activeChildren() === 0 &&
 				activity.msSinceActivity() >= MAX_QUIET_MS;
-			if (activity.msSinceStart() >= MAX_TURN_DURATION_MS || quietTooLong) {
+			const deadlineReached =
+				deadlineAt !== undefined && Date.now() >= deadlineAt;
+			if (
+				activity.msSinceStart() >= MAX_TURN_DURATION_MS ||
+				quietTooLong ||
+				deadlineReached
+			) {
 				return settleExhaustedTurn({ activity, logger, turn });
 			}
 

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
@@ -44,6 +44,7 @@ export type EveTurnProgress = Readonly<{
 	lastPreview?: CapturedPreview;
 	pendingText: string;
 	reasoningStreamId?: string;
+	sawToolActivity: boolean;
 	subagentChildSessionIds: ReadonlySet<string>;
 	subagentStartedAtByCallId: ReadonlyMap<string, number>;
 	toolInputs: ReadonlyMap<string, Record<string, unknown>>;
@@ -72,6 +73,7 @@ export type EveTurnTransition = Readonly<{
 export const createEveTurnProgress = (): EveTurnProgress => ({
 	finalText: "",
 	pendingText: "",
+	sawToolActivity: false,
 	subagentChildSessionIds: new Set(),
 	subagentStartedAtByCallId: new Map(),
 	toolInputs: new Map(),
@@ -149,7 +151,15 @@ const reduceRequestedActions = ({
 		toolLabels.set(action.callId, label);
 		if (action.input) toolInputs.set(action.callId, action.input);
 	}
-	return { effects, progress: { ...progress, toolInputs, toolLabels } };
+	return {
+		effects,
+		progress: {
+			...progress,
+			sawToolActivity: progress.sawToolActivity || event.actions.length > 0,
+			toolInputs,
+			toolLabels,
+		},
+	};
 };
 
 const reduceActionResult = ({
@@ -321,7 +331,7 @@ const reduceInputRequest = ({
  * pending batch, so the turn starts, receives and completes without working. */
 const turnDeferredItsInput = (progress: EveTurnProgress) =>
 	progress.turnStarted &&
-	progress.toolLabels.size === 0 &&
+	!progress.sawToolActivity &&
 	progress.subagentChildSessionIds.size === 0;
 
 const reduceTerminalEvent = ({

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -91,6 +91,7 @@ export const runAgentTurn = async ({
 		run?.resolveSessionId(session.sessionId);
 		return consumeAgentTurn({
 			auth,
+			deadlineAt: ctx.deadlineAt,
 			env,
 			logger,
 			onAction,

--- a/apps/leaf/src/internal/agentRuntime/domain/agentTurnContext.ts
+++ b/apps/leaf/src/internal/agentRuntime/domain/agentTurnContext.ts
@@ -31,6 +31,7 @@ export type AgentActionProgress = Readonly<{
 }>;
 
 export type AgentTurnContext = Readonly<{
+	deadlineAt?: number;
 	eveSession?: EveSessionRef;
 	env: AppEnv;
 	id: string;

--- a/apps/leaf/src/internal/agentRuntime/eve/eveEventSchemas.ts
+++ b/apps/leaf/src/internal/agentRuntime/eve/eveEventSchemas.ts
@@ -129,6 +129,8 @@ const eveEventSchema = eveEventEnvelopeSchema.transform((envelope) => {
 			return event({ schema: messageAppendedSchema, type: envelope.type });
 		case "message.completed":
 			return event({ schema: messageCompletedSchema, type: envelope.type });
+		case "step.failed":
+			return event({ schema: failureSchema, type: envelope.type });
 		case "turn.failed":
 			return event({ schema: failureSchema, type: envelope.type });
 		case "session.failed":

--- a/apps/leaf/src/providers/slack/setup/setupSlackAgentTurn.ts
+++ b/apps/leaf/src/providers/slack/setup/setupSlackAgentTurn.ts
@@ -1,9 +1,11 @@
+import { ms } from "@autumn/shared";
 import type {
 	AgentTurnContext,
 	AgentTurnParams,
 } from "../../../internal/agentRuntime/domain/agentTurnContext.js";
 import { findEveSessionForThread } from "../../../internal/agentRuntime/eve/repo.js";
 import { getInstallationOAuthAccessToken } from "../../../internal/installations/actions/getInstallationOAuthAccessToken.js";
+import { MESSAGE_TIMEOUT_MS } from "../../../lib/chatAgentConfig.js";
 import { db } from "../../../lib/db.js";
 import { logger as rootLogger } from "../../../lib/logger.js";
 import type { SlackAgentTurnParams } from "../domain/slackAgentTurn.js";
@@ -11,6 +13,8 @@ import { prepareAttachmentMessage } from "./prepareAttachments.js";
 import { resolveSlackAdminOrgContext } from "./resolveSlackAdminOrg.js";
 import { resolveSlackCallerAuth } from "./resolveSlackCallerAuth.js";
 import { getDefaultChatEnv, selectChatEnv } from "./selectChatEnv.js";
+
+const SETTLE_BEFORE_BACKSTOP_MS = ms.seconds(30);
 
 export const setupSlackAgentTurn = async ({
 	agentRunId,
@@ -132,6 +136,7 @@ export const setupSlackAgentTurn = async ({
 	});
 	const context: AgentTurnContext = {
 		autumnUserId,
+		deadlineAt: Date.now() + MESSAGE_TIMEOUT_MS - SETTLE_BEFORE_BACKSTOP_MS,
 		env,
 		eveSession: existingSession,
 		id: agentRunId ?? crypto.randomUUID(),

--- a/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
+++ b/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
@@ -223,6 +223,56 @@ describe("a parent quiet past the cap settles on the clock", () => {
 		expect(log.quiet_ms).toBeLessThan(QUIET_CAP_MS + PASS_ADVANCE_MS);
 	});
 
+	test("a caller deadline settles the turn before its own backstop", async () => {
+		// A live child suppresses the quiet cap, so without a deadline the turn
+		// runs to the 15 min ceiling -- long past the caller's 3m20s wall.
+		childKeepsStreaming = true;
+		childEvents = Array.from({ length: 3 }, () =>
+			event({
+				actions: [{ toolName: "autumn__previewAttach" }],
+				type: "actions.requested",
+			}),
+		);
+		streamPasses = nineQuietPasses([
+			event({ type: "turn.started" }),
+			event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
+			event({
+				finishReason: "stop",
+				message: "Partial answer so far.",
+				type: "message.completed",
+			}),
+		]);
+
+		const abandoned: AbandonedLog[] = [];
+		const logger = {
+			error: (
+				_message: string,
+				meta?: { event?: string; data?: AbandonedLog },
+			) => {
+				if (meta?.event === "leaf.eve_turn_abandoned" && meta.data) {
+					abandoned.push(meta.data);
+				}
+			},
+			info: () => {},
+			warn: () => {},
+		};
+		const outcome = await consumeAgentTurn({
+			auth: {} as never,
+			// Two passes of virtual clock, so the third crosses it.
+			deadlineAt: TURN_START.getTime() + 2 * PASS_ADVANCE_MS,
+			env: AppEnv.Sandbox,
+			logger: logger as never,
+			onAction: async () => undefined,
+			orgId: "org_1",
+			session: session(),
+			token: "t",
+		} as never);
+
+		expect(outcome).toMatchObject({ kind: "answered" });
+		expect(abandoned).toHaveLength(1);
+		expect(parentStreamCalls).toBeLessThan(5);
+	});
+
 	test("a live child suppresses the quiet cap even when the parent is silent", async () => {
 		// Same silent parent, but a child relay is still streaming: the turn is
 		// working, so neither the quiet cap nor the resync budget may settle it.

--- a/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
+++ b/apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts
@@ -121,6 +121,31 @@ describe("a withdrawal that eve defers is redelivered", () => {
 		repostedMessages = [];
 	});
 
+	test("a parked turn that ran tools is not mistaken for a deferral", async () => {
+		// toolLabels is cleared as each result lands, so a completed tool call
+		// used to leave the map empty and read as a deferred message.
+		parentPasses = [
+			[
+				event({ type: "turn.started" }),
+				event({
+					actions: [{ callId: "c1", toolName: "autumn__getCustomer" }],
+					type: "actions.requested",
+				}),
+				event({
+					result: { callId: "c1", toolName: "autumn__getCustomer" },
+					status: "ok",
+					type: "action.result",
+				}),
+				event({ type: "session.waiting" }),
+			],
+		];
+
+		const outcome = await consume();
+
+		expect(outcome).toMatchObject({ kind: "silent" });
+		expect(repostedMessages).toHaveLength(0);
+	});
+
 	test("the parked no-op turn does not silently swallow the message", async () => {
 		// Exactly what eve emits for a deferred message: a turn that starts,
 		// receives, completes and parks without ever doing any work.


### PR DESCRIPTION
Three P0 items from an architecture audit of the turn lifecycle. Two are bugs, one closes a drift window.

## 1. A completed turn was reposting the user's message

`turnDeferredItsInput` — shipped this morning in `3da6b1bb15` — read `toolLabels.size` to decide eve had parked holding the message.

**`toolLabels` is an in-flight map.** Entries are set on `actions.requested` and **deleted** on `action.result`. So it is empty in two cases: a turn that ran no tools, *and* a turn whose tools all completed.

A parked turn that finished its work therefore read as `deferred`, and `runAgentTurn` reposted the message — a duplicate delivery to the user. My original fix had a far wider blast radius than intended.

Latch the signal instead: `sawToolActivity` is set once and never cleared.

**Red/green verified both directions.** With the latch, a parked turn that ran and completed one tool settles `silent` with no repost. Restoring `toolLabels.size === 0` fails that test.

## 2. `step.failed` was invisible

Eve opens **both** of its failure cascades with `step.failed`:

```
terminal:     step.failed -> turn.failed -> session.failed
recoverable:  step.failed -> turn.failed -> session.waiting
```

Leaf had no case for it, so it parsed as `{type:"unknown"}` and every path ignored it — a failed step read as silence until an idle timer fired minutes later.

It now parses with the same shape as `turn.failed`. Deliberately **not** terminal on its own: the cascade tail decides, and treating a recoverable step as fatal would end turns eve intends to continue.

## 3. `eve` was a floating dependency

`^0.16.2` accepts every `0.16.x` patch — on the runtime whose stream protocol leaf parses by hand, and whose payload routing caused today's dropped-message incident. A patch changing park timing would move leaf's behaviour with no commit on our side. Pinned exactly; the lockfile already resolved to `0.16.2`, so no version change.

## Testing

488 unit tests pass (up from 487), typecheck and Biome clean.

## What this deliberately does not do

An earlier draft proposed consolidating the four turn-consume paths into one core. **Two audits rejected it and I agree.** The duplication is under 10% by logic — the shared set is mostly braces and imports — and the three paths return disjoint types (`EveTurnOutcome` / `ResumedAgentTurn` / `{stuck}`), with drain writing back mid-stream and resumed doing post-hoc child replay. A shared core would be a thin `for await` wrapping ~900 lines of policy.

Still open, tracked separately: threading the outer Slack deadline inward (the inner budgets are hardcoded past it), extracting the write-attribution ledger, and filing `routeDeliverPayload` upstream — the dropped-message defect is eve-side and unreachable from leaf.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four turn-lifecycle issues: a completed turn no longer gets mistaken for a deferred message and reposts the user's input, `step.failed` events are handled instead of ignored, Slack turns settle gracefully before the caller's backstop kills them, and `eve` no longer floats across patches.

**Bug Fixes**
- Deferral detection latches `sawToolActivity` instead of reading the in-flight `toolLabels` size, so a parked turn that ran and completed tools settles silently with no repost.
- `step.failed` now parses with the same failure schema as `turn.failed` and stays non-terminal so recoverable cascades can continue.
- Slack turns carry a deadline 30s inside their 3m20s backstop; a slow turn now settles and returns whatever text arrived instead of dying to a raw timeout. The web path leaves the deadline unset and keeps today's behavior.

**Dependencies**
- Pinned `eve` from `^0.16.2` to the exact `0.16.2`; the lockfile already resolved there.

<sup>Written for commit 0ae8249b70e33e2d48b2b9d9c6631a98dd363560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR corrects Leaf’s turn-lifecycle classification, recognizes Eve step-failure events, gives Slack turns an earlier settlement deadline, and pins the Eve protocol dependency.
- **Bug fixes:** Latches completed tool activity so a finished turn is not mistaken for a deferred message and reposted.
- **Bug fixes:** Parses `step.failed` events using the existing failure-event shape.
- **Improvements:** Propagates Slack’s caller deadline into turn consumption so Leaf can settle before the outer timeout.
- **Improvements:** Pins Eve to version `0.16.2` to prevent unreviewed protocol changes.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts | Adds a persistent tool-activity latch and uses it when distinguishing completed work from a deferred input. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts | Accepts an optional caller deadline and settles the turn when that deadline is reached. |
| apps/leaf/src/internal/agentRuntime/eve/eveEventSchemas.ts | Recognizes `step.failed` with the same payload schema used by other Eve failure events. |
| apps/leaf/src/providers/slack/setup/setupSlackAgentTurn.ts | Sets the Slack turn deadline thirty seconds before the configured message timeout. |
| apps/leaf/package.json | Pins the Eve dependency to the protocol version already represented by the lockfile. |
| apps/leaf/tests/unit/harness/withdrawal-deferred-park.test.ts | Adds regression coverage proving that completed tool work is not redelivered as deferred input. |
| apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts | Adds coverage showing that a caller deadline settles a turn before its outer backstop. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    U[Slack user message] --> S[Set up agent turn]
    S -->|deadlineAt| R[Run agent turn]
    R --> C[Consume Eve event stream]
    C --> A{Event type}
    A -->|actions.requested| L[Latch tool activity]
    A -->|step.failed| F[Parse failure event]
    A -->|session waiting/completed| D{Work activity observed?}
    D -->|Yes| Q[Settle silently or with answer]
    D -->|No| P[Classify as deferred]
    C --> T{Caller deadline reached?}
    T -->|Yes| E[Settle before Slack backstop]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: 🐛 the turn settles before the call..."](https://github.com/useautumn/autumn/commit/0ae8249b70e33e2d48b2b9d9c6631a98dd363560) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57485897)</sub>

<!-- /greptile_comment -->