### PR TITLE
hotfix: remove connection_search disableTool files (eve fails to boot)

### DIFF
--- a/apps/leaf/agent/subagents/billing/tools/connection_search.ts
+++ b/apps/leaf/agent/subagents/billing/tools/connection_search.ts
@@ -1,3 +1,0 @@
-import { disabledFrameworkTool } from "../../../lib/disabledTools.js";
-
-export default disabledFrameworkTool;

--- a/apps/leaf/agent/subagents/investigator/tools/connection_search.ts
+++ b/apps/leaf/agent/subagents/investigator/tools/connection_search.ts
@@ -1,3 +1,0 @@
-import { disabledFrameworkTool } from "../../../lib/disabledTools.js";
-
-export default disabledFrameworkTool;

--- a/apps/leaf/agent/tools/connection_search.ts
+++ b/apps/leaf/agent/tools/connection_search.ts
@@ -1,1 +1,0 @@
-export { disabledFrameworkTool as default } from "../lib/disabledTools.js";


### PR DESCRIPTION
Reverts the three files added in #3112. **Prod is currently down** -- the embedded eve server crashes on startup.

## The crash

```
error: agent/tools/connection_search.ts exports disableTool() but
"connection_search" is not a framework tool. Rename the file to one of:
ask_question, bash, glob, grep, load_skill, read_file, todo, web_fetch,
web_search, write_file.
  at resolveRuntimeAgentNode (eve.mjs:74382)
  at resolveRuntimeAgentGraph
  at loadFullBundle
```

## Why

`disableTool()` validates against `ALL_FRAMEWORK_TOOLS` -- a fixed list of 10 static tools. `connection_search` is not one of them; it is a *dynamic resolver* appended by `createConnectionSearchResolver()` when `connections.length > 0`. Because it is gated on connections existing, it cannot be removed through the `tools/` mechanism at all.

## How this reached prod

The validation runs **only at runtime**. `eve build` and `eve info` both accept the files, and the compiled manifest lists `connection_search` under `disabledFrameworkTools` on all three agents -- which is what I verified against. Nothing catches it until `resolveRuntimeAgentNode` runs on boot.

## Consequence

This restores the original stall risk from #3112: a model that calls `connection_search` gets no tool dispatch and the child goes silent. That is a rare, phrasing-triggered hang; the current state is a total outage, so reverting is strictly better.

Proper fix to follow -- guard the unknown/failed tool call so the step errors instead of stalling, which covers the whole class rather than removing one tool.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the three `connection_search` `disableTool` files so `eve` boots again in production.

- `disableTool()` validates against a fixed list of 10 framework tools, but `connection_search` is a dynamic resolver that only exists when connections are configured, so boot throws and the server never starts.
- `eve build` and `eve info` accept the files, so the break only surfaces at runtime in production.
- Reverting restores the rare stall when a model calls `connection_search`, but that beats a total outage; a proper guard for the unknown tool call will follow.

<sup>Written for commit 7de6d8407abec7b6d40a905bdd5c450603377e7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This hotfix removes three invalid `connection_search` disable-tool files so the embedded Eve server can boot again.

- **Bug fixes:** Removes the main-agent disable entry that causes runtime validation to reject the dynamic `connection_search` resolver.
- **Bug fixes:** Removes the equivalent disable entries from the billing and investigator subagents.
- **Improvements:** Restores production availability while deferring the acknowledged unknown-tool stall to a broader follow-up fix.
</details>


<h3>Confidence Score: 5/5</h3>

The hotfix appears safe to merge and directly removes the files identified as causing the production startup failure.

The PR only deletes three equivalent invalid disable-tool declarations; the remaining rare agent-stall behavior is explicitly acknowledged as restored pre-existing behavior and is deferred to a broader follow-up fix.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/agent/tools/connection_search.ts | Deletes the invalid main-agent disable-tool export that prevents Eve runtime initialization. |
| apps/leaf/agent/subagents/billing/tools/connection_search.ts | Deletes the same invalid disable-tool export from the billing subagent. |
| apps/leaf/agent/subagents/investigator/tools/connection_search.ts | Deletes the same invalid disable-tool export from the investigator subagent. |

<sub>Reviews (1): Last reviewed commit: ["hotfix: remove connection\_search disable..."](https://github.com/useautumn/autumn/commit/7de6d8407abec7b6d40a905bdd5c450603377e7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57518826)</sub>

<!-- /greptile_comment -->