### PR TITLE
Name minted Stripe Prices by kind, and label only real customize mints.

### DIFF
--- a/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
@@ -10,6 +10,8 @@ import {
 	TierInfinite,
 	type UsagePriceConfig,
 	RecaseError,
+	priceToStripeNickname,
+	type StripePriceNicknameSource,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle";
 import { PriceService } from "@server/internal/products/prices/PriceService";
@@ -30,6 +32,7 @@ interface StripeMeteredPriceParams {
 	product: Product;
 	org: Organization;
 	currency?: string;
+	source?: StripePriceNicknameSource;
 }
 
 export const createStripeMeteredPrice = async ({
@@ -39,6 +42,7 @@ export const createStripeMeteredPrice = async ({
 	product,
 	org,
 	currency: targetCurrency,
+	source = "catalog",
 }: StripeMeteredPriceParams) => {
 	const config = price.config as UsagePriceConfig;
 	const orgDefault = (org.default_currency || "usd").toLowerCase();
@@ -101,7 +105,12 @@ export const createStripeMeteredPrice = async ({
 		product: config.stripe_product_id,
 		...priceAmountData,
 		currency,
-		nickname: `Autumn Price (${feature!.name}) [Placeholder]`,
+		nickname: priceToStripeNickname({
+			price,
+			featureName: feature!.name,
+			source,
+			isPlaceholder: true,
+		}),
 		recurring: {
 			...(billingIntervalToStripe({
 				interval: price.config!.interval,
@@ -161,6 +170,7 @@ export const createStripeArrearProrated = async ({
 	stripeCli,
 	currency: targetCurrency,
 	mintPlaceholder = true,
+	source = "catalog",
 }: {
 	db: DrizzleCli;
 	price: Price;
@@ -171,6 +181,7 @@ export const createStripeArrearProrated = async ({
 	stripeCli: Stripe;
 	currency?: string;
 	mintPlaceholder?: boolean;
+	source?: StripePriceNicknameSource;
 }) => {
 	const relatedEnt = getPriceEntitlement(price, entitlements);
 
@@ -227,7 +238,11 @@ export const createStripeArrearProrated = async ({
 			recurring: {
 				...(recurringData as any),
 			},
-			nickname: `Autumn Price (${relatedEnt.feature.name})`,
+			nickname: priceToStripeNickname({
+				price,
+				featureName: relatedEnt.feature.name,
+				source,
+			}),
 		},
 		{
 			idempotencyKey: buildStripePriceIdempotencyKey({
@@ -256,6 +271,7 @@ export const createStripeArrearProrated = async ({
 			product,
 			org,
 			currency,
+			source,
 		});
 		setPriceCurrencyStripeId({
 			config,

--- a/server/src/external/stripe/createStripePrice/createStripeFixedPrice.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeFixedPrice.ts
@@ -7,7 +7,9 @@ import type {
 import {
 	atmnToStripeAmount,
 	priceConfigForCurrency,
+	priceToStripeNickname,
 	setPriceCurrencyStripeId,
+	type StripePriceNicknameSource,
 } from "@autumn/shared";
 import type { DrizzleCli } from "@server/db/initDrizzle";
 import { PriceService } from "@server/internal/products/prices/PriceService";
@@ -22,6 +24,7 @@ export const createStripeFixedPrice = async ({
 	product,
 	org,
 	currency: targetCurrency,
+	source = "catalog",
 }: {
 	db: DrizzleCli;
 	stripeCli: Stripe;
@@ -29,6 +32,7 @@ export const createStripeFixedPrice = async ({
 	product: Product;
 	org: Organization;
 	currency?: string;
+	source?: StripePriceNicknameSource;
 }) => {
 	const config = price.config as FixedPriceConfig;
 	const orgDefault = (org.default_currency || "usd").toLowerCase();
@@ -61,7 +65,7 @@ export const createStripeFixedPrice = async ({
 				}) as any),
 			},
 
-			nickname: `Autumn Price (Fixed)`,
+			nickname: priceToStripeNickname({ price, source }),
 		},
 		{
 			idempotencyKey: buildStripePriceIdempotencyKey({

--- a/server/src/external/stripe/createStripePrice/createStripeInArrear.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeInArrear.ts
@@ -9,6 +9,8 @@ import {
 	type Product,
 	priceConfigForCurrency,
 	priceToEnt,
+	priceToStripeNickname,
+	type StripePriceNicknameSource,
 	setPriceCurrencyStripeId,
 	TierInfinite,
 	type UsagePriceConfig,
@@ -225,6 +227,7 @@ export const createStripeInArrearPrice = async ({
 	internalEntityId,
 	useCheckout = false,
 	currency: targetCurrency,
+	source = "catalog",
 }: {
 	db: DrizzleCli;
 	stripeCli: Stripe;
@@ -238,6 +241,7 @@ export const createStripeInArrearPrice = async ({
 	internalEntityId?: string;
 	useCheckout?: boolean;
 	currency?: string;
+	source?: StripePriceNicknameSource;
 }) => {
 	const config = price.config as UsagePriceConfig;
 	const orgDefault = (org.default_currency || "usd").toLowerCase();
@@ -350,7 +354,11 @@ export const createStripeInArrearPrice = async ({
 						usage_type: "metered",
 					}
 				: undefined,
-			nickname: `Autumn Price (${relatedEnt.feature.name})`,
+			nickname: priceToStripeNickname({
+				price,
+				featureName: relatedEnt.feature.name,
+				source,
+			}),
 		},
 		{
 			idempotencyKey: buildStripePriceIdempotencyKey({

--- a/server/src/external/stripe/createStripePrice/createStripePrepaid.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrepaid.ts
@@ -7,8 +7,10 @@ import {
 	type Price,
 	type Product,
 	priceConfigForCurrency,
+	priceToStripeNickname,
 	priceToStripeTiersMode,
 	setPriceCurrencyStripeId,
+	type StripePriceNicknameSource,
 	TierInfinite,
 	type UsagePriceConfig,
 	type UsageTier,
@@ -68,6 +70,7 @@ export const createStripePrepaid = async ({
 	curStripeProd,
 	stripeCli,
 	currency: targetCurrency,
+	source = "catalog",
 }: {
 	db: DrizzleCli;
 	price: Price;
@@ -77,6 +80,7 @@ export const createStripePrepaid = async ({
 	curStripeProd: { id: string } | null;
 	stripeCli: Stripe;
 	currency?: string;
+	source?: StripePriceNicknameSource;
 }) => {
 	const relatedEnt = getPriceEntitlement(price, entitlements);
 
@@ -123,6 +127,11 @@ export const createStripePrepaid = async ({
 			product: stripeProductId,
 			unit_amount_decimal: unitAmountDecimalStr,
 			currency,
+			nickname: priceToStripeNickname({
+				price,
+				featureName: relatedEnt.feature.name,
+				source,
+			}),
 		});
 
 		config.stripe_product_id = stripePrice.product as string;
@@ -154,7 +163,11 @@ export const createStripePrepaid = async ({
 			recurring: {
 				...(recurringData as any),
 			},
-			nickname: `Autumn Price (${relatedEnt.feature.name})`,
+			nickname: priceToStripeNickname({
+				price,
+				featureName: relatedEnt.feature.name,
+				source,
+			}),
 		});
 
 		config.stripe_product_id = stripePrice.product as string;

--- a/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
@@ -3,6 +3,7 @@ import {
 	type FullProduct,
 	getPriceCurrencyStripeId,
 	type Price,
+	type StripePriceNicknameSource,
 	priceToEnt,
 	priceUtils,
 	RecaseError,
@@ -21,12 +22,14 @@ export const createStripePrepaidPriceV2 = async ({
 	product,
 	currentStripeProduct,
 	currency: targetCurrency,
+	source = "catalog",
 }: {
 	ctx: AutumnContext;
 	price: Price;
 	product: FullProduct;
 	currentStripeProduct?: { id: string };
 	currency?: string;
+	source?: StripePriceNicknameSource;
 }) => {
 	const { org, db, env } = ctx;
 
@@ -94,6 +97,7 @@ export const createStripePrepaidPriceV2 = async ({
 		org,
 		stripeProductId,
 		currency,
+		source,
 	});
 
 	const stripeCli = createStripeCli({ org, env });

--- a/server/src/external/stripe/createStripePrice/createStripePrice.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrice.ts
@@ -11,6 +11,7 @@ import {
 	priceToEnt,
 	priceToRequiredStripeSlots,
 	priceUtils,
+	type StripePriceNicknameSource,
 	RecaseError,
 	type RequiredStripeResourceSlot,
 	setPriceCurrencyStripeId,
@@ -165,6 +166,7 @@ export const createStripePriceIFNotExist = async ({
 	useCheckout = false,
 	currency: targetCurrency,
 	billingVersion = LATEST_BILLING_VERSION,
+	source = "catalog",
 }: {
 	ctx: AutumnContext;
 	price: Price;
@@ -174,6 +176,7 @@ export const createStripePriceIFNotExist = async ({
 	useCheckout?: boolean;
 	currency?: string;
 	billingVersion?: BillingVersion;
+	source?: StripePriceNicknameSource;
 }) => {
 	// Fetch latest price data...
 
@@ -260,6 +263,7 @@ export const createStripePriceIFNotExist = async ({
 				product,
 				org,
 				currency,
+				source,
 			});
 		}
 	}
@@ -293,6 +297,7 @@ export const createStripePriceIFNotExist = async ({
 				org,
 				curStripeProd: resolvedStripeProduct,
 				currency,
+				source,
 			});
 		}
 
@@ -308,6 +313,7 @@ export const createStripePriceIFNotExist = async ({
 				product,
 				currentStripeProduct: resolvedStripeProduct ?? undefined,
 				currency,
+				source,
 			});
 		}
 	}
@@ -331,6 +337,7 @@ export const createStripePriceIFNotExist = async ({
 				curStripeProd: resolvedStripeProduct,
 				currency,
 				mintPlaceholder: requiresSlot("stripe_placeholder_price_id"),
+				source,
 			});
 		} else if (
 			requiresSlot("stripe_placeholder_price_id") &&
@@ -344,6 +351,7 @@ export const createStripePriceIFNotExist = async ({
 				product,
 				org,
 				currency,
+				source,
 			});
 			setPriceCurrencyStripeId({
 				config,
@@ -374,6 +382,7 @@ export const createStripePriceIFNotExist = async ({
 			internalEntityId,
 			useCheckout,
 			currency,
+			source,
 		});
 
 		if (CREATE_STRIPE_EMPTY_PRICES && !stripeEmptyPrice) {

--- a/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts
@@ -283,6 +283,7 @@ export const initStripeResourcesForBillingPlan = async ({
 					useCheckout: false,
 					currency,
 					billingVersion: billingContext.billingVersion,
+					source: price.is_custom ? "customize" : "catalog",
 				}),
 			);
 		}

--- a/server/tests/integration/billing/stripe-resources/price-nicknames.test.ts
+++ b/server/tests/integration/billing/stripe-resources/price-nicknames.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Stripe Price nicknames at mint time.
+ *
+ * Contract:
+ *   catalog fixed → "Base price"
+ *   catalog prepaid → "Prepaid price (Messages)"
+ *   catalog usage → "Usage-based price (Words)"
+ *   attach customize mint → "Base price (custom)"
+ *   migrate $20 → $40: Autumn row is_custom, Stripe nickname is not
+ */
+
+import { expect, test } from "bun:test";
+import type {
+	AttachParamsV1Input,
+	UpdatePlanParamsV2Input,
+} from "@autumn/shared";
+import { isFixedPrice, isPrepaidPrice } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features";
+import { items } from "@tests/utils/fixtures/items";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import { migrationRepo } from "@/internal/migrations/v2/repos/index.js";
+import { runMigrationInChunks } from "@/internal/migrations/v2/run/runMigrationInChunks.js";
+import { generateId } from "@/utils/genUtils.js";
+import { loadCustomerAndCatalogPrices } from "../misc/utils/findCatalogAndCustomPrices";
+import { customerFixedStripePriceId } from "./utils/customerFixedStripePriceId";
+import { expectStripePriceNickname } from "./utils/expectStripePriceNickname";
+
+const updatePlanPriceInPlace = async ({
+	autumn,
+	planId,
+	amount,
+}: {
+	autumn: Awaited<ReturnType<typeof initScenario>>["autumnV2_3"];
+	planId: string;
+	amount: number;
+}) => {
+	const body: UpdatePlanParamsV2Input = {
+		plan_id: planId,
+		disable_version: true,
+		migration: { draft: true },
+		price: itemsV2.monthlyPrice({ amount }),
+	};
+	const response = (await autumn.post("/plans.update", body)) as {
+		migration?: { id: string };
+		migrations?: { id: string }[];
+	};
+	const migrationId = response.migrations?.[0]?.id ?? response.migration?.id;
+	if (!migrationId) throw new Error(`expected a catalog draft for ${planId}`);
+	return migrationId;
+};
+
+test.concurrent(
+	`${chalk.yellowBright("price nickname: catalog base / prepaid / usage")}`,
+	async () => {
+		const pro = products.pro({
+			id: "nick-catalog-kinds",
+			items: [
+				items.prepaidMessages({ includedUsage: 100, billingUnits: 100 }),
+				items.consumable({ featureId: TestFeature.Words }),
+			],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "nick-catalog",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+		});
+
+		const { catalogPrices } = await loadCustomerAndCatalogPrices({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+
+		const nicknames: string[] = [];
+		for (const price of catalogPrices) {
+			const stripePriceId = isPrepaidPrice(price)
+				? price.config.stripe_prepaid_price_v2_id
+				: price.config.stripe_price_id;
+			expect(stripePriceId).toBeTruthy();
+			const stripePrice = await ctx.stripeCli.prices.retrieve(stripePriceId!);
+			nicknames.push(stripePrice.nickname ?? "");
+			if (isFixedPrice(price)) {
+				expect(stripePrice.nickname).toBe("Base price");
+			} else if (isPrepaidPrice(price)) {
+				expect(stripePrice.nickname).toBe("Prepaid price (Messages)");
+			} else {
+				expect(stripePrice.nickname).toBe("Usage-based price (Words)");
+			}
+		}
+		expect(nicknames).toContain("Base price");
+		expect(nicknames).toContain("Prepaid price (Messages)");
+		expect(nicknames).toContain("Usage-based price (Words)");
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("price nickname: customize mint is Base price (custom)")}`,
+	async () => {
+		const pro = products.pro({ id: "nick-custom-base", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "nick-custom",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 25 }) },
+		});
+
+		const { customerStripePriceId } = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		expect(customerStripePriceId).toBeTruthy();
+		await expectStripePriceNickname({
+			ctx,
+			stripePriceId: customerStripePriceId!,
+			nickname: "Base price (custom)",
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("price nickname: migrate $20 → $40 is_custom row is not (custom)")}`,
+	async () => {
+		const pro = products.pro({ id: "nick-migrate-base", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "nick-migrate",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [s.billing.attach({ productId: pro.id })],
+		});
+
+		const migrationId = await updatePlanPriceInPlace({
+			autumn: autumnV2_3,
+			planId: pro.id,
+			amount: 40,
+		});
+		const [migration] = await migrationRepo.get({ ctx, id: migrationId });
+		if (!migration) throw new Error(`Migration ${migrationId} not found`);
+		await runMigrationInChunks({
+			ctx,
+			migration,
+			migrationRunId: generateId("mrun"),
+			dryRun: false,
+		});
+
+		const { customerPrices } = await loadCustomerAndCatalogPrices({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+		const customerFixed = customerPrices.find((price) => isFixedPrice(price));
+		expect(customerFixed?.is_custom).toBe(true);
+		expect(customerFixed?.config.stripe_price_id).toBeTruthy();
+		await expectStripePriceNickname({
+			ctx,
+			stripePriceId: customerFixed!.config.stripe_price_id!,
+			nickname: "Base price",
+		});
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/utils/expectStripePriceNickname.ts
+++ b/server/tests/integration/billing/stripe-resources/utils/expectStripePriceNickname.ts
@@ -1,0 +1,15 @@
+import { expect } from "bun:test";
+import type Stripe from "stripe";
+
+export const expectStripePriceNickname = async ({
+	ctx,
+	stripePriceId,
+	nickname,
+}: {
+	ctx: { stripeCli: Stripe };
+	stripePriceId: string;
+	nickname: string;
+}) => {
+	const stripePrice = await ctx.stripeCli.prices.retrieve(stripePriceId);
+	expect(stripePrice.nickname).toBe(nickname);
+};

--- a/shared/utils/productUtils/priceUtils/convertPrice/priceToStripeCreatePriceParams.ts
+++ b/shared/utils/productUtils/priceUtils/convertPrice/priceToStripeCreatePriceParams.ts
@@ -6,6 +6,10 @@ import { priceToEnt } from "@utils/productUtils/convertProductUtils";
 import { priceToStripePrepaidV2Tiers } from "@utils/productUtils/priceUtils/convertPrice/priceToStripePrepaidV2Tiers";
 import { priceToStripeRecurringParams } from "@utils/productUtils/priceUtils/convertPrice/priceToStripeRecurringParams";
 import type Stripe from "stripe";
+import {
+	type StripePriceNicknameSource,
+	priceToStripeNickname,
+} from "./priceToStripeNickname";
 import { priceToStripeTiersMode } from "./priceToStripeTiersMode";
 
 export const priceToStripeCreatePriceParams = ({
@@ -14,12 +18,14 @@ export const priceToStripeCreatePriceParams = ({
 	org,
 	stripeProductId,
 	currency: targetCurrency,
+	source = "catalog",
 }: {
 	price: Price;
 	product: FullProduct;
 	org: Organization;
 	stripeProductId: string;
 	currency?: string;
+	source?: StripePriceNicknameSource;
 }): Stripe.PriceCreateParams => {
 	const currency = (
 		targetCurrency ??
@@ -60,6 +66,10 @@ export const priceToStripeCreatePriceParams = ({
 		...priceAmountData,
 		recurring: recurringData,
 		currency,
-		nickname: `Autumn Price (${entitlement.feature.name})`,
+		nickname: priceToStripeNickname({
+			price,
+			featureName: entitlement.feature.name,
+			source,
+		}),
 	};
 };

--- a/shared/utils/productUtils/priceUtils/convertPrice/priceToStripeNickname.test.ts
+++ b/shared/utils/productUtils/priceUtils/convertPrice/priceToStripeNickname.test.ts
@@ -1,0 +1,98 @@
+/**
+ * priceToStripeNickname
+ *
+ * Contract:
+ *   fixed → Base price
+ *   prepaid → Prepaid price (feature)
+ *   in-arrear / prorated → Usage-based price (feature)
+ *   customize source → " (custom)"
+ *   placeholder → " [Placeholder]"
+ *   missing feature name → no parentheses
+ */
+
+import { describe, expect, test } from "bun:test";
+import { BillingInterval } from "@models/productModels/intervals/billingInterval";
+import { PriceType } from "@models/productModels/priceModels/priceEnums";
+import type { Price } from "@models/productModels/priceModels/priceModels";
+import { BillWhen } from "@models/productModels/priceModels/priceConfig/usagePriceConfig";
+import { priceToStripeNickname } from "./priceToStripeNickname";
+
+const fixed = (): Price =>
+	({
+		id: "pr_fixed",
+		config: {
+			type: PriceType.Fixed,
+			amount: 20,
+			interval: BillingInterval.Month,
+		},
+	}) as Price;
+
+const usage = ({ billWhen }: { billWhen: BillWhen }): Price =>
+	({
+		id: "pr_usage",
+		config: {
+			type: PriceType.Usage,
+			bill_when: billWhen,
+			interval: BillingInterval.Month,
+			usage_tiers: [{ to: -1, amount: 1 }],
+		},
+	}) as Price;
+
+describe("priceToStripeNickname", () => {
+	test("fixed catalog → Base price", () => {
+		expect(priceToStripeNickname({ price: fixed() })).toBe("Base price");
+	});
+
+	test("fixed customize → Base price (custom)", () => {
+		expect(
+			priceToStripeNickname({ price: fixed(), source: "customize" }),
+		).toBe("Base price (custom)");
+	});
+
+	test("prepaid catalog → Prepaid price (Messages)", () => {
+		expect(
+			priceToStripeNickname({
+				price: usage({ billWhen: BillWhen.StartOfPeriod }),
+				featureName: "Messages",
+			}),
+		).toBe("Prepaid price (Messages)");
+	});
+
+	test("prepaid customize → Prepaid price (Messages) (custom)", () => {
+		expect(
+			priceToStripeNickname({
+				price: usage({ billWhen: BillWhen.StartOfPeriod }),
+				featureName: "Messages",
+				source: "customize",
+			}),
+		).toBe("Prepaid price (Messages) (custom)");
+	});
+
+	test("in-arrear → Usage-based price (Words)", () => {
+		expect(
+			priceToStripeNickname({
+				price: usage({ billWhen: BillWhen.EndOfPeriod }),
+				featureName: "Words",
+			}),
+		).toBe("Usage-based price (Words)");
+	});
+
+	test("prorated placeholder customize", () => {
+		expect(
+			priceToStripeNickname({
+				price: usage({ billWhen: BillWhen.EndOfPeriod }),
+				featureName: "Users",
+				isPlaceholder: true,
+				source: "customize",
+			}),
+		).toBe("Usage-based price (Users) [Placeholder] (custom)");
+	});
+
+	test("prepaid without feature name omits parentheses", () => {
+		expect(
+			priceToStripeNickname({
+				price: usage({ billWhen: BillWhen.StartOfPeriod }),
+			}),
+		).toBe("Prepaid price");
+	});
+});

--- a/shared/utils/productUtils/priceUtils/convertPrice/priceToStripeNickname.ts
+++ b/shared/utils/productUtils/priceUtils/convertPrice/priceToStripeNickname.ts
@@ -1,0 +1,35 @@
+import { BillingType } from "@models/productModels/priceModels/priceEnums";
+import type { Price } from "@models/productModels/priceModels/priceModels";
+import { getBillingType } from "../../priceUtils";
+
+export type StripePriceNicknameSource = "catalog" | "customize";
+
+const priceKindLabel = ({ billingType }: { billingType: BillingType }) => {
+	if (billingType === BillingType.UsageInAdvance) return "Prepaid price";
+	if (
+		billingType === BillingType.UsageInArrear ||
+		billingType === BillingType.InArrearProrated
+	) {
+		return "Usage-based price";
+	}
+	return "Base price";
+};
+
+export const priceToStripeNickname = ({
+	price,
+	featureName,
+	source = "catalog",
+	isPlaceholder = false,
+}: {
+	price: Price;
+	featureName?: string | null;
+	source?: StripePriceNicknameSource;
+	isPlaceholder?: boolean;
+}) => {
+	const kind = priceKindLabel({ billingType: getBillingType(price.config) });
+	const withFeature =
+		kind === "Base price" || !featureName ? kind : `${kind} (${featureName})`;
+	const placeholder = isPlaceholder ? " [Placeholder]" : "";
+	const custom = source === "customize" ? " (custom)" : "";
+	return `${withFeature}${placeholder}${custom}`;
+};

--- a/shared/utils/productUtils/priceUtils/index.ts
+++ b/shared/utils/productUtils/priceUtils/index.ts
@@ -8,6 +8,7 @@ export * from "./classifyPriceUtils.js";
 export * from "./comparePrice/pricesAreSame.js";
 export * from "./convertAmountUtils.js";
 export * from "./convertPrice/priceToRequiredStripeSlots.js";
+export * from "./convertPrice/priceToStripeNickname.js";
 export * from "./convertPrice/priceToStripeTiersMode.js";
 export * from "./convertPriceUtils.js";
 export * from "./findPrice/findPriceByFeatureId.js";


### PR DESCRIPTION
Catalog and migration keep Base/Prepaid/Usage-based; attach customize is the only path that suffixes (custom), even when the Autumn row is is_custom.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names minted Stripe Prices by kind instead of the generic `Autumn Price (...)` label, and scopes the `(custom)` suffix to attach-customize mints only.

- Stripe Prices now use kind-based nicknames: `Base price`, `Prepaid price (feature)`, and `Usage-based price (feature)`, with an optional `[Placeholder]` marker.
- Catalog mints and migration-generated prices keep the plain kind name even when the Autumn row is `is_custom`; only attach-customize mints append `(custom)`.
- Adds `priceToStripeNickname` in `@autumn/shared` and integration tests covering catalog kinds, customize mints, and upgrade migration nicknames.

<sup>Written for commit eed2e3e1121a8bc8a4f162e81df4ac184943a6c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces kind-based Stripe Price nicknames and attempts to reserve the custom suffix for prices minted during attach customization.
- **[Improvements]** Names Stripe Prices as Base, Prepaid, or Usage-based prices and includes feature and placeholder context where relevant.
- **[Bug fixes]** Propagates a nickname-source value through Stripe Price creation and adds coverage for catalog, customization, and migration scenarios.
- **[API changes]** Exports the shared `priceToStripeNickname` helper and `StripePriceNicknameSource` type.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because shared billing and migration paths can still label an ordinary migration mint as attach-customized.

The current initializer continues to convert `price.is_custom` directly into the customize mint source, and migration billing evaluation reaches that initializer; therefore an Autumn row that is custom for migration or customer-state reasons can still produce a misleading Stripe nickname.

**Files Needing Attention:** server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/utils/productUtils/priceUtils/convertPrice/priceToStripeNickname.ts | Centralizes kind-based Stripe nickname formatting, including feature, placeholder, and customization labels. |
| server/src/external/stripe/createStripePrice/createStripePrice.ts | Propagates the nickname source consistently through the concrete Stripe Price minting implementations. |
| server/src/internal/billing/v2/providers/stripe/utils/common/initStripeResourcesForProducts.ts | Still derives mint origin from `price.is_custom`, leaving the previously reported migration and shared-operation misclassification unresolved. |
| server/tests/integration/billing/stripe-resources/price-nicknames.test.ts | Adds integration coverage for kind labels, attach customization, and migration nicknames, but does not invalidate the remaining source-inference defect. |

<sub>Reviews (4): Last reviewed commit: ["Name minted Stripe Prices by kind, and l..."](https://github.com/useautumn/autumn/commit/eed2e3e1121a8bc8a4f162e81df4ac184943a6c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57535565)</sub>

<!-- /greptile_comment -->