### PR TITLE
release

### DIFF
--- a/apps/leaf/agent/subagents/billing/tools/connection_search.ts
+++ b/apps/leaf/agent/subagents/billing/tools/connection_search.ts
@@ -1,0 +1,3 @@
+import { disabledFrameworkTool } from "../../../lib/disabledTools.js";
+
+export default disabledFrameworkTool;

--- a/apps/leaf/agent/subagents/investigator/tools/connection_search.ts
+++ b/apps/leaf/agent/subagents/investigator/tools/connection_search.ts
@@ -1,0 +1,3 @@
+import { disabledFrameworkTool } from "../../../lib/disabledTools.js";
+
+export default disabledFrameworkTool;

--- a/apps/leaf/agent/tools/connection_search.ts
+++ b/apps/leaf/agent/tools/connection_search.ts
@@ -1,0 +1,1 @@
+export { disabledFrameworkTool as default } from "../lib/disabledTools.js";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disables the `connection_search` tool on every leaf agent so billing subagents no longer stall turns and time out.

- Removes the tool's availability in billing, investigator, and root leaf agent tool sets.
- Prevents model calls to `connection_search` that previously went unexecuted and hung the parent agent.

<sup>Written for commit 878507674fb25ef4162fd49d3f75b44332680d87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR disables the framework-provided `connection_search` tool for the main Leaf agent and its billing and investigator subagents.

- **[Bug fixes]** Adds disabled tool entry points for all three agents, preventing unsupported connection searches from stalling an agent turn.
- **[Improvements]** Uses the existing shared disabled-tool implementation consistently across the agent hierarchy.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete correctness, security, or maintainability issues identified.

The new entry points use valid relative imports and follow the repository's existing pattern for disabling unsupported framework tools across the main agent and both subagents.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/agent/subagents/billing/tools/connection_search.ts | Adds a correctly resolved disabled `connection_search` entry point for the billing subagent. |
| apps/leaf/agent/subagents/investigator/tools/connection_search.ts | Adds a correctly resolved disabled `connection_search` entry point for the investigator subagent. |
| apps/leaf/agent/tools/connection_search.ts | Re-exports the shared disabled framework tool as the main agent's `connection_search` entry point. |

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #3112 from useautumn/..."](https://github.com/useautumn/autumn/commit/878507674fb25ef4162fd49d3f75b44332680d87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57514159)</sub>

<!-- /greptile_comment -->