### PR TITLE
fix: a follow-up message no longer swallows the next approval card

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
@@ -89,6 +89,12 @@ export const eveTurnProducedOutput = ({
 	text?: string;
 }) => Boolean(text?.trim() || catalogDecision);
 
+const isTurnActivityEvent = (event: EveEvent) =>
+	event.type === "step.started" ||
+	event.type === "input.requested" ||
+	event.type === "subagent.called" ||
+	event.type === "subagent.completed";
+
 const approvalForGatedWrite = ({
 	chained,
 	progress,
@@ -386,7 +392,9 @@ export const reduceEveTurnEvent = ({
 	if (event.type === "action.result") {
 		return reduceActionResult({ capturedPreview, event, progress });
 	}
-	if (!progress.turnStarted) return { effects: [], progress };
+	if (!(progress.turnStarted || isTurnActivityEvent(event))) {
+		return { effects: [], progress };
+	}
 
 	switch (event.type) {
 		case "subagent.called": {


### PR DESCRIPTION
**P0.** Every follow-up message sent while an approval card is pending kills the turn. Five occurrences today, five failures, zero exceptions.

## Root cause

`eveTurnReducer.ts` dropped every event until `turn.started` arrived:

```ts
if (!progress.turnStarted) return { effects: [], progress };
```

**A turn resumed after a withdrawal never re-emits `turn.started`** — eve already started that turn. So when the child raises its next approval, `input.requested` hits that guard and vanishes. No card, no outcome. The parent then waits for events that will never come until the wall clock kills it.

## Proven locally, both directions

Driving the reducer directly with the prod event shape:

| input | outcome |
|---|---|
| `input.requested`, no `turn.started` | **swallowed** — no outcome, no effects |
| same event, with `turn.started` | `suspended` — card raised |
| same event, **after this fix** | `suspended` — card raised |

## Matching prod exactly

```
13:24:52  child parks → approval card posted        ✅ eve_input_parked, approval_created
13:25:00  follow-up → card withdrawn, stream reopens at index 32
13:25:27  child parks AGAIN → nothing               ❌ no eve_input_parked, no approval_created
          parent frozen, then "Chat agent timed out"
```

`eve_input_parked` and `approval_created` fire for the first card and never again after a supersede. Five sessions frozen at fixed indexes: `...AEG` (78), `...ATE` (31), `...DJD` (37), `...MSY` (42), `...P95`.

## Why this rule, specifically

`consumeResumedAgentTurn.ts:204-208` already had it right — it counts `step.started`, `actions.requested`, `action.result`, `input.requested` and `subagent.completed` as evidence the turn is live, precisely because a resumed turn has no `turn.started`. The two paths had different rules for the same situation and only one was correct. This mirrors the proven one.

## The next action works, not just the card

Verified the outcome carries what approve/deny needs: `toolCallId` (`aitxt-…`), `_eveApproveOptionId`, `_eveDenyOptionId`, and a `save_session` effect. `suspended` → `resolveAgentTurnOutcome` → `kind: "approval"` → Slack posts the card — the same path the working first card already takes.

## Testing

489 unit tests pass, typecheck and Biome clean. Nine lines changed.

**Regression tests to follow** — pushing the fix first given prod impact.

## Also on this branch, not yet deployed

Four earlier commits merged to `dev` but have never reached prod (the only deploy since was rolled back for an unrelated DSN issue): the deadline threading, `step.failed` parsing, the deferred-park latch, and the eve pin. Those change *how* a stalled turn fails; **this** commit is why turns were stalling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where a follow-up message after an approval card would swallow the next approval event, freezing the turn until timeout. Now events that indicate turn activity (`input.requested`, `step.started`, `subagent.called`, `subagent.completed`) are processed even without `turn.started`, matching the behavior already used in `consumeResumedAgentTurn`.

<sup>Written for commit 4e02925d8d073dee0ba121e2e89fd9f2bea7f275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the Eve event reducer so a resumed turn can recognize activity without receiving another `turn.started` event.

- **Bug fixes:** Processes `input.requested` on resumed turns so a follow-up message no longer hides the next approval card and leaves the conversation waiting indefinitely.
- **Improvements:** Treats step and subagent lifecycle events as evidence that the turn is active.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects established in the changed behavior.

The reducer now accepts the activity events needed by resumed turns, and the surrounding stream and progress handling did not establish an incorrect approval, routing, or persistent-status outcome.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts | Broadens the reducer’s pre-start gate to recognize resumed-turn activity, restoring approval handling when no second `turn.started` event is emitted. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Follow-up resumes existing turn] --> B{turn.started emitted?}
  B -->|Yes| C[Process subsequent events]
  B -->|No| D{Activity event received?}
  D -->|input.requested| E[Create approval or question outcome]
  D -->|step or subagent event| F[Process turn activity]
  D -->|Other event| G[Ignore until activity begins]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: 🐛 a follow-up message no longer sw..."](https://github.com/useautumn/autumn/commit/4e02925d8d073dee0ba121e2e89fd9f2bea7f275) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57504366)</sub>

**Context used:**

- Context used - When generating the key changes section of the sum... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Automation and external integrations](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/automation-and-external-integrations.md)

<!-- /greptile_comment -->