### PR TITLE
fix: recover the turn when a tool call never dispatches

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts
@@ -35,6 +35,7 @@ export type EveTurnOutcome =
 	| { kind: "parked"; question?: PendingQuestion; text: string }
 	| { kind: "deferred" }
 	| { kind: "silent" }
+	| { kind: "stalled"; tools: readonly string[] }
 	| { kind: "stopped"; stopReason: RunStopReason; text: string }
 	| { approval: AgentApprovalRequest; kind: "suspended"; text: string }
 	| { kind: "unreachable" };
@@ -340,6 +341,12 @@ const turnDeferredItsInput = (progress: EveTurnProgress) =>
 	!progress.sawToolActivity &&
 	progress.subagentChildSessionIds.size === 0;
 
+/** A requested call clears from toolLabels when its result lands, so anything
+ * still there at a park was never dispatched and no result is coming. */
+const undispatchedToolNames = (progress: EveTurnProgress) => [
+	...new Set(progress.toolLabels.values()),
+];
+
 const reduceTerminalEvent = ({
 	event,
 	progress,
@@ -351,6 +358,21 @@ const reduceTerminalEvent = ({
 	const catalogDecision = catalogPlanNeedingDecision(
 		progress.lastPreview?.preview,
 	);
+	const stalledTools = undispatchedToolNames(progress);
+	const outcome: EveTurnOutcome = eveTurnProducedOutput({
+		catalogDecision,
+		text,
+	})
+		? { catalogDecision, kind: "answered", text }
+		: stalledTools.length > 0
+			? { kind: "stalled", tools: stalledTools }
+			: { kind: turnDeferredItsInput(progress) ? "deferred" : "silent" };
+	if (outcome.kind === "stalled") {
+		logger.warn("Eve parked with tool calls that never ran", {
+			event: "leaf.eve_turn_stalled",
+			data: { tools: stalledTools },
+		});
+	}
 	return {
 		effects: [
 			{
@@ -358,9 +380,7 @@ const reduceTerminalEvent = ({
 				status: event.type === "session.completed" ? "completed" : "waiting",
 			},
 		],
-		outcome: eveTurnProducedOutput({ catalogDecision, text })
-			? { catalogDecision, kind: "answered", text }
-			: { kind: turnDeferredItsInput(progress) ? "deferred" : "silent" },
+		outcome,
 		progress,
 	};
 };

--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts
@@ -1,4 +1,5 @@
 import { db } from "../../../../lib/db.js";
+import { stalledToolNudge } from "../../../../ui/messages.js";
 import { isInternalAutumnSlackProvider } from "../../../slackAdmin/provider.js";
 import type {
 	AgentTurnContext,
@@ -152,6 +153,23 @@ export const runAgentTurn = async ({
 			// its own deferred input, and must not read as a fresh deferral.
 			outcome =
 				redelivered.kind === "deferred" ? { kind: "silent" } : redelivered;
+		}
+		if (outcome.kind === "stalled") {
+			logger.warn("Eve parked on undispatched tool calls; nudging the turn", {
+				event: "leaf.eve_stalled_turn_nudged",
+				data: {
+					session_id: session.sessionId,
+					stream_index: session.state.streamIndex,
+					tools: outcome.tools,
+				},
+			});
+			await postEveMessage({
+				auth: { ...auth, orgInstructions: prepared.orgContext?.instructions },
+				message: stalledToolNudge(outcome.tools),
+				session,
+			});
+			const resumed = await consume(session);
+			outcome = resumed.kind === "stalled" ? { kind: "silent" } : resumed;
 		}
 		const result = await resolveAgentTurnOutcome({
 			env,

--- a/apps/leaf/src/ui/messages.ts
+++ b/apps/leaf/src/ui/messages.ts
@@ -40,6 +40,13 @@ export const QUESTION_ANSWER_FAILED_MESSAGE =
 export const questionAnswerFailedWithDetail = (detail: string) =>
 	`I couldn't record that answer (${detail}). Reply in the thread instead.`;
 
+export const stalledToolNudge = (tools: readonly string[]) =>
+	`(Your last turn requested ${tools.join(", ")} but ${
+		tools.length === 1 ? "it" : "they"
+	} never ran and no result is coming. Do not call ${
+		tools.length === 1 ? "it" : "them"
+	} again — every tool you need is already registered and callable by name. Continue the user's request with the tools you have.)`;
+
 // Run lifecycle
 
 export const RUN_TIMED_OUT_MESSAGE =

--- a/apps/leaf/tests/unit/harness/stalled-tool-call.test.ts
+++ b/apps/leaf/tests/unit/harness/stalled-tool-call.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type EveTurnOutcome,
+	type EveTurnProgress,
+	reduceEveTurnEvent,
+} from "../../../src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.js";
+import type { EveEvent } from "../../../src/internal/agentRuntime/eve/eveEventSchemas.js";
+
+const blankProgress = (): EveTurnProgress => ({
+	finalText: "",
+	pendingText: "",
+	sawToolActivity: false,
+	subagentChildSessionIds: new Set(),
+	subagentStartedAtByCallId: new Map(),
+	toolInputs: new Map(),
+	toolLabels: new Map(),
+	turnStarted: false,
+});
+
+const event = (partial: Record<string, unknown>) =>
+	partial as unknown as EveEvent;
+
+const drive = (events: Array<Record<string, unknown>>) => {
+	let progress = blankProgress();
+	let outcome: EveTurnOutcome | undefined;
+	for (const raw of events) {
+		const transition = reduceEveTurnEvent({ event: event(raw), progress });
+		progress = transition.progress;
+		if (transition.outcome) outcome = transition.outcome;
+	}
+	return outcome;
+};
+
+const ranTools = [
+	{ callId: "c1", toolName: "autumn__getCustomer" },
+	{ callId: "c2", toolName: "autumn__listPlans" },
+];
+
+describe("a tool call that never dispatches", () => {
+	test("parking with an unresolved call reports the stalled tool", () => {
+		// Prod 2026-08-27 13:48: the child asked for connection_search, eve never
+		// dispatched it, and the turn parked with no result and no next step.
+		const outcome = drive([
+			{ type: "turn.started" },
+			{ type: "step.started" },
+			{ actions: ranTools, type: "actions.requested" },
+			...ranTools.map((result) => ({
+				result,
+				status: "ok",
+				type: "action.result",
+			})),
+			{ type: "step.started" },
+			{
+				actions: [{ callId: "c3", toolName: "connection_search" }],
+				type: "actions.requested",
+			},
+			{ type: "session.waiting" },
+		]);
+
+		expect(outcome).toMatchObject({
+			kind: "stalled",
+			tools: ["Connection search"],
+		});
+	});
+
+	test("a turn whose calls all resolved stays silent", () => {
+		const outcome = drive([
+			{ type: "turn.started" },
+			{ type: "step.started" },
+			{ actions: ranTools, type: "actions.requested" },
+			...ranTools.map((result) => ({
+				result,
+				status: "ok",
+				type: "action.result",
+			})),
+			{ type: "session.waiting" },
+		]);
+
+		expect(outcome).toMatchObject({ kind: "silent" });
+	});
+
+	test("the model's tool-calls finish does not count as an answer", () => {
+		// eve emits message.completed with finishReason "tool-calls" carrying the
+		// undispatched call, which must not read as a reply to the user.
+		const outcome = drive([
+			{ type: "turn.started" },
+			{ type: "step.started" },
+			{
+				actions: [{ callId: "c1", toolName: "connection_search" }],
+				type: "actions.requested",
+			},
+			{ finishReason: "tool-calls", message: "", type: "message.completed" },
+			{ type: "session.waiting" },
+		]);
+
+		expect(outcome).toMatchObject({ kind: "stalled" });
+	});
+
+	test("a turn that answered is unaffected by an unresolved call", () => {
+		const outcome = drive([
+			{ type: "turn.started" },
+			{ type: "step.started" },
+			{
+				actions: [{ callId: "c1", toolName: "connection_search" }],
+				type: "actions.requested",
+			},
+			{ message: "Here is the plan.", type: "message.completed" },
+			{ type: "session.waiting" },
+		]);
+
+		expect(outcome).toMatchObject({ kind: "answered" });
+	});
+});


### PR DESCRIPTION
Fixes the stall behind the "Looking through your plans" hangs, at the level of the class rather than the one tool. Replaces the approach in #3112, which was reverted in #3114 for crashing eve on boot.

## Reproduced first

Driving the reducer with the exact prod event sequence (child `wrun_01M11QNVG2M0Y24HKF6X1ZF363`, 2026-08-27 13:48) -- three tools run, the model asks for a fourth, eve never dispatches it:

| | before | after |
|---|---|---|
| stalled turn | `{"kind":"silent"}` | `{"kind":"stalled","tools":["Connection search"]}` |
| healthy turn | `{"kind":"silent"}` | `{"kind":"silent"}` |

Both used to park as `silent`, so leaf posted nothing and the thread froze on the last status line while the parent waited out the full timeout.

## The signal

`toolLabels` tracks in-flight calls: an entry is added on `actions.requested` and deleted on `action.result`. Anything still present when the turn parks was requested but never ran, and no result is coming. That is a precise, tool-agnostic signature -- it catches any undispatched call, not just `connection_search`.

## The recovery

A stalled turn posts a short note back to the agent saying the call will not return and it should continue with the tools it already has, then re-consumes. The agent finishes the user's request normally instead of the thread dying. A second stall settles to `silent` rather than looping, matching the existing `deferred` redelivery pattern directly above it.

New log `leaf.eve_turn_stalled` (tools) and `leaf.eve_stalled_turn_nudged` (session, stream index, tools) make this visible in Axiom rather than silent.

## Validation

Red/green: the two stalled-detection tests **fail against the unfixed reducer** (2 fail / 2 pass), all 4 pass with the fix. The controls -- a fully-resolved turn and an answered turn -- pass either way, so they pin the behaviour that must not change.

Full suite 493 pass / 0 fail, `bun run ts` clean, biome clean on the touched files.

**Boot verified**: `bun .output/server/index.mjs` reaches `Listening on`. #3112 passed build and `eve info` but crashed at `resolveRuntimeAgentNode` on startup; booting the built server is the check that catches that class, and it is now part of what I run before pushing agent-config changes.

## Note

This handles the stall gracefully but does not stop the model reaching for `connection_search`. eve's framework prompt advertises it while leaf's says never to search, and the framework text sits next to the tool definition. Worth countering in the subagent instructions as a follow-up -- with this guard in place, a call that slips through is recoverable rather than fatal.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stall behind the "Looking through your plans" hang: a requested tool call that never dispatched used to park the turn as `silent`, leaving the thread frozen on the last status line while the parent waited out its full timeout. Now such turns are detected as `stalled` and recovered by nudging the agent to continue with the tools it already has.

Detection is class-level rather than per tool: a call clears from `toolLabels` when its result lands, so anything still present at park time was requested but never ran.

- A stalled turn posts a note that the call will not return, then re-consumes so the agent finishes the user's request instead of the thread dying.
- A second stall settles to `silent` rather than looping, matching the existing `deferred` redelivery pattern.
- Logs `leaf.eve_turn_stalled` and `leaf.eve_stalled_turn_nudged` for visibility in Axiom.
- Red/green tests cover stalled and healthy turns; the full suite passes and the built server boots, which catches the class of failure the previous approach hit at startup.

<sup>Written for commit aee10b6a8a05ff212fa9b5929212d4f8dc6f6120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR detects agent turns that park with unresolved tool requests and nudges the agent to continue instead of leaving the conversation stalled.

- **Bug fixes:** Adds a `stalled` reducer outcome based on unresolved tool labels and retries the turn with a recovery message.
- **Improvements:** Adds warnings with session and tool details so stalled turns can be diagnosed.
- **Bug fixes:** Adds reducer tests for unresolved, resolved, tool-call-only, and answered turns.
</details>


<h3>Confidence Score: 4/5</h3>

The stalled-turn fix needs to adopt the session returned by the recovery post before it is safe to merge.

Eve can re-home a run while accepting the nudge, but the new branch resumes with the old session ID, token, and cursor, allowing it to miss the recovery response.

**Files Needing Attention:** apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/eveTurnReducer.ts | Adds stalled-turn classification and logging when unresolved tool labels remain at a terminal event. |
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts | Adds the recovery nudge and re-consumption flow, but fails to adopt the session state returned by the nudge post. |
| apps/leaf/src/ui/messages.ts | Adds the fixed agent-facing message used to explain an undispatched tool request. |
| apps/leaf/tests/unit/harness/stalled-tool-call.test.ts | Covers reducer classification but does not exercise session re-homing during the full post-and-resume recovery path. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant E as Eve
    participant L as Leaf
    participant A as Agent
    E->>L: session.waiting with unresolved tool label
    L->>L: classify outcome as stalled
    L->>E: post recovery nudge
    E-->>L: returned session ID and continuation token
    Note over L: Current code ignores returned session state
    L->>E: consume using original session cursor
    E-->>A: resumed answer or missed events after re-home
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/runAgentTurn.ts:166-171
**Posted session state discarded**

If Eve re-homes the run or rotates its continuation token while accepting this nudge, `postEveMessage` returns the updated session state but this branch discards it and consumes with the old ID, token, and cursor, causing Leaf to skip the recovery response and return no useful answer.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: recover the turn when a tool call n..."](https://github.com/useautumn/autumn/commit/aee10b6a8a05ff212fa9b5929212d4f8dc6f6120) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57522117)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->