### PR TITLE
fix: renaming a version slug no longer mints a new version

### DIFF
--- a/vite/src/views/products/plan/catalog/resolvePlanChangePreview.ts
+++ b/vite/src/views/products/plan/catalog/resolvePlanChangePreview.ts
@@ -31,11 +31,15 @@ export const resolveEffectiveVersionChoice = ({
 	choice,
 	showNewOption,
 	showAllOption,
+	isMetadataOnly = false,
 }: {
 	choice: CatalogVersionChoice;
 	showNewOption: boolean;
 	showAllOption: boolean;
+	/** No content to version, so the save edits the row it targets. */
+	isMetadataOnly?: boolean;
 }): CatalogVersionChoice => {
+	if (isMetadataOnly) return "update";
 	if (choice === "new" && !showNewOption) return "update";
 	if (choice === "all" && !showAllOption) return "update";
 	return choice;
@@ -113,6 +117,7 @@ export const resolvePlanChangePreview = ({
 		choice: versionChoice,
 		showNewOption,
 		showAllOption,
+		isMetadataOnly,
 	});
 
 	const strategy = strategyForCatalogPreview({

--- a/vite/tests/views/products/plan/catalog/resolve-plan-change-preview.test.ts
+++ b/vite/tests/views/products/plan/catalog/resolve-plan-change-preview.test.ts
@@ -45,6 +45,35 @@ describe("resolvePlanChangePreview", () => {
 		).toBe("update");
 	});
 
+	test("a metadata-only save edits its row instead of minting a version", () => {
+		expect(
+			resolveEffectiveVersionChoice({
+				choice: "new",
+				showNewOption: true,
+				showAllOption: true,
+				isMetadataOnly: true,
+			}),
+		).toBe("update");
+
+		const model = resolvePlanChangePreview({
+			preview: planPreview({
+				state: { has_customers: true, will_archive: false },
+				plan_change: { item_changes: [] },
+				version_slug: "v1",
+				new_version_slug: "launch",
+			} as Partial<CatalogPlanUpdatePreview>),
+			versionChoice: "new",
+			variantSelection: null,
+			licenseParentSelection: null,
+			isLatest: true,
+			namesByPlanId: {},
+		});
+
+		expect(model.isMetadataOnly).toBe(true);
+		expect(model.effectiveVersionChoice).toBe("update");
+		expect(model.strategy).toBeUndefined();
+	});
+
 	test("shows child all_versions when the child has siblings and license parents", () => {
 		expect(
 			resolveVersioningOptionVisibility({


### PR DESCRIPTION
## Problem

Renaming a plan's version slug on the dashboard creates a **new version** instead of renaming the existing one. Same bug hits **plan ID renames**.

## Cause

`PlanChangeDialog` initialises `versionChoice` to `"new"`:

```
rename slug -> preview classifies it as metadata-only
            -> dialog opens (just to confirm the rename)
            -> version-strategy radios are HIDDEN for metadata-only...
            -> ...but the "new" default is still live
            -> save sends versioning: "new_version"
            -> server mints v(N+1) instead of editing v(N)
```

For a real content edit the default is fine — the radios render and the user can pick. For a metadata-only save, `showVersionStrategy` is `false`, so the user never sees or chooses the strategy that silently mints.

Triggers whenever the plan has customers and is on its latest version, which is the normal case — those are exactly the conditions that put `new_version` in the server's `options` list.

## Fix

A metadata-only save has no content to version, so it now always targets the row it edits. One line in `resolveEffectiveVersionChoice`.

## Testing

- Added a regression test; confirmed it fails before the fix (`Expected: "update"` / `Received: "new"`) and passes after.
- All 529 vite tests pass, `tsc --noEmit` clean, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes renaming a version slug (or plan ID) on the dashboard so it edits the existing version instead of minting a new one. Metadata-only saves now always target the row they edit; previously they fell back to a hidden 'new version' default and the server created v(N+1).

<sup>Written for commit 004da7af08bf4d5ce50ecf73c8888544d16c9558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes metadata-only plan renames so they update the intended catalog row instead of accidentally creating a new version.

- **Bug fixes:** Forces metadata-only saves to use the existing-row update strategy.
- **Improvements:** Adds regression coverage for version-slug renames when the plan has customers and is on its latest version.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The new metadata-only override matches current dialog reachability and backend rename semantics, while content-changing previews remain excluded from this path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/products/plan/catalog/resolvePlanChangePreview.ts | Metadata-only previews now resolve to the existing-row update choice, preventing hidden default state from minting a version. |
| vite/tests/views/products/plan/catalog/resolve-plan-change-preview.test.ts | Adds focused regression coverage confirming metadata-only saves update the targeted row without selecting a versioning strategy. |

<sub>Reviews (1): Last reviewed commit: ["fix: renaming a version slug no longer m..."](https://github.com/useautumn/autumn/commit/004da7af08bf4d5ce50ecf73c8888544d16c9558) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57512177)</sub>

<!-- /greptile_comment -->