### PR TITLE
feat: merge subscription_params through reserved-key Stripe builders

### DIFF
--- a/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts
@@ -9,6 +9,7 @@ import { stripePhaseStartsInFuture } from "@autumn/shared";
 import type { AutumnContext } from "@server/honoUtils/HonoEnv";
 import { buildStripeSubscriptionItemsUpdate } from "@server/internal/billing/v2/providers/stripe/utils/subscriptionItems/buildStripeSubscriptionItemsUpdate";
 import { buildStripeSubscriptionCreateAction } from "@server/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionCreateAction";
+import { buildStripeSubscriptionCancelParams } from "@server/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams";
 import { buildStripeSubscriptionUpdateAction } from "@server/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction";
 import type Stripe from "stripe";
 import { billingPlanToOneOffStripeItemSpecs } from "@/internal/billing/v2/providers/stripe/utils/stripeItemSpec/billingPlanToOneOffStripeItemSpecs";
@@ -126,6 +127,10 @@ export const buildStripeSubscriptionAction = ({
 		return {
 			type: "cancel" as const,
 			stripeSubscriptionId: stripeSubscription.id,
+			params: buildStripeSubscriptionCancelParams({
+				params: {},
+				subscriptionParams: billingContext.subscriptionParams,
+			}),
 		};
 	}
 

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams.ts
@@ -1,0 +1,65 @@
+import type Stripe from "stripe";
+
+const SUBSCRIPTION_UPDATE_RESERVED_KEYS = [
+	"items",
+	"cancel_at",
+	"proration_behavior",
+	"payment_behavior",
+	"trial_end",
+	"trial_settings",
+	"discounts",
+	"automatic_tax",
+	"metadata",
+	"expand",
+	"default_payment_method",
+	"default_tax_rates",
+	"billing_cycle_anchor",
+	"collection_method",
+	"days_until_due",
+	"payment_settings",
+] as const satisfies readonly (keyof Stripe.SubscriptionUpdateParams)[];
+
+const SUBSCRIPTION_CANCEL_RESERVED_KEYS = [
+	"expand",
+] as const satisfies readonly (keyof Stripe.SubscriptionCancelParams)[];
+
+const omitReservedKeys = ({
+	params,
+	reservedKeys,
+}: {
+	params?: Record<string, unknown>;
+	reservedKeys: readonly string[];
+}): Record<string, unknown> => {
+	if (!params) return {};
+	return Object.fromEntries(
+		Object.entries(params).filter(([key]) => !reservedKeys.includes(key)),
+	);
+};
+
+export const buildStripeSubscriptionUpdateParams = ({
+	params,
+	subscriptionParams,
+}: {
+	params: Stripe.SubscriptionUpdateParams;
+	subscriptionParams?: Record<string, unknown>;
+}): Stripe.SubscriptionUpdateParams => ({
+	...(omitReservedKeys({
+		params: subscriptionParams,
+		reservedKeys: SUBSCRIPTION_UPDATE_RESERVED_KEYS,
+	}) as Stripe.SubscriptionUpdateParams),
+	...params,
+});
+
+export const buildStripeSubscriptionCancelParams = ({
+	params,
+	subscriptionParams,
+}: {
+	params: Stripe.SubscriptionCancelParams;
+	subscriptionParams?: Record<string, unknown>;
+}): Stripe.SubscriptionCancelParams => ({
+	...(omitReservedKeys({
+		params: subscriptionParams,
+		reservedKeys: SUBSCRIPTION_CANCEL_RESERVED_KEYS,
+	}) as Stripe.SubscriptionCancelParams),
+	...params,
+});

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts
@@ -9,6 +9,7 @@ import { notNullish } from "@shared/utils/utils";
 import type Stripe from "stripe";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 import { stripeDiscountsToParams } from "@/internal/billing/v2/providers/stripe/utils/discounts/stripeDiscountsToParams";
+import { buildStripeSubscriptionUpdateParams } from "@/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams";
 import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 
 export const buildStripeSubscriptionUpdateAction = ({
@@ -121,6 +122,9 @@ export const buildStripeSubscriptionUpdateAction = ({
 	return {
 		type: "update" as const,
 		stripeSubscriptionId: stripeSubscription.id,
-		params,
+		params: buildStripeSubscriptionUpdateParams({
+			params,
+			subscriptionParams: billingContext.subscriptionParams,
+		}),
 	};
 };

--- a/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts
@@ -7,6 +7,10 @@ import { buildAutumnSubscriptionMetadata } from "@/internal/billing/v2/providers
 import { mergeStripeMetadata } from "@/internal/billing/v2/providers/stripe/utils/common/mergeStripeMetadata";
 import { shouldEnableStripeAutomaticTax } from "@/internal/billing/v2/providers/stripe/utils/tax/shouldEnableStripeAutomaticTax";
 import { buildInvoiceModeSubscriptionParams } from "./buildInvoiceModeSubscriptionParams";
+import {
+	buildStripeSubscriptionCancelParams,
+	buildStripeSubscriptionUpdateParams,
+} from "./buildStripeSubscriptionParams";
 import { willStripeSubscriptionUpdateCreateInvoice } from "./willStripeSubscriptionUpdateCreateInvoice";
 
 export const executeStripeSubscriptionOperation = async ({
@@ -99,15 +103,18 @@ export const executeStripeSubscriptionOperation = async ({
 
 			return await stripeClient.subscriptions.update(
 				subscriptionAction.stripeSubscriptionId,
-				{
-					...paramsWithoutAutoTax,
-					...(subscriptionHasDefaultPm ? {} : fallbackPaymentMethodParams),
-					...(updateWillCreateInvoice ? invoiceModeParams : {}),
-					...(autumnMeta && { metadata: autumnMeta }),
-					...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
-					...taxRateParams,
-					expand: ["latest_invoice"],
-				},
+				buildStripeSubscriptionUpdateParams({
+					params: {
+						...paramsWithoutAutoTax,
+						...(subscriptionHasDefaultPm ? {} : fallbackPaymentMethodParams),
+						...(updateWillCreateInvoice ? invoiceModeParams : {}),
+						...(autumnMeta && { metadata: autumnMeta }),
+						...(wantsAutoTax ? { automatic_tax: { enabled: true } } : {}),
+						...taxRateParams,
+						expand: ["latest_invoice"],
+					},
+					subscriptionParams: billingContext.subscriptionParams,
+				}),
 				autumnStripeRequestOptions({ source: idempotencySource }),
 			);
 		}
@@ -130,10 +137,13 @@ export const executeStripeSubscriptionOperation = async ({
 		case "cancel":
 			return await stripeClient.subscriptions.cancel(
 				subscriptionAction.stripeSubscriptionId,
-				{
-					...subscriptionAction.params,
-					expand: ["latest_invoice"],
-				},
+				buildStripeSubscriptionCancelParams({
+					params: {
+						...subscriptionAction.params,
+						expand: ["latest_invoice"],
+					},
+					subscriptionParams: billingContext.subscriptionParams,
+				}),
 				autumnStripeRequestOptions({ source: idempotencySource }),
 			);
 

--- a/server/tests/unit/billing/stripe/subscriptions/build-stripe-subscription-params.test.ts
+++ b/server/tests/unit/billing/stripe/subscriptions/build-stripe-subscription-params.test.ts
@@ -1,0 +1,105 @@
+/**
+ * buildStripeSubscriptionUpdateParams / buildStripeSubscriptionCancelParams
+ *
+ * Contract:
+ *   New behaviors:
+ *     user subscription_params pass through onto the Stripe payload
+ *     reserved keys (items, cancel_at, proration_behavior, metadata, expand, …)
+ *       are stripped from the user bag and always taken from Autumn
+ *     Autumn-owned keys win collisions even when Autumn sets them
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	buildStripeSubscriptionCancelParams,
+	buildStripeSubscriptionUpdateParams,
+} from "@/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams";
+import chalk from "chalk";
+
+const userCancellationDetails = {
+	cancellation_details: {
+		feedback: "too_expensive" as const,
+		comment: "Switching to a competitor",
+	},
+};
+
+describe(chalk.yellowBright("buildStripeSubscriptionUpdateParams"), () => {
+	test("keeps user extras and Autumn items", () => {
+		const params = buildStripeSubscriptionUpdateParams({
+			params: {
+				items: [{ id: "si_autumn", quantity: 2 }],
+				proration_behavior: "none",
+			},
+			subscriptionParams: userCancellationDetails,
+		});
+
+		expect(params.cancellation_details).toEqual(
+			userCancellationDetails.cancellation_details,
+		);
+		expect(params.items).toEqual([{ id: "si_autumn", quantity: 2 }]);
+		expect(params.proration_behavior).toBe("none");
+	});
+
+	test("drops user items when Autumn omitted them", () => {
+		const params = buildStripeSubscriptionUpdateParams({
+			params: { proration_behavior: "none" },
+			subscriptionParams: {
+				items: [{ id: "si_user", quantity: 99 }],
+				...userCancellationDetails,
+			},
+		});
+
+		expect(params.items).toBeUndefined();
+		expect(params.cancellation_details).toEqual(
+			userCancellationDetails.cancellation_details,
+		);
+	});
+
+	test("Autumn items win over user items", () => {
+		const params = buildStripeSubscriptionUpdateParams({
+			params: { items: [{ id: "si_autumn", quantity: 1 }] },
+			subscriptionParams: { items: [{ id: "si_user", quantity: 99 }] },
+		});
+
+		expect(params.items).toEqual([{ id: "si_autumn", quantity: 1 }]);
+	});
+
+	test("Autumn expand and metadata win", () => {
+		const params = buildStripeSubscriptionUpdateParams({
+			params: {
+				expand: ["latest_invoice"],
+				metadata: { autumn_source: "updateSubscription" },
+			},
+			subscriptionParams: {
+				expand: ["customer"],
+				metadata: { stolen: "yes" },
+			},
+		});
+
+		expect(params.expand).toEqual(["latest_invoice"]);
+		expect(params.metadata).toEqual({ autumn_source: "updateSubscription" });
+	});
+});
+
+describe(chalk.yellowBright("buildStripeSubscriptionCancelParams"), () => {
+	test("keeps user extras and Autumn expand", () => {
+		const params = buildStripeSubscriptionCancelParams({
+			params: { expand: ["latest_invoice"] },
+			subscriptionParams: userCancellationDetails,
+		});
+
+		expect(params.cancellation_details).toEqual(
+			userCancellationDetails.cancellation_details,
+		);
+		expect(params.expand).toEqual(["latest_invoice"]);
+	});
+
+	test("Autumn expand wins over user expand", () => {
+		const params = buildStripeSubscriptionCancelParams({
+			params: { expand: ["latest_invoice"] },
+			subscriptionParams: { expand: ["customer"] },
+		});
+
+		expect(params.expand).toEqual(["latest_invoice"]);
+	});
+});

--- a/server/tests/unit/billing/stripe/subscriptions/execute-stripe-subscription-params.test.ts
+++ b/server/tests/unit/billing/stripe/subscriptions/execute-stripe-subscription-params.test.ts
@@ -1,0 +1,125 @@
+/**
+ * executeStripeSubscriptionOperation merges subscription_params on update
+ * and cancel. Reserved keys stay Autumn-owned.
+ *
+ * Contract:
+ *   New behaviors:
+ *     update: user extras reach subscriptions.update; items/expand do not
+ *     cancel: user extras reach subscriptions.cancel; expand stays Autumn's
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { BillingContext, StripeSubscriptionAction } from "@autumn/shared";
+import chalk from "chalk";
+import type Stripe from "stripe";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { mockModuleWithRestore } from "../../../utils/mockModuleWithRestore.js";
+
+const mockState = {
+	updateCalls: [] as Stripe.SubscriptionUpdateParams[],
+	cancelCalls: [] as Stripe.SubscriptionCancelParams[],
+};
+
+await mockModuleWithRestore("@server/external/connect/createStripeCli", () => ({
+	createStripeCli: () => ({
+		subscriptions: {
+			update: async (
+				_subscriptionId: string,
+				params: Stripe.SubscriptionUpdateParams,
+			) => {
+				mockState.updateCalls.push(params);
+				return { id: "sub_updated" };
+			},
+			cancel: async (
+				_subscriptionId: string,
+				params: Stripe.SubscriptionCancelParams,
+			) => {
+				mockState.cancelCalls.push(params);
+				return { id: "sub_canceled" };
+			},
+		},
+	}),
+}));
+
+const { executeStripeSubscriptionOperation } = await import(
+	"@/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation"
+);
+
+const ctx = {
+	org: { id: "org_123", config: { automatic_tax: false } },
+	env: "sandbox",
+} as unknown as AutumnContext;
+
+const subscriptionParams = {
+	cancellation_details: {
+		feedback: "too_expensive" as const,
+		comment: "Switching to a competitor",
+	},
+	items: [{ id: "si_user", quantity: 99 }],
+	expand: ["customer"],
+};
+
+const billingContext = {
+	stripeCustomer: { id: "cus_123" },
+	stripeSubscription: {
+		id: "sub_123",
+		billing_mode: { type: "flexible" },
+	},
+	subscriptionParams,
+} as unknown as BillingContext;
+
+describe(
+	chalk.yellowBright("executeStripeSubscriptionOperation subscription_params"),
+	() => {
+		beforeEach(() => {
+			mockState.updateCalls = [];
+			mockState.cancelCalls = [];
+		});
+
+		afterAll(() => {
+			mock.restore();
+		});
+
+		test("forwards extras on update and keeps reserved keys", async () => {
+			const subscriptionAction: StripeSubscriptionAction = {
+				type: "update",
+				stripeSubscriptionId: "sub_123",
+				params: { items: [{ id: "si_autumn", quantity: 2 }] },
+			};
+
+			await executeStripeSubscriptionOperation({
+				ctx,
+				billingContext,
+				subscriptionAction,
+			});
+
+			expect(mockState.updateCalls).toHaveLength(1);
+			expect(mockState.updateCalls[0]?.cancellation_details).toEqual(
+				subscriptionParams.cancellation_details,
+			);
+			expect(mockState.updateCalls[0]?.items).toEqual([
+				{ id: "si_autumn", quantity: 2 },
+			]);
+			expect(mockState.updateCalls[0]?.expand).toEqual(["latest_invoice"]);
+		});
+
+		test("forwards extras on cancel and keeps expand", async () => {
+			const subscriptionAction: StripeSubscriptionAction = {
+				type: "cancel",
+				stripeSubscriptionId: "sub_123",
+			};
+
+			await executeStripeSubscriptionOperation({
+				ctx,
+				billingContext,
+				subscriptionAction,
+			});
+
+			expect(mockState.cancelCalls).toHaveLength(1);
+			expect(mockState.cancelCalls[0]?.cancellation_details).toEqual(
+				subscriptionParams.cancellation_details,
+			);
+			expect(mockState.cancelCalls[0]?.expand).toEqual(["latest_invoice"]);
+		});
+	},
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Mirrors checkout's `buildCheckoutSessionParams` for Stripe subscription writes.

```
user subscription_params
        │
        ▼
omit reserved keys (items, cancel_at, expand, metadata, …)
        │
        ▼
{ ...userExtras, ...autumnParams }   ← Autumn always wins
```

Two helpers, one merge rule:

- `buildStripeSubscriptionUpdateParams` — `subscriptions.update`
- `buildStripeSubscriptionCancelParams` — `subscriptions.cancel`

Called from:

- the update action builder (so the stored action already includes user extras)
- execute, for both the update payload and the cancel payload (so execute-owned keys like `expand` / `metadata` still win)

`refund_last_payment` is unchanged. Create is unchanged. Same-sub inequality reject is still later.

## Reserved on update

`items`, `cancel_at`, `proration_behavior`, `payment_behavior`, `trial_end`, `trial_settings`, `discounts`, `automatic_tax`, `metadata`, `expand`, `default_payment_method`, `default_tax_rates`, `billing_cycle_anchor`, `collection_method`, `days_until_due`, `payment_settings`

## Reserved on cancel

`expand`

## Test plan

- Unit: user extras pass through; user `items` / `expand` / `metadata` cannot override Autumn
- Unit: execute update and cancel forward `cancellation_details` and keep Autumn `expand`
- Typecheck: `bunx tsgo --build --noEmit` from `server/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfc4e11f-ed3f-4fa7-80fa-f06687200b5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfc4e11f-ed3f-4fa7-80fa-f06687200b5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `subscriptionParams` pass-through to Stripe subscription update and cancel calls, mirroring the existing checkout builder. Previously, user extras like `cancellation_details` were dropped on writes; now they reach Stripe, but reserved keys (`items`, `expand`, `metadata`, and the rest) are always taken from Autumn.

**Behavior**
- User-provided keys not in the reserved lists flow through to `subscriptions.update` and `subscriptions.cancel`.
- Autumn-owned keys always win over user values, and user attempts to set them are stripped.
- The stored cancel action now carries merged params so `executeStripeSubscriptionOperation` doesn't lose user extras.

<sup>Written for commit 869ff7f8037573ee31ba6db6b16fe45b67e418c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds reserved-key builders that merge user-provided Stripe subscription parameters into subscription update and cancellation writes while preserving Autumn-owned values.

- **[API changes, Improvements]** Adds shared parameter builders for Stripe subscription updates and cancellations.
- **[API changes]** Forwards additional `subscription_params` through action construction and execution.
- **[Improvements]** Adds unit coverage for parameter forwarding and reserved-key precedence.
</details>


<h3>Confidence Score: 3/5</h3>

The PR should not merge until user parameters are prevented from bypassing Autumn's cancellation decisions and incompatible update parameters cannot reach Stripe's cancellation endpoint.

The new generic merge can directly schedule cancellation through cancel_at_period_end and can make immediate cancellation fail when the shared parameter bag contains fields accepted only by subscription updates.

**Files Needing Attention:** server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams.ts, server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts, server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams.ts | Adds the central merge policy, but leaves a cancellation control unreserved and forwards update-only keys to cancellation calls. |
| server/src/internal/billing/v2/providers/stripe/actionBuilders/buildStripeSubscriptionAction.ts | Adds user parameters to generated cancel actions, exposing the generic bag to an endpoint with a narrower parameter contract. |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionUpdateAction.ts | Stores merged user extras in update actions while preserving listed Autumn-owned fields. |
| server/src/internal/billing/v2/providers/stripe/utils/subscriptions/executeStripeSubscriptionOperation.ts | Applies the builders before Stripe update and cancel calls, making omitted reservations and incompatible keys observable at execution. |
| server/tests/unit/billing/stripe/subscriptions/build-stripe-subscription-params.test.ts | Covers basic pass-through and precedence but not cancellation scheduling controls or operation-incompatible keys. |
| server/tests/unit/billing/stripe/subscriptions/execute-stripe-subscription-params.test.ts | Confirms forwarding at execution but exercises only cancellation_details, which is valid for both endpoints. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request["Billing request<br/>subscription_params"] --> Context["Billing context"]
  Context --> Plan{"Computed subscription action"}
  Plan -->|Update| UpdateBuilder["Update parameter builder<br/>omit reserved update keys"]
  Plan -->|Cancel| CancelBuilder["Cancel parameter builder<br/>omit expand"]
  UpdateBuilder --> Update["Stripe subscriptions.update"]
  CancelBuilder --> Cancel["Stripe subscriptions.cancel"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams.ts:3-20
**Cancellation control bypasses Autumn**

When an update or multi-update request supplies `subscription_params.cancel_at_period_end`, this builder forwards it to Stripe instead of preserving Autumn's cancellation decision, scheduling cancellation outside the normal billing plan and leaving Stripe and Autumn state inconsistent until webhook reconciliation.

```suggestion
const SUBSCRIPTION_UPDATE_RESERVED_KEYS = [
	"items",
	"cancel_at",
	"cancel_at_period_end",
	"proration_behavior",
	"payment_behavior",
	"trial_end",
	"trial_settings",
	"discounts",
	"automatic_tax",
	"metadata",
	"expand",
	"default_payment_method",
	"default_tax_rates",
	"billing_cycle_anchor",
	"collection_method",
	"days_until_due",
	"payment_settings",
] as const satisfies readonly (keyof Stripe.SubscriptionUpdateParams)[];
```

### Issue 2
server/src/internal/billing/v2/providers/stripe/utils/subscriptions/buildStripeSubscriptionParams.ts:22-24
**Cancel receives update parameters**

When a request supplies an update-only Stripe parameter and removes every subscription item, the generic bag reaches `subscriptions.cancel`; for example, forwarding `trial_end` makes Stripe reject the cancellation instead of completing the billing operation.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: merge subscription\_params through ..."](https://github.com/useautumn/autumn/commit/869ff7f8037573ee31ba6db6b16fe45b67e418c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57512829)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->