### PR TITLE
fix: disable connection_search on every leaf agent

### DIFF
--- a/apps/leaf/agent/subagents/billing/tools/connection_search.ts
+++ b/apps/leaf/agent/subagents/billing/tools/connection_search.ts
@@ -1,0 +1,3 @@
+import { disabledFrameworkTool } from "../../../lib/disabledTools.js";
+
+export default disabledFrameworkTool;

--- a/apps/leaf/agent/subagents/investigator/tools/connection_search.ts
+++ b/apps/leaf/agent/subagents/investigator/tools/connection_search.ts
@@ -1,0 +1,3 @@
+import { disabledFrameworkTool } from "../../../lib/disabledTools.js";
+
+export default disabledFrameworkTool;

--- a/apps/leaf/agent/tools/connection_search.ts
+++ b/apps/leaf/agent/tools/connection_search.ts
@@ -1,0 +1,1 @@
+export { disabledFrameworkTool as default } from "../lib/disabledTools.js";


### PR DESCRIPTION
## What went wrong

A billing turn stalled and timed out. The Braintrust trace shows the child's second model call completing normally, then nothing:

```
13:48:44  billing subagent spawned
13:48:50  getCustomer, listPlans, getAgentRules   -> "Looking through your plans"
13:48:50  chat (6711ms, 18 output tokens) -> tool_calls: [connection_search]
          --- no execute_tool, no step 2, silence ---
13:49:40  "Chat agent timed out"
```

The model asked for `connection_search` (keywords: `"security add on"`). No tool executed, no further step ran, and the parent kept waiting on a child that had stopped emitting.

## Why it surfaced now

`connection_search` is eve's dynamic tool-discovery tool, auto-registered on any agent that declares a connection. Leaf pre-registers every Autumn tool directly with exact server schemas, so discovery is dead weight -- `autumnDirectTools` already says the model "never spends a turn on connection_search", and `discoveredConnectionTools` guards the collision case with "the prompt says never to search".

Nothing enforced that. It stayed dormant while phrasing mapped onto directly-registered tool names; "attach the security add on" didn't, so the model reached for discovery for the first time.

## The fix

Disable it on all three agents via eve's documented mechanism -- a `disableTool()` default export at `tools/<slug>.ts`, the same pattern already used for `bash`, `web_search`, etc.

## Validation

Compiled manifest (`.eve/compile/compiled-agent-manifest.json`), clean recompile:

| agent | before | after |
|---|---|---|
| root | absent | `connection_search` disabled |
| billing | absent | `connection_search` disabled |
| investigator | absent | `connection_search` disabled |

`eve info`: 0 errors, 0 warnings. `bun run ts` clean. `bun run test`: 489 pass, 0 fail.

## Follow-up (not in this PR)

Neither eve nor leaf repairs an unknown tool call, so a model naming any unregistered tool can stall a step. This PR removes the one surface we hit; the general guard is a separate change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables `connection_search` on all three leaf agents to prevent stalled turns that time out when the model tries to use the tool.

The billing subagent hit a stall when it called `connection_search`: the model emitted the tool call, nothing executed, and the parent waited on a dead child until timeout. Since Autumn tools are pre-registered with exact schemas, discovery is redundant, so this removes the failure surface using the same `disabledFrameworkTool` mechanism already used for `bash` and `web_search`.

<sup>Written for commit 87699fde662bcebbb706748c6e42ae62c772a8ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR disables the unnecessary `connection_search` framework tool for Leaf’s root, billing, and investigator agents, preventing discovered-tool calls from stalling agent turns.

- **Bug fixes:** Registers `connection_search` as disabled for the billing subagent.
- **Bug fixes:** Registers `connection_search` as disabled for the investigator subagent.
- **Bug fixes:** Registers `connection_search` as disabled for the root Leaf agent.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with all three agents using the repository’s established mechanism for disabling framework tools.

The new modules resolve to the shared `disabledFrameworkTool` export and mirror existing disabled-tool registrations in their respective agent directories, with no blocking or non-blocking defects identified.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/agent/subagents/billing/tools/connection_search.ts | Correctly disables `connection_search` using the same shared export and relative import pattern as existing billing-agent disabled tools. |
| apps/leaf/agent/subagents/investigator/tools/connection_search.ts | Correctly disables `connection_search` using the established investigator-agent tool convention. |
| apps/leaf/agent/tools/connection_search.ts | Correctly disables `connection_search` for the root agent through the shared framework-tool disablement export. |

<sub>Reviews (1): Last reviewed commit: ["fix: disable connection\_search on every ..."](https://github.com/useautumn/autumn/commit/87699fde662bcebbb706748c6e42ae62c772a8ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57513120)</sub>

<!-- /greptile_comment -->