### PR TITLE
Reuse matching custom fixed Stripe Prices across customers on the same plan.

### DIFF
--- a/plans/stripe-price-reuse.md
+++ b/plans/stripe-price-reuse.md
@@ -1,0 +1,277 @@
+# Stripe price reuse finder
+
+2026-08-27 · `john/stripe-price-reuse` · on `97faae499c`
+
+When customize (or any init) needs a Stripe Price, find an Autumn price
+row we already minted that is **the same definition**, copy its
+`stripe_*` ids, then let the retrieve we already do reject a dead or
+drifted Stripe object. Do not list Stripe. Do not search `stripe.prices`.
+
+---
+
+## The hole
+
+```
+A  billing.attach  Pro  customize.price $25
+   new pr_A (is_custom)
+   carryForward candidates = catalog only          ← getFull drops is_custom
+   pricesAreSame($25, $20) = false
+   mint price_A
+
+B  same attach
+   new pr_B
+   same candidates
+   mint price_B
+```
+
+`composeFullProductQuery` loads `prices.is_custom = false` only
+(`composeFullProductQuery.ts:22`). The matcher is fine. The candidate
+set is not.
+
+`reuse-stripe-prices-custom-plan.test.ts` asserts customer vs **catalog**.
+Nothing asserts A then B.
+
+---
+
+## What this function is
+
+A third candidate source on the existing init path. Not a new matcher.
+
+```
+initStripeResourcesForProducts / ForBillingPlan
+  applyStripeResourceReuseForProduct      in-memory catalog + caller candidates
+  applyStripeReuseFromVariantFamilies     other versions / variants, catalog only
++ findReusableStripeResourcesForProducts  DB: custom siblings (and later versions)
+  createStripePriceIFNotExist
+    checkCurStripePrice retrieve          already paid; this is the validate
+```
+
+In-memory reuse stays first and free. The finder runs only for prices
+that still miss a required slot (`priceHasMissingStripeResources`).
+
+Miss → mint. The finder never blocks attach on Stripe HTTP.
+
+---
+
+## Not doing
+
+- Stripe `prices.list` / Search / `stripe.prices` sync DB
+- Replacing `getPriceStripeReuseLevel` / `pricesAreSame` / `entsAreSame`
+- Copying `"stripeProductOnly"` (feature Product / meter already carry)
+- Copying `product.processor.id` across different `product.id`s
+- Entity-level prepaid (inline price)
+- `$0` fixed (`shouldInitializeStripePrice`)
+- lookup_key / concurrent A+B dedup (both miss, two mints — accept)
+- Patch customize carry (`add_items` without `carryForward`) — later unit
+- Org-wide “same price in general”
+
+---
+
+## Match — already written
+
+`"full"` only. `getPriceStripeReuseLevel` + `copyStripeResourcesToMatchingPrice`.
+
+Hard filters (all must pass):
+
+| gate | already |
+|---|---|
+| org + env | product join |
+| not self | `price.id` |
+| usable stripe id | non-null, not preview |
+| same `config.type` | fixed ≠ usage |
+| `pricesAreSame` | amount, interval, interval_count, bill_when, billing_units, feature ids, tiers, proration, allocated behavior, currencies |
+| usage: `entsAreSame` | feature, allowance, interval, entity_feature_id, pooled, usage_limit, rollover |
+| currency slot | the attach currency’s `stripe_*` id |
+
+`pricesAreSame` treats add/remove of a catalog currency as compatible
+(versioning). For reuse that may be too loose — see **open**.
+
+---
+
+## Query — one batched read
+
+Not per price. Collect every target still missing a slot, one `WHERE
+internal_product_id IN (...)`.
+
+`prices.internal_product_id` is indexed. `config.internal_feature_id`
+is indexed for usage.
+
+```
+listStripeReuseCandidatePrices({ ctx, internalProductIds, excludePriceIds })
+  prices
+    join products   org_id, env, id, internal_id, processor
+    left join ents  on prices.entitlement_id
+  where
+    products.org_id = ctx.org.id
+    products.env    = ctx.env
+    prices.internal_product_id IN (...)
+    prices.id NOT IN exclude
+    stripe_price_id present          (or the slot we actually need)
+    not preview prefix
+  order by
+    is_custom ASC,                   catalog first
+    created_at ASC
+  limit 100
+```
+
+SQL prefilter (false negative OK, false positive not):
+
+- fixed: `config->>'amount'`, `config->>'interval'`
+- usage: `config->>'feature_id'`, `config->>'bill_when'`, interval
+
+Tiers stay in memory. `getPriceStripeReuseLevel === "full"` is the
+source of truth.
+
+**Unit 1 scope = same `internal_product_id` only.** Same `product.id`
+(other versions) and variant family already have a catalog-only path.
+Custom-across-versions is unit 3 if we still want it.
+
+Load the paired entitlement. `"full"` for usage needs `entsAreSame`.
+`getFull` will not have given us custom ents.
+
+---
+
+## Rank
+
+`copyStripeResourcesToMatchingPrice` takes the first `"full"` in array
+order. Sort, then pass `[winner]`.
+
+```
+1. is_custom = false
+2. same Stripe Product
+     fixed → product.processor.id
+     usage → candidate.config.stripe_product_id
+             vs target / feature.stripe_product_id / plan processor
+     (if target has no product id yet, this key is a tie)
+3. same product.id
+4. same internal_id
+5. oldest created_at
+```
+
+Never copy plan `processor.id` from a different `product.id`
+(migrations already set `reuseProcessor: false`).
+
+---
+
+## Validate — no extra HTTP
+
+After we stamp a borrowed id, `checkCurStripePrice` already retrieves it.
+
+```
+own id + active + shape ok        reuse
+own id + !active + shape ok       reactivate (today)
+borrowed + !active                skip, mint
+any + currency mismatch           skip, mint (today)
+any + !stripePriceShapesEqual     skip, mint   ← new, kills drift
+```
+
+Borrowed = `PriceService.getByStripeId` owner is not the target row.
+Own-row inactive can still reactivate. Borrowed inactive cannot.
+
+---
+
+## Shape
+
+```
+server/src/internal/products/stripeResourceUtils/findReusableStripeResources/
+  findReusableStripeResourcesForProducts.ts   orchestrator
+  findReusableStripeResources.ts              one target → winner | null
+  listStripeReuseCandidatePrices.ts           one query
+  rankStripeReuseCandidates.ts                pure sort
+
+shared/utils/productUtils/priceUtils/match/
+  getPriceStripeReuseLevel.ts                 unchanged
+  copyStripeResourcesToMatchingPrice.ts       unchanged
+```
+
+```ts
+findReusableStripeResourcesForProducts({ ctx, products }): Promise<void>
+findReusableStripeResources({
+  targetPrice,
+  targetEntitlements,
+  targetProduct,
+  candidates,
+}): Price | null
+```
+
+Orchestrator reads as:
+
+```
+missing = prices still missing a slot
+if none: return
+candidates = listStripeReuseCandidatePrices(...)
+for each missing:
+  winner = findReusableStripeResources(...)
+  if winner: copyStripeResourcesToMatchingPrice({ candidatePrices: [winner] })
+  persist config if the row exists
+```
+
+Customize rows are often not in the DB yet (insert is execute). Stamp
+in memory; `PriceService.update` is a no-op until the row exists.
+`createStripePriceIFNotExist` then sees the stamped id and retrieves.
+
+---
+
+## Latency
+
+- 0 queries when every price already has its slot (catalog attach)
+- 1 indexed query when something is missing
+- 0 new Stripe HTTP (retrieve is already in `checkCurStripePrice`)
+- `LIMIT 100` after amount/interval prefilter
+- skip the finder if Stripe writes are disabled / no Stripe account
+
+---
+
+## Units
+
+### 1 · [ ] finder + matrix (no attach)
+
+**goal** — one function that is wrong-never, miss-ok
+**steps** — list query · rank · `findReusableStripeResources` · unit matrix
+**verify** — `bun test` the matrix file
+
+**scenarios** — findReusableStripeResources
+- A custom $25, B custom $25, same Pro, fixed
+- A $25, B $20 catalog
+- A $25 monthly, B $25 yearly
+- A prepaid $25, B prepaid $25, same feature
+- A prepaid $25, B consumable $25, same feature
+- A messages $25, B seats $25
+- USD $25 vs EUR $25
+- preview `stripe_price_id`
+- two matching custom rows → oldest, catalog beats custom
+- other org / other `internal_product_id`
+- usage ents differ (allowance / entity_feature_id)
+
+**shape** — signatures above
+
+### 2 · [ ] borrowed retrieve
+
+**goal** — stamped id that is inactive or drifted does not land on a sub
+**steps** — `checkCurStripePrice` borrowed / shape branches
+**verify** — unit: inactive borrowed → mint; drifted amount → mint; own inactive + same shape → reactivate
+
+### 3 · [ ] wire into init + attach customize
+
+**goal** — A then B share `stripe_price_id`
+**steps** — call finder after variant-family reuse in both init wrappers
+**verify** — `bun t` new feature-products-style file: two customers, customize $25
+
+**scenarios** — billing.attach customize
+- Pro $20 catalog, A $25, B $25 · attach
+- Pro $20, A $25, B $20 (no customize) · attach
+- Pro + prepaid messages, A $10, B $10 · attach
+- concurrent A+B $25 · attach (two mints OK)
+
+### 4 · [ ] updateSubscription customize
+
+**goal** — same finder, second action
+**verify** — A attach $25, C updateSubscription to $25
+
+---
+
+## Open
+
+- ? `pricesAreSame` currency compatibility vs `priceCurrencyDefinitionsAreSame` for reuse
+- ? Unit 1 stays `internal_product_id` only, or same `product.id` in the first query
+- ? `LIMIT 100` after prefilter — OK, or catalog-only subquery then custom

--- a/server/experiments/explainFindNewestReusableFixedPrice.ts
+++ b/server/experiments/explainFindNewestReusableFixedPrice.ts
@@ -1,0 +1,168 @@
+import {
+	AppEnv,
+	BillingInterval,
+	isFixedPrice,
+	organizations,
+	type Price,
+	priceConfigForCurrency,
+	prices,
+	PriceType,
+	products,
+} from "@autumn/shared";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
+import { initDrizzle } from "../src/db/initDrizzle";
+import { composeNewestReusableFixedPriceQuery } from "../src/internal/products/prices/repos/findNewestReusableFixedPrice";
+
+const STATEMENT_TIMEOUT_MS = 30_000;
+
+// Infisical staging DATABASE_URL is the unit-test Neon. Mintlify lives on the replica.
+const dbUrl = process.env.DATABASE_REPLICA_URL || process.env.DATABASE_URL || "";
+const maskedUrl = dbUrl.replace(/:\/\/[^@]+@/, "://***:***@") || "(empty)";
+
+if (/autumn-prod|-prod-/i.test(dbUrl) && process.env.ALLOW_NON_STAGING !== "1") {
+	throw new Error(`DATABASE_URL looks like prod (${maskedUrl}). Use staging.`);
+}
+
+const orgSlug = (
+	process.env.EXPLAIN_ORG_SLUG ?? "mintlify"
+).toLowerCase();
+const env = process.env.EXPLAIN_ENV === "sandbox" ? AppEnv.Sandbox : AppEnv.Live;
+const analyze = process.argv.includes("--analyze");
+
+const requireRow = <T>(row: T | undefined, label: string): T => {
+	if (!row) throw new Error(`${label} not found`);
+	return row;
+};
+
+const main = async () => {
+	console.log("DATABASE URL host:", maskedUrl);
+	console.log(`org slug: ${orgSlug}  env: ${env}  analyze: ${analyze}`);
+
+	const { db } = initDrizzle({
+		databaseUrl: dbUrl,
+		maxConnections: 2,
+		name: "explain-reusable-price",
+	});
+
+	const org = requireRow(
+		(
+			await db
+				.select({
+					id: organizations.id,
+					slug: organizations.slug,
+					default_currency: organizations.default_currency,
+				})
+				.from(organizations)
+				.where(sql`lower(${organizations.slug}) = ${orgSlug}`)
+				.limit(1)
+		)[0],
+		`organization slug ${orgSlug}`,
+	);
+
+	const orgDefaultCurrency = (org.default_currency ?? "usd").toLowerCase();
+
+	const product = requireRow(
+		(
+			await db
+				.select({
+					id: products.id,
+					priceCount: sql<number>`count(*)::int`,
+				})
+				.from(products)
+				.innerJoin(
+					prices,
+					eq(prices.internal_product_id, products.internal_id),
+				)
+				.where(
+					and(
+						eq(products.org_id, org.id),
+						eq(products.env, env),
+						isNull(products.deleted_at),
+						sql`${prices.config} ->> 'type' = ${PriceType.Fixed}`,
+					),
+				)
+				.groupBy(products.id)
+				.orderBy(desc(sql`count(*)`))
+				.limit(1)
+		)[0],
+		`fixed-price product for ${orgSlug}`,
+	);
+
+	const sample = requireRow(
+		(
+			await db
+				.select({ price: prices })
+				.from(prices)
+				.innerJoin(
+					products,
+					eq(prices.internal_product_id, products.internal_id),
+				)
+				.where(
+					and(
+						eq(products.org_id, org.id),
+						eq(products.env, env),
+						eq(products.id, product.id),
+						isNull(products.deleted_at),
+						sql`${prices.config} ->> 'type' = ${PriceType.Fixed}`,
+					),
+				)
+				.orderBy(desc(prices.created_at))
+				.limit(1)
+		)[0],
+		`sample fixed price on ${product.id}`,
+	);
+
+	const targetPrice = sample.price as Price;
+	if (!isFixedPrice(targetPrice)) {
+		throw new Error("sample price is not fixed");
+	}
+
+	const targetCurrency = orgDefaultCurrency;
+	const { amount } = priceConfigForCurrency({
+		config: targetPrice.config,
+		currency: targetCurrency,
+		orgDefault: orgDefaultCurrency,
+	});
+	if (amount == null) {
+		throw new Error(`sample price has no ${targetCurrency} amount`);
+	}
+
+	const query = composeNewestReusableFixedPriceQuery({
+		db,
+		orgId: org.id,
+		env,
+		productId: product.id,
+		excludePriceId: targetPrice.id,
+		targetCurrency,
+		orgDefaultCurrency,
+		amount,
+		interval: targetPrice.config.interval ?? BillingInterval.Month,
+		intervalCount: targetPrice.config.interval_count ?? 1,
+	});
+
+	console.log(
+		`product.id=${product.id}  fixed prices=${product.priceCount}  amount=${amount}  interval=${targetPrice.config.interval}`,
+	);
+
+	const explain = analyze
+		? sql`EXPLAIN (ANALYZE, BUFFERS, VERBOSE, FORMAT TEXT) ${query}`
+		: sql`EXPLAIN (VERBOSE, FORMAT TEXT) ${query}`;
+
+	const plan = await db.transaction(async (tx) => {
+		await tx.execute(
+			sql.raw(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`),
+		);
+		return tx.execute(explain);
+	});
+
+	const rows = Array.isArray(plan)
+		? plan
+		: ((plan as { rows?: Record<string, unknown>[] }).rows ?? []);
+	for (const row of rows) {
+		console.log((row as Record<string, unknown>)["QUERY PLAN"]);
+	}
+
+	process.exit(0);
+};
+
+await main();

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -25,6 +25,7 @@ import { isStripeConnected } from "@/internal/orgs/orgUtils.js";
 import { checkStripeProductExists } from "@/internal/products/productUtils";
 import { applyStripeResourceReuseForProduct } from "@/internal/products/stripeResourceUtils/applyStripeResourceReuseForProduct";
 import { applyStripeReuseFromVariantFamilies } from "@/internal/products/stripeResourceUtils/applyStripeReuseFromVariantFamilies";
+import { findReusableStripePrice } from "@/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice";
 import {
 	planLicenseToCustomStripeInitProduct,
 	planLicenseToStripeInitProduct,
@@ -71,9 +72,15 @@ export const initStripeResourcesForProducts = async ({
 			)
 			.filter((licenseProduct) => licenseProduct !== null),
 	);
+	const initProducts = [...products, ...customLicenseProducts];
+	await findReusableStripePrice({
+		ctx,
+		products: initProducts,
+		currency: orgToCurrency({ org }).toLowerCase(),
+	});
 
 	const batchProductUpdates = [];
-	for (const product of [...products, ...customLicenseProducts]) {
+	for (const product of initProducts) {
 		if (product.processor?.id != null) continue;
 
 		batchProductUpdates.push(
@@ -90,7 +97,7 @@ export const initStripeResourcesForProducts = async ({
 
 	const batchPriceUpdates = [];
 
-	for (const product of [...products, ...customLicenseProducts]) {
+	for (const product of initProducts) {
 		for (const price of product.prices) {
 			batchPriceUpdates.push(
 				createStripePriceIFNotExist({
@@ -236,6 +243,12 @@ export const initStripeResourcesForBillingPlan = async ({
 	await applyStripeReuseFromVariantFamilies({ ctx, products: targetProducts });
 
 	if (orgDisableStripeWrites({ ctx })) return;
+
+	await findReusableStripePrice({
+		ctx,
+		products: targetProducts,
+		currency,
+	});
 
 	const batchProductUpdates = [];
 	for (const product of targetProducts) {

--- a/server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts
+++ b/server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts
@@ -1,0 +1,99 @@
+import {
+	type AppEnv,
+	isFixedPrice,
+	orgToCurrency,
+	type Price,
+	priceConfigForCurrency,
+	prices,
+	PriceType,
+	products,
+} from "@autumn/shared";
+import { and, desc, eq, ne, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { liveProductWhere } from "@/internal/products/repos/liveProductWhere.js";
+import { composeAttachCurrencyFixedMatch } from "./utils/composeAttachCurrencyFixedMatch.js";
+
+export const composeNewestReusableFixedPriceQuery = ({
+	db,
+	orgId,
+	env,
+	productId,
+	excludePriceId,
+	targetCurrency,
+	orgDefaultCurrency,
+	amount,
+	interval,
+	intervalCount,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	productId: string;
+	excludePriceId: string;
+	targetCurrency: string;
+	orgDefaultCurrency: string;
+	amount: number;
+	interval: string;
+	intervalCount: number;
+}) =>
+	db
+		.select({ price: prices })
+		.from(prices)
+		.innerJoin(products, eq(prices.internal_product_id, products.internal_id))
+		.where(
+			and(
+				eq(products.org_id, orgId),
+				eq(products.env, env),
+				eq(products.id, productId),
+				liveProductWhere,
+				ne(prices.id, excludePriceId),
+				sql`${prices.config} ->> 'type' = ${PriceType.Fixed}`,
+				sql`${prices.config} ->> 'interval' = ${interval}`,
+				sql`COALESCE((${prices.config} ->> 'interval_count')::int, 1) = ${intervalCount}`,
+				composeAttachCurrencyFixedMatch({
+					targetCurrency,
+					orgDefaultCurrency,
+					amount,
+				}),
+			),
+		)
+		.orderBy(desc(prices.created_at))
+		.limit(1);
+
+export const findNewestReusableFixedPrice = async ({
+	ctx,
+	targetPrice,
+	productId,
+	targetCurrency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	productId: string;
+	targetCurrency: string;
+}): Promise<Price | null> => {
+	if (!isFixedPrice(targetPrice)) return null;
+
+	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+	const { amount } = priceConfigForCurrency({
+		config: targetPrice.config,
+		currency: targetCurrency,
+		orgDefault: orgDefaultCurrency,
+	});
+	if (amount == null) return null;
+
+	const rows = await composeNewestReusableFixedPriceQuery({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		productId,
+		excludePriceId: targetPrice.id,
+		targetCurrency,
+		orgDefaultCurrency,
+		amount,
+		interval: targetPrice.config.interval,
+		intervalCount: targetPrice.config.interval_count ?? 1,
+	});
+
+	return (rows[0]?.price as Price | undefined) ?? null;
+};

--- a/server/src/internal/products/prices/repos/priceRepo.ts
+++ b/server/src/internal/products/prices/repos/priceRepo.ts
@@ -1,0 +1,7 @@
+import { findNewestReusableFixedPrice } from "./findNewestReusableFixedPrice.js";
+import { listDistinctBasePricesByCustomerLicense } from "./listDistinctBasePricesByCustomerLicense.js";
+
+export const priceRepo = {
+	findNewestReusableFixedPrice,
+	listDistinctBasePricesByCustomerLicense,
+} as const;

--- a/server/src/internal/products/prices/repos/utils/composeAttachCurrencyFixedMatch.ts
+++ b/server/src/internal/products/prices/repos/utils/composeAttachCurrencyFixedMatch.ts
@@ -1,0 +1,37 @@
+import { PREVIEW_STRIPE_PRICE_ID_PREFIX, prices } from "@autumn/shared";
+import { type SQL, sql } from "drizzle-orm";
+
+const usableStripePriceId = (slot: SQL) => sql`
+	${slot} IS NOT NULL
+	AND ${slot} <> ''
+	AND ${slot} NOT LIKE ${`${PREVIEW_STRIPE_PRICE_ID_PREFIX}%`}
+`;
+
+/** This currency's amount + stripe_price_id, whether it is base or overlay. */
+export const composeAttachCurrencyFixedMatch = ({
+	targetCurrency,
+	orgDefaultCurrency,
+	amount,
+}: {
+	targetCurrency: string;
+	orgDefaultCurrency: string;
+	amount: number;
+}) => {
+	const currency = targetCurrency.toLowerCase();
+	const orgDefault = orgDefaultCurrency.toLowerCase();
+	const baseStripePriceId = sql`${prices.config} ->> 'stripe_price_id'`;
+	const overlayStripePriceId = sql`${prices.config} -> 'currencies' -> ${currency} ->> 'stripe_price_id'`;
+
+	return sql`(
+		(
+			lower(coalesce(${prices.config} ->> 'base_currency', ${orgDefault})) = ${currency}
+			AND (${prices.config} ->> 'amount')::numeric = ${amount}
+			AND ${usableStripePriceId(baseStripePriceId)}
+		)
+		OR
+		(
+			(${prices.config} -> 'currencies' -> ${currency} ->> 'amount')::numeric = ${amount}
+			AND ${usableStripePriceId(overlayStripePriceId)}
+		)
+	)`;
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyAttachCurrencyStripeSlot.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyAttachCurrencyStripeSlot.ts
@@ -1,0 +1,44 @@
+import {
+	type CurrencyAwarePriceConfig,
+	getPriceCurrencyStripeId,
+	type Price,
+	setPriceCurrencyStripeId,
+} from "@autumn/shared";
+
+export const copyAttachCurrencyStripeSlot = ({
+	targetPrice,
+	sourcePrice,
+	currency,
+	orgDefaultCurrency,
+}: {
+	targetPrice: Price;
+	sourcePrice: Price;
+	currency: string;
+	orgDefaultCurrency: string;
+}): boolean => {
+	const slot = "stripe_price_id" as const;
+	const sourceId = getPriceCurrencyStripeId({
+		config: sourcePrice.config as CurrencyAwarePriceConfig,
+		currency,
+		orgDefault: orgDefaultCurrency,
+		slot,
+	});
+	if (!sourceId) return false;
+
+	const targetId = getPriceCurrencyStripeId({
+		config: targetPrice.config as CurrencyAwarePriceConfig,
+		currency,
+		orgDefault: orgDefaultCurrency,
+		slot,
+	});
+	if (targetId) return false;
+
+	setPriceCurrencyStripeId({
+		config: targetPrice.config as CurrencyAwarePriceConfig,
+		currency,
+		orgDefault: orgDefaultCurrency,
+		slot,
+		id: sourceId,
+	});
+	return true;
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts
@@ -1,0 +1,82 @@
+import {
+	type FullProduct,
+	getPriceStripeReuseLevel,
+	type Price,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { priceRepo } from "@/internal/products/prices/repos/priceRepo.js";
+import { hasEmptyStripeResource } from "./hasEmptyStripeResource.js";
+import { isUsableStripePrice } from "./isUsableStripePrice.js";
+import { stampAttachCurrencyStripeSlot } from "./stampAttachCurrencyStripeSlot.js";
+
+const findReusableStripePriceForTarget = async ({
+	ctx,
+	targetPrice,
+	product,
+	currency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	product: FullProduct;
+	currency: string;
+}) => {
+	if (!hasEmptyStripeResource({ ctx, targetPrice, currency })) return;
+
+	const candidate = await priceRepo.findNewestReusableFixedPrice({
+		ctx,
+		targetPrice,
+		productId: product.id,
+		targetCurrency: currency,
+	});
+	if (!candidate) return;
+
+	if (
+		getPriceStripeReuseLevel({
+			newPrice: targetPrice,
+			candidatePrice: candidate,
+			newEntitlements: [],
+			candidateEntitlements: [],
+		}) !== "full"
+	) {
+		return;
+	}
+
+	const usable = await isUsableStripePrice({
+		ctx,
+		targetPrice,
+		candidate,
+		product,
+		currency,
+	});
+	if (!usable) return;
+
+	await stampAttachCurrencyStripeSlot({
+		ctx,
+		targetPrice,
+		sourcePrice: candidate,
+		currency,
+	});
+};
+
+export const findReusableStripePrice = async ({
+	ctx,
+	products,
+	currency,
+}: {
+	ctx: AutumnContext;
+	products: FullProduct[];
+	currency: string;
+}) => {
+	await Promise.all(
+		products.flatMap((product) =>
+			product.prices.map((price) =>
+				findReusableStripePriceForTarget({
+					ctx,
+					targetPrice: price,
+					product,
+					currency,
+				}),
+			),
+		),
+	);
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripeResources.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripeResources.ts
@@ -1,0 +1,97 @@
+import {
+	type CurrencyAwarePriceConfig,
+	getPriceCurrencyStripeId,
+	getPriceStripeReuseLevel,
+	isFixedPrice,
+	type Price,
+} from "@autumn/shared";
+import { copyAttachCurrencyStripeSlot } from "./copyAttachCurrencyStripeSlot.js";
+import { rankStripeReuseCandidates } from "./rankStripeReuseCandidates.js";
+import type {
+	StripeReuseCandidate,
+	StripeReuseProductRef,
+} from "./types/stripeReuseCandidate.js";
+
+const candidateHasAttachCurrencySlot = ({
+	price,
+	currency,
+	orgDefaultCurrency,
+}: {
+	price: Price;
+	currency: string;
+	orgDefaultCurrency: string;
+}) =>
+	Boolean(
+		getPriceCurrencyStripeId({
+			config: price.config as CurrencyAwarePriceConfig,
+			currency,
+			orgDefault: orgDefaultCurrency,
+			slot: "stripe_price_id",
+		}),
+	);
+
+const isSameProductScope = ({
+	targetProduct,
+	candidateProduct,
+}: {
+	targetProduct: StripeReuseProductRef;
+	candidateProduct: StripeReuseProductRef;
+}) =>
+	candidateProduct.id === targetProduct.id &&
+	candidateProduct.org_id === targetProduct.org_id &&
+	candidateProduct.env === targetProduct.env;
+
+export const findReusableStripeResources = ({
+	targetPrice,
+	targetProduct,
+	candidates,
+	currency,
+	orgDefaultCurrency,
+}: {
+	targetPrice: Price;
+	targetProduct: StripeReuseProductRef;
+	candidates: StripeReuseCandidate[];
+	currency: string;
+	orgDefaultCurrency: string;
+}): Price | null => {
+	if (!isFixedPrice(targetPrice)) return null;
+
+	const matches = candidates.filter((candidate) => {
+		if (candidate.price.id === targetPrice.id) return false;
+		if (!isFixedPrice(candidate.price)) return false;
+		if (
+			!isSameProductScope({
+				targetProduct,
+				candidateProduct: candidate.product,
+			})
+		) {
+			return false;
+		}
+		if (
+			getPriceStripeReuseLevel({
+				newPrice: targetPrice,
+				candidatePrice: candidate.price,
+				newEntitlements: [],
+				candidateEntitlements: [],
+			}) !== "full"
+		) {
+			return false;
+		}
+		return candidateHasAttachCurrencySlot({
+			price: candidate.price,
+			currency,
+			orgDefaultCurrency,
+		});
+	});
+
+	const [winner] = rankStripeReuseCandidates({ candidates: matches });
+	if (!winner) return null;
+
+	const copied = copyAttachCurrencyStripeSlot({
+		targetPrice,
+		sourcePrice: winner.price,
+		currency,
+		orgDefaultCurrency,
+	});
+	return copied ? winner.price : null;
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/hasEmptyStripeResource.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/hasEmptyStripeResource.ts
@@ -1,0 +1,36 @@
+import {
+	type CurrencyAwarePriceConfig,
+	getPriceCurrencyStripeId,
+	isFixedPrice,
+	orgToCurrency,
+	type Price,
+	priceConfigForCurrency,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+export const hasEmptyStripeResource = ({
+	ctx,
+	targetPrice,
+	currency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	currency: string;
+}): boolean => {
+	if (!isFixedPrice(targetPrice)) return false;
+
+	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+	const { amount } = priceConfigForCurrency({
+		config: targetPrice.config,
+		currency,
+		orgDefault: orgDefaultCurrency,
+	});
+	if (amount == null || amount <= 0) return false;
+
+	return !getPriceCurrencyStripeId({
+		config: targetPrice.config as CurrencyAwarePriceConfig,
+		currency,
+		orgDefault: orgDefaultCurrency,
+		slot: "stripe_price_id",
+	});
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts
@@ -1,0 +1,54 @@
+import {
+	type CurrencyAwarePriceConfig,
+	type FixedPriceConfig,
+	type FullProduct,
+	getPriceCurrencyStripeId,
+	isFixedPrice,
+	orgToCurrency,
+	type Price,
+} from "@autumn/shared";
+import { createStripeCli } from "@/external/connect/createStripeCli.js";
+import { getStripePrice } from "@/external/stripe/prices/operations/getStripePrice.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { stripePriceMatchesFixedPrice } from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.js";
+
+export const isUsableStripePrice = async ({
+	ctx,
+	targetPrice,
+	candidate,
+	product,
+	currency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	candidate: Price;
+	product: FullProduct;
+	currency: string;
+}): Promise<boolean> => {
+	if (!isFixedPrice(targetPrice)) return false;
+
+	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+	const stripePriceId = getPriceCurrencyStripeId({
+		config: candidate.config as CurrencyAwarePriceConfig,
+		currency,
+		orgDefault: orgDefaultCurrency,
+		slot: "stripe_price_id",
+	});
+	const expectedStripeProductId =
+		product.processor?.id ??
+		(candidate.config as FixedPriceConfig).stripe_product_id;
+	if (!stripePriceId || !expectedStripeProductId) return false;
+
+	const stripePrice = await getStripePrice({
+		stripeClient: createStripeCli({ org: ctx.org, env: ctx.env }),
+		stripePriceId,
+	});
+	if (!stripePrice) return false;
+
+	return stripePriceMatchesFixedPrice({
+		stripePrice,
+		price: targetPrice,
+		stripeProductId: expectedStripeProductId,
+		currency,
+	});
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/rankStripeReuseCandidates.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/rankStripeReuseCandidates.ts
@@ -1,0 +1,15 @@
+import type { StripeReuseCandidate } from "./types/stripeReuseCandidate.js";
+
+/** Catalog rows first, then newest custom — a remint becomes the next winner. */
+export const rankStripeReuseCandidates = ({
+	candidates,
+}: {
+	candidates: StripeReuseCandidate[];
+}): StripeReuseCandidate[] =>
+	[...candidates].sort((left, right) => {
+		const leftCustom = left.price.is_custom === true ? 1 : 0;
+		const rightCustom = right.price.is_custom === true ? 1 : 0;
+		if (leftCustom !== rightCustom) return leftCustom - rightCustom;
+
+		return (right.price.created_at ?? 0) - (left.price.created_at ?? 0);
+	});

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/stampAttachCurrencyStripeSlot.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/stampAttachCurrencyStripeSlot.ts
@@ -1,0 +1,30 @@
+import { orgToCurrency, type Price } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { PriceService } from "@/internal/products/prices/PriceService.js";
+import { copyAttachCurrencyStripeSlot } from "./copyAttachCurrencyStripeSlot.js";
+
+export const stampAttachCurrencyStripeSlot = async ({
+	ctx,
+	targetPrice,
+	sourcePrice,
+	currency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	sourcePrice: Price;
+	currency: string;
+}) => {
+	const copied = copyAttachCurrencyStripeSlot({
+		targetPrice,
+		sourcePrice,
+		currency,
+		orgDefaultCurrency: orgToCurrency({ org: ctx.org }).toLowerCase(),
+	});
+	if (!copied) return;
+
+	await PriceService.update({
+		db: ctx.db,
+		id: targetPrice.id,
+		update: { config: targetPrice.config },
+	});
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/types/stripeReuseCandidate.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/types/stripeReuseCandidate.ts
@@ -1,0 +1,12 @@
+import type { AppEnv, Price } from "@autumn/shared";
+
+export type StripeReuseProductRef = {
+	id: string;
+	org_id: string;
+	env: AppEnv;
+};
+
+export type StripeReuseCandidate = {
+	price: Price;
+	product: StripeReuseProductRef;
+};

--- a/server/tests/integration/billing/stripe-resources/find-newest-reusable-fixed-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/find-newest-reusable-fixed-price.test.ts
@@ -1,0 +1,245 @@
+/**
+ * findNewestReusableFixedPrice
+ *
+ * Contract:
+ *   newest created_at $25 with a usable stripe slot wins
+ *   catalog $20 / interval mismatch / preview / self / other product.id → no
+ *   USD attach uses base amount + stripe_price_id
+ *   EUR attach uses currencies.eur amount + slot; USD-only → no
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	PREVIEW_STRIPE_PRICE_ID_PREFIX,
+	type Price,
+	PriceType,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { PriceService } from "@/internal/products/prices/PriceService.js";
+import { priceRepo } from "@/internal/products/prices/repos/priceRepo.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { uniqueSuffix } from "./feature-products/utils/createUnmintedFeaturePlans.js";
+
+const targetFixed = ({
+	amount = 25,
+	interval = BillingInterval.Month,
+	currencies,
+}: {
+	amount?: number;
+	interval?: BillingInterval;
+	currencies?: Record<string, { amount: number }>;
+}): Price => ({
+	id: generateId("pr"),
+	org_id: "unused",
+	created_at: Date.now(),
+	internal_product_id: "unused",
+	is_custom: true,
+	config: {
+		type: PriceType.Fixed,
+		amount,
+		interval,
+		interval_count: 1,
+		stripe_product_id: null,
+		feature_id: null,
+		internal_feature_id: null,
+		...(currencies ? { currencies } : {}),
+	},
+	proration_config: null,
+});
+
+test.concurrent(
+	`${chalk.yellowBright("priceRepo: findNewestReusableFixedPrice")}`,
+	async () => {
+		const suffix = uniqueSuffix();
+		const pro = products.pro({ id: `fnrf-pro-${suffix}`, items: [] });
+		const premium = products.premium({
+			id: `fnrf-prem-${suffix}`,
+			items: [],
+		});
+
+		const { ctx } = await initScenario({
+			setup: [s.products({ list: [pro, premium], createInStripe: false })],
+			actions: [],
+		});
+
+		const fullPro = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: pro.id,
+		});
+		const fullPremium = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: premium.id,
+		});
+
+		const insertFixed = async ({
+			id,
+			internalProductId,
+			createdAt,
+			amount,
+			interval = BillingInterval.Month,
+			stripePriceId,
+			currencies,
+		}: {
+			id: string;
+			internalProductId: string;
+			createdAt: number;
+			amount: number;
+			interval?: BillingInterval;
+			stripePriceId?: string | null;
+			currencies?: Record<
+				string,
+				{ amount: number; stripe_price_id?: string }
+			>;
+		}) => {
+			await PriceService.insert({
+				db: ctx.db,
+				data: {
+					id,
+					org_id: ctx.org.id,
+					internal_product_id: internalProductId,
+					created_at: createdAt,
+					is_custom: true,
+					config: {
+						type: PriceType.Fixed,
+						amount,
+						interval,
+						interval_count: 1,
+						stripe_price_id: stripePriceId,
+						stripe_product_id: null,
+						feature_id: null,
+						internal_feature_id: null,
+						...(currencies ? { currencies } : {}),
+					},
+					proration_config: null,
+				},
+			});
+		};
+
+		const older = generateId("pr");
+		const newer = generateId("pr");
+		const preview = generateId("pr");
+		const yearly = generateId("pr");
+		const usdOnly = generateId("pr");
+		const usdEur = generateId("pr");
+		const otherPlan = generateId("pr");
+		const now = Date.now();
+
+		await insertFixed({
+			id: older,
+			internalProductId: fullPro.internal_id,
+			createdAt: now - 100,
+			amount: 25,
+			stripePriceId: "price_old_25",
+		});
+		await insertFixed({
+			id: newer,
+			internalProductId: fullPro.internal_id,
+			createdAt: now,
+			amount: 25,
+			stripePriceId: "price_new_25",
+		});
+		await insertFixed({
+			id: preview,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 50,
+			amount: 25,
+			stripePriceId: `${PREVIEW_STRIPE_PRICE_ID_PREFIX}25`,
+		});
+		await insertFixed({
+			id: yearly,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 10,
+			amount: 25,
+			interval: BillingInterval.Year,
+			stripePriceId: "price_year_25",
+		});
+		await insertFixed({
+			id: usdOnly,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 20,
+			amount: 25,
+			stripePriceId: "price_usd_only",
+		});
+		await insertFixed({
+			id: usdEur,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 30,
+			amount: 25,
+			stripePriceId: "price_usd_from_fx",
+			currencies: { eur: { amount: 25, stripe_price_id: "price_eur_25" } },
+		});
+		await insertFixed({
+			id: otherPlan,
+			internalProductId: fullPremium.internal_id,
+			createdAt: now + 40,
+			amount: 25,
+			stripePriceId: "price_prem_25",
+		});
+
+		const find = ({
+			target,
+			productId = pro.id,
+			targetCurrency = "usd",
+		}: {
+			target: Price;
+			productId?: string;
+			targetCurrency?: string;
+		}) =>
+			priceRepo.findNewestReusableFixedPrice({
+				ctx,
+				targetPrice: target,
+				productId,
+				targetCurrency,
+			});
+
+		const target25 = targetFixed({ amount: 25 });
+
+		expect((await find({ target: target25 }))?.id).toBe(usdEur);
+		expect(
+			(await find({ target: { ...target25, id: usdEur } }))?.id,
+		).toBe(usdOnly);
+
+		expect(
+			await find({
+				target: targetFixed({ amount: 25, interval: BillingInterval.Year }),
+			}),
+		).toMatchObject({ id: yearly });
+		expect(await find({ target: targetFixed({ amount: 20 }) })).toBeNull();
+
+		expect(
+			(
+				await find({
+					target: targetFixed({
+						amount: 25,
+						currencies: { eur: { amount: 25 } },
+					}),
+					targetCurrency: "eur",
+				})
+			)?.id,
+		).toBe(usdEur);
+		expect(
+			await find({
+				target: {
+					...targetFixed({
+						amount: 25,
+						currencies: { eur: { amount: 25 } },
+					}),
+					id: usdEur,
+				},
+				targetCurrency: "eur",
+			}),
+		).toBeNull();
+
+		expect(
+			(await find({ target: target25, productId: premium.id }))?.id,
+		).toBe(otherPlan);
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/reuse-custom-fixed-price-edges.test.ts
+++ b/server/tests/integration/billing/stripe-resources/reuse-custom-fixed-price-edges.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Attach-level miss cases for custom fixed Stripe reuse.
+ *
+ * Query-level EUR / interval / other product.id coverage lives in
+ * find-newest-reusable-fixed-price.test.ts (#5). These prove the
+ * attach path also misses when Stripe is dead or the shape diverges.
+ *
+ * Contract:
+ *   borrowed Stripe inactive → B mints a new id
+ *   monthly $40 vs yearly $40 → different ids
+ *   Pro $40 must not take Premium $40
+ */
+
+import { test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	customerFixedStripePriceId,
+	expectDistinctFixedStripePrices,
+} from "./utils/customerFixedStripePriceId";
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom fixed: dead borrowed Stripe → B mints a new Price")}`,
+	async () => {
+		const customerBId = "reuse-edge-b-dead";
+		const pro = products.pro({ id: "reuse-edge-ab-dead", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-edge-a-dead",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		});
+
+		const a = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		if (!a.customerStripePriceId) {
+			throw new Error("expected A to mint a Stripe Price");
+		}
+		await ctx.stripeCli.prices.update(a.customerStripePriceId, {
+			active: false,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerBId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		});
+
+		await expectDistinctFixedStripePrices({
+			ctx,
+			leftCustomerId: customerId,
+			rightCustomerId: customerBId,
+			leftCatalogProductId: pro.id,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom fixed: monthly $40 vs yearly $40 mint different Prices")}`,
+	async () => {
+		const customerBId = "reuse-edge-b-interval";
+		const pro = products.pro({ id: "reuse-edge-ab-interval", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-edge-a-interval",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.annualPrice({ amount: 40 }) },
+		});
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerBId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 40 }) },
+		});
+
+		await expectDistinctFixedStripePrices({
+			ctx,
+			leftCustomerId: customerId,
+			rightCustomerId: customerBId,
+			leftCatalogProductId: pro.id,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom fixed: Pro $40 must not take Premium $40")}`,
+	async () => {
+		const customerBId = "reuse-edge-b-plan";
+		const pro = products.pro({ id: "reuse-edge-pro", items: [] });
+		const premium = products.premium({ id: "reuse-edge-prem", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-edge-a-plan",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro, premium] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 40 }) },
+		});
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerBId,
+			plan_id: premium.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 40 }) },
+		});
+
+		await expectDistinctFixedStripePrices({
+			ctx,
+			leftCustomerId: customerId,
+			rightCustomerId: customerBId,
+			leftCatalogProductId: pro.id,
+			rightCatalogProductId: premium.id,
+		});
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/reuse-custom-fixed-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/reuse-custom-fixed-price.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Customize A then B: same diverging fixed price shares one Stripe Price.
+ *
+ * Catalog / variant reuse already ran. This path only fires when the
+ * attach-currency slot is still empty (Pro $20 → customize $25).
+ *
+ * Contract:
+ *   A $25 then B $25 → same stripe_price_id, not the catalog $20 id
+ *   A $25 then B catalog $20 → B uses the catalog id
+ *   A $25 then B $30 → different stripe_price_ids
+ *   A attach $25 then C updateSubscription → $25 → same Stripe as A
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	ApiCustomerV5,
+	AttachParamsV1Input,
+	UpdateSubscriptionV1ParamsInput,
+} from "@autumn/shared";
+import { expectCustomerProducts } from "@tests/integration/billing/utils/expectCustomerProductCorrect";
+import { expectStripeSubscriptionCorrect } from "@tests/integration/billing/utils/expectStripeSubCorrect";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	customerFixedStripePriceId,
+	expectSharedFixedStripePrice,
+} from "./utils/customerFixedStripePriceId";
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom fixed: A $25 then B $25 share one Stripe Price")}`,
+	async () => {
+		const customerBId = "reuse-custom-b-same";
+		const pro = products.pro({ id: "reuse-custom-ab-same", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-custom-a-same",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const customize25: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		};
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(customize25);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			...customize25,
+			customer_id: customerBId,
+		});
+
+		const a = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		const b = await customerFixedStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+		});
+
+		expect(a.customerStripePriceId).toBeTruthy();
+		expect(b.customerStripePriceId).toBe(a.customerStripePriceId);
+		expect(a.customerStripePriceId).not.toBe(a.catalogStripePriceId);
+
+		const customerA = await autumnV2_3.customers.get<ApiCustomerV5>(customerId);
+		const customerB =
+			await autumnV2_3.customers.get<ApiCustomerV5>(customerBId);
+		await expectCustomerProducts({ customer: customerA, active: [pro.id] });
+		await expectCustomerProducts({ customer: customerB, active: [pro.id] });
+		await expectStripeSubscriptionCorrect({ ctx, customerId });
+		await expectStripeSubscriptionCorrect({ ctx, customerId: customerBId });
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom fixed: A $25 then B catalog $20 uses catalog Stripe Price")}`,
+	async () => {
+		const customerBId = "reuse-custom-b-catalog";
+		const pro = products.pro({ id: "reuse-custom-ab-catalog", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-custom-a-catalog",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		});
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerBId,
+			plan_id: pro.id,
+		});
+
+		const a = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		const b = await customerFixedStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+		});
+
+		expect(a.customerStripePriceId).toBeTruthy();
+		expect(b.customerStripePriceId).toBe(b.catalogStripePriceId);
+		expect(b.customerStripePriceId).not.toBe(a.customerStripePriceId);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom fixed: A $25 then B $30 mint different Stripe Prices")}`,
+	async () => {
+		const customerBId = "reuse-custom-b-diverge";
+		const pro = products.pro({ id: "reuse-custom-ab-diverge", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-custom-a-diverge",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		});
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerBId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 30 }) },
+		});
+
+		const a = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		const b = await customerFixedStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+		});
+
+		expect(a.customerStripePriceId).toBeTruthy();
+		expect(b.customerStripePriceId).toBeTruthy();
+		expect(b.customerStripePriceId).not.toBe(a.customerStripePriceId);
+		expect(b.customerStripePriceId).not.toBe(b.catalogStripePriceId);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom fixed: A attach $25 then C updateSubscription $25 share Stripe")}`,
+	async () => {
+		const customerCId = "reuse-custom-c-update";
+		const pro = products.pro({ id: "reuse-custom-ac-update", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-custom-a-update",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerCId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		});
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerCId,
+			plan_id: pro.id,
+		});
+
+		await autumnV2_3.subscriptions.update<UpdateSubscriptionV1ParamsInput>({
+			customer_id: customerCId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		});
+
+		await expectSharedFixedStripePrice({
+			ctx,
+			customerIds: [customerId, customerCId],
+			catalogProductId: pro.id,
+		});
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/reuse-migration-fixed-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/reuse-migration-fixed-price.test.ts
@@ -1,0 +1,183 @@
+/**
+ * In-place catalog $20 → $40 then migrate attached customers.
+ *
+ * Contract:
+ *   A+B on $20 → catalog $40 → migrate both → same $40 stripe_price_id,
+ *     not the retired $20 id
+ *   A already $40 custom, B still $20 → catalog $40 → migrate → B uses
+ *     one live $40 (A's or catalog's), not a third mint
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	AttachParamsV1Input,
+	UpdatePlanParamsV2Input,
+} from "@autumn/shared";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { runMigrationInChunks } from "@/internal/migrations/v2/run/runMigrationInChunks.js";
+import { generateId } from "@/utils/genUtils.js";
+import { customerFixedStripePriceId } from "./utils/customerFixedStripePriceId";
+
+const updatePlanPriceInPlace = async ({
+	autumn,
+	planId,
+	amount,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+	amount: number;
+}) => {
+	const body: UpdatePlanParamsV2Input = {
+		plan_id: planId,
+		disable_version: true,
+		migration: { draft: true },
+		price: itemsV2.monthlyPrice({ amount }),
+	};
+	const response = (await autumn.post("/plans.update", body)) as {
+		migration?: { id: string };
+		migrations?: { id: string }[];
+	};
+	const migrationId = response.migrations?.[0]?.id ?? response.migration?.id;
+	if (!migrationId) throw new Error(`expected a catalog draft for ${planId}`);
+	return migrationId;
+};
+
+const runCatalogDraft = async ({
+	ctx,
+	migrationId,
+}: {
+	ctx: Awaited<ReturnType<typeof initScenario>>["ctx"];
+	migrationId: string;
+}) => {
+	const [migration] = await migrationRepo.get({ ctx, id: migrationId });
+	if (!migration) throw new Error(`Migration ${migrationId} not found`);
+	await runMigrationInChunks({
+		ctx,
+		migration,
+		migrationRunId: generateId("mrun"),
+		dryRun: false,
+	});
+};
+
+test.concurrent(
+	`${chalk.yellowBright("reuse migrate fixed: A+B $20 → catalog $40 share one Stripe Price")}`,
+	async () => {
+		const customerBId = "reuse-mig-b-both";
+		const pro = products.pro({ id: "reuse-mig-ab-both", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-mig-a-both",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [
+				s.parallel(
+					s.billing.attach({ productId: pro.id }),
+					s.billing.attach({
+						customerId: customerBId,
+						productId: pro.id,
+					}),
+				),
+			],
+		});
+
+		const before = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+
+		const migrationId = await updatePlanPriceInPlace({
+			autumn: autumnV2_3,
+			planId: pro.id,
+			amount: 40,
+		});
+		await runCatalogDraft({ ctx, migrationId });
+
+		const a = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		const b = await customerFixedStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+		});
+
+		expect(a.customerStripePriceId).toBeTruthy();
+		expect(b.customerStripePriceId).toBe(a.customerStripePriceId);
+		expect(a.customerStripePriceId).not.toBe(before.catalogStripePriceId);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse migrate fixed: B $20 → $40 reuses one live $40 Stripe Price")}`,
+	async () => {
+		const customerBId = "reuse-mig-b-reuse";
+		const pro = products.pro({ id: "reuse-mig-ab-reuse", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-mig-a-reuse",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 40 }) },
+		});
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerBId,
+			plan_id: pro.id,
+		});
+
+		const aBefore = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		const bBefore = await customerFixedStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+		});
+
+		const migrationId = await updatePlanPriceInPlace({
+			autumn: autumnV2_3,
+			planId: pro.id,
+			amount: 40,
+		});
+		await runCatalogDraft({ ctx, migrationId });
+
+		const aAfter = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		const bAfter = await customerFixedStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+		});
+
+		expect(bAfter.customerStripePriceId).toBeTruthy();
+		expect(bAfter.customerStripePriceId).not.toBe(bBefore.customerStripePriceId);
+		expect([
+			aBefore.customerStripePriceId,
+			aAfter.catalogStripePriceId,
+			aAfter.customerStripePriceId,
+		]).toContain(bAfter.customerStripePriceId);
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/utils/customerFixedStripePriceId.ts
+++ b/server/tests/integration/billing/stripe-resources/utils/customerFixedStripePriceId.ts
@@ -1,0 +1,87 @@
+import { expect } from "bun:test";
+import { type FixedPriceConfig, isFixedPrice, type Price } from "@autumn/shared";
+import { loadCustomerAndCatalogPrices } from "@tests/integration/billing/misc/utils/findCatalogAndCustomPrices";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+export const fixedStripePriceId = ({ prices }: { prices: Price[] }) => {
+	const fixed = prices.find((price) => isFixedPrice(price));
+	return (
+		(fixed?.config as FixedPriceConfig | undefined)?.stripe_price_id ?? null
+	);
+};
+
+export const customerFixedStripePriceId = async ({
+	ctx,
+	customerId,
+	catalogProductId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	catalogProductId: string;
+}) => {
+	const { customerPrices, catalogPrices } = await loadCustomerAndCatalogPrices({
+		ctx,
+		customerId,
+		catalogProductId,
+	});
+	return {
+		customerStripePriceId: fixedStripePriceId({ prices: customerPrices }),
+		catalogStripePriceId: fixedStripePriceId({ prices: catalogPrices }),
+	};
+};
+
+export const expectSharedFixedStripePrice = async ({
+	ctx,
+	customerIds,
+	catalogProductId,
+	notCatalog = true,
+}: {
+	ctx: AutumnContext;
+	customerIds: string[];
+	catalogProductId: string;
+	notCatalog?: boolean;
+}) => {
+	const results = await Promise.all(
+		customerIds.map((customerId) =>
+			customerFixedStripePriceId({ ctx, customerId, catalogProductId }),
+		),
+	);
+	const first = results[0]?.customerStripePriceId;
+	expect(first).toBeTruthy();
+	for (const result of results) {
+		expect(result.customerStripePriceId).toBe(first);
+		if (notCatalog) {
+			expect(result.customerStripePriceId).not.toBe(result.catalogStripePriceId);
+		}
+	}
+	return results;
+};
+
+export const expectDistinctFixedStripePrices = async ({
+	ctx,
+	leftCustomerId,
+	rightCustomerId,
+	leftCatalogProductId,
+	rightCatalogProductId,
+}: {
+	ctx: AutumnContext;
+	leftCustomerId: string;
+	rightCustomerId: string;
+	leftCatalogProductId: string;
+	rightCatalogProductId?: string;
+}) => {
+	const left = await customerFixedStripePriceId({
+		ctx,
+		customerId: leftCustomerId,
+		catalogProductId: leftCatalogProductId,
+	});
+	const right = await customerFixedStripePriceId({
+		ctx,
+		customerId: rightCustomerId,
+		catalogProductId: rightCatalogProductId ?? leftCatalogProductId,
+	});
+	expect(left.customerStripePriceId).toBeTruthy();
+	expect(right.customerStripePriceId).toBeTruthy();
+	expect(right.customerStripePriceId).not.toBe(left.customerStripePriceId);
+	return { left, right };
+};

--- a/server/tests/unit/billing/init-stripe-resources-for-products.test.ts
+++ b/server/tests/unit/billing/init-stripe-resources-for-products.test.ts
@@ -1,11 +1,13 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+	AppEnv,
 	type AutumnBillingPlan,
 	type BillingContext,
 	BillingInterval,
 	BillWhen,
 	type FullCusProduct,
 	type FullCustomerPrice,
+	type FullProduct,
 	type Price,
 	PriceType,
 	type UsagePriceConfig,
@@ -16,6 +18,7 @@ const mockState = {
 	priceIds: [] as string[],
 	currencies: [] as (string | undefined)[],
 	productCalls: 0,
+	finderCalls: 0,
 };
 
 await mockModuleWithRestore(
@@ -40,7 +43,19 @@ await mockModuleWithRestore("@/internal/products/productUtils", () => ({
 	},
 }));
 
-import { initStripeResourcesForBillingPlan } from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts";
+await mockModuleWithRestore(
+	"@/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice",
+	() => ({
+		findReusableStripePrice: async () => {
+			mockState.finderCalls++;
+		},
+	}),
+);
+
+import {
+	initStripeResourcesForBillingPlan,
+	initStripeResourcesForProducts,
+} from "@/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts";
 import { customerProductToStripeItemSpecs } from "@/internal/billing/v2/providers/stripe/utils/subscriptionItems/customerProductToStripeItemSpecs";
 
 import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
@@ -166,6 +181,7 @@ describe("initStripeResourcesForBillingPlan", () => {
 		mockState.priceIds = [];
 		mockState.currencies = [];
 		mockState.productCalls = 0;
+		mockState.finderCalls = 0;
 	});
 
 	test("uses preview Stripe IDs without initializing Stripe resources during dry run", async () => {
@@ -411,6 +427,75 @@ describe("initStripeResourcesForBillingPlan", () => {
 		});
 
 		expect(mockState.currencies).toEqual(["eur"]);
+	});
+});
+
+const unInitedProduct = ({ env }: { env: AppEnv }): FullProduct =>
+	({
+		id: "pro",
+		name: "Pro",
+		internal_id: "prod_internal",
+		org_id: "org_1",
+		env,
+		version: 1,
+		created_at: 1,
+		processor: null,
+		base_internal_product_id: null,
+		base_variant_id: null,
+		is_add_on: false,
+		is_default: false,
+		archived: false,
+		group: "",
+		description: null,
+		config: {},
+		metadata: {},
+		prices: [fixedPrice({ id: "price_1" })],
+		entitlements: [],
+		free_trial: null,
+		licenses: [],
+	}) as unknown as FullProduct;
+
+const connectedCtx = ({ env }: { env: AppEnv }): AutumnContext =>
+	({
+		db: {},
+		env,
+		org: {
+			id: "org_1",
+			default_currency: "usd",
+			config: { disable_stripe_writes: false },
+			stripe_config: { test_api_key: "sk_test_x", live_api_key: "sk_live_x" },
+		},
+		logger: { debug: () => undefined, info: () => undefined },
+	}) as unknown as AutumnContext;
+
+describe("initStripeResourcesForProducts Live finder gate", () => {
+	beforeEach(() => {
+		mockState.priceIds = [];
+		mockState.currencies = [];
+		mockState.productCalls = 0;
+		mockState.finderCalls = 0;
+	});
+
+	test("Live without allowLiveCreate skips findReusableStripePrice", async () => {
+		await initStripeResourcesForProducts({
+			ctx: connectedCtx({ env: AppEnv.Live }),
+			products: [unInitedProduct({ env: AppEnv.Live })],
+			lookupVariantFamilies: false,
+		});
+
+		expect(mockState.finderCalls).toBe(0);
+		expect(mockState.priceIds).toEqual([]);
+	});
+
+	test("Live + allowLiveCreate calls findReusableStripePrice", async () => {
+		await initStripeResourcesForProducts({
+			ctx: connectedCtx({ env: AppEnv.Live }),
+			products: [unInitedProduct({ env: AppEnv.Live })],
+			allowLiveCreate: true,
+			lookupVariantFamilies: false,
+		});
+
+		expect(mockState.finderCalls).toBe(1);
 	});
 });
 

--- a/server/tests/unit/catalog-v2/init-catalog-stripe-resources.test.ts
+++ b/server/tests/unit/catalog-v2/init-catalog-stripe-resources.test.ts
@@ -115,6 +115,13 @@ await mockModuleWithRestore(
 	}),
 );
 
+await mockModuleWithRestore(
+	"@/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice",
+	() => ({
+		findReusableStripePrice: async () => {},
+	}),
+);
+
 await mockModuleWithRestore("@/internal/products/productUtils", () => ({
 	checkStripeProductExists: async () => {
 		mockState.productCreateCalls++;

--- a/server/tests/unit/products/find-reusable-stripe-price.test.ts
+++ b/server/tests/unit/products/find-reusable-stripe-price.test.ts
@@ -1,0 +1,218 @@
+/**
+ * findReusableStripePrice
+ *
+ * Contract:
+ *   attach-currency slot already filled → no query, no retrieve
+ *   newest full match + live Stripe → stamp that slot
+ *   query miss / dead Stripe → leave empty
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	AppEnv,
+	BillingInterval,
+	type FullProduct,
+	getPriceCurrencyStripeId,
+	type Price,
+	PriceType,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const mockState = {
+	queryCalls: 0,
+	retrieveCalls: [] as string[],
+	persistCalls: 0,
+	candidate: null as Price | null,
+	stripePrice: null as { id: string; active: boolean } | null,
+};
+
+await mockModuleWithRestore(
+	"@/internal/products/prices/repos/priceRepo.js",
+	() => ({
+		priceRepo: {
+			findNewestReusableFixedPrice: async () => {
+				mockState.queryCalls += 1;
+				return mockState.candidate;
+			},
+		},
+	}),
+);
+
+await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
+	createStripeCli: () => ({}),
+}));
+
+await mockModuleWithRestore(
+	"@/external/stripe/prices/operations/getStripePrice.js",
+	() => ({
+		getStripePrice: async ({ stripePriceId }: { stripePriceId: string }) => {
+			mockState.retrieveCalls.push(stripePriceId);
+			if (!mockState.stripePrice) return undefined;
+			return {
+				id: mockState.stripePrice.id,
+				object: "price",
+				active: mockState.stripePrice.active,
+				currency: "usd",
+				billing_scheme: "per_unit",
+				unit_amount: 2500,
+				unit_amount_decimal: "2500",
+				product: "prod_pro",
+				recurring: {
+					interval: "month",
+					interval_count: 1,
+					usage_type: "licensed",
+				},
+				type: "recurring",
+			};
+		},
+	}),
+);
+
+await mockModuleWithRestore(
+	"@/internal/products/prices/PriceService.js",
+	() => ({
+		PriceService: {
+			update: async () => {
+				mockState.persistCalls += 1;
+			},
+		},
+	}),
+);
+
+const { findReusableStripePrice } = await import(
+	"@/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.js"
+);
+
+const ctx = {
+	db: {},
+	env: AppEnv.Sandbox,
+	org: { id: "org_1", default_currency: "usd" },
+} as unknown as AutumnContext;
+
+const fixedPrice = ({
+	id,
+	amount,
+	stripePriceId = null,
+}: {
+	id: string;
+	amount: number;
+	stripePriceId?: string | null;
+}): Price => ({
+	id,
+	org_id: "org_1",
+	created_at: 1,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Fixed,
+		amount,
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_price_id: stripePriceId,
+		stripe_product_id: stripePriceId ? "prod_pro" : null,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+	proration_config: null,
+});
+
+const product = ({ price }: { price: Price }): FullProduct =>
+	({
+		id: "pro",
+		internal_id: "ip_pro",
+		org_id: "org_1",
+		env: AppEnv.Sandbox,
+		processor: { type: "stripe", id: "prod_pro" },
+		prices: [price],
+		entitlements: [],
+	}) as unknown as FullProduct;
+
+describe("findReusableStripePrice", () => {
+	beforeEach(() => {
+		mockState.queryCalls = 0;
+		mockState.retrieveCalls = [];
+		mockState.persistCalls = 0;
+		mockState.candidate = null;
+		mockState.stripePrice = null;
+	});
+
+	test("skips query when the attach-currency slot is already filled", async () => {
+		const price = fixedPrice({
+			id: "pr_filled",
+			amount: 20,
+			stripePriceId: "price_catalog",
+		});
+
+		await findReusableStripePrice({
+			ctx,
+			products: [product({ price })],
+			currency: "usd",
+		});
+
+		expect(mockState.queryCalls).toBe(0);
+		expect(mockState.retrieveCalls).toEqual([]);
+		expect(price.config.stripe_price_id).toBe("price_catalog");
+	});
+
+	test("stamps the attach-currency slot from a live borrowed Stripe Price", async () => {
+		const target = fixedPrice({ id: "pr_b", amount: 25 });
+		mockState.candidate = fixedPrice({
+			id: "pr_a",
+			amount: 25,
+			stripePriceId: "price_a_25",
+		});
+		mockState.stripePrice = { id: "price_a_25", active: true };
+
+		await findReusableStripePrice({
+			ctx,
+			products: [product({ price: target })],
+			currency: "usd",
+		});
+
+		expect(mockState.queryCalls).toBe(1);
+		expect(mockState.retrieveCalls).toEqual(["price_a_25"]);
+		expect(
+			getPriceCurrencyStripeId({
+				config: target.config,
+				currency: "usd",
+				orgDefault: "usd",
+				slot: "stripe_price_id",
+			}),
+		).toBe("price_a_25");
+		expect(mockState.persistCalls).toBe(1);
+	});
+
+	test("leaves the slot empty when Stripe is dead or the query misses", async () => {
+		const missed = fixedPrice({ id: "pr_miss", amount: 25 });
+		await findReusableStripePrice({
+			ctx,
+			products: [product({ price: missed })],
+			currency: "usd",
+		});
+		expect(missed.config.stripe_price_id).toBeNull();
+		expect(mockState.retrieveCalls).toEqual([]);
+
+		const dead = fixedPrice({ id: "pr_dead", amount: 25 });
+		mockState.candidate = fixedPrice({
+			id: "pr_a",
+			amount: 25,
+			stripePriceId: "price_dead",
+		});
+		mockState.stripePrice = { id: "price_dead", active: false };
+
+		await findReusableStripePrice({
+			ctx,
+			products: [product({ price: dead })],
+			currency: "usd",
+		});
+
+		expect(mockState.retrieveCalls).toEqual(["price_dead"]);
+		expect(dead.config.stripe_price_id).toBeNull();
+		expect(mockState.persistCalls).toBe(0);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/server/tests/unit/products/find-reusable-stripe-resources.test.ts
+++ b/server/tests/unit/products/find-reusable-stripe-resources.test.ts
@@ -1,0 +1,359 @@
+/**
+ * findReusableStripeResources (fixed only).
+ *
+ * Contract:
+ *   $25/$25 same Pro → stamp donor stripe_price_id
+ *   amount or interval mismatch → null
+ *   USD-only vs USD+EUR, USD attach → copy USD slot only
+ *   EUR attach, USD slot only → null
+ *   other product.id / org / env → null
+ *   same product.id across versions → match
+ *   catalog beats custom; newest custom wins
+ *   usage candidate → null
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	type FixedPriceConfig,
+	getPriceCurrencyStripeId,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import { findReusableStripeResources } from "@/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripeResources.js";
+import type {
+	StripeReuseCandidate,
+	StripeReuseProductRef,
+} from "@/internal/products/stripeResourceUtils/findReusableStripeResources/types/stripeReuseCandidate.js";
+
+const orgDefaultCurrency = "usd";
+const now = 1_800_000_000_000;
+
+const pro: StripeReuseProductRef = {
+	id: "pro",
+	org_id: "org_1",
+	env: AppEnv.Sandbox,
+};
+
+const fixedConfig = (
+	overrides: Partial<FixedPriceConfig> = {},
+): FixedPriceConfig => ({
+	type: PriceType.Fixed,
+	amount: 25,
+	interval: BillingInterval.Month,
+	interval_count: 1,
+	stripe_product_id: null,
+	feature_id: null,
+	internal_feature_id: null,
+	...overrides,
+});
+
+const fixedPrice = ({
+	id,
+	isCustom = false,
+	createdAt = now,
+	config,
+}: {
+	id: string;
+	isCustom?: boolean;
+	createdAt?: number;
+	config?: Partial<FixedPriceConfig>;
+}): Price => ({
+	id,
+	org_id: pro.org_id,
+	created_at: createdAt,
+	internal_product_id: "ip_pro",
+	is_custom: isCustom,
+	config: fixedConfig(config),
+	proration_config: null,
+});
+
+const candidate = ({
+	price,
+	product = pro,
+}: {
+	price: Price;
+	product?: StripeReuseProductRef;
+}): StripeReuseCandidate => ({ price, product });
+
+const find = ({
+	target,
+	candidates,
+	currency = "usd",
+	product = pro,
+}: {
+	target: Price;
+	candidates: StripeReuseCandidate[];
+	currency?: string;
+	product?: StripeReuseProductRef;
+}) =>
+	findReusableStripeResources({
+		targetPrice: target,
+		targetProduct: product,
+		candidates,
+		currency,
+		orgDefaultCurrency,
+	});
+
+const usagePrice = (): Price => ({
+	id: "pr_usage",
+	org_id: pro.org_id,
+	created_at: now,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Usage,
+		bill_when: BillWhen.EndOfPeriod,
+		billing_units: 1,
+		internal_feature_id: "feat_messages",
+		feature_id: "messages",
+		usage_tiers: [{ amount: 25, to: TierInfinite }],
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_price_id: "price_usage_25",
+	} satisfies UsagePriceConfig,
+	proration_config: null,
+});
+
+describe("findReusableStripeResources — fixed", () => {
+	test("same $25 monthly on Pro stamps the donor stripe_price_id", () => {
+		const target = fixedPrice({ id: "pr_b" });
+		const donor = fixedPrice({
+			id: "pr_a",
+			isCustom: true,
+			config: { stripe_price_id: "price_25" },
+		});
+		donor.internal_product_id = "ip_pro_v1";
+
+		expect(find({ target, candidates: [candidate({ price: donor })] })?.id).toBe(
+			"pr_a",
+		);
+		expect(
+			getPriceCurrencyStripeId({
+				config: target.config,
+				currency: "usd",
+				orgDefault: orgDefaultCurrency,
+				slot: "stripe_price_id",
+			}),
+		).toBe("price_25");
+	});
+
+	test("amount or interval mismatch does not match", () => {
+		const target = fixedPrice({ id: "pr_b" });
+		const cheaper = fixedPrice({
+			id: "pr_20",
+			config: { amount: 20, stripe_price_id: "price_20" },
+		});
+		const yearly = fixedPrice({
+			id: "pr_year",
+			config: { interval: BillingInterval.Year, stripe_price_id: "price_year" },
+		});
+
+		expect(find({ target, candidates: [candidate({ price: cheaper })] })).toBeNull();
+		expect(find({ target, candidates: [candidate({ price: yearly })] })).toBeNull();
+		expect(target.config.stripe_price_id).toBeFalsy();
+	});
+
+	test("USD attach on USD+EUR copies the USD slot only", () => {
+		const target = fixedPrice({
+			id: "pr_b",
+			config: {
+				currencies: { eur: { amount: 25 } },
+			},
+		});
+		const eurTarget = fixedPrice({
+			id: "pr_b_eur",
+			config: {
+				currencies: { eur: { amount: 25 } },
+			},
+		});
+		const donor = fixedPrice({
+			id: "pr_a",
+			isCustom: true,
+			config: {
+				stripe_price_id: "price_usd",
+				currencies: { eur: { amount: 25, stripe_price_id: "price_eur" } },
+			},
+		});
+
+		expect(find({ target, candidates: [candidate({ price: donor })] })?.id).toBe(
+			"pr_a",
+		);
+		expect(
+			getPriceCurrencyStripeId({
+				config: target.config,
+				currency: "usd",
+				orgDefault: orgDefaultCurrency,
+				slot: "stripe_price_id",
+			}),
+		).toBe("price_usd");
+		expect(
+			getPriceCurrencyStripeId({
+				config: target.config,
+				currency: "eur",
+				orgDefault: orgDefaultCurrency,
+				slot: "stripe_price_id",
+			}),
+		).toBeUndefined();
+
+		expect(
+			find({
+				target: eurTarget,
+				candidates: [candidate({ price: donor })],
+				currency: "eur",
+			})?.id,
+		).toBe("pr_a");
+		expect(
+			getPriceCurrencyStripeId({
+				config: eurTarget.config,
+				currency: "eur",
+				orgDefault: orgDefaultCurrency,
+				slot: "stripe_price_id",
+			}),
+		).toBe("price_eur");
+		expect(
+			getPriceCurrencyStripeId({
+				config: eurTarget.config,
+				currency: "usd",
+				orgDefault: orgDefaultCurrency,
+				slot: "stripe_price_id",
+			}),
+		).toBeUndefined();
+	});
+
+	test("EUR attach with only a USD slot does not match", () => {
+		const target = fixedPrice({
+			id: "pr_b",
+			config: { currencies: { eur: { amount: 25 } } },
+		});
+		const usdOnly = fixedPrice({
+			id: "pr_a",
+			isCustom: true,
+			config: { stripe_price_id: "price_usd" },
+		});
+
+		expect(
+			find({
+				target,
+				candidates: [candidate({ price: usdOnly })],
+				currency: "eur",
+			}),
+		).toBeNull();
+		expect(
+			getPriceCurrencyStripeId({
+				config: target.config,
+				currency: "eur",
+				orgDefault: orgDefaultCurrency,
+				slot: "stripe_price_id",
+			}),
+		).toBeUndefined();
+	});
+
+	test("other product.id, org, or env does not match", () => {
+		const target = fixedPrice({ id: "pr_b" });
+		const donor = fixedPrice({
+			id: "pr_a",
+			config: { stripe_price_id: "price_25" },
+		});
+
+		expect(
+			find({
+				target,
+				candidates: [
+					candidate({
+						price: donor,
+						product: { ...pro, id: "premium" },
+					}),
+				],
+			}),
+		).toBeNull();
+		expect(
+			find({
+				target,
+				candidates: [
+					candidate({
+						price: donor,
+						product: { ...pro, org_id: "org_other" },
+					}),
+				],
+			}),
+		).toBeNull();
+		expect(
+			find({
+				target,
+				candidates: [
+					candidate({
+						price: donor,
+						product: { ...pro, env: AppEnv.Live },
+					}),
+				],
+			}),
+		).toBeNull();
+	});
+
+	test("catalog beats custom; newest custom wins among customs", () => {
+		const olderCustom = fixedPrice({
+			id: "pr_old",
+			isCustom: true,
+			createdAt: now - 100,
+			config: { stripe_price_id: "price_old" },
+		});
+		const newerCustom = fixedPrice({
+			id: "pr_new",
+			isCustom: true,
+			createdAt: now,
+			config: { stripe_price_id: "price_new" },
+		});
+		const catalog = fixedPrice({
+			id: "pr_cat",
+			createdAt: now - 200,
+			config: { stripe_price_id: "price_cat" },
+		});
+
+		expect(
+			find({
+				target: fixedPrice({ id: "pr_b1" }),
+				candidates: [
+					candidate({ price: olderCustom }),
+					candidate({ price: newerCustom }),
+				],
+			})?.id,
+		).toBe("pr_new");
+		expect(
+			find({
+				target: fixedPrice({ id: "pr_b2" }),
+				candidates: [
+					candidate({ price: newerCustom }),
+					candidate({ price: catalog }),
+				],
+			})?.id,
+		).toBe("pr_cat");
+	});
+
+	test("usage target or candidate is ignored", () => {
+		const target = fixedPrice({ id: "pr_b" });
+		expect(
+			find({
+				target,
+				candidates: [candidate({ price: usagePrice() })],
+			}),
+		).toBeNull();
+		expect(
+			find({
+				target: usagePrice(),
+				candidates: [
+					candidate({
+						price: fixedPrice({
+							id: "pr_a",
+							config: { stripe_price_id: "price_25" },
+						}),
+					}),
+				],
+			}),
+		).toBeNull();
+	});
+});

--- a/server/tests/unit/products/is-usable-stripe-price.test.ts
+++ b/server/tests/unit/products/is-usable-stripe-price.test.ts
@@ -1,0 +1,194 @@
+/**
+ * isUsableStripePrice
+ *
+ * Contract:
+ *   retrieves the candidate's Stripe Price, then:
+ *   live + same shape + currency → true
+ *   missing / inactive / drift / wrong currency / usage autumn price → false
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	type FullProduct,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const stripeProductId = "prod_pro";
+const currency = "usd";
+
+const mockState = {
+	retrieveCalls: [] as string[],
+	stripePrice: null as {
+		id: string;
+		active: boolean;
+		currency?: string;
+		unitAmount?: number;
+	} | null,
+};
+
+await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
+	createStripeCli: () => ({}),
+}));
+
+await mockModuleWithRestore(
+	"@/external/stripe/prices/operations/getStripePrice.js",
+	() => ({
+		getStripePrice: async ({ stripePriceId }: { stripePriceId: string }) => {
+			mockState.retrieveCalls.push(stripePriceId);
+			if (!mockState.stripePrice) return undefined;
+			return {
+				id: mockState.stripePrice.id,
+				object: "price",
+				active: mockState.stripePrice.active,
+				currency: mockState.stripePrice.currency ?? "usd",
+				billing_scheme: "per_unit",
+				unit_amount: mockState.stripePrice.unitAmount ?? 2500,
+				unit_amount_decimal: String(mockState.stripePrice.unitAmount ?? 2500),
+				product: stripeProductId,
+				recurring: {
+					interval: "month",
+					interval_count: 1,
+					usage_type: "licensed",
+				},
+				type: "recurring",
+			};
+		},
+	}),
+);
+
+const { isUsableStripePrice } = await import(
+	"@/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.js"
+);
+
+const ctx = {
+	env: AppEnv.Sandbox,
+	org: { id: "org_1", default_currency: "usd" },
+} as unknown as AutumnContext;
+
+const autumnFixed = (): Price => ({
+	id: "pr_b",
+	org_id: "org_1",
+	created_at: 1_800_000_000_000,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Fixed,
+		amount: 25,
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_product_id: null,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+	proration_config: null,
+});
+
+const autumnUsage = (): Price => ({
+	id: "pr_usage",
+	org_id: "org_1",
+	created_at: 1_800_000_000_000,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Usage,
+		bill_when: BillWhen.EndOfPeriod,
+		billing_units: 1,
+		internal_feature_id: "feat_messages",
+		feature_id: "messages",
+		usage_tiers: [{ amount: 25, to: TierInfinite }],
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_price_id: "price_usage_25",
+	} satisfies UsagePriceConfig,
+	proration_config: null,
+});
+
+const candidateFixed = (): Price => ({
+	...autumnFixed(),
+	id: "pr_a",
+	config: {
+		...autumnFixed().config,
+		stripe_price_id: "price_a_25",
+		stripe_product_id: stripeProductId,
+	},
+});
+
+const product = ({
+	targetPrice = autumnFixed(),
+}: {
+	targetPrice?: Price;
+} = {}): FullProduct =>
+	({
+		id: "pro",
+		internal_id: "ip_pro",
+		org_id: "org_1",
+		env: AppEnv.Sandbox,
+		processor: { type: "stripe", id: stripeProductId },
+		prices: [targetPrice],
+		entitlements: [],
+	}) as unknown as FullProduct;
+
+const usable = ({
+	targetPrice = autumnFixed(),
+	candidate = candidateFixed(),
+}: {
+	targetPrice?: Price;
+	candidate?: Price;
+} = {}) =>
+	isUsableStripePrice({
+		ctx,
+		targetPrice,
+		candidate,
+		product: product({ targetPrice }),
+		currency,
+	});
+
+describe("isUsableStripePrice", () => {
+	beforeEach(() => {
+		mockState.retrieveCalls = [];
+		mockState.stripePrice = null;
+	});
+
+	test("retrieves and returns true for a live matching Stripe Price", async () => {
+		mockState.stripePrice = { id: "price_a_25", active: true };
+
+		expect(await usable()).toBe(true);
+		expect(mockState.retrieveCalls).toEqual(["price_a_25"]);
+	});
+
+	test("returns false for missing, inactive, drifted, or wrong-currency prices", async () => {
+		expect(await usable()).toBe(false);
+		expect(mockState.retrieveCalls).toEqual(["price_a_25"]);
+
+		mockState.retrieveCalls = [];
+		mockState.stripePrice = { id: "price_a_25", active: false };
+		expect(await usable()).toBe(false);
+
+		mockState.stripePrice = {
+			id: "price_a_25",
+			active: true,
+			unitAmount: 2000,
+		};
+		expect(await usable()).toBe(false);
+
+		mockState.stripePrice = { id: "price_a_25", active: true, currency: "eur" };
+		expect(await usable()).toBe(false);
+	});
+
+	test("returns false for a usage autumn price without retrieving", async () => {
+		expect(await usable({ targetPrice: autumnUsage() })).toBe(false);
+		expect(mockState.retrieveCalls).toEqual([]);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});


### PR DESCRIPTION
When two customers customize a plan the same way, look up the newest full-match Autumn price and stamp that attach-currency Stripe id after one retrieve instead of minting a second Price.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses a matching custom fixed Stripe Price when two customers customize a plan the same way, instead of minting a second Price.

- Only fires for fixed prices still missing their attach-currency Stripe slot, after in-memory and variant-family reuse, in the attach, subscription-update, and migration paths.
- Finds the newest matching fixed price on the same product in one indexed query and copies its attach-currency Stripe id.
- Retrieves the borrowed id once before stamping; inactive, missing, or drifted Stripe prices skip reuse and mint a new one.
- Usage and `$0` fixed prices are not eligible, and no query or retrieve runs when every slot is already filled.
- Concurrent customizations can still each mint; that race is accepted.

<sup>Written for commit 659de2429ced711b83df77317050c9feafaff488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds reuse of an existing matching custom fixed Stripe Price during plan attachment and subscription updates.

- **Improvements:** Searches for a recent same-plan Price with the requested amount, interval, currency slot, and usable Stripe object.
- **Improvements:** Copies the selected attach-currency Stripe Price ID before normal resource initialization.
- **Bug fixes:** Adds coverage for repeated customizations, currencies, inactive Stripe Prices, migrations, and catalog initialization.
</details>


<h3>Confidence Score: 2/5</h3>

The PR is not yet safe to merge because candidate selection can still miss reusable Prices, transient Stripe errors can abort billing, and borrowed Prices can diverge from the target plan's Stripe Product mapping.

The current code still limits candidate selection before complete validation, allows optional Stripe retrieval failures to reject billing initialization, and validates donor Prices before ensuring that the target plan retains the same Stripe Product mapping.

**Files Needing Attention:** server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts, server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts, server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts, server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts | Adds the candidate query, but selecting one partially matched row before complete validation still allows newer incompatible rows to hide reusable candidates. |
| server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts | Coordinates reuse for each target Price, but rejected candidates have no next-candidate path and retrieval failures reject the full initialization batch. |
| server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts | Validates the Stripe Price's shape, but errors propagate and targets without a processor mapping can be validated against a donor product that is not retained. |
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Integrates database-backed Price reuse into both initialization paths before Stripe Product and Price creation. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Initialize billing plan] --> B[Apply in-memory and variant reuse]
  B --> C[Find newest matching database Price]
  C --> D[Validate full Autumn definition]
  D --> E[Retrieve and validate Stripe Price]
  E --> F[Stamp attach-currency Stripe Price ID]
  F --> G[Initialize missing Stripe Products]
  G --> H[Create any still-missing Stripe Prices]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Reuse matching custom fixed Stripe Price..."](https://github.com/useautumn/autumn/commit/659de2429ced711b83df77317050c9feafaff488) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57535540)</sub>

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)
- Knowledge Base — [Catalog and entitlement management](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/catalog-management.md)

<!-- /greptile_comment -->