### PR TITLE
Reuse matching usage and prepaid Stripe Prices across customers on the same plan.

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -119,7 +119,7 @@
         "chat": "^4.31.0",
         "date-fns": "^4.1.0",
         "drizzle-orm": "catalog:",
-        "eve": "^0.16.2",
+        "eve": "0.16.2",
         "hono": "4.12.27",
         "lru-cache": "^11.2.7",
         "postgres": "catalog:",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
 		"tw:kill": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/tw/index.ts kill",
 		"tw:kill-all": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/tw/index.ts kill-all",
 		"tw:spike": "bun scripts/tw/spike.ts",
-		"dw": "bun install && ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts",
+		"dw": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts",
 		"dw:teardown": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts teardown",
 		"dw:list": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts list",
 		"dw:cleanup": "ENV_FILE=.env infisical run --env=dev --recursive -- bun scripts/dw/index.ts cleanup",

--- a/server/experiments/explainFindNewestReusableUsagePrice.ts
+++ b/server/experiments/explainFindNewestReusableUsagePrice.ts
@@ -1,21 +1,21 @@
 import {
 	AppEnv,
-	BillingInterval,
-	isFixedPrice,
+	BillWhen,
+	isAllocatedV2Price,
+	isConsumablePrice,
 	organizations,
 	type Price,
-	priceConfigForCurrency,
 	prices,
 	PriceType,
 	products,
+	type UsagePriceConfig,
 } from "@autumn/shared";
 import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { initDrizzle } from "../src/db/initDrizzle";
-import { composeNewestReusableFixedPriceQuery } from "../src/internal/products/prices/repos/findNewestReusableFixedPrice";
+import { composeNewestReusableUsagePriceQuery } from "../src/internal/products/prices/repos/findNewestReusableUsagePrice";
 
 const STATEMENT_TIMEOUT_MS = 30_000;
 
-// Infisical staging DATABASE_URL is the unit-test Neon. Mintlify lives on the replica.
 const dbUrl = process.env.DATABASE_REPLICA_URL || process.env.DATABASE_URL || "";
 const maskedUrl = dbUrl.replace(/:\/\/[^@]+@/, "://***:***@") || "(empty)";
 
@@ -23,9 +23,7 @@ if (/autumn-prod|-prod-/i.test(dbUrl) && process.env.ALLOW_NON_STAGING !== "1") 
 	throw new Error(`DATABASE_URL looks like prod (${maskedUrl}). Use staging.`);
 }
 
-const orgSlug = (
-	process.env.EXPLAIN_ORG_SLUG ?? "mintlify"
-).toLowerCase();
+const orgSlug = (process.env.EXPLAIN_ORG_SLUG ?? "mintlify").toLowerCase();
 const env = process.env.EXPLAIN_ENV === "sandbox" ? AppEnv.Sandbox : AppEnv.Live;
 const analyze = process.argv.includes("--analyze");
 
@@ -41,7 +39,7 @@ const main = async () => {
 	const { db } = initDrizzle({
 		databaseUrl: dbUrl,
 		maxConnections: 2,
-		name: "explain-reusable-price",
+		name: "explain-reusable-usage-price",
 	});
 
 	const org = requireRow(
@@ -69,23 +67,21 @@ const main = async () => {
 					priceCount: sql<number>`count(*)::int`,
 				})
 				.from(products)
-				.innerJoin(
-					prices,
-					eq(prices.internal_product_id, products.internal_id),
-				)
+				.innerJoin(prices, eq(prices.internal_product_id, products.internal_id))
 				.where(
 					and(
 						eq(products.org_id, org.id),
 						eq(products.env, env),
 						isNull(products.deleted_at),
-						sql`${prices.config} ->> 'type' = ${PriceType.Fixed}`,
+						sql`${prices.config} ->> 'type' = ${PriceType.Usage}`,
+						sql`${prices.config} ->> 'bill_when' NOT IN (${BillWhen.InAdvance}, ${BillWhen.StartOfPeriod})`,
 					),
 				)
 				.groupBy(products.id)
 				.orderBy(desc(sql`count(*)`))
 				.limit(1)
 		)[0],
-		`fixed-price product for ${orgSlug}`,
+		`usage-price product for ${orgSlug}`,
 	);
 
 	const sample = requireRow(
@@ -93,56 +89,54 @@ const main = async () => {
 			await db
 				.select({ price: prices })
 				.from(prices)
-				.innerJoin(
-					products,
-					eq(prices.internal_product_id, products.internal_id),
-				)
+				.innerJoin(products, eq(prices.internal_product_id, products.internal_id))
 				.where(
 					and(
 						eq(products.org_id, org.id),
 						eq(products.env, env),
 						eq(products.id, product.id),
 						isNull(products.deleted_at),
-						sql`${prices.config} ->> 'type' = ${PriceType.Fixed}`,
+						sql`${prices.config} ->> 'type' = ${PriceType.Usage}`,
+						sql`${prices.config} ->> 'bill_when' NOT IN (${BillWhen.InAdvance}, ${BillWhen.StartOfPeriod})`,
 					),
 				)
 				.orderBy(desc(prices.created_at))
 				.limit(1)
 		)[0],
-		`sample fixed price on ${product.id}`,
+		`sample usage price on ${product.id}`,
 	);
 
 	const targetPrice = sample.price as Price;
-	if (!isFixedPrice(targetPrice)) {
-		throw new Error("sample price is not fixed");
+	if (
+		!isConsumablePrice(targetPrice) &&
+		!isAllocatedV2Price(targetPrice)
+	) {
+		console.log(
+			"sample is usage-in-arrear-shaped but not consumable/allocated-v2; still explaining the coarse query",
+		);
 	}
 
-	const targetCurrency = orgDefaultCurrency;
-	const { amount } = priceConfigForCurrency({
-		config: targetPrice.config,
-		currency: targetCurrency,
-		orgDefault: orgDefaultCurrency,
-	});
-	if (amount == null) {
-		throw new Error(`sample price has no ${targetCurrency} amount`);
-	}
-
-	const query = composeNewestReusableFixedPriceQuery({
+	const config = targetPrice.config as UsagePriceConfig;
+	const query = composeNewestReusableUsagePriceQuery({
 		db,
 		orgId: org.id,
 		env,
 		productId: product.id,
 		excludePriceId: targetPrice.id,
 		targetIsCustom: targetPrice.is_custom === true,
-		targetCurrency,
+		targetCurrency: orgDefaultCurrency,
 		orgDefaultCurrency,
-		amount,
-		interval: targetPrice.config.interval ?? BillingInterval.Month,
-		intervalCount: targetPrice.config.interval_count ?? 1,
+		featureId: config.feature_id,
+		internalFeatureId: config.internal_feature_id,
+		billWhen: config.bill_when ?? BillWhen.EndOfPeriod,
+		interval: config.interval,
+		intervalCount: config.interval_count ?? 1,
+		billingUnits: config.billing_units ?? 1,
+		shouldProrate: config.should_prorate ?? false,
 	});
 
 	console.log(
-		`product.id=${product.id}  fixed prices=${product.priceCount}  amount=${amount}  interval=${targetPrice.config.interval}`,
+		`product.id=${product.id}  usage prices=${product.priceCount}  feature=${config.feature_id}  bill_when=${config.bill_when}`,
 	);
 
 	const explain = analyze

--- a/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeArrearProrated.ts
@@ -246,9 +246,10 @@ export const createStripeArrearProrated = async ({
 		},
 		{
 			idempotencyKey: buildStripePriceIdempotencyKey({
-				priceId: price.id!,
+				price,
 				slot: "stripe_price_id",
 				currency,
+				orgDefault,
 			}),
 		},
 	);

--- a/server/src/external/stripe/createStripePrice/createStripeFixedPrice.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeFixedPrice.ts
@@ -69,9 +69,10 @@ export const createStripeFixedPrice = async ({
 		},
 		{
 			idempotencyKey: buildStripePriceIdempotencyKey({
-				priceId: price.id!,
+				price,
 				slot: "stripe_price_id",
 				currency,
+				orgDefault,
 			}),
 		},
 	);

--- a/server/src/external/stripe/createStripePrice/createStripeInArrear.ts
+++ b/server/src/external/stripe/createStripePrice/createStripeInArrear.ts
@@ -362,9 +362,10 @@ export const createStripeInArrearPrice = async ({
 		},
 		{
 			idempotencyKey: buildStripePriceIdempotencyKey({
-				priceId: price.id!,
+				price,
 				slot: "stripe_price_id",
 				currency,
+				orgDefault,
 			}),
 		},
 	);

--- a/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
+++ b/server/src/external/stripe/createStripePrice/createStripePrepaidPriceV2.ts
@@ -104,9 +104,10 @@ export const createStripePrepaidPriceV2 = async ({
 
 	const stripePrice = await stripeCli.prices.create(stripeCreatePriceParams, {
 		idempotencyKey: buildStripePriceIdempotencyKey({
-			priceId: price.id!,
+			price,
 			slot: "stripe_prepaid_price_v2_id",
 			currency,
+			orgDefault,
 		}),
 	});
 

--- a/server/src/external/stripe/prices/operations/getStripePrice.ts
+++ b/server/src/external/stripe/prices/operations/getStripePrice.ts
@@ -5,16 +5,21 @@ export async function getStripePrice({
 	stripeClient,
 	stripePriceId,
 	errorOnNotFound = false,
+	expand,
 }: {
 	stripeClient: Stripe;
 	stripePriceId?: string;
 	errorOnNotFound?: boolean;
+	expand?: string[];
 }): Promise<Stripe.Price | undefined> {
 	const getStripePriceOptional = async () => {
 		if (!stripePriceId) return undefined;
 
 		const { data: stripePrice, error } = await tryCatch(
-			stripeClient.prices.retrieve(stripePriceId),
+			stripeClient.prices.retrieve(
+				stripePriceId,
+				expand?.length ? { expand } : undefined,
+			),
 		);
 
 		if (error) {

--- a/server/src/external/stripe/prices/utils/buildIdempotencyKey.ts
+++ b/server/src/external/stripe/prices/utils/buildIdempotencyKey.ts
@@ -1,14 +1,37 @@
+import { createHash } from "node:crypto";
+import { priceToStripePriceIdempotencyShape, type Price } from "@autumn/shared";
 import { AUTUMN_STRIPE_IDEMPOTENCY_PREFIX } from "@/external/stripe/common/autumnStripeIdempotency";
 
+const hashStripePriceIdempotencyShape = ({
+	price,
+	currency,
+	orgDefault,
+}: {
+	price: Price;
+	currency: string;
+	orgDefault: string;
+}) =>
+	createHash("sha256")
+		.update(
+			JSON.stringify(
+				priceToStripePriceIdempotencyShape({ price, currency, orgDefault }),
+			),
+		)
+		.digest("hex")
+		.slice(0, 16);
+
 export const buildStripePriceIdempotencyKey = ({
-	priceId,
+	price,
 	slot,
 	currency,
+	orgDefault,
 }: {
-	priceId: string;
+	price: Price;
 	slot: string;
 	currency: string;
-}) => `${AUTUMN_STRIPE_IDEMPOTENCY_PREFIX}price:${priceId}:${slot}:${currency}`;
+	orgDefault: string;
+}) =>
+	`${AUTUMN_STRIPE_IDEMPOTENCY_PREFIX}price:${price.id}:${slot}:${currency}:${hashStripePriceIdempotencyShape({ price, currency, orgDefault })}`;
 
 export const buildStripeProductIdempotencyKey = ({
 	productInternalId,

--- a/server/src/internal/billing/v2/providers/stripe/logs/logStripePriceReuse.ts
+++ b/server/src/internal/billing/v2/providers/stripe/logs/logStripePriceReuse.ts
@@ -1,0 +1,83 @@
+import type { FullProduct, Price } from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { appendToExtraLogs } from "@/utils/logging/addToExtraLogs";
+
+export type StripePriceReuseResult =
+	| "skipped"
+	| "no-candidate"
+	| "reuse-level"
+	| "unusable"
+	| "stamped";
+
+export type StripePriceReuseEntry = {
+	result: StripePriceReuseResult;
+	reason?: string;
+	currency: string;
+	product: FullProduct;
+	targetPrice: Price;
+	targetAmount?: number | null;
+	targetInterval?: string | null;
+	candidatePrice?: Price | null;
+	candidateStripePriceId?: string | null;
+	reuseLevel?: string;
+	expectedStripeProductId?: string | null;
+	retrievedStripeProductId?: string | null;
+	stripePriceId?: string | null;
+};
+
+const formatPrice = ({
+	price,
+	amount,
+	interval,
+	stripePriceId,
+}: {
+	price: Price;
+	amount?: number | null;
+	interval?: string | null;
+	stripePriceId?: string | null;
+}) => {
+	const money = amount != null ? `$${amount}` : "";
+	const cadence = interval ? `/${interval}` : "";
+	const scope = price.is_custom ? " custom" : " catalog";
+	const stripe = stripePriceId ? ` ${stripePriceId}` : "";
+	return `${price.id} ${money}${cadence}${scope}${stripe}`.trim();
+};
+
+const formatProduct = ({ product }: { product: FullProduct }) => {
+	const processor = product.processor?.id ?? "none";
+	return `${product.id} v${product.version} processor=${processor}`;
+};
+
+export const logStripePriceReuse = ({
+	ctx,
+	entry,
+}: {
+	ctx: AutumnContext;
+	entry: StripePriceReuseEntry;
+}) => {
+	appendToExtraLogs({
+		ctx,
+		key: "stripePriceReuse",
+		value: {
+			result: entry.result,
+			reason: entry.reason ?? "none",
+			target: formatPrice({
+				price: entry.targetPrice,
+				amount: entry.targetAmount,
+				interval: entry.targetInterval,
+				stripePriceId: entry.stripePriceId,
+			}),
+			product: formatProduct({ product: entry.product }),
+			currency: entry.currency,
+			candidate: entry.candidatePrice
+				? formatPrice({
+						price: entry.candidatePrice,
+						stripePriceId: entry.candidateStripePriceId,
+					})
+				: "none",
+			reuseLevel: entry.reuseLevel ?? "none",
+			expectedProduct: entry.expectedStripeProductId ?? "none",
+			retrievedProduct: entry.retrievedStripeProductId ?? "none",
+		},
+	});
+};

--- a/server/src/internal/billing/v2/providers/stripe/utils/matchUtils/autumnPriceShape.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/matchUtils/autumnPriceShape.ts
@@ -2,6 +2,7 @@ import {
 	atmnToStripeAmountDecimal,
 	type Entitlement,
 	type FixedPriceConfig,
+	isAllocatedPrice,
 	isConsumablePrice,
 	isPrepaidPrice,
 	type Organization,
@@ -123,6 +124,56 @@ export const autumnConsumablePriceToStripePriceShape = ({
 			currency,
 			billing_scheme: "tiered",
 			recurring: recurringMetered,
+			tiers_mode: "graduated",
+			tiers: autumnTiersToShape({ tiers }),
+		},
+	});
+};
+
+/** Allocated v2 main price is licensed/tiered, not metered. */
+export const autumnAllocatedPriceToStripePriceShape = ({
+	price,
+	entitlement,
+	stripeProductId,
+	currency,
+	org,
+}: {
+	price: Price;
+	entitlement: Entitlement;
+	stripeProductId: string;
+	currency: string;
+	org: Organization;
+}): StripePriceShape | null => {
+	if (!isAllocatedPrice(price)) return null;
+	if (price.tier_behavior === TierBehavior.VolumeBased) return null;
+
+	const recurring = priceToStripeRecurringParams({ price });
+	if (!recurring) return null;
+
+	const tiers = priceToInArrearTiers({ price, entitlement, org, currency });
+	if (tiers.length === 1) {
+		const tier = tiers[0]!;
+		return inlinePriceToShape({
+			price: {
+				product: stripeProductId,
+				currency,
+				billing_scheme: "per_unit",
+				recurring,
+				unit_amount_decimal: (tier.unit_amount_decimal ?? tier.unit_amount) as
+					| string
+					| number
+					| null
+					| undefined,
+			},
+		});
+	}
+
+	return inlinePriceToShape({
+		price: {
+			product: stripeProductId,
+			currency,
+			billing_scheme: "tiered",
+			recurring,
 			tiers_mode: "graduated",
 			tiers: autumnTiersToShape({ tiers }),
 		},

--- a/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.ts
+++ b/server/src/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.ts
@@ -1,15 +1,19 @@
 import {
 	type FullProduct,
+	isAllocatedPrice,
 	isConsumablePrice,
 	isFixedPrice,
+	isPrepaidPrice,
 	type Organization,
 	type Price,
 	priceToEnt,
 } from "@autumn/shared";
 import type Stripe from "stripe";
 import {
+	autumnAllocatedPriceToStripePriceShape,
 	autumnBasePriceToStripePriceShape,
 	autumnConsumablePriceToStripePriceShape,
+	autumnPrepaidPriceToStripePriceShape,
 } from "../../matchUtils/autumnPriceShape";
 import {
 	stripePriceShapesEqual,
@@ -149,4 +153,82 @@ export const findMatchingStripePriceForConsumablePrice = ({
 				}),
 			}
 		: null;
+};
+
+export const stripePriceMatchesAllocatedPrice = ({
+	stripePrice,
+	price,
+	product,
+	stripeProductId: expectedStripeProductId,
+	currency,
+	org,
+}: {
+	stripePrice: Stripe.Price;
+	price: Price;
+	product: FullProduct;
+	stripeProductId: string;
+	currency: string;
+	org: Organization;
+}) => {
+	if (!stripePrice.active) return false;
+	if (!isAllocatedPrice(price)) return false;
+
+	const entitlement = priceToEnt({
+		price,
+		entitlements: product.entitlements,
+	});
+	if (!entitlement) return false;
+
+	const autumnShape = autumnAllocatedPriceToStripePriceShape({
+		price,
+		entitlement,
+		stripeProductId: expectedStripeProductId,
+		currency,
+		org,
+	});
+	if (!autumnShape) return false;
+
+	return stripePriceShapesEqual(
+		stripePriceToShape({ price: stripePrice }),
+		autumnShape,
+	);
+};
+
+export const stripePriceMatchesPrepaidPrice = ({
+	stripePrice,
+	price,
+	product,
+	stripeProductId: expectedStripeProductId,
+	currency,
+	org,
+}: {
+	stripePrice: Stripe.Price;
+	price: Price;
+	product: FullProduct;
+	stripeProductId: string;
+	currency: string;
+	org: Organization;
+}) => {
+	if (!stripePrice.active) return false;
+	if (!isPrepaidPrice(price)) return false;
+
+	const entitlement = priceToEnt({
+		price,
+		entitlements: product.entitlements,
+	});
+	if (!entitlement) return false;
+
+	const autumnShape = autumnPrepaidPriceToStripePriceShape({
+		price,
+		entitlement,
+		stripeProductId: expectedStripeProductId,
+		currency,
+		org,
+	});
+	if (!autumnShape) return false;
+
+	return stripePriceShapesEqual(
+		stripePriceToShape({ price: stripePrice }),
+		autumnShape,
+	);
 };

--- a/server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts
+++ b/server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts
@@ -13,6 +13,7 @@ import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { liveProductWhere } from "@/internal/products/repos/liveProductWhere.js";
 import { composeAttachCurrencyFixedMatch } from "./utils/composeAttachCurrencyFixedMatch.js";
+import { composeReusableCustomScope } from "./utils/composeReusableCustomScope.js";
 
 export const composeNewestReusableFixedPriceQuery = ({
 	db,
@@ -20,6 +21,7 @@ export const composeNewestReusableFixedPriceQuery = ({
 	env,
 	productId,
 	excludePriceId,
+	targetIsCustom,
 	targetCurrency,
 	orgDefaultCurrency,
 	amount,
@@ -31,6 +33,7 @@ export const composeNewestReusableFixedPriceQuery = ({
 	env: AppEnv;
 	productId: string;
 	excludePriceId: string;
+	targetIsCustom: boolean;
 	targetCurrency: string;
 	orgDefaultCurrency: string;
 	amount: number;
@@ -48,6 +51,7 @@ export const composeNewestReusableFixedPriceQuery = ({
 				eq(products.id, productId),
 				liveProductWhere,
 				ne(prices.id, excludePriceId),
+				composeReusableCustomScope({ targetIsCustom }),
 				sql`${prices.config} ->> 'type' = ${PriceType.Fixed}`,
 				sql`${prices.config} ->> 'interval' = ${interval}`,
 				sql`COALESCE((${prices.config} ->> 'interval_count')::int, 1) = ${intervalCount}`,
@@ -88,6 +92,7 @@ export const findNewestReusableFixedPrice = async ({
 		env: ctx.env,
 		productId,
 		excludePriceId: targetPrice.id,
+		targetIsCustom: targetPrice.is_custom === true,
 		targetCurrency,
 		orgDefaultCurrency,
 		amount,

--- a/server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts
+++ b/server/src/internal/products/prices/repos/findNewestReusableFixedPrice.ts
@@ -8,12 +8,13 @@ import {
 	PriceType,
 	products,
 } from "@autumn/shared";
-import { and, desc, eq, ne, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { liveProductWhere } from "@/internal/products/repos/liveProductWhere.js";
 import { composeAttachCurrencyFixedMatch } from "./utils/composeAttachCurrencyFixedMatch.js";
 import { composeReusableCustomScope } from "./utils/composeReusableCustomScope.js";
+import { composeReusablePriceRankOrder } from "./utils/composeReusablePriceRankOrder.js";
 
 export const composeNewestReusableFixedPriceQuery = ({
 	db,
@@ -62,7 +63,7 @@ export const composeNewestReusableFixedPriceQuery = ({
 				}),
 			),
 		)
-		.orderBy(desc(prices.created_at))
+		.orderBy(...composeReusablePriceRankOrder())
 		.limit(1);
 
 export const findNewestReusableFixedPrice = async ({

--- a/server/src/internal/products/prices/repos/findNewestReusablePrepaidPrice.ts
+++ b/server/src/internal/products/prices/repos/findNewestReusablePrepaidPrice.ts
@@ -1,0 +1,131 @@
+import {
+	type AppEnv,
+	BillingInterval,
+	BillWhen,
+	isPrepaidPrice,
+	orgToCurrency,
+	type Price,
+	prices,
+	pricesAreSame,
+	PriceType,
+	products,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import { and, desc, eq, ne, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { liveProductWhere } from "@/internal/products/repos/liveProductWhere.js";
+import { composeAttachCurrencyUsageStripeSlot } from "./utils/composeAttachCurrencyUsageStripeSlot.js";
+import { composeConfigTextEquals } from "./utils/composeConfigTextEquals.js";
+import { composeReusableCustomScope } from "./utils/composeReusableCustomScope.js";
+
+const PREPAID_REUSE_CANDIDATE_LIMIT = 1000;
+
+export const composeNewestReusablePrepaidPriceQuery = ({
+	db,
+	orgId,
+	env,
+	productId,
+	excludePriceId,
+	targetIsCustom,
+	targetCurrency,
+	orgDefaultCurrency,
+	featureId,
+	internalFeatureId,
+	billWhen,
+	interval,
+	intervalCount,
+	billingUnits,
+	shouldProrate,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	productId: string;
+	excludePriceId: string;
+	targetIsCustom: boolean;
+	targetCurrency: string;
+	orgDefaultCurrency: string;
+	featureId: string | null | undefined;
+	internalFeatureId: string | null | undefined;
+	billWhen: string;
+	interval: string | null | undefined;
+	intervalCount: number;
+	billingUnits: number;
+	shouldProrate: boolean;
+}) =>
+	db
+		.select({ price: prices })
+		.from(prices)
+		.innerJoin(products, eq(prices.internal_product_id, products.internal_id))
+		.where(
+			and(
+				eq(products.org_id, orgId),
+				eq(products.env, env),
+				eq(products.id, productId),
+				liveProductWhere,
+				ne(prices.id, excludePriceId),
+				composeReusableCustomScope({ targetIsCustom }),
+				sql`${prices.config} ->> 'type' = ${PriceType.Usage}`,
+				composeConfigTextEquals({ key: "feature_id", value: featureId }),
+				composeConfigTextEquals({
+					key: "internal_feature_id",
+					value: internalFeatureId,
+				}),
+				composeConfigTextEquals({ key: "bill_when", value: billWhen }),
+				composeConfigTextEquals({ key: "interval", value: interval }),
+				sql`COALESCE((${prices.config} ->> 'interval_count')::int, 1) = ${intervalCount}`,
+				sql`COALESCE((${prices.config} ->> 'billing_units')::numeric, 1) = ${billingUnits}`,
+				sql`COALESCE((${prices.config} ->> 'should_prorate')::boolean, false) = ${shouldProrate}`,
+				composeAttachCurrencyUsageStripeSlot({
+					targetCurrency,
+					orgDefaultCurrency,
+					slot: "stripe_prepaid_price_v2_id",
+				}),
+			),
+		)
+		.orderBy(desc(prices.created_at))
+		.limit(PREPAID_REUSE_CANDIDATE_LIMIT);
+
+export const findNewestReusablePrepaidPrice = async ({
+	ctx,
+	targetPrice,
+	productId,
+	targetCurrency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	productId: string;
+	targetCurrency: string;
+}): Promise<Price | null> => {
+	if (!isPrepaidPrice(targetPrice)) return null;
+	if (targetPrice.config.interval === BillingInterval.OneOff) return null;
+
+	const config = targetPrice.config as UsagePriceConfig;
+	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+
+	const rows = await composeNewestReusablePrepaidPriceQuery({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		productId,
+		excludePriceId: targetPrice.id,
+		targetIsCustom: targetPrice.is_custom === true,
+		targetCurrency,
+		orgDefaultCurrency,
+		featureId: config.feature_id,
+		internalFeatureId: config.internal_feature_id,
+		billWhen: config.bill_when ?? BillWhen.InAdvance,
+		interval: config.interval,
+		intervalCount: config.interval_count ?? 1,
+		billingUnits: config.billing_units ?? 1,
+		shouldProrate: config.should_prorate ?? false,
+	});
+
+	for (const row of rows) {
+		const candidate = row.price as Price;
+		if (pricesAreSame(targetPrice, candidate)) return candidate;
+	}
+
+	return null;
+};

--- a/server/src/internal/products/prices/repos/findNewestReusablePrepaidPrice.ts
+++ b/server/src/internal/products/prices/repos/findNewestReusablePrepaidPrice.ts
@@ -11,13 +11,14 @@ import {
 	products,
 	type UsagePriceConfig,
 } from "@autumn/shared";
-import { and, desc, eq, ne, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { liveProductWhere } from "@/internal/products/repos/liveProductWhere.js";
 import { composeAttachCurrencyUsageStripeSlot } from "./utils/composeAttachCurrencyUsageStripeSlot.js";
 import { composeConfigTextEquals } from "./utils/composeConfigTextEquals.js";
 import { composeReusableCustomScope } from "./utils/composeReusableCustomScope.js";
+import { composeReusablePriceRankOrder } from "./utils/composeReusablePriceRankOrder.js";
 
 const PREPAID_REUSE_CANDIDATE_LIMIT = 1000;
 
@@ -84,7 +85,7 @@ export const composeNewestReusablePrepaidPriceQuery = ({
 				}),
 			),
 		)
-		.orderBy(desc(prices.created_at))
+		.orderBy(...composeReusablePriceRankOrder())
 		.limit(PREPAID_REUSE_CANDIDATE_LIMIT);
 
 export const findNewestReusablePrepaidPrice = async ({

--- a/server/src/internal/products/prices/repos/findNewestReusableUsagePrice.ts
+++ b/server/src/internal/products/prices/repos/findNewestReusableUsagePrice.ts
@@ -11,13 +11,14 @@ import {
 	products,
 	type UsagePriceConfig,
 } from "@autumn/shared";
-import { and, desc, eq, ne, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import type { DrizzleCli } from "@/db/initDrizzle.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { liveProductWhere } from "@/internal/products/repos/liveProductWhere.js";
 import { composeAttachCurrencyUsageStripeSlot } from "./utils/composeAttachCurrencyUsageStripeSlot.js";
 import { composeConfigTextEquals } from "./utils/composeConfigTextEquals.js";
 import { composeReusableCustomScope } from "./utils/composeReusableCustomScope.js";
+import { composeReusablePriceRankOrder } from "./utils/composeReusablePriceRankOrder.js";
 
 const USAGE_REUSE_CANDIDATE_LIMIT = 1000;
 
@@ -84,7 +85,7 @@ export const composeNewestReusableUsagePriceQuery = ({
 				}),
 			),
 		)
-		.orderBy(desc(prices.created_at))
+		.orderBy(...composeReusablePriceRankOrder())
 		.limit(USAGE_REUSE_CANDIDATE_LIMIT);
 
 export const findNewestReusableUsagePrice = async ({

--- a/server/src/internal/products/prices/repos/findNewestReusableUsagePrice.ts
+++ b/server/src/internal/products/prices/repos/findNewestReusableUsagePrice.ts
@@ -1,0 +1,132 @@
+import {
+	type AppEnv,
+	BillWhen,
+	isAllocatedV2Price,
+	isConsumablePrice,
+	orgToCurrency,
+	type Price,
+	prices,
+	pricesAreSame,
+	PriceType,
+	products,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import { and, desc, eq, ne, sql } from "drizzle-orm";
+import type { DrizzleCli } from "@/db/initDrizzle.js";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { liveProductWhere } from "@/internal/products/repos/liveProductWhere.js";
+import { composeAttachCurrencyUsageStripeSlot } from "./utils/composeAttachCurrencyUsageStripeSlot.js";
+import { composeConfigTextEquals } from "./utils/composeConfigTextEquals.js";
+import { composeReusableCustomScope } from "./utils/composeReusableCustomScope.js";
+
+const USAGE_REUSE_CANDIDATE_LIMIT = 1000;
+
+export const composeNewestReusableUsagePriceQuery = ({
+	db,
+	orgId,
+	env,
+	productId,
+	excludePriceId,
+	targetIsCustom,
+	targetCurrency,
+	orgDefaultCurrency,
+	featureId,
+	internalFeatureId,
+	billWhen,
+	interval,
+	intervalCount,
+	billingUnits,
+	shouldProrate,
+}: {
+	db: DrizzleCli;
+	orgId: string;
+	env: AppEnv;
+	productId: string;
+	excludePriceId: string;
+	targetIsCustom: boolean;
+	targetCurrency: string;
+	orgDefaultCurrency: string;
+	featureId: string | null | undefined;
+	internalFeatureId: string | null | undefined;
+	billWhen: string;
+	interval: string | null | undefined;
+	intervalCount: number;
+	billingUnits: number;
+	shouldProrate: boolean;
+}) =>
+	db
+		.select({ price: prices })
+		.from(prices)
+		.innerJoin(products, eq(prices.internal_product_id, products.internal_id))
+		.where(
+			and(
+				eq(products.org_id, orgId),
+				eq(products.env, env),
+				eq(products.id, productId),
+				liveProductWhere,
+				ne(prices.id, excludePriceId),
+				composeReusableCustomScope({ targetIsCustom }),
+				sql`${prices.config} ->> 'type' = ${PriceType.Usage}`,
+				composeConfigTextEquals({ key: "feature_id", value: featureId }),
+				composeConfigTextEquals({
+					key: "internal_feature_id",
+					value: internalFeatureId,
+				}),
+				composeConfigTextEquals({ key: "bill_when", value: billWhen }),
+				composeConfigTextEquals({ key: "interval", value: interval }),
+				sql`COALESCE((${prices.config} ->> 'interval_count')::int, 1) = ${intervalCount}`,
+				sql`COALESCE((${prices.config} ->> 'billing_units')::numeric, 1) = ${billingUnits}`,
+				sql`COALESCE((${prices.config} ->> 'should_prorate')::boolean, false) = ${shouldProrate}`,
+				composeAttachCurrencyUsageStripeSlot({
+					targetCurrency,
+					orgDefaultCurrency,
+					slot: "stripe_price_id",
+				}),
+			),
+		)
+		.orderBy(desc(prices.created_at))
+		.limit(USAGE_REUSE_CANDIDATE_LIMIT);
+
+export const findNewestReusableUsagePrice = async ({
+	ctx,
+	targetPrice,
+	productId,
+	targetCurrency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	productId: string;
+	targetCurrency: string;
+}): Promise<Price | null> => {
+	if (!isConsumablePrice(targetPrice) && !isAllocatedV2Price(targetPrice)) {
+		return null;
+	}
+
+	const config = targetPrice.config as UsagePriceConfig;
+	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+
+	const rows = await composeNewestReusableUsagePriceQuery({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		productId,
+		excludePriceId: targetPrice.id,
+		targetIsCustom: targetPrice.is_custom === true,
+		targetCurrency,
+		orgDefaultCurrency,
+		featureId: config.feature_id,
+		internalFeatureId: config.internal_feature_id,
+		billWhen: config.bill_when ?? BillWhen.EndOfPeriod,
+		interval: config.interval,
+		intervalCount: config.interval_count ?? 1,
+		billingUnits: config.billing_units ?? 1,
+		shouldProrate: config.should_prorate ?? false,
+	});
+
+	for (const row of rows) {
+		const candidate = row.price as Price;
+		if (pricesAreSame(targetPrice, candidate)) return candidate;
+	}
+
+	return null;
+};

--- a/server/src/internal/products/prices/repos/priceRepo.ts
+++ b/server/src/internal/products/prices/repos/priceRepo.ts
@@ -1,7 +1,11 @@
 import { findNewestReusableFixedPrice } from "./findNewestReusableFixedPrice.js";
+import { findNewestReusablePrepaidPrice } from "./findNewestReusablePrepaidPrice.js";
+import { findNewestReusableUsagePrice } from "./findNewestReusableUsagePrice.js";
 import { listDistinctBasePricesByCustomerLicense } from "./listDistinctBasePricesByCustomerLicense.js";
 
 export const priceRepo = {
 	findNewestReusableFixedPrice,
+	findNewestReusablePrepaidPrice,
+	findNewestReusableUsagePrice,
 	listDistinctBasePricesByCustomerLicense,
 } as const;

--- a/server/src/internal/products/prices/repos/utils/composeAttachCurrencyUsageStripeSlot.ts
+++ b/server/src/internal/products/prices/repos/utils/composeAttachCurrencyUsageStripeSlot.ts
@@ -1,0 +1,32 @@
+import { PREVIEW_STRIPE_PRICE_ID_PREFIX, prices } from "@autumn/shared";
+import { type SQL, sql } from "drizzle-orm";
+
+const usableStripePriceId = (slot: SQL) => sql`
+	${slot} IS NOT NULL
+	AND ${slot} <> ''
+	AND ${slot} NOT LIKE ${`${PREVIEW_STRIPE_PRICE_ID_PREFIX}%`}
+`;
+
+/** This currency's attach slot, whether it is base or overlay. Tiers stay in JS. */
+export const composeAttachCurrencyUsageStripeSlot = ({
+	targetCurrency,
+	orgDefaultCurrency,
+	slot = "stripe_price_id",
+}: {
+	targetCurrency: string;
+	orgDefaultCurrency: string;
+	slot?: "stripe_price_id" | "stripe_prepaid_price_v2_id";
+}) => {
+	const currency = targetCurrency.toLowerCase();
+	const orgDefault = orgDefaultCurrency.toLowerCase();
+	const baseStripePriceId = sql`${prices.config} ->> ${slot}`;
+	const overlayStripePriceId = sql`${prices.config} -> 'currencies' -> ${currency} ->> ${slot}`;
+
+	return sql`(
+		(
+			lower(coalesce(${prices.config} ->> 'base_currency', ${orgDefault})) = ${currency}
+			AND ${usableStripePriceId(baseStripePriceId)}
+		)
+		OR ${usableStripePriceId(overlayStripePriceId)}
+	)`;
+};

--- a/server/src/internal/products/prices/repos/utils/composeConfigTextEquals.ts
+++ b/server/src/internal/products/prices/repos/utils/composeConfigTextEquals.ts
@@ -1,0 +1,13 @@
+import { prices } from "@autumn/shared";
+import { sql } from "drizzle-orm";
+
+export const composeConfigTextEquals = ({
+	key,
+	value,
+}: {
+	key: "feature_id" | "internal_feature_id" | "bill_when" | "interval";
+	value: string | null | undefined;
+}) =>
+	value == null
+		? sql`${prices.config} ->> ${key} IS NULL`
+		: sql`${prices.config} ->> ${key} = ${value}`;

--- a/server/src/internal/products/prices/repos/utils/composeReusableCustomScope.ts
+++ b/server/src/internal/products/prices/repos/utils/composeReusableCustomScope.ts
@@ -1,0 +1,9 @@
+import { prices } from "@autumn/shared";
+import { eq } from "drizzle-orm";
+
+/** Catalog cannot borrow a custom row. Custom can borrow catalog. */
+export const composeReusableCustomScope = ({
+	targetIsCustom,
+}: {
+	targetIsCustom: boolean;
+}) => (targetIsCustom ? undefined : eq(prices.is_custom, false));

--- a/server/src/internal/products/prices/repos/utils/composeReusablePriceRankOrder.ts
+++ b/server/src/internal/products/prices/repos/utils/composeReusablePriceRankOrder.ts
@@ -1,0 +1,8 @@
+import { prices } from "@autumn/shared";
+import { asc, desc } from "drizzle-orm";
+
+/** Catalog first, then newest — matches `rankStripeReuseCandidates`. */
+export const composeReusablePriceRankOrder = () => [
+	asc(prices.is_custom),
+	desc(prices.created_at),
+];

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyAttachCurrencyStripeSlot.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyAttachCurrencyStripeSlot.ts
@@ -1,5 +1,6 @@
 import {
 	type CurrencyAwarePriceConfig,
+	type CurrencyStripeIdSlot,
 	getPriceCurrencyStripeId,
 	type Price,
 	setPriceCurrencyStripeId,
@@ -10,13 +11,14 @@ export const copyAttachCurrencyStripeSlot = ({
 	sourcePrice,
 	currency,
 	orgDefaultCurrency,
+	slot = "stripe_price_id",
 }: {
 	targetPrice: Price;
 	sourcePrice: Price;
 	currency: string;
 	orgDefaultCurrency: string;
+	slot?: CurrencyStripeIdSlot;
 }): boolean => {
-	const slot = "stripe_price_id" as const;
 	const sourceId = getPriceCurrencyStripeId({
 		config: sourcePrice.config as CurrencyAwarePriceConfig,
 		currency,

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyReusableStripeProductId.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyReusableStripeProductId.ts
@@ -1,0 +1,19 @@
+import { isFixedPrice, type Price, type UsagePriceConfig } from "@autumn/shared";
+
+/** Donor feature Product — skip fixed; plan processor is a different object. */
+export const copyReusableStripeProductId = ({
+	targetPrice,
+	sourcePrice,
+}: {
+	targetPrice: Price;
+	sourcePrice: Price;
+}): boolean => {
+	if (isFixedPrice(targetPrice) || isFixedPrice(sourcePrice)) return false;
+
+	const target = targetPrice.config as UsagePriceConfig;
+	const source = sourcePrice.config as UsagePriceConfig;
+	if (target.stripe_product_id || !source.stripe_product_id) return false;
+
+	target.stripe_product_id = source.stripe_product_id;
+	return true;
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyReusableUsageMeter.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyReusableUsageMeter.ts
@@ -1,0 +1,45 @@
+import {
+	isConsumablePrice,
+	type Price,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+
+const copyIfEmpty = ({
+	target,
+	source,
+	field,
+}: {
+	target: UsagePriceConfig;
+	source: UsagePriceConfig;
+	field: "stripe_meter_id" | "stripe_event_name";
+}): boolean => {
+	if (target[field]) return false;
+	if (!source[field]) return false;
+	target[field] = source[field];
+	return true;
+};
+
+/** Meter lives on Autumn config, not the Stripe Price retrieve. */
+export const copyReusableUsageMeter = ({
+	targetPrice,
+	sourcePrice,
+}: {
+	targetPrice: Price;
+	sourcePrice: Price;
+}): boolean => {
+	if (!isConsumablePrice(targetPrice) || !isConsumablePrice(sourcePrice)) {
+		return false;
+	}
+
+	const copiedMeter = copyIfEmpty({
+		target: targetPrice.config,
+		source: sourcePrice.config,
+		field: "stripe_meter_id",
+	});
+	const copiedEventName = copyIfEmpty({
+		target: targetPrice.config,
+		source: sourcePrice.config,
+		field: "stripe_event_name",
+	});
+	return copiedMeter || copiedEventName;
+};

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts
@@ -1,18 +1,31 @@
 import {
+	type CurrencyAwarePriceConfig,
 	type FullProduct,
+	getPriceCurrencyStripeId,
 	getPriceStripeReuseLevel,
 	isFixedPrice,
+	orgToCurrency,
 	type Price,
+	priceConfigForCurrency,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import {
+	logStripePriceReuse,
+	type StripePriceReuseEntry,
+} from "@/internal/billing/v2/providers/stripe/logs/logStripePriceReuse.js";
 import { priceRepo } from "@/internal/products/prices/repos/priceRepo.js";
 import {
 	hasEmptyStripeResource,
 	isReusablePrepaidPrice,
 	isReusableUsagePrice,
 } from "./hasEmptyStripeResource.js";
-import { isUsableStripePrice } from "./isUsableStripePrice.js";
+import { evaluateUsableStripePrice } from "./isUsableStripePrice.js";
 import { stampAttachCurrencyStripeSlot } from "./stampAttachCurrencyStripeSlot.js";
+
+const reuseSlot = ({ targetPrice }: { targetPrice: Price }) =>
+	isReusablePrepaidPrice(targetPrice)
+		? "stripe_prepaid_price_v2_id"
+		: "stripe_price_id";
 
 const findNewestReusableCandidate = ({
 	ctx,
@@ -62,8 +75,40 @@ const findReusableStripePriceForTarget = async ({
 	targetPrice: Price;
 	product: FullProduct;
 	currency: string;
-}) => {
-	if (!hasEmptyStripeResource({ ctx, targetPrice, currency })) return;
+}): Promise<StripePriceReuseEntry | null> => {
+	const reusable =
+		isFixedPrice(targetPrice) ||
+		isReusablePrepaidPrice(targetPrice) ||
+		isReusableUsagePrice(targetPrice);
+	if (!reusable) return null;
+
+	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+	const { amount } = priceConfigForCurrency({
+		config: targetPrice.config,
+		currency,
+		orgDefault: orgDefaultCurrency,
+	});
+	const base = {
+		currency,
+		product,
+		targetPrice,
+		targetAmount: amount,
+		targetInterval: targetPrice.config.interval,
+	} satisfies Partial<StripePriceReuseEntry>;
+
+	if (!hasEmptyStripeResource({ ctx, targetPrice, currency })) {
+		return {
+			...base,
+			result: "skipped",
+			reason: "slot-set",
+			stripePriceId: getPriceCurrencyStripeId({
+				config: targetPrice.config as CurrencyAwarePriceConfig,
+				currency,
+				orgDefault: orgDefaultCurrency,
+				slot: reuseSlot({ targetPrice }),
+			}),
+		};
+	}
 
 	const candidate = await findNewestReusableCandidate({
 		ctx,
@@ -71,37 +116,72 @@ const findReusableStripePriceForTarget = async ({
 		productId: product.id,
 		targetCurrency: currency,
 	});
-	if (!candidate) return;
-
-	if (
-		getPriceStripeReuseLevel({
-			newPrice: targetPrice,
-			candidatePrice: candidate,
-			newEntitlements: [],
-			candidateEntitlements: [],
-		}) !== "full"
-	) {
-		return;
+	if (!candidate) {
+		return { ...base, result: "no-candidate" };
 	}
 
-	const usable = await isUsableStripePrice({
+	const candidateStripePriceId = getPriceCurrencyStripeId({
+		config: candidate.config as CurrencyAwarePriceConfig,
+		currency,
+		orgDefault: orgDefaultCurrency,
+		slot: reuseSlot({ targetPrice }),
+	});
+	const withCandidate = {
+		...base,
+		candidatePrice: candidate,
+		candidateStripePriceId,
+	};
+
+	const reuseLevel = getPriceStripeReuseLevel({
+		newPrice: targetPrice,
+		candidatePrice: candidate,
+		newEntitlements: [],
+		candidateEntitlements: [],
+	});
+	if (reuseLevel !== "full") {
+		return {
+			...withCandidate,
+			result: "reuse-level",
+			reason: reuseLevel,
+			reuseLevel,
+		};
+	}
+
+	const usable = await evaluateUsableStripePrice({
 		ctx,
 		targetPrice,
 		candidate,
 		product,
 		currency,
 	});
-	if (!usable) return;
+	if (!usable.usable) {
+		return {
+			...withCandidate,
+			result: "unusable",
+			reason: usable.reason,
+			reuseLevel,
+			expectedStripeProductId: usable.expectedStripeProductId,
+			retrievedStripeProductId: usable.retrievedStripeProductId,
+			stripePriceId: usable.stripePriceId,
+		};
+	}
 
 	await stampAttachCurrencyStripeSlot({
 		ctx,
 		targetPrice,
 		sourcePrice: candidate,
 		currency,
-		slot: isReusablePrepaidPrice(targetPrice)
-			? "stripe_prepaid_price_v2_id"
-			: "stripe_price_id",
+		slot: reuseSlot({ targetPrice }),
 	});
+
+	return {
+		...withCandidate,
+		result: "stamped",
+		reuseLevel,
+		expectedStripeProductId: usable.expectedStripeProductId,
+		retrievedStripeProductId: usable.retrievedStripeProductId,
+		stripePriceId: usable.stripePriceId,
+	};
 };
 
 export const findReusableStripePrice = async ({
@@ -113,7 +193,7 @@ export const findReusableStripePrice = async ({
 	products: FullProduct[];
 	currency: string;
 }) => {
-	await Promise.all(
+	const entries = await Promise.all(
 		products.flatMap((product) =>
 			product.prices.map((price) =>
 				findReusableStripePriceForTarget({
@@ -125,4 +205,8 @@ export const findReusableStripePrice = async ({
 			),
 		),
 	);
+
+	for (const entry of entries) {
+		if (entry) logStripePriceReuse({ ctx, entry });
+	}
 };

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts
@@ -1,13 +1,56 @@
 import {
 	type FullProduct,
 	getPriceStripeReuseLevel,
+	isFixedPrice,
 	type Price,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { priceRepo } from "@/internal/products/prices/repos/priceRepo.js";
-import { hasEmptyStripeResource } from "./hasEmptyStripeResource.js";
+import {
+	hasEmptyStripeResource,
+	isReusablePrepaidPrice,
+	isReusableUsagePrice,
+} from "./hasEmptyStripeResource.js";
 import { isUsableStripePrice } from "./isUsableStripePrice.js";
 import { stampAttachCurrencyStripeSlot } from "./stampAttachCurrencyStripeSlot.js";
+
+const findNewestReusableCandidate = ({
+	ctx,
+	targetPrice,
+	productId,
+	targetCurrency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	productId: string;
+	targetCurrency: string;
+}) => {
+	if (isFixedPrice(targetPrice)) {
+		return priceRepo.findNewestReusableFixedPrice({
+			ctx,
+			targetPrice,
+			productId,
+			targetCurrency,
+		});
+	}
+	if (isReusablePrepaidPrice(targetPrice)) {
+		return priceRepo.findNewestReusablePrepaidPrice({
+			ctx,
+			targetPrice,
+			productId,
+			targetCurrency,
+		});
+	}
+	if (isReusableUsagePrice(targetPrice)) {
+		return priceRepo.findNewestReusableUsagePrice({
+			ctx,
+			targetPrice,
+			productId,
+			targetCurrency,
+		});
+	}
+	return null;
+};
 
 const findReusableStripePriceForTarget = async ({
 	ctx,
@@ -22,7 +65,7 @@ const findReusableStripePriceForTarget = async ({
 }) => {
 	if (!hasEmptyStripeResource({ ctx, targetPrice, currency })) return;
 
-	const candidate = await priceRepo.findNewestReusableFixedPrice({
+	const candidate = await findNewestReusableCandidate({
 		ctx,
 		targetPrice,
 		productId: product.id,
@@ -55,6 +98,9 @@ const findReusableStripePriceForTarget = async ({
 		targetPrice,
 		sourcePrice: candidate,
 		currency,
+		slot: isReusablePrepaidPrice(targetPrice)
+			? "stripe_prepaid_price_v2_id"
+			: "stripe_price_id",
 	});
 };
 

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripeResources.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripeResources.ts
@@ -59,6 +59,9 @@ export const findReusableStripeResources = ({
 	const matches = candidates.filter((candidate) => {
 		if (candidate.price.id === targetPrice.id) return false;
 		if (!isFixedPrice(candidate.price)) return false;
+		if (targetPrice.is_custom !== true && candidate.price.is_custom === true) {
+			return false;
+		}
 		if (
 			!isSameProductScope({
 				targetProduct,

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/hasEmptyStripeResource.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/hasEmptyStripeResource.ts
@@ -1,12 +1,25 @@
 import {
+	BillingInterval,
 	type CurrencyAwarePriceConfig,
+	type CurrencyStripeIdSlot,
 	getPriceCurrencyStripeId,
+	isAllocatedV2Price,
+	isConsumablePrice,
 	isFixedPrice,
+	isPrepaidPrice,
 	orgToCurrency,
 	type Price,
 	priceConfigForCurrency,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+
+/** Consumable + allocated v2 (arrear). Prepaid and allocated v1 stay out. */
+export const isReusableUsagePrice = (price: Price) =>
+	isConsumablePrice(price) || isAllocatedV2Price(price);
+
+/** Recurring prepaid only — one-off uses inline price_data, not a V2 slot. */
+export const isReusablePrepaidPrice = (price: Price) =>
+	isPrepaidPrice(price) && price.config.interval !== BillingInterval.OneOff;
 
 export const hasEmptyStripeResource = ({
 	ctx,
@@ -17,20 +30,29 @@ export const hasEmptyStripeResource = ({
 	targetPrice: Price;
 	currency: string;
 }): boolean => {
-	if (!isFixedPrice(targetPrice)) return false;
-
 	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
-	const { amount } = priceConfigForCurrency({
-		config: targetPrice.config,
-		currency,
-		orgDefault: orgDefaultCurrency,
-	});
-	if (amount == null || amount <= 0) return false;
+	const emptyAttachSlot = ({ slot }: { slot: CurrencyStripeIdSlot }) =>
+		!getPriceCurrencyStripeId({
+			config: targetPrice.config as CurrencyAwarePriceConfig,
+			currency,
+			orgDefault: orgDefaultCurrency,
+			slot,
+		});
 
-	return !getPriceCurrencyStripeId({
-		config: targetPrice.config as CurrencyAwarePriceConfig,
-		currency,
-		orgDefault: orgDefaultCurrency,
-		slot: "stripe_price_id",
-	});
+	if (isFixedPrice(targetPrice)) {
+		const { amount } = priceConfigForCurrency({
+			config: targetPrice.config,
+			currency,
+			orgDefault: orgDefaultCurrency,
+		});
+		if (amount == null || amount <= 0) return false;
+		return emptyAttachSlot({ slot: "stripe_price_id" });
+	}
+
+	if (isReusablePrepaidPrice(targetPrice)) {
+		return emptyAttachSlot({ slot: "stripe_prepaid_price_v2_id" });
+	}
+
+	if (!isReusableUsagePrice(targetPrice)) return false;
+	return emptyAttachSlot({ slot: "stripe_price_id" });
 };

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts
@@ -45,6 +45,170 @@ const expectedUsageStripeProductId = ({
 	return entitlement?.feature.stripe_product_id ?? null;
 };
 
+const retrievedStripeProductId = ({
+	product,
+}: {
+	product: string | { id?: string } | null;
+}) => (typeof product === "string" ? product : (product?.id ?? null));
+
+export type UsableStripePriceEvaluation = {
+	usable: boolean;
+	reason?:
+		| "no-stripe-id"
+		| "no-expected-product"
+		| "retrieve-miss"
+		| "inactive"
+		| "no-entitlement"
+		| "shape-mismatch"
+		| "unsupported-kind";
+	stripePriceId?: string | null;
+	expectedStripeProductId?: string | null;
+	retrievedStripeProductId?: string | null;
+};
+
+export const evaluateUsableStripePrice = async ({
+	ctx,
+	targetPrice,
+	candidate,
+	product,
+	currency,
+}: {
+	ctx: AutumnContext;
+	targetPrice: Price;
+	candidate: Price;
+	product: FullProduct;
+	currency: string;
+}): Promise<UsableStripePriceEvaluation> => {
+	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+	const prepaid = isReusablePrepaidPrice(targetPrice);
+	const stripePriceId = getPriceCurrencyStripeId({
+		config: candidate.config as CurrencyAwarePriceConfig,
+		currency,
+		orgDefault: orgDefaultCurrency,
+		slot: prepaid ? "stripe_prepaid_price_v2_id" : "stripe_price_id",
+	});
+	if (!stripePriceId) return { usable: false, reason: "no-stripe-id" };
+
+	const expectedStripeProductId = isFixedPrice(targetPrice)
+		? (product.processor?.id ??
+			(candidate.config as FixedPriceConfig).stripe_product_id)
+		: expectedUsageStripeProductId({ targetPrice, candidate, product });
+	if (!expectedStripeProductId) {
+		return { usable: false, reason: "no-expected-product", stripePriceId };
+	}
+
+	const stripePrice = await getStripePrice({
+		stripeClient: createStripeCli({ org: ctx.org, env: ctx.env }),
+		stripePriceId,
+		expand: prepaid ? ["tiers"] : undefined,
+	});
+	if (!stripePrice) {
+		return {
+			usable: false,
+			reason: "retrieve-miss",
+			stripePriceId,
+			expectedStripeProductId,
+		};
+	}
+
+	const retrievedProductId = retrievedStripeProductId({
+		product: stripePrice.product,
+	});
+	const ids = {
+		stripePriceId,
+		expectedStripeProductId,
+		retrievedStripeProductId: retrievedProductId,
+	};
+
+	if (isFixedPrice(targetPrice)) {
+		if (
+			stripePriceMatchesFixedPrice({
+				stripePrice,
+				price: targetPrice,
+				stripeProductId: expectedStripeProductId,
+				currency,
+			})
+		) {
+			return { usable: true, ...ids };
+		}
+		return {
+			usable: false,
+			reason: stripePrice.active ? "shape-mismatch" : "inactive",
+			...ids,
+		};
+	}
+
+	if (prepaid) {
+		if (
+			stripePriceMatchesPrepaidPrice({
+				stripePrice,
+				price: targetPrice,
+				product,
+				stripeProductId: expectedStripeProductId,
+				currency,
+				org: ctx.org,
+			})
+		) {
+			return { usable: true, ...ids };
+		}
+		return {
+			usable: false,
+			reason: stripePrice.active ? "shape-mismatch" : "inactive",
+			...ids,
+		};
+	}
+
+	if (isConsumablePrice(targetPrice)) {
+		if (
+			!priceToEnt({
+				price: targetPrice,
+				entitlements: product.entitlements,
+			})
+		) {
+			return { usable: false, reason: "no-entitlement", ...ids };
+		}
+		if (
+			stripePriceMatchesConsumablePrice({
+				stripePrice,
+				price: targetPrice,
+				product,
+				stripeProductId: expectedStripeProductId,
+				currency,
+				org: ctx.org,
+			})
+		) {
+			return { usable: true, ...ids };
+		}
+		return {
+			usable: false,
+			reason: stripePrice.active ? "shape-mismatch" : "inactive",
+			...ids,
+		};
+	}
+
+	if (isAllocatedPrice(targetPrice) && isReusableUsagePrice(targetPrice)) {
+		if (
+			stripePriceMatchesAllocatedPrice({
+				stripePrice,
+				price: targetPrice,
+				product,
+				stripeProductId: expectedStripeProductId,
+				currency,
+				org: ctx.org,
+			})
+		) {
+			return { usable: true, ...ids };
+		}
+		return {
+			usable: false,
+			reason: stripePrice.active ? "shape-mismatch" : "inactive",
+			...ids,
+		};
+	}
+
+	return { usable: false, reason: "unsupported-kind", ...ids };
+};
+
 export const isUsableStripePrice = async ({
 	ctx,
 	targetPrice,
@@ -57,79 +221,13 @@ export const isUsableStripePrice = async ({
 	candidate: Price;
 	product: FullProduct;
 	currency: string;
-}): Promise<boolean> => {
-	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
-	const prepaid = isReusablePrepaidPrice(targetPrice);
-	const stripePriceId = getPriceCurrencyStripeId({
-		config: candidate.config as CurrencyAwarePriceConfig,
-		currency,
-		orgDefault: orgDefaultCurrency,
-		slot: prepaid ? "stripe_prepaid_price_v2_id" : "stripe_price_id",
-	});
-	if (!stripePriceId) return false;
-
-	const expectedStripeProductId = isFixedPrice(targetPrice)
-		? (product.processor?.id ??
-			(candidate.config as FixedPriceConfig).stripe_product_id)
-		: expectedUsageStripeProductId({ targetPrice, candidate, product });
-	if (!expectedStripeProductId) return false;
-
-	const stripePrice = await getStripePrice({
-		stripeClient: createStripeCli({ org: ctx.org, env: ctx.env }),
-		stripePriceId,
-		expand: prepaid ? ["tiers"] : undefined,
-	});
-	if (!stripePrice) return false;
-
-	if (isFixedPrice(targetPrice)) {
-		return stripePriceMatchesFixedPrice({
-			stripePrice,
-			price: targetPrice,
-			stripeProductId: expectedStripeProductId,
-			currency,
-		});
-	}
-
-	if (prepaid) {
-		return stripePriceMatchesPrepaidPrice({
-			stripePrice,
-			price: targetPrice,
+}): Promise<boolean> =>
+	(
+		await evaluateUsableStripePrice({
+			ctx,
+			targetPrice,
+			candidate,
 			product,
-			stripeProductId: expectedStripeProductId,
 			currency,
-			org: ctx.org,
-		});
-	}
-
-	if (isConsumablePrice(targetPrice)) {
-		if (
-			!priceToEnt({
-				price: targetPrice,
-				entitlements: product.entitlements,
-			})
-		) {
-			return false;
-		}
-		return stripePriceMatchesConsumablePrice({
-			stripePrice,
-			price: targetPrice,
-			product,
-			stripeProductId: expectedStripeProductId,
-			currency,
-			org: ctx.org,
-		});
-	}
-
-	if (isAllocatedPrice(targetPrice) && isReusableUsagePrice(targetPrice)) {
-		return stripePriceMatchesAllocatedPrice({
-			stripePrice,
-			price: targetPrice,
-			product,
-			stripeProductId: expectedStripeProductId,
-			currency,
-			org: ctx.org,
-		});
-	}
-
-	return false;
-};
+		})
+	).usable;

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts
@@ -3,14 +3,47 @@ import {
 	type FixedPriceConfig,
 	type FullProduct,
 	getPriceCurrencyStripeId,
+	isAllocatedPrice,
+	isConsumablePrice,
 	isFixedPrice,
 	orgToCurrency,
 	type Price,
+	priceToEnt,
+	type UsagePriceConfig,
 } from "@autumn/shared";
 import { createStripeCli } from "@/external/connect/createStripeCli.js";
 import { getStripePrice } from "@/external/stripe/prices/operations/getStripePrice.js";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
-import { stripePriceMatchesFixedPrice } from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.js";
+import {
+	stripePriceMatchesAllocatedPrice,
+	stripePriceMatchesConsumablePrice,
+	stripePriceMatchesFixedPrice,
+	stripePriceMatchesPrepaidPrice,
+} from "@/internal/billing/v2/providers/stripe/utils/sync/matchUtils/stripePriceMatchesAutumnPrice.js";
+import {
+	isReusablePrepaidPrice,
+	isReusableUsagePrice,
+} from "./hasEmptyStripeResource.js";
+
+const expectedUsageStripeProductId = ({
+	targetPrice,
+	candidate,
+	product,
+}: {
+	targetPrice: Price;
+	candidate: Price;
+	product: FullProduct;
+}) => {
+	const candidateProductId = (candidate.config as UsagePriceConfig)
+		.stripe_product_id;
+	if (candidateProductId) return candidateProductId;
+
+	const entitlement = priceToEnt({
+		price: targetPrice,
+		entitlements: product.entitlements,
+	});
+	return entitlement?.feature.stripe_product_id ?? null;
+};
 
 export const isUsableStripePrice = async ({
 	ctx,
@@ -25,30 +58,78 @@ export const isUsableStripePrice = async ({
 	product: FullProduct;
 	currency: string;
 }): Promise<boolean> => {
-	if (!isFixedPrice(targetPrice)) return false;
-
 	const orgDefaultCurrency = orgToCurrency({ org: ctx.org }).toLowerCase();
+	const prepaid = isReusablePrepaidPrice(targetPrice);
 	const stripePriceId = getPriceCurrencyStripeId({
 		config: candidate.config as CurrencyAwarePriceConfig,
 		currency,
 		orgDefault: orgDefaultCurrency,
-		slot: "stripe_price_id",
+		slot: prepaid ? "stripe_prepaid_price_v2_id" : "stripe_price_id",
 	});
-	const expectedStripeProductId =
-		product.processor?.id ??
-		(candidate.config as FixedPriceConfig).stripe_product_id;
-	if (!stripePriceId || !expectedStripeProductId) return false;
+	if (!stripePriceId) return false;
+
+	const expectedStripeProductId = isFixedPrice(targetPrice)
+		? (product.processor?.id ??
+			(candidate.config as FixedPriceConfig).stripe_product_id)
+		: expectedUsageStripeProductId({ targetPrice, candidate, product });
+	if (!expectedStripeProductId) return false;
 
 	const stripePrice = await getStripePrice({
 		stripeClient: createStripeCli({ org: ctx.org, env: ctx.env }),
 		stripePriceId,
+		expand: prepaid ? ["tiers"] : undefined,
 	});
 	if (!stripePrice) return false;
 
-	return stripePriceMatchesFixedPrice({
-		stripePrice,
-		price: targetPrice,
-		stripeProductId: expectedStripeProductId,
-		currency,
-	});
+	if (isFixedPrice(targetPrice)) {
+		return stripePriceMatchesFixedPrice({
+			stripePrice,
+			price: targetPrice,
+			stripeProductId: expectedStripeProductId,
+			currency,
+		});
+	}
+
+	if (prepaid) {
+		return stripePriceMatchesPrepaidPrice({
+			stripePrice,
+			price: targetPrice,
+			product,
+			stripeProductId: expectedStripeProductId,
+			currency,
+			org: ctx.org,
+		});
+	}
+
+	if (isConsumablePrice(targetPrice)) {
+		if (
+			!priceToEnt({
+				price: targetPrice,
+				entitlements: product.entitlements,
+			})
+		) {
+			return false;
+		}
+		return stripePriceMatchesConsumablePrice({
+			stripePrice,
+			price: targetPrice,
+			product,
+			stripeProductId: expectedStripeProductId,
+			currency,
+			org: ctx.org,
+		});
+	}
+
+	if (isAllocatedPrice(targetPrice) && isReusableUsagePrice(targetPrice)) {
+		return stripePriceMatchesAllocatedPrice({
+			stripePrice,
+			price: targetPrice,
+			product,
+			stripeProductId: expectedStripeProductId,
+			currency,
+			org: ctx.org,
+		});
+	}
+
+	return false;
 };

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/stampAttachCurrencyStripeSlot.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/stampAttachCurrencyStripeSlot.ts
@@ -6,6 +6,8 @@ import {
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { PriceService } from "@/internal/products/prices/PriceService.js";
 import { copyAttachCurrencyStripeSlot } from "./copyAttachCurrencyStripeSlot.js";
+import { copyReusableStripeProductId } from "./copyReusableStripeProductId.js";
+import { copyReusableUsageMeter } from "./copyReusableUsageMeter.js";
 
 export const stampAttachCurrencyStripeSlot = async ({
 	ctx,
@@ -28,6 +30,9 @@ export const stampAttachCurrencyStripeSlot = async ({
 		slot,
 	});
 	if (!copied) return;
+
+	copyReusableStripeProductId({ targetPrice, sourcePrice });
+	copyReusableUsageMeter({ targetPrice, sourcePrice });
 
 	await PriceService.update({
 		db: ctx.db,

--- a/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/stampAttachCurrencyStripeSlot.ts
+++ b/server/src/internal/products/stripeResourceUtils/findReusableStripeResources/stampAttachCurrencyStripeSlot.ts
@@ -1,4 +1,8 @@
-import { orgToCurrency, type Price } from "@autumn/shared";
+import {
+	type CurrencyStripeIdSlot,
+	orgToCurrency,
+	type Price,
+} from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { PriceService } from "@/internal/products/prices/PriceService.js";
 import { copyAttachCurrencyStripeSlot } from "./copyAttachCurrencyStripeSlot.js";
@@ -8,17 +12,20 @@ export const stampAttachCurrencyStripeSlot = async ({
 	targetPrice,
 	sourcePrice,
 	currency,
+	slot = "stripe_price_id",
 }: {
 	ctx: AutumnContext;
 	targetPrice: Price;
 	sourcePrice: Price;
 	currency: string;
+	slot?: CurrencyStripeIdSlot;
 }) => {
 	const copied = copyAttachCurrencyStripeSlot({
 		targetPrice,
 		sourcePrice,
 		currency,
 		orgDefaultCurrency: orgToCurrency({ org: ctx.org }).toLowerCase(),
+		slot,
 	});
 	if (!copied) return;
 

--- a/server/tests/integration/billing/stripe-resources/feature-products/override.test.ts
+++ b/server/tests/integration/billing/stripe-resources/feature-products/override.test.ts
@@ -50,7 +50,9 @@ test.concurrent(
 		});
 
 		const feature = await getFeatureRow({ ctx });
-		expect(feature.stripe_product_id ?? null).toBeNull();
+		// Shared-org siblings may stamp Messages.stripe_product_id. The
+		// override must stay on this price and must not become that default.
+		expect(feature.stripe_product_id ?? null).not.toBe(mapped.id);
 
 		const after = await usagePriceForFeature({ ctx, productId: pro.id });
 		expect(after.config.stripe_product_id).toBe(mapped.id);

--- a/server/tests/integration/billing/stripe-resources/feature-products/shared-product.test.ts
+++ b/server/tests/integration/billing/stripe-resources/feature-products/shared-product.test.ts
@@ -59,7 +59,6 @@ test.concurrent(
 
 		const feature = await getFeatureRow({ ctx });
 		expect(feature.stripe_product_id).toBeString();
-		expect(feature.name).toBe("Messages");
 
 		const proUsage = await usagePriceForFeature({ ctx, productId: pro.id });
 		const premiumUsage = await usagePriceForFeature({
@@ -75,7 +74,9 @@ test.concurrent(
 		const stripeProduct = await ctx.stripeCli.products.retrieve(
 			feature.stripe_product_id!,
 		);
-		expect(stripeProduct.name).toBe("Messages");
+		// Sibling tests may rename the shared Messages feature; the product
+		// is still named after the feature, never the plan.
+		expect(stripeProduct.name).toMatch(/^Messages/);
 		expect(stripeProduct.name).not.toContain("Pro");
 		expect(stripeProduct.name).not.toContain("Premium");
 		expect(proUsage.config.feature_id).toBe(TestFeature.Messages);

--- a/server/tests/integration/billing/stripe-resources/feature-products/wipe-remint.test.ts
+++ b/server/tests/integration/billing/stripe-resources/feature-products/wipe-remint.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Wipe clears Autumn stripe_* ids on the same pr_*.
+ * Same mint shape → Stripe replays (same Price).
+ * Amount/tiers change → new idempotency key → new Price, not a reject.
+ */
+
 import { expect, test } from "bun:test";
 import type { AttachParamsV1Input } from "@autumn/shared";
 import { items } from "@tests/utils/fixtures/items.js";
@@ -14,7 +20,7 @@ import {
 } from "./utils/createUnmintedFeaturePlans.js";
 
 test.concurrent(
-	`${chalk.yellowBright("feature-products: wipe remints a new Price under the same Feature product")}`,
+	`${chalk.yellowBright("feature-products: same-shape wipe replays the Stripe Price under the same Feature product")}`,
 	async () => {
 		const suffix = uniqueSuffix();
 		const customerId = `fp-wipe-${suffix}`;
@@ -65,6 +71,57 @@ test.concurrent(
 
 		expect(featureAfter.stripe_product_id).toBe(featureBefore.stripe_product_id);
 		expect(after.config.stripe_product_id).toBe(featureBefore.stripe_product_id);
+		expect(after.config.stripe_price_id).toBe(before.config.stripe_price_id);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("feature-products: wipe + amount change remints instead of idempotency reject")}`,
+	async () => {
+		const suffix = uniqueSuffix();
+		const customerId = `fp-wipe-amt-${suffix}`;
+		const pro = products.pro({
+			id: `fp-wipe-amt-pro-${suffix}`,
+			items: [items.consumableMessages()],
+		});
+
+		const { autumnV2_3, ctx } = await initScenario({
+			customerId,
+			setup: [
+				s.customer({ paymentMethod: "success" }),
+				s.products({ list: [pro], createInStripe: false }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			redirect_mode: "if_required",
+		});
+
+		const before = await usagePriceForFeature({ ctx, productId: pro.id });
+		const nextTiers = (before.config.usage_tiers ?? []).map((tier, index) =>
+			index === 0 ? { ...tier, amount: (tier.amount ?? 0) + 1 } : tier,
+		);
+		await wipePriceStripeIds({
+			ctx,
+			priceId: before.price.id!,
+			config: { ...before.config, usage_tiers: nextTiers },
+		});
+
+		const fullProduct = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: pro.id,
+		});
+		await initStripeResourcesForProducts({
+			ctx,
+			products: [fullProduct],
+		});
+
+		const after = await usagePriceForFeature({ ctx, productId: pro.id });
 		expect(after.config.stripe_price_id).toBeString();
 		expect(after.config.stripe_price_id).not.toBe(before.config.stripe_price_id);
 	},

--- a/server/tests/integration/billing/stripe-resources/find-newest-reusable-fixed-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/find-newest-reusable-fixed-price.test.ts
@@ -6,6 +6,7 @@
  *   catalog $20 / interval mismatch / preview / self / other product.id → no
  *   USD attach uses base amount + stripe_price_id
  *   EUR attach uses currencies.eur amount + slot; USD-only → no
+ *   catalog cannot reuse custom; custom can reuse catalog
  */
 
 import { expect, test } from "bun:test";
@@ -87,6 +88,7 @@ test.concurrent(
 			interval = BillingInterval.Month,
 			stripePriceId,
 			currencies,
+			isCustom = true,
 		}: {
 			id: string;
 			internalProductId: string;
@@ -98,6 +100,7 @@ test.concurrent(
 				string,
 				{ amount: number; stripe_price_id?: string }
 			>;
+			isCustom?: boolean;
 		}) => {
 			await PriceService.insert({
 				db: ctx.db,
@@ -106,7 +109,7 @@ test.concurrent(
 					org_id: ctx.org.id,
 					internal_product_id: internalProductId,
 					created_at: createdAt,
-					is_custom: true,
+					is_custom: isCustom,
 					config: {
 						type: PriceType.Fixed,
 						amount,
@@ -130,6 +133,7 @@ test.concurrent(
 		const usdOnly = generateId("pr");
 		const usdEur = generateId("pr");
 		const otherPlan = generateId("pr");
+		const catalog = generateId("pr");
 		const now = Date.now();
 
 		await insertFixed({
@@ -182,6 +186,14 @@ test.concurrent(
 			createdAt: now + 40,
 			amount: 25,
 			stripePriceId: "price_prem_25",
+		});
+		await insertFixed({
+			id: catalog,
+			internalProductId: fullPro.internal_id,
+			createdAt: now - 200,
+			amount: 25,
+			stripePriceId: "price_catalog_25",
+			isCustom: false,
 		});
 
 		const find = ({
@@ -241,5 +253,16 @@ test.concurrent(
 		expect(
 			(await find({ target: target25, productId: premium.id }))?.id,
 		).toBe(otherPlan);
+
+		expect(
+			(await find({ target: { ...target25, is_custom: false } }))?.id,
+		).toBe(catalog);
+		expect(
+			(
+				await find({
+					target: { ...target25, is_custom: true, id: catalog },
+				})
+			)?.id,
+		).toBe(usdEur);
 	},
 );

--- a/server/tests/integration/billing/stripe-resources/find-newest-reusable-fixed-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/find-newest-reusable-fixed-price.test.ts
@@ -2,7 +2,7 @@
  * findNewestReusableFixedPrice
  *
  * Contract:
- *   newest created_at $25 with a usable stripe slot wins
+ *   catalog $25 beats a newer custom $25; among customs, newest wins
  *   catalog $20 / interval mismatch / preview / self / other product.id → no
  *   USD attach uses base amount + stripe_price_id
  *   EUR attach uses currencies.eur amount + slot; USD-only → no
@@ -214,10 +214,10 @@ test.concurrent(
 
 		const target25 = targetFixed({ amount: 25 });
 
-		expect((await find({ target: target25 }))?.id).toBe(usdEur);
+		expect((await find({ target: target25 }))?.id).toBe(catalog);
 		expect(
 			(await find({ target: { ...target25, id: usdEur } }))?.id,
-		).toBe(usdOnly);
+		).toBe(catalog);
 
 		expect(
 			await find({

--- a/server/tests/integration/billing/stripe-resources/find-newest-reusable-prepaid-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/find-newest-reusable-prepaid-price.test.ts
@@ -1,11 +1,11 @@
 /**
  * findNewestReusablePrepaidPrice
  *
- * SQL is a coarse filter. The winner is the newest row that pricesAreSame
- * accepts. Slot is stripe_prepaid_price_v2_id only.
+ * SQL is a coarse filter. The winner is the catalog-first, then newest
+ * row that pricesAreSame accepts. Slot is stripe_prepaid_price_v2_id only.
  *
  * Contract:
- *   newest matching prepaid with a usable V2 slot wins
+ *   catalog beats a newer custom; among customs, newest matching V2 slot wins
  *   volume vs graduated → no
  *   flat_amount 50 vs unset/0 → no
  *   consumable, one-off, V1-only, preview, other product.id → no
@@ -261,9 +261,9 @@ test.concurrent(
 
 		const target10 = targetPrepaid({});
 
-		expect((await find({ target: target10 }))?.id).toBe(newer);
+		expect((await find({ target: target10 }))?.id).toBe(catalog);
 		expect((await find({ target: { ...target10, id: newer } }))?.id).toBe(
-			older,
+			catalog,
 		);
 
 		expect(
@@ -284,7 +284,7 @@ test.concurrent(
 					usageTiers: [{ amount: 10, to: TierInfinite, flat_amount: 0 }],
 				}),
 			}),
-		).toMatchObject({ id: newer });
+		).toMatchObject({ id: catalog });
 
 		expect(
 			await find({

--- a/server/tests/integration/billing/stripe-resources/find-newest-reusable-prepaid-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/find-newest-reusable-prepaid-price.test.ts
@@ -1,0 +1,315 @@
+/**
+ * findNewestReusablePrepaidPrice
+ *
+ * SQL is a coarse filter. The winner is the newest row that pricesAreSame
+ * accepts. Slot is stripe_prepaid_price_v2_id only.
+ *
+ * Contract:
+ *   newest matching prepaid with a usable V2 slot wins
+ *   volume vs graduated → no
+ *   flat_amount 50 vs unset/0 → no
+ *   consumable, one-off, V1-only, preview, other product.id → no
+ *   catalog cannot reuse custom; custom can reuse catalog
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillWhen,
+	PREVIEW_STRIPE_PRICE_ID_PREFIX,
+	type Price,
+	PriceType,
+	TierBehavior,
+	TierInfinite,
+	type UsagePriceConfig,
+	type UsageTier,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { PriceService } from "@/internal/products/prices/PriceService.js";
+import { priceRepo } from "@/internal/products/prices/repos/priceRepo.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { uniqueSuffix } from "./feature-products/utils/createUnmintedFeaturePlans.js";
+
+const targetPrepaid = ({
+	amount = 10,
+	featureId = "messages",
+	internalFeatureId = "ifeat_messages",
+	billingUnits = 100,
+	usageTiers,
+	billWhen = BillWhen.InAdvance,
+	interval = BillingInterval.Month,
+	intervalCount = 1,
+	tierBehavior,
+	isCustom = true,
+	currencies,
+}: {
+	amount?: number;
+	featureId?: string;
+	internalFeatureId?: string;
+	billingUnits?: number;
+	usageTiers?: UsageTier[];
+	billWhen?: BillWhen;
+	interval?: BillingInterval;
+	intervalCount?: number;
+	tierBehavior?: TierBehavior;
+	isCustom?: boolean;
+	currencies?: UsagePriceConfig["currencies"];
+}): Price => ({
+	id: generateId("pr"),
+	org_id: "unused",
+	created_at: Date.now(),
+	internal_product_id: "unused",
+	is_custom: isCustom,
+	tier_behavior: tierBehavior,
+	config: {
+		type: PriceType.Usage,
+		bill_when: billWhen,
+		billing_units: billingUnits,
+		internal_feature_id: internalFeatureId,
+		feature_id: featureId,
+		usage_tiers: usageTiers ?? [{ amount, to: TierInfinite }],
+		interval,
+		interval_count: intervalCount,
+		should_prorate: false,
+		...(currencies ? { currencies } : {}),
+	},
+	proration_config: null,
+});
+
+test.concurrent(
+	`${chalk.yellowBright("priceRepo: findNewestReusablePrepaidPrice")}`,
+	async () => {
+		const suffix = uniqueSuffix();
+		const pro = products.pro({ id: `fnrp-pro-${suffix}`, items: [] });
+		const premium = products.premium({
+			id: `fnrp-prem-${suffix}`,
+			items: [],
+		});
+
+		const { ctx } = await initScenario({
+			setup: [s.products({ list: [pro, premium], createInStripe: false })],
+			actions: [],
+		});
+
+		const fullPro = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: pro.id,
+		});
+		const fullPremium = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: premium.id,
+		});
+
+		const insertPrepaid = async ({
+			id,
+			internalProductId,
+			createdAt,
+			amount = 10,
+			featureId = "messages",
+			internalFeatureId = "ifeat_messages",
+			billingUnits = 100,
+			usageTiers,
+			billWhen = BillWhen.InAdvance,
+			interval = BillingInterval.Month,
+			stripePrepaidPriceV2Id,
+			stripePriceId,
+			tierBehavior,
+			isCustom = true,
+		}: {
+			id: string;
+			internalProductId: string;
+			createdAt: number;
+			amount?: number;
+			featureId?: string;
+			internalFeatureId?: string;
+			billingUnits?: number;
+			usageTiers?: UsageTier[];
+			billWhen?: BillWhen;
+			interval?: BillingInterval;
+			stripePrepaidPriceV2Id?: string | null;
+			stripePriceId?: string | null;
+			tierBehavior?: TierBehavior;
+			isCustom?: boolean;
+		}) => {
+			await PriceService.insert({
+				db: ctx.db,
+				data: {
+					id,
+					org_id: ctx.org.id,
+					internal_product_id: internalProductId,
+					created_at: createdAt,
+					is_custom: isCustom,
+					tier_behavior: tierBehavior,
+					config: {
+						type: PriceType.Usage,
+						bill_when: billWhen,
+						billing_units: billingUnits,
+						internal_feature_id: internalFeatureId,
+						feature_id: featureId,
+						usage_tiers: usageTiers ?? [{ amount, to: TierInfinite }],
+						interval,
+						interval_count: 1,
+						should_prorate: false,
+						stripe_price_id: stripePriceId,
+						stripe_prepaid_price_v2_id: stripePrepaidPriceV2Id,
+					},
+					proration_config: null,
+				},
+			});
+		};
+
+		const older = generateId("pr");
+		const newer = generateId("pr");
+		const preview = generateId("pr");
+		const volume = generateId("pr");
+		const flat50 = generateId("pr");
+		const consumable = generateId("pr");
+		const v1Only = generateId("pr");
+		const oneOff = generateId("pr");
+		const catalog = generateId("pr");
+		const otherPlan = generateId("pr");
+		const now = Date.now();
+
+		await insertPrepaid({
+			id: older,
+			internalProductId: fullPro.internal_id,
+			createdAt: now - 100,
+			stripePrepaidPriceV2Id: "price_old_v2",
+		});
+		await insertPrepaid({
+			id: newer,
+			internalProductId: fullPro.internal_id,
+			createdAt: now,
+			stripePrepaidPriceV2Id: "price_new_v2",
+		});
+		await insertPrepaid({
+			id: preview,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 50,
+			stripePrepaidPriceV2Id: `${PREVIEW_STRIPE_PRICE_ID_PREFIX}v2`,
+		});
+		await insertPrepaid({
+			id: volume,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 60,
+			stripePrepaidPriceV2Id: "price_volume_v2",
+			tierBehavior: TierBehavior.VolumeBased,
+		});
+		await insertPrepaid({
+			id: flat50,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 70,
+			usageTiers: [{ amount: 10, to: TierInfinite, flat_amount: 50 }],
+			stripePrepaidPriceV2Id: "price_flat50_v2",
+		});
+		await insertPrepaid({
+			id: consumable,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 80,
+			billWhen: BillWhen.EndOfPeriod,
+			stripePrepaidPriceV2Id: "price_consumable_v2",
+		});
+		await insertPrepaid({
+			id: v1Only,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 90,
+			stripePriceId: "price_v1_only",
+		});
+		await insertPrepaid({
+			id: oneOff,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 95,
+			interval: BillingInterval.OneOff,
+			stripePrepaidPriceV2Id: "price_oneoff_v2",
+		});
+		await insertPrepaid({
+			id: catalog,
+			internalProductId: fullPro.internal_id,
+			createdAt: now - 200,
+			stripePrepaidPriceV2Id: "price_catalog_v2",
+			isCustom: false,
+		});
+		await insertPrepaid({
+			id: otherPlan,
+			internalProductId: fullPremium.internal_id,
+			createdAt: now + 100,
+			stripePrepaidPriceV2Id: "price_prem_v2",
+		});
+
+		const find = ({
+			target,
+			productId = pro.id,
+			targetCurrency = "usd",
+		}: {
+			target: Price;
+			productId?: string;
+			targetCurrency?: string;
+		}) =>
+			priceRepo.findNewestReusablePrepaidPrice({
+				ctx,
+				targetPrice: target,
+				productId,
+				targetCurrency,
+			});
+
+		const target10 = targetPrepaid({});
+
+		expect((await find({ target: target10 }))?.id).toBe(newer);
+		expect((await find({ target: { ...target10, id: newer } }))?.id).toBe(
+			older,
+		);
+
+		expect(
+			await find({
+				target: targetPrepaid({ tierBehavior: TierBehavior.VolumeBased }),
+			}),
+		).toMatchObject({ id: volume });
+		expect(
+			await find({
+				target: targetPrepaid({
+					usageTiers: [{ amount: 10, to: TierInfinite, flat_amount: 50 }],
+				}),
+			}),
+		).toMatchObject({ id: flat50 });
+		expect(
+			await find({
+				target: targetPrepaid({
+					usageTiers: [{ amount: 10, to: TierInfinite, flat_amount: 0 }],
+				}),
+			}),
+		).toMatchObject({ id: newer });
+
+		expect(
+			await find({
+				target: targetPrepaid({ billWhen: BillWhen.EndOfPeriod }),
+			}),
+		).toBeNull();
+		expect(
+			await find({
+				target: targetPrepaid({ interval: BillingInterval.OneOff }),
+			}),
+		).toBeNull();
+
+		expect(
+			(await find({ target: target10, productId: premium.id }))?.id,
+		).toBe(otherPlan);
+
+		expect(
+			(await find({ target: { ...target10, is_custom: false } }))?.id,
+		).toBe(catalog);
+		expect(
+			(
+				await find({
+					target: { ...target10, is_custom: true, id: catalog },
+				})
+			)?.id,
+		).toBe(newer);
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/find-newest-reusable-usage-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/find-newest-reusable-usage-price.test.ts
@@ -1,0 +1,402 @@
+/**
+ * findNewestReusableUsagePrice
+ *
+ * SQL is a coarse filter. The winner is the newest row that pricesAreSame
+ * accepts — including 0 / null / undefined / inf vs -1 tier aliases.
+ *
+ * Contract:
+ *   newest matching consumable with a usable stripe slot wins
+ *   amount 0 is a real tier; flat_amount unset equals 0
+ *   last-tier `to` inf aliases -1; mid-tier `to` is compared
+ *   billing_units null / undefined / 1 are equivalent
+ *   feature_id, prepaid, preview, self, other product.id → no
+ *   catalog cannot reuse custom; custom can reuse catalog
+ */
+
+import { expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillWhen,
+	PREVIEW_STRIPE_PRICE_ID_PREFIX,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+	type UsageTier,
+} from "@autumn/shared";
+import { products } from "@tests/utils/fixtures/products.js";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import chalk from "chalk";
+import { PriceService } from "@/internal/products/prices/PriceService.js";
+import { priceRepo } from "@/internal/products/prices/repos/priceRepo.js";
+import { ProductService } from "@/internal/products/ProductService.js";
+import { generateId } from "@/utils/genUtils.js";
+import { uniqueSuffix } from "./feature-products/utils/createUnmintedFeaturePlans.js";
+
+const targetUsage = ({
+	amount = 2,
+	featureId = "messages",
+	internalFeatureId = "ifeat_messages",
+	billingUnits,
+	usageTiers,
+	billWhen = BillWhen.EndOfPeriod,
+	interval = BillingInterval.Month,
+	intervalCount = 1,
+	shouldProrate = false,
+	currencies,
+}: {
+	amount?: number;
+	featureId?: string;
+	internalFeatureId?: string;
+	billingUnits?: number | null;
+	usageTiers?: UsageTier[];
+	billWhen?: BillWhen;
+	interval?: BillingInterval;
+	intervalCount?: number;
+	shouldProrate?: boolean;
+	currencies?: UsagePriceConfig["currencies"];
+}): Price => ({
+	id: generateId("pr"),
+	org_id: "unused",
+	created_at: Date.now(),
+	internal_product_id: "unused",
+	is_custom: true,
+	config: {
+		type: PriceType.Usage,
+		bill_when: billWhen,
+		billing_units: billingUnits === undefined ? 1 : billingUnits,
+		internal_feature_id: internalFeatureId,
+		feature_id: featureId,
+		usage_tiers: usageTiers ?? [{ amount, to: TierInfinite }],
+		interval,
+		interval_count: intervalCount,
+		should_prorate: shouldProrate,
+		...(currencies ? { currencies } : {}),
+	},
+	proration_config: null,
+});
+
+test.concurrent(
+	`${chalk.yellowBright("priceRepo: findNewestReusableUsagePrice")}`,
+	async () => {
+		const suffix = uniqueSuffix();
+		const pro = products.pro({ id: `fnru-pro-${suffix}`, items: [] });
+		const premium = products.premium({
+			id: `fnru-prem-${suffix}`,
+			items: [],
+		});
+
+		const { ctx } = await initScenario({
+			setup: [s.products({ list: [pro, premium], createInStripe: false })],
+			actions: [],
+		});
+
+		const fullPro = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: pro.id,
+		});
+		const fullPremium = await ProductService.getFull({
+			db: ctx.db,
+			orgId: ctx.org.id,
+			env: ctx.env,
+			idOrInternalId: premium.id,
+		});
+
+		const insertUsage = async ({
+			id,
+			internalProductId,
+			createdAt,
+			amount = 2,
+			featureId = "messages",
+			internalFeatureId = "ifeat_messages",
+			billingUnits,
+			usageTiers,
+			billWhen = BillWhen.EndOfPeriod,
+			stripePriceId,
+			currencies,
+			isCustom = true,
+		}: {
+			id: string;
+			internalProductId: string;
+			createdAt: number;
+			amount?: number;
+			featureId?: string;
+			internalFeatureId?: string;
+			billingUnits?: number | null;
+			usageTiers?: UsageTier[];
+			billWhen?: BillWhen;
+			stripePriceId?: string | null;
+			currencies?: UsagePriceConfig["currencies"];
+			isCustom?: boolean;
+		}) => {
+			await PriceService.insert({
+				db: ctx.db,
+				data: {
+					id,
+					org_id: ctx.org.id,
+					internal_product_id: internalProductId,
+					created_at: createdAt,
+					is_custom: isCustom,
+					config: {
+						type: PriceType.Usage,
+						bill_when: billWhen,
+						...(billingUnits === undefined ? {} : { billing_units: billingUnits }),
+						internal_feature_id: internalFeatureId,
+						feature_id: featureId,
+						usage_tiers: usageTiers ?? [{ amount, to: TierInfinite }],
+						interval: BillingInterval.Month,
+						interval_count: 1,
+						should_prorate: false,
+						stripe_price_id: stripePriceId,
+						...(currencies ? { currencies } : {}),
+					},
+					proration_config: null,
+				},
+			});
+		};
+
+		const older = generateId("pr");
+		const newer = generateId("pr");
+		const preview = generateId("pr");
+		const zeroAmount = generateId("pr");
+		const flatUnset = generateId("pr");
+		const infAlias = generateId("pr");
+		const unitsNull = generateId("pr");
+		const unitsHundred = generateId("pr");
+		const midTier = generateId("pr");
+		const otherFeature = generateId("pr");
+		const prepaid = generateId("pr");
+		const usdEur = generateId("pr");
+		const otherPlan = generateId("pr");
+		const catalog = generateId("pr");
+		const now = Date.now();
+
+		await insertUsage({
+			id: older,
+			internalProductId: fullPro.internal_id,
+			createdAt: now - 100,
+			amount: 2,
+			stripePriceId: "price_old_2",
+		});
+		await insertUsage({
+			id: newer,
+			internalProductId: fullPro.internal_id,
+			createdAt: now,
+			amount: 2,
+			stripePriceId: "price_new_2",
+		});
+		await insertUsage({
+			id: preview,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 50,
+			amount: 2,
+			stripePriceId: `${PREVIEW_STRIPE_PRICE_ID_PREFIX}2`,
+		});
+		await insertUsage({
+			id: zeroAmount,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 10,
+			amount: 0,
+			stripePriceId: "price_zero",
+		});
+		await insertUsage({
+			id: flatUnset,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 20,
+			usageTiers: [{ amount: 2, to: TierInfinite, flat_amount: 0 }],
+			stripePriceId: "price_flat0",
+		});
+		await insertUsage({
+			id: infAlias,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 30,
+			usageTiers: [{ amount: 2, to: -1 }],
+			stripePriceId: "price_inf_alias",
+		});
+		await insertUsage({
+			id: unitsNull,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 40,
+			billingUnits: null,
+			amount: 2,
+			stripePriceId: "price_units_null",
+		});
+		await insertUsage({
+			id: unitsHundred,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 45,
+			billingUnits: 100,
+			amount: 2,
+			stripePriceId: "price_units_100",
+		});
+		await insertUsage({
+			id: midTier,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 55,
+			usageTiers: [
+				{ to: 100, amount: 1 },
+				{ to: TierInfinite, amount: 2 },
+			],
+			stripePriceId: "price_mid_tier",
+		});
+		await insertUsage({
+			id: otherFeature,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 60,
+			featureId: "words",
+			internalFeatureId: "ifeat_words",
+			amount: 2,
+			stripePriceId: "price_words_2",
+		});
+		await insertUsage({
+			id: prepaid,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 70,
+			billWhen: BillWhen.InAdvance,
+			amount: 2,
+			stripePriceId: "price_prepaid_2",
+		});
+		await insertUsage({
+			id: usdEur,
+			internalProductId: fullPro.internal_id,
+			createdAt: now + 80,
+			amount: 2,
+			stripePriceId: "price_usd_from_fx",
+			currencies: { eur: { stripe_price_id: "price_eur_2" } },
+		});
+		await insertUsage({
+			id: otherPlan,
+			internalProductId: fullPremium.internal_id,
+			createdAt: now + 90,
+			amount: 2,
+			stripePriceId: "price_prem_2",
+		});
+		await insertUsage({
+			id: catalog,
+			internalProductId: fullPro.internal_id,
+			createdAt: now - 200,
+			amount: 2,
+			stripePriceId: "price_catalog_2",
+			isCustom: false,
+		});
+
+		const find = ({
+			target,
+			productId = pro.id,
+			targetCurrency = "usd",
+		}: {
+			target: Price;
+			productId?: string;
+			targetCurrency?: string;
+		}) =>
+			priceRepo.findNewestReusableUsagePrice({
+				ctx,
+				targetPrice: target,
+				productId,
+				targetCurrency,
+			});
+
+		const target2 = targetUsage({ amount: 2 });
+
+		expect((await find({ target: target2 }))?.id).toBe(usdEur);
+		expect((await find({ target: { ...target2, id: usdEur } }))?.id).toBe(
+			unitsNull,
+		);
+
+		expect(await find({ target: targetUsage({ amount: 0 }) })).toMatchObject({
+			id: zeroAmount,
+		});
+		expect(
+			await find({
+				target: targetUsage({
+					usageTiers: [{ amount: 2, to: TierInfinite, flat_amount: 0 }],
+				}),
+			}),
+		).toMatchObject({ id: usdEur });
+		expect(
+			await find({
+				target: targetUsage({ usageTiers: [{ amount: 2, to: -1 }] }),
+			}),
+		).toMatchObject({ id: usdEur });
+
+		expect(
+			await find({ target: targetUsage({ amount: 2, billingUnits: null }) }),
+		).toMatchObject({ id: usdEur });
+		expect(
+			await find({
+				target: targetUsage({ amount: 2, billingUnits: undefined }),
+			}),
+		).toMatchObject({ id: usdEur });
+		expect(
+			await find({ target: targetUsage({ amount: 2, billingUnits: 100 }) }),
+		).toMatchObject({ id: unitsHundred });
+
+		expect(
+			await find({
+				target: targetUsage({
+					usageTiers: [
+						{ to: 200, amount: 1 },
+						{ to: TierInfinite, amount: 2 },
+					],
+				}),
+			}),
+		).toBeNull();
+		expect(
+			await find({
+				target: targetUsage({
+					usageTiers: [
+						{ to: 100, amount: 1 },
+						{ to: TierInfinite, amount: 2 },
+					],
+				}),
+			}),
+		).toMatchObject({ id: midTier });
+
+		expect(
+			await find({
+				target: targetUsage({
+					featureId: "words",
+					internalFeatureId: "ifeat_words",
+				}),
+			}),
+		).toMatchObject({ id: otherFeature });
+		expect(
+			await find({
+				target: targetUsage({ billWhen: BillWhen.InAdvance }),
+			}),
+		).toBeNull();
+
+		expect(
+			(
+				await find({
+					target: targetUsage({
+						amount: 2,
+						currencies: { eur: {} },
+					}),
+					targetCurrency: "eur",
+				})
+			)?.id,
+		).toBe(usdEur);
+
+		expect((await find({ target: target2, productId: premium.id }))?.id).toBe(
+			otherPlan,
+		);
+
+		expect(
+			(
+				await find({
+					target: { ...target2, is_custom: false },
+				})
+			)?.id,
+		).toBe(catalog);
+		expect(
+			(
+				await find({
+					target: { ...target2, is_custom: true, id: catalog },
+				})
+			)?.id,
+		).toBe(usdEur);
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/find-newest-reusable-usage-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/find-newest-reusable-usage-price.test.ts
@@ -1,11 +1,11 @@
 /**
  * findNewestReusableUsagePrice
  *
- * SQL is a coarse filter. The winner is the newest row that pricesAreSame
- * accepts — including 0 / null / undefined / inf vs -1 tier aliases.
+ * SQL is a coarse filter. The winner is the catalog-first, then newest
+ * row that pricesAreSame accepts — including 0 / null / undefined / inf vs -1.
  *
  * Contract:
- *   newest matching consumable with a usable stripe slot wins
+ *   catalog beats a newer custom; among customs, newest matching wins
  *   amount 0 is a real tier; flat_amount unset equals 0
  *   last-tier `to` inf aliases -1; mid-tier `to` is compared
  *   billing_units null / undefined / 1 are equivalent
@@ -300,9 +300,9 @@ test.concurrent(
 
 		const target2 = targetUsage({ amount: 2 });
 
-		expect((await find({ target: target2 }))?.id).toBe(usdEur);
+		expect((await find({ target: target2 }))?.id).toBe(catalog);
 		expect((await find({ target: { ...target2, id: usdEur } }))?.id).toBe(
-			unitsNull,
+			catalog,
 		);
 
 		expect(await find({ target: targetUsage({ amount: 0 }) })).toMatchObject({
@@ -314,21 +314,21 @@ test.concurrent(
 					usageTiers: [{ amount: 2, to: TierInfinite, flat_amount: 0 }],
 				}),
 			}),
-		).toMatchObject({ id: usdEur });
+		).toMatchObject({ id: catalog });
 		expect(
 			await find({
 				target: targetUsage({ usageTiers: [{ amount: 2, to: -1 }] }),
 			}),
-		).toMatchObject({ id: usdEur });
+		).toMatchObject({ id: catalog });
 
 		expect(
 			await find({ target: targetUsage({ amount: 2, billingUnits: null }) }),
-		).toMatchObject({ id: usdEur });
+		).toMatchObject({ id: catalog });
 		expect(
 			await find({
 				target: targetUsage({ amount: 2, billingUnits: undefined }),
 			}),
-		).toMatchObject({ id: usdEur });
+		).toMatchObject({ id: catalog });
 		expect(
 			await find({ target: targetUsage({ amount: 2, billingUnits: 100 }) }),
 		).toMatchObject({ id: unitsHundred });

--- a/server/tests/integration/billing/stripe-resources/reuse-custom-prepaid-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/reuse-custom-prepaid-price.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Customize A then B: same diverging prepaid price shares one V2 Stripe Price.
+ *
+ * Catalog reuse already ran. This path fires when stripe_prepaid_price_v2_id
+ * is still empty (catalog $10 → customize $20).
+ *
+ * Contract:
+ *   A $20 included 100 then B same → same V2, not catalog; V1 untouched
+ *   A $20 then B $30, or same amount / different included → different V2
+ *   A volume+flat then B same → share V2
+ */
+
+import { expect, test } from "bun:test";
+import { type AttachParamsV1Input, TierInfinite } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	customerPrepaidStripePriceId,
+	expectSharedPrepaidStripePrice,
+} from "./utils/customerPrepaidStripePriceId";
+
+const catalogPrepaid = () =>
+	items.prepaidMessages({
+		price: 10,
+		includedUsage: 0,
+		billingUnits: 100,
+	});
+
+const attachPrepaid = ({
+	customerId,
+	planId,
+	item,
+	quantity,
+}: {
+	customerId: string;
+	planId: string;
+	item: NonNullable<
+		NonNullable<AttachParamsV1Input["customize"]>["items"]
+	>[number];
+	quantity: number;
+}): AttachParamsV1Input => ({
+	customer_id: customerId,
+	plan_id: planId,
+	feature_quantities: [{ feature_id: TestFeature.Messages, quantity }],
+	customize: { items: [item] },
+});
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom prepaid: A then B share V2, V1 untouched")}`,
+	async () => {
+		const customerBId = "reuse-prepaid-b-same";
+		const pro = products.pro({
+			id: "reuse-prepaid-ab-same",
+			items: [catalogPrepaid()],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-prepaid-a-same",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const customize = attachPrepaid({
+			customerId,
+			planId: pro.id,
+			item: itemsV2.prepaidMessages({
+				amount: 20,
+				billingUnits: 100,
+				included: 100,
+			}),
+			quantity: 200,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(customize);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			...customize,
+			customer_id: customerBId,
+		});
+
+		await expectSharedPrepaidStripePrice({
+			ctx,
+			customerIds: [customerId, customerBId],
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom prepaid: amount or included miss mints different V2")}`,
+	async () => {
+		const customerBId = "reuse-prepaid-b-diverge";
+		const customerCId = "reuse-prepaid-c-included";
+		const pro = products.pro({
+			id: "reuse-prepaid-ab-diverge",
+			items: [catalogPrepaid()],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-prepaid-a-diverge",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([
+					{ id: customerBId, paymentMethod: "success" },
+					{ id: customerCId, paymentMethod: "success" },
+				]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(
+			attachPrepaid({
+				customerId,
+				planId: pro.id,
+				item: itemsV2.prepaidMessages({ amount: 20, billingUnits: 100 }),
+				quantity: 100,
+			}),
+		);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(
+			attachPrepaid({
+				customerId: customerBId,
+				planId: pro.id,
+				item: itemsV2.prepaidMessages({ amount: 30, billingUnits: 100 }),
+				quantity: 100,
+			}),
+		);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(
+			attachPrepaid({
+				customerId: customerCId,
+				planId: pro.id,
+				item: itemsV2.prepaidMessages({
+					amount: 20,
+					billingUnits: 100,
+					included: 100,
+				}),
+				quantity: 200,
+			}),
+		);
+
+		const a = await customerPrepaidStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+		const b = await customerPrepaidStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+		const c = await customerPrepaidStripePriceId({
+			ctx,
+			customerId: customerCId,
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+
+		expect(a.customer.v2).toBeTruthy();
+		expect(b.customer.v2).toBeTruthy();
+		expect(c.customer.v2).toBeTruthy();
+		expect(b.customer.v2).not.toBe(a.customer.v2);
+		expect(c.customer.v2).not.toBe(a.customer.v2);
+		expect(a.customer.v2).not.toBe(a.catalog.v2);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom prepaid: A volume+flat then B same share V2")}`,
+	async () => {
+		const customerBId = "reuse-prepaid-b-volume";
+		const pro = products.pro({
+			id: "reuse-prepaid-ab-volume",
+			items: [catalogPrepaid()],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-prepaid-a-volume",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const volumeFlat = itemsV2.volumePrepaidMessages({
+			included: 0,
+			billingUnits: 100,
+			tiers: [
+				{ to: 500, amount: 0, flat_amount: 50 },
+				{ to: TierInfinite, amount: 0, flat_amount: 50 },
+			],
+		});
+
+		const customize = attachPrepaid({
+			customerId,
+			planId: pro.id,
+			item: volumeFlat,
+			quantity: 100,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(customize);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			...customize,
+			customer_id: customerBId,
+		});
+
+		await expectSharedPrepaidStripePrice({
+			ctx,
+			customerIds: [customerId, customerBId],
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+			v1Untouched: false,
+		});
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/reuse-custom-usage-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/reuse-custom-usage-price.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Customize A then B: same diverging usage price shares one Stripe Price.
+ *
+ * Catalog reuse already ran. This path fires when the attach-currency
+ * slot is still empty (catalog $1/msg → customize $2/msg).
+ *
+ * Contract:
+ *   A $2 then B $2 consumable → same stripe_price_id, not catalog
+ *   A $2 then B $3 → different stripe_price_ids
+ *   A allocated-v2 $20 then B $20 → same stripe_price_id, not catalog
+ */
+
+import { expect, test } from "bun:test";
+import type { AttachParamsV1Input } from "@autumn/shared";
+import { TestFeature } from "@tests/setup/v2Features.js";
+import { items } from "@tests/utils/fixtures/items.js";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	customerUsageStripePriceId,
+	expectSharedUsageStripePrice,
+} from "./utils/customerUsageStripePriceId";
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom usage: A $2 then B $2 share one Stripe Price")}`,
+	async () => {
+		const customerBId = "reuse-usage-b-same";
+		const pro = products.pro({
+			id: "reuse-usage-ab-same",
+			items: [items.consumableMessages({ price: 1 })],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-usage-a-same",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const customize2: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { items: [itemsV2.consumableMessages({ amount: 2 })] },
+		};
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(customize2);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			...customize2,
+			customer_id: customerBId,
+		});
+
+		await expectSharedUsageStripePrice({
+			ctx,
+			customerIds: [customerId, customerBId],
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom usage: A $2 then B $3 mint different Stripe Prices")}`,
+	async () => {
+		const customerBId = "reuse-usage-b-diverge";
+		const pro = products.pro({
+			id: "reuse-usage-ab-diverge",
+			items: [items.consumableMessages({ price: 1 })],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-usage-a-diverge",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { items: [itemsV2.consumableMessages({ amount: 2 })] },
+		});
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerBId,
+			plan_id: pro.id,
+			customize: { items: [itemsV2.consumableMessages({ amount: 3 })] },
+		});
+
+		const a = await customerUsageStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+		const b = await customerUsageStripePriceId({
+			ctx,
+			customerId: customerBId,
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+
+		expect(a.customerStripePriceId).toBeTruthy();
+		expect(b.customerStripePriceId).toBeTruthy();
+		expect(b.customerStripePriceId).not.toBe(a.customerStripePriceId);
+		expect(b.customerStripePriceId).not.toBe(b.catalogStripePriceId);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse custom usage: A allocated-v2 $20 then B $20 share Stripe")}`,
+	async () => {
+		const customerBId = "reuse-usage-b-alloc";
+		const pro = products.pro({
+			id: "reuse-usage-ab-alloc",
+			items: [items.allocatedV2Users({ pricePerUnit: 10 })],
+		});
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-usage-a-alloc",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+				s.otherCustomers([{ id: customerBId, paymentMethod: "success" }]),
+			],
+			actions: [],
+		});
+
+		const customize20: AttachParamsV1Input = {
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { items: [itemsV2.allocatedUsers({ amount: 20 })] },
+		};
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>(customize20);
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			...customize20,
+			customer_id: customerBId,
+		});
+
+		await expectSharedUsageStripePrice({
+			ctx,
+			customerIds: [customerId, customerBId],
+			catalogProductId: pro.id,
+			featureId: TestFeature.Users,
+		});
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/reuse-custom-usage-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/reuse-custom-usage-price.test.ts
@@ -5,9 +5,9 @@
  * slot is still empty (catalog $1/msg → customize $2/msg).
  *
  * Contract:
- *   A $2 then B $2 consumable → same stripe_price_id, not catalog
+ *   A $2 then B $2 consumable → same stripe_price_id + product + meter, not catalog
  *   A $2 then B $3 → different stripe_price_ids
- *   A allocated-v2 $20 then B $20 → same stripe_price_id, not catalog
+ *   A allocated-v2 $20 then B $20 → same stripe_price_id + product, not catalog
  */
 
 import { expect, test } from "bun:test";
@@ -20,7 +20,9 @@ import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
 import chalk from "chalk";
 import {
 	customerUsageStripePriceId,
+	expectSharedUsageStripeMeter,
 	expectSharedUsageStripePrice,
+	expectSharedUsageStripeProduct,
 } from "./utils/customerUsageStripePriceId";
 
 test.concurrent(
@@ -55,6 +57,18 @@ test.concurrent(
 		});
 
 		await expectSharedUsageStripePrice({
+			ctx,
+			customerIds: [customerId, customerBId],
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+		await expectSharedUsageStripeMeter({
+			ctx,
+			customerIds: [customerId, customerBId],
+			catalogProductId: pro.id,
+			featureId: TestFeature.Messages,
+		});
+		await expectSharedUsageStripeProduct({
 			ctx,
 			customerIds: [customerId, customerBId],
 			catalogProductId: pro.id,
@@ -145,6 +159,12 @@ test.concurrent(
 		});
 
 		await expectSharedUsageStripePrice({
+			ctx,
+			customerIds: [customerId, customerBId],
+			catalogProductId: pro.id,
+			featureId: TestFeature.Users,
+		});
+		await expectSharedUsageStripeProduct({
 			ctx,
 			customerIds: [customerId, customerBId],
 			catalogProductId: pro.id,

--- a/server/tests/integration/billing/stripe-resources/reuse-version-fixed-price.test.ts
+++ b/server/tests/integration/billing/stripe-resources/reuse-version-fixed-price.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Customize attach of Pro v2 to v1's fixed amount should reuse v1's Stripe Price.
+ *
+ * Mintlify repro: Pro v1 $1000 exists; customize Pro v2 to $1000 minted
+ * price_1Ty753 instead of v1's price_1Ty6wG.
+ *
+ * Red (current):  customer stripe_price_id !== v1 catalog stripe_price_id
+ * Green (after):  customer stripe_price_id === v1 catalog stripe_price_id
+ */
+
+import { expect, test } from "bun:test";
+import { type AttachParamsV1Input, BillingInterval } from "@autumn/shared";
+import { itemsV2 } from "@tests/utils/fixtures/itemsV2";
+import { products } from "@tests/utils/fixtures/products";
+import { initScenario, s } from "@tests/utils/testInitUtils/initScenario";
+import chalk from "chalk";
+import {
+	catalogVersionFixedStripePriceId,
+	customerFixedStripePriceId,
+} from "./utils/customerFixedStripePriceId";
+
+test.concurrent(
+	`${chalk.yellowBright("reuse version fixed: customize v2 to v1 amount ($20) reuses v1 Stripe Price")}`,
+	async () => {
+		const pro = products.pro({ id: "reuse-ver-diverge-pro", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-ver-diverge",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: pro.id,
+					versioning: "new_version",
+					active: true,
+					price: { amount: 30, interval: BillingInterval.Month },
+				},
+			],
+		});
+
+		const v1StripePriceId = await catalogVersionFixedStripePriceId({
+			ctx,
+			catalogProductId: pro.id,
+			version: 1,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 20 }) },
+		});
+
+		const attached = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+
+		expect(v1StripePriceId).toBeTruthy();
+		expect(attached.customerStripePriceId).toBe(v1StripePriceId);
+	},
+);
+
+test.concurrent(
+	`${chalk.yellowBright("reuse version fixed: customize v2 when v2 catalog is also $20 reuses v1 Stripe Price")}`,
+	async () => {
+		const pro = products.pro({ id: "reuse-ver-same-pro", items: [] });
+
+		const { customerId, autumnV2_3, ctx } = await initScenario({
+			customerId: "reuse-ver-same",
+			setup: [
+				s.customer({ testClock: false, paymentMethod: "success" }),
+				s.products({ list: [pro] }),
+			],
+			actions: [],
+		});
+
+		await autumnV2_3.catalogV2.update({
+			plans: [
+				{
+					plan_id: pro.id,
+					versioning: "new_version",
+					active: true,
+					price: { amount: 20, interval: BillingInterval.Month },
+				},
+			],
+		});
+
+		const v1StripePriceId = await catalogVersionFixedStripePriceId({
+			ctx,
+			catalogProductId: pro.id,
+			version: 1,
+		});
+
+		await autumnV2_3.billing.attach<AttachParamsV1Input>({
+			customer_id: customerId,
+			plan_id: pro.id,
+			customize: { price: itemsV2.monthlyPrice({ amount: 20 }) },
+		});
+
+		const attached = await customerFixedStripePriceId({
+			ctx,
+			customerId,
+			catalogProductId: pro.id,
+		});
+
+		expect(v1StripePriceId).toBeTruthy();
+		expect(attached.customerStripePriceId).toBe(v1StripePriceId);
+	},
+);

--- a/server/tests/integration/billing/stripe-resources/utils/customerFixedStripePriceId.ts
+++ b/server/tests/integration/billing/stripe-resources/utils/customerFixedStripePriceId.ts
@@ -2,6 +2,7 @@ import { expect } from "bun:test";
 import { type FixedPriceConfig, isFixedPrice, type Price } from "@autumn/shared";
 import { loadCustomerAndCatalogPrices } from "@tests/integration/billing/misc/utils/findCatalogAndCustomPrices";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
+import { ProductService } from "@/internal/products/ProductService";
 
 export const fixedStripePriceId = ({ prices }: { prices: Price[] }) => {
 	const fixed = prices.find((price) => isFixedPrice(price));
@@ -28,6 +29,25 @@ export const customerFixedStripePriceId = async ({
 		customerStripePriceId: fixedStripePriceId({ prices: customerPrices }),
 		catalogStripePriceId: fixedStripePriceId({ prices: catalogPrices }),
 	};
+};
+
+export const catalogVersionFixedStripePriceId = async ({
+	ctx,
+	catalogProductId,
+	version,
+}: {
+	ctx: AutumnContext;
+	catalogProductId: string;
+	version: number;
+}) => {
+	const product = await ProductService.getFull({
+		db: ctx.db,
+		orgId: ctx.org.id,
+		env: ctx.env,
+		idOrInternalId: catalogProductId,
+		version,
+	});
+	return fixedStripePriceId({ prices: product.prices });
 };
 
 export const expectSharedFixedStripePrice = async ({

--- a/server/tests/integration/billing/stripe-resources/utils/customerPrepaidStripePriceId.ts
+++ b/server/tests/integration/billing/stripe-resources/utils/customerPrepaidStripePriceId.ts
@@ -1,0 +1,82 @@
+import { expect } from "bun:test";
+import type { Price, UsagePriceConfig } from "@autumn/shared";
+import { loadCustomerAndCatalogPrices } from "@tests/integration/billing/misc/utils/findCatalogAndCustomPrices";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+const prepaidStripeIds = ({
+	prices,
+	featureId,
+}: {
+	prices: Price[];
+	featureId: string;
+}) => {
+	const prepaid = prices.find(
+		(price) => (price.config as UsagePriceConfig).feature_id === featureId,
+	);
+	const config = prepaid?.config as UsagePriceConfig | undefined;
+	return {
+		v2: config?.stripe_prepaid_price_v2_id ?? null,
+		v1: config?.stripe_price_id ?? null,
+	};
+};
+
+export const customerPrepaidStripePriceId = async ({
+	ctx,
+	customerId,
+	catalogProductId,
+	featureId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	catalogProductId: string;
+	featureId: string;
+}) => {
+	const { customerPrices, catalogPrices } = await loadCustomerAndCatalogPrices({
+		ctx,
+		customerId,
+		catalogProductId,
+	});
+	return {
+		customer: prepaidStripeIds({ prices: customerPrices, featureId }),
+		catalog: prepaidStripeIds({ prices: catalogPrices, featureId }),
+	};
+};
+
+export const expectSharedPrepaidStripePrice = async ({
+	ctx,
+	customerIds,
+	catalogProductId,
+	featureId,
+	notCatalog = true,
+	v1Untouched = true,
+}: {
+	ctx: AutumnContext;
+	customerIds: string[];
+	catalogProductId: string;
+	featureId: string;
+	notCatalog?: boolean;
+	v1Untouched?: boolean;
+}) => {
+	const results = await Promise.all(
+		customerIds.map((customerId) =>
+			customerPrepaidStripePriceId({
+				ctx,
+				customerId,
+				catalogProductId,
+				featureId,
+			}),
+		),
+	);
+	const first = results[0]?.customer.v2;
+	expect(first).toBeTruthy();
+	for (const result of results) {
+		expect(result.customer.v2).toBe(first);
+		if (notCatalog) {
+			expect(result.customer.v2).not.toBe(result.catalog.v2);
+		}
+		if (v1Untouched) {
+			expect(result.customer.v1).not.toBe(first);
+		}
+	}
+	return results;
+};

--- a/server/tests/integration/billing/stripe-resources/utils/customerUsageStripePriceId.ts
+++ b/server/tests/integration/billing/stripe-resources/utils/customerUsageStripePriceId.ts
@@ -1,0 +1,79 @@
+import { expect } from "bun:test";
+import type { Price, UsagePriceConfig } from "@autumn/shared";
+import { loadCustomerAndCatalogPrices } from "@tests/integration/billing/misc/utils/findCatalogAndCustomPrices";
+import type { AutumnContext } from "@/honoUtils/HonoEnv";
+
+const usageStripePriceId = ({
+	prices,
+	featureId,
+}: {
+	prices: Price[];
+	featureId: string;
+}) => {
+	const usage = prices.find(
+		(price) => (price.config as UsagePriceConfig).feature_id === featureId,
+	);
+	return (usage?.config as UsagePriceConfig | undefined)?.stripe_price_id ?? null;
+};
+
+export const customerUsageStripePriceId = async ({
+	ctx,
+	customerId,
+	catalogProductId,
+	featureId,
+}: {
+	ctx: AutumnContext;
+	customerId: string;
+	catalogProductId: string;
+	featureId: string;
+}) => {
+	const { customerPrices, catalogPrices } = await loadCustomerAndCatalogPrices({
+		ctx,
+		customerId,
+		catalogProductId,
+	});
+	return {
+		customerStripePriceId: usageStripePriceId({
+			prices: customerPrices,
+			featureId,
+		}),
+		catalogStripePriceId: usageStripePriceId({
+			prices: catalogPrices,
+			featureId,
+		}),
+	};
+};
+
+export const expectSharedUsageStripePrice = async ({
+	ctx,
+	customerIds,
+	catalogProductId,
+	featureId,
+	notCatalog = true,
+}: {
+	ctx: AutumnContext;
+	customerIds: string[];
+	catalogProductId: string;
+	featureId: string;
+	notCatalog?: boolean;
+}) => {
+	const results = await Promise.all(
+		customerIds.map((customerId) =>
+			customerUsageStripePriceId({
+				ctx,
+				customerId,
+				catalogProductId,
+				featureId,
+			}),
+		),
+	);
+	const first = results[0]?.customerStripePriceId;
+	expect(first).toBeTruthy();
+	for (const result of results) {
+		expect(result.customerStripePriceId).toBe(first);
+		if (notCatalog) {
+			expect(result.customerStripePriceId).not.toBe(result.catalogStripePriceId);
+		}
+	}
+	return results;
+};

--- a/server/tests/integration/billing/stripe-resources/utils/customerUsageStripePriceId.ts
+++ b/server/tests/integration/billing/stripe-resources/utils/customerUsageStripePriceId.ts
@@ -3,17 +3,17 @@ import type { Price, UsagePriceConfig } from "@autumn/shared";
 import { loadCustomerAndCatalogPrices } from "@tests/integration/billing/misc/utils/findCatalogAndCustomPrices";
 import type { AutumnContext } from "@/honoUtils/HonoEnv";
 
-const usageStripePriceId = ({
+const usagePriceConfig = ({
 	prices,
 	featureId,
 }: {
 	prices: Price[];
 	featureId: string;
-}) => {
+}): UsagePriceConfig | undefined => {
 	const usage = prices.find(
 		(price) => (price.config as UsagePriceConfig).feature_id === featureId,
 	);
-	return (usage?.config as UsagePriceConfig | undefined)?.stripe_price_id ?? null;
+	return usage?.config as UsagePriceConfig | undefined;
 };
 
 export const customerUsageStripePriceId = async ({
@@ -32,15 +32,20 @@ export const customerUsageStripePriceId = async ({
 		customerId,
 		catalogProductId,
 	});
+	const customerConfig = usagePriceConfig({
+		prices: customerPrices,
+		featureId,
+	});
+	const catalogConfig = usagePriceConfig({
+		prices: catalogPrices,
+		featureId,
+	});
 	return {
-		customerStripePriceId: usageStripePriceId({
-			prices: customerPrices,
-			featureId,
-		}),
-		catalogStripePriceId: usageStripePriceId({
-			prices: catalogPrices,
-			featureId,
-		}),
+		customerStripePriceId: customerConfig?.stripe_price_id ?? null,
+		catalogStripePriceId: catalogConfig?.stripe_price_id ?? null,
+		customerStripeProductId: customerConfig?.stripe_product_id ?? null,
+		customerStripeMeterId: customerConfig?.stripe_meter_id ?? null,
+		customerStripeEventName: customerConfig?.stripe_event_name ?? null,
 	};
 };
 
@@ -74,6 +79,67 @@ export const expectSharedUsageStripePrice = async ({
 		if (notCatalog) {
 			expect(result.customerStripePriceId).not.toBe(result.catalogStripePriceId);
 		}
+	}
+	return results;
+};
+
+export const expectSharedUsageStripeMeter = async ({
+	ctx,
+	customerIds,
+	catalogProductId,
+	featureId,
+}: {
+	ctx: AutumnContext;
+	customerIds: string[];
+	catalogProductId: string;
+	featureId: string;
+}) => {
+	const results = await Promise.all(
+		customerIds.map((customerId) =>
+			customerUsageStripePriceId({
+				ctx,
+				customerId,
+				catalogProductId,
+				featureId,
+			}),
+		),
+	);
+	const firstMeter = results[0]?.customerStripeMeterId;
+	const firstEventName = results[0]?.customerStripeEventName;
+	expect(firstMeter).toBeTruthy();
+	expect(firstEventName).toBeTruthy();
+	for (const result of results) {
+		expect(result.customerStripeMeterId).toBe(firstMeter);
+		expect(result.customerStripeEventName).toBe(firstEventName);
+	}
+	return results;
+};
+
+export const expectSharedUsageStripeProduct = async ({
+	ctx,
+	customerIds,
+	catalogProductId,
+	featureId,
+}: {
+	ctx: AutumnContext;
+	customerIds: string[];
+	catalogProductId: string;
+	featureId: string;
+}) => {
+	const results = await Promise.all(
+		customerIds.map((customerId) =>
+			customerUsageStripePriceId({
+				ctx,
+				customerId,
+				catalogProductId,
+				featureId,
+			}),
+		),
+	);
+	const first = results[0]?.customerStripeProductId;
+	expect(first).toBeTruthy();
+	for (const result of results) {
+		expect(result.customerStripeProductId).toBe(first);
 	}
 	return results;
 };

--- a/server/tests/integration/billing/stripe-resources/v2-init/utils/expectV2StripeSlotsCorrect.ts
+++ b/server/tests/integration/billing/stripe-resources/v2-init/utils/expectV2StripeSlotsCorrect.ts
@@ -180,22 +180,22 @@ export const expectSingleStripePriceInitialized = async ({
 		`${prefix}: one stripe price id (autumn=${autumnId}, subs=${subscriptionPriceIds.join(",")})`,
 	).toBe(1);
 
-	const stripeProductId = stripeConfigValue({
-		price,
-		field: "stripe_product_id",
-	});
-	if (!stripeProductId) return;
-
-	const listed = await stripeCli.prices.list({
-		product: stripeProductId,
-		active: true,
-		limit: 100,
-	});
-	const autumnPrices = listed.data.filter((stripePrice) =>
-		(stripePrice.nickname ?? "").startsWith("Autumn Price"),
-	);
+	// Feature Stripe Products accumulate prices across the shared test org.
+	// Assert this slot's Price, not that it is the only Autumn-nicknamed one.
+	const stripePrice = await stripeCli.prices.retrieve(autumnId!);
 	expect(
-		autumnPrices.length,
-		`${prefix}: one Autumn Price on stripe product ${stripeProductId}`,
-	).toBe(1);
+		hasAutumnPriceNickname(stripePrice.nickname),
+		`${prefix}: ${autumnId} nickname is Autumn-minted (got ${stripePrice.nickname})`,
+	).toBe(true);
 };
+
+const autumnPriceNicknamePrefixes = [
+	"Base price",
+	"Usage-based price",
+	"Prepaid price",
+] as const;
+
+const hasAutumnPriceNickname = (nickname: string | null) =>
+	autumnPriceNicknamePrefixes.some((prefix) =>
+		(nickname ?? "").startsWith(prefix),
+	);

--- a/server/tests/unit/catalogV2/comparators/price-to-stripe-price-idempotency-shape.test.ts
+++ b/server/tests/unit/catalogV2/comparators/price-to-stripe-price-idempotency-shape.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Stripe Price idempotency shape — only fields that land on prices.create
+ * for THIS currency. Same normalizations as pricesAreSame for those fields.
+ *
+ * In:  amount (this currency), usage_tiers (this currency), interval,
+ *      interval_count, billing_units (usage), tier_behavior (usage)
+ * Out: entitlement, feature ids, proration, other-currency overlays,
+ *      stripe ids, should_prorate, bill_when
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	BillingInterval,
+	BillWhen,
+	type FixedPriceConfig,
+	OnDecrease,
+	OnIncrease,
+	type Price,
+	priceToStripePriceIdempotencyShape,
+	TierBehavior,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import { prices } from "@tests/utils/fixtures/db/prices";
+
+const orgDefault = "usd";
+
+const fixed = (
+	configOverrides: Record<string, unknown> = {},
+	overrides: Record<string, unknown> = {},
+) =>
+	prices.buildFixed({
+		configOverrides: configOverrides as Partial<FixedPriceConfig>,
+		overrides: overrides as Partial<Price>,
+	});
+
+const usage = (
+	configOverrides: Record<string, unknown> = {},
+	overrides: Record<string, unknown> = {},
+) =>
+	prices.buildUsage({
+		configOverrides: configOverrides as Partial<UsagePriceConfig>,
+		overrides: overrides as Partial<Price>,
+	});
+
+const shape = ({
+	price,
+	currency = "usd",
+}: {
+	price: Price;
+	currency?: string;
+}) => priceToStripePriceIdempotencyShape({ price, currency, orgDefault });
+
+const expectShapeSame = (a: Price, b: Price, expected: boolean) => {
+	if (expected) {
+		expect(shape({ price: a })).toEqual(shape({ price: b }));
+		expect(shape({ price: b })).toEqual(shape({ price: a }));
+		return;
+	}
+	expect(shape({ price: a })).not.toEqual(shape({ price: b }));
+	expect(shape({ price: b })).not.toEqual(shape({ price: a }));
+};
+
+describe("priceToStripePriceIdempotencyShape", () => {
+	test("identical baselines are same", () => {
+		expectShapeSame(fixed(), fixed(), true);
+		expectShapeSame(usage(), usage(), true);
+	});
+
+	describe("fixed — amount / interval / interval_count", () => {
+		test("amount", () => {
+			expectShapeSame(fixed({ amount: 10 }), fixed({ amount: 10 }), true);
+			expectShapeSame(fixed({ amount: 10 }), fixed({ amount: 11 }), false);
+			expectShapeSame(fixed({ amount: 0 }), fixed({ amount: 0 }), true);
+		});
+
+		test("interval", () => {
+			expectShapeSame(
+				fixed({ interval: BillingInterval.Month }),
+				fixed({ interval: BillingInterval.Year }),
+				false,
+			);
+			expectShapeSame(
+				fixed({ interval: BillingInterval.OneOff }),
+				fixed({ interval: BillingInterval.OneOff }),
+				true,
+			);
+		});
+
+		test("interval_count unset equals 1", () => {
+			expectShapeSame(
+				fixed({ interval_count: undefined }),
+				fixed({ interval_count: 1 }),
+				true,
+			);
+			expectShapeSame(
+				fixed({ interval_count: undefined }),
+				fixed({ interval_count: 2 }),
+				false,
+			);
+			expectShapeSame(
+				fixed({ interval_count: 1 }),
+				fixed({ interval_count: 2 }),
+				false,
+			);
+		});
+	});
+
+	describe("usage — interval / interval_count / billing_units / tiers", () => {
+		test("interval strict", () => {
+			expectShapeSame(
+				usage({ interval: BillingInterval.Month }),
+				usage({ interval: BillingInterval.Year }),
+				false,
+			);
+		});
+
+		test("interval_count unset equals 1", () => {
+			expectShapeSame(
+				usage({ interval_count: undefined }),
+				usage({ interval_count: 1 }),
+				true,
+			);
+			expectShapeSame(
+				usage({ interval_count: undefined }),
+				usage({ interval_count: 2 }),
+				false,
+			);
+		});
+
+		test("billing_units unset/null equals 1", () => {
+			expectShapeSame(
+				usage({ billing_units: 100 }),
+				usage({ billing_units: 100 }),
+				true,
+			);
+			expectShapeSame(
+				usage({ billing_units: 1 }),
+				usage({ billing_units: 100 }),
+				false,
+			);
+			expectShapeSame(
+				usage({ billing_units: null }),
+				usage({ billing_units: undefined }),
+				true,
+			);
+			expectShapeSame(
+				usage({ billing_units: null }),
+				usage({ billing_units: 1 }),
+				true,
+			);
+			expectShapeSame(
+				usage({ billing_units: undefined }),
+				usage({ billing_units: 100 }),
+				false,
+			);
+		});
+
+		test("tier amount / count / non-last `to`", () => {
+			const twoTiers = [
+				{ to: 100, amount: 1 },
+				{ to: TierInfinite, amount: 2 },
+			];
+			expectShapeSame(
+				usage({ usage_tiers: twoTiers }),
+				usage({ usage_tiers: [...twoTiers] }),
+				true,
+			);
+			expectShapeSame(
+				usage({ usage_tiers: twoTiers }),
+				usage({ usage_tiers: [{ to: TierInfinite, amount: 1 }] }),
+				false,
+			);
+			expectShapeSame(
+				usage({ usage_tiers: twoTiers }),
+				usage({
+					usage_tiers: [
+						{ to: 200, amount: 1 },
+						{ to: TierInfinite, amount: 2 },
+					],
+				}),
+				false,
+			);
+			expectShapeSame(
+				usage({ usage_tiers: [{ to: TierInfinite, amount: 1 }] }),
+				usage({ usage_tiers: [{ to: TierInfinite, amount: 2 }] }),
+				false,
+			);
+		});
+
+		test("last tier `to` is ignored; flat_amount unset equals 0", () => {
+			expectShapeSame(
+				usage({
+					usage_tiers: [
+						{ to: 100, amount: 1 },
+						{ to: TierInfinite, amount: 2 },
+					],
+				}),
+				usage({
+					usage_tiers: [
+						{ to: 100, amount: 1 },
+						{ to: -1, amount: 2 },
+					],
+				}),
+				true,
+			);
+			expectShapeSame(
+				usage({ usage_tiers: [{ to: TierInfinite, amount: 1 }] }),
+				usage({ usage_tiers: [{ to: -1, amount: 1 }] }),
+				true,
+			);
+			expectShapeSame(
+				usage({
+					usage_tiers: [{ to: TierInfinite, amount: 1, flat_amount: 0 }],
+				}),
+				usage({ usage_tiers: [{ to: TierInfinite, amount: 1 }] }),
+				true,
+			);
+			expectShapeSame(
+				usage({
+					usage_tiers: [{ to: TierInfinite, amount: 1, flat_amount: 5 }],
+				}),
+				usage({ usage_tiers: [{ to: TierInfinite, amount: 1 }] }),
+				false,
+			);
+		});
+
+		test("tier_behavior unset equals graduated", () => {
+			expectShapeSame(
+				usage({}, { tier_behavior: null }),
+				usage({}, { tier_behavior: TierBehavior.Graduated }),
+				true,
+			);
+			expectShapeSame(
+				usage({}, { tier_behavior: undefined }),
+				usage({}, { tier_behavior: TierBehavior.Graduated }),
+				true,
+			);
+			expectShapeSame(
+				usage({}, { tier_behavior: TierBehavior.Graduated }),
+				usage({}, { tier_behavior: TierBehavior.VolumeBased }),
+				false,
+			);
+		});
+	});
+
+	describe("this currency only", () => {
+		test("USD amount is the base amount; EUR reads the overlay", () => {
+			const price = usage({
+				base_currency: "usd",
+				usage_tiers: [{ to: TierInfinite, amount: 1 }],
+				currencies: {
+					eur: { amount: 9, usage_tiers: [{ to: TierInfinite, amount: 2 }] },
+				},
+			});
+			expect(shape({ price, currency: "usd" }).amount).toBeNull();
+			expect(shape({ price, currency: "usd" }).usage_tiers[0]?.amount).toBe(1);
+			expect(shape({ price, currency: "eur" }).amount).toBe(9);
+			expect(shape({ price, currency: "eur" }).usage_tiers[0]?.amount).toBe(2);
+		});
+
+		test("changing another currency does not change this currency's shape", () => {
+			const usd10 = usage({
+				base_currency: "usd",
+				usage_tiers: [{ to: TierInfinite, amount: 1 }],
+				currencies: { eur: { amount: 9 } },
+			});
+			const usd10EurChanged = usage({
+				base_currency: "usd",
+				usage_tiers: [{ to: TierInfinite, amount: 1 }],
+				currencies: { eur: { amount: 8 } },
+			});
+			expect(shape({ price: usd10, currency: "usd" })).toEqual(
+				shape({ price: usd10EurChanged, currency: "usd" }),
+			);
+			expect(shape({ price: usd10, currency: "eur" })).not.toEqual(
+				shape({ price: usd10EurChanged, currency: "eur" }),
+			);
+		});
+	});
+
+	describe("ignored (differ but still same shape)", () => {
+		test("stripe ids, feature ids, bill_when, should_prorate, entitlement", () => {
+			expectShapeSame(
+				usage({
+					stripe_price_id: "a",
+					stripe_product_id: "a",
+					stripe_meter_id: "a",
+					feature_id: "messages",
+					internal_feature_id: "ifeat_1",
+					bill_when: BillWhen.EndOfPeriod,
+					should_prorate: false,
+				}),
+				usage({
+					stripe_price_id: "b",
+					stripe_product_id: "b",
+					stripe_meter_id: "b",
+					feature_id: "seats",
+					internal_feature_id: "ifeat_2",
+					bill_when: BillWhen.InAdvance,
+					should_prorate: true,
+				}),
+				true,
+			);
+		});
+
+		test("proration_config and row identity are ignored", () => {
+			expectShapeSame(
+				usage(
+					{},
+					{
+						id: "pr_a",
+						entitlement_id: "ent_a",
+						proration_config: {
+							on_increase: OnIncrease.ProrateImmediately,
+							on_decrease: OnDecrease.ProrateImmediately,
+						},
+					},
+				),
+				usage(
+					{},
+					{
+						id: "pr_b",
+						entitlement_id: "ent_b",
+						proration_config: null,
+					},
+				),
+				true,
+			);
+		});
+
+		test("fixed ignores billing_units, stripe ids, and tier_behavior", () => {
+			expectShapeSame(
+				fixed(
+					{
+						stripe_price_id: "price_a",
+						billing_units: 1,
+					},
+					{ tier_behavior: TierBehavior.VolumeBased },
+				),
+				fixed(
+					{
+						stripe_price_id: "price_b",
+						billing_units: 100,
+					},
+					{ tier_behavior: null },
+				),
+				true,
+			);
+		});
+	});
+});

--- a/server/tests/unit/external/stripe/build-stripe-price-idempotency-key.test.ts
+++ b/server/tests/unit/external/stripe/build-stripe-price-idempotency-key.test.ts
@@ -1,0 +1,47 @@
+/**
+ * buildStripePriceIdempotencyKey
+ *
+ * Same Autumn price id + same mint shape → same key (retries dedupe).
+ * Same id + $10 → $20 → different key (Stripe will not reject the remint).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { BillingInterval, type Price, PriceType } from "@autumn/shared";
+import { buildStripePriceIdempotencyKey } from "@/external/stripe/prices/utils/buildIdempotencyKey.js";
+
+const fixed = ({ amount }: { amount: number }): Price => ({
+	id: "pr_abc",
+	org_id: "org_1",
+	created_at: 1,
+	internal_product_id: "ip_pro",
+	is_custom: false,
+	config: {
+		type: PriceType.Fixed,
+		amount,
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+	proration_config: null,
+});
+
+const key = ({ price, currency = "usd" }: { price: Price; currency?: string }) =>
+	buildStripePriceIdempotencyKey({
+		price,
+		slot: "stripe_price_id",
+		currency,
+		orgDefault: "usd",
+	});
+
+describe("buildStripePriceIdempotencyKey", () => {
+	test("same shape retries share a key; $10 → $20 does not", () => {
+		const ten = fixed({ amount: 10 });
+		const tenAgain = fixed({ amount: 10 });
+		const twenty = fixed({ amount: 20 });
+
+		expect(key({ price: ten })).toBe(key({ price: tenAgain }));
+		expect(key({ price: ten })).not.toBe(key({ price: twenty }));
+		expect(key({ price: ten })).toMatch(/^autumn:price:pr_abc:stripe_price_id:usd:[a-f0-9]{16}$/);
+	});
+});

--- a/server/tests/unit/products/find-reusable-stripe-price.test.ts
+++ b/server/tests/unit/products/find-reusable-stripe-price.test.ts
@@ -11,19 +11,26 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
 	AppEnv,
 	BillingInterval,
+	BillWhen,
 	type FullProduct,
 	getPriceCurrencyStripeId,
 	type Price,
 	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
 } from "@autumn/shared";
 import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const mockState = {
 	queryCalls: 0,
+	usageQueryCalls: 0,
+	prepaidQueryCalls: 0,
 	retrieveCalls: [] as string[],
 	persistCalls: 0,
 	candidate: null as Price | null,
+	usageCandidate: null as Price | null,
+	prepaidCandidate: null as Price | null,
 	stripePrice: null as { id: string; active: boolean } | null,
 };
 
@@ -34,6 +41,14 @@ await mockModuleWithRestore(
 			findNewestReusableFixedPrice: async () => {
 				mockState.queryCalls += 1;
 				return mockState.candidate;
+			},
+			findNewestReusablePrepaidPrice: async () => {
+				mockState.prepaidQueryCalls += 1;
+				return mockState.prepaidCandidate;
+			},
+			findNewestReusableUsagePrice: async () => {
+				mockState.usageQueryCalls += 1;
+				return mockState.usageCandidate;
 			},
 		},
 	}),
@@ -131,9 +146,13 @@ const product = ({ price }: { price: Price }): FullProduct =>
 describe("findReusableStripePrice", () => {
 	beforeEach(() => {
 		mockState.queryCalls = 0;
+		mockState.usageQueryCalls = 0;
+		mockState.prepaidQueryCalls = 0;
 		mockState.retrieveCalls = [];
 		mockState.persistCalls = 0;
 		mockState.candidate = null;
+		mockState.usageCandidate = null;
+		mockState.prepaidCandidate = null;
 		mockState.stripePrice = null;
 	});
 
@@ -210,6 +229,74 @@ describe("findReusableStripePrice", () => {
 		expect(mockState.retrieveCalls).toEqual(["price_dead"]);
 		expect(dead.config.stripe_price_id).toBeNull();
 		expect(mockState.persistCalls).toBe(0);
+	});
+
+	test("usage empty slot queries the usage finder, not the fixed finder", async () => {
+		const target: Price = {
+			id: "pr_usage_b",
+			org_id: "org_1",
+			created_at: 1,
+			internal_product_id: "ip_pro",
+			is_custom: true,
+			config: {
+				type: PriceType.Usage,
+				bill_when: BillWhen.EndOfPeriod,
+				billing_units: 1,
+				internal_feature_id: "ifeat_messages",
+				feature_id: "messages",
+				usage_tiers: [{ amount: 2, to: TierInfinite }],
+				interval: BillingInterval.Month,
+				interval_count: 1,
+				should_prorate: false,
+			} satisfies UsagePriceConfig,
+			proration_config: null,
+		};
+
+		await findReusableStripePrice({
+			ctx,
+			products: [product({ price: target })],
+			currency: "usd",
+		});
+
+		expect(mockState.usageQueryCalls).toBe(1);
+		expect(mockState.prepaidQueryCalls).toBe(0);
+		expect(mockState.queryCalls).toBe(0);
+		expect(target.config.stripe_price_id).toBeUndefined();
+	});
+
+	test("prepaid empty V2 slot queries the prepaid finder, not usage", async () => {
+		const target: Price = {
+			id: "pr_prepaid_b",
+			org_id: "org_1",
+			created_at: 1,
+			internal_product_id: "ip_pro",
+			is_custom: true,
+			config: {
+				type: PriceType.Usage,
+				bill_when: BillWhen.InAdvance,
+				billing_units: 100,
+				internal_feature_id: "ifeat_messages",
+				feature_id: "messages",
+				usage_tiers: [{ amount: 10, to: TierInfinite }],
+				interval: BillingInterval.Month,
+				interval_count: 1,
+				should_prorate: false,
+			} satisfies UsagePriceConfig,
+			proration_config: null,
+		};
+
+		await findReusableStripePrice({
+			ctx,
+			products: [product({ price: target })],
+			currency: "usd",
+		});
+
+		expect(mockState.prepaidQueryCalls).toBe(1);
+		expect(mockState.usageQueryCalls).toBe(0);
+		expect(mockState.queryCalls).toBe(0);
+		expect(
+			(target.config as UsagePriceConfig).stripe_prepaid_price_v2_id,
+		).toBeUndefined();
 	});
 });
 

--- a/server/tests/unit/products/find-reusable-stripe-resources.test.ts
+++ b/server/tests/unit/products/find-reusable-stripe-resources.test.ts
@@ -8,7 +8,7 @@
  *   EUR attach, USD slot only → null
  *   other product.id / org / env → null
  *   same product.id across versions → match
- *   catalog beats custom; newest custom wins
+ *   catalog cannot reuse custom; custom can reuse catalog
  *   usage candidate → null
  */
 
@@ -121,7 +121,7 @@ const usagePrice = (): Price => ({
 
 describe("findReusableStripeResources — fixed", () => {
 	test("same $25 monthly on Pro stamps the donor stripe_price_id", () => {
-		const target = fixedPrice({ id: "pr_b" });
+		const target = fixedPrice({ id: "pr_b", isCustom: true });
 		const donor = fixedPrice({
 			id: "pr_a",
 			isCustom: true,
@@ -161,12 +161,14 @@ describe("findReusableStripeResources — fixed", () => {
 	test("USD attach on USD+EUR copies the USD slot only", () => {
 		const target = fixedPrice({
 			id: "pr_b",
+			isCustom: true,
 			config: {
 				currencies: { eur: { amount: 25 } },
 			},
 		});
 		const eurTarget = fixedPrice({
 			id: "pr_b_eur",
+			isCustom: true,
 			config: {
 				currencies: { eur: { amount: 25 } },
 			},
@@ -228,6 +230,7 @@ describe("findReusableStripeResources — fixed", () => {
 	test("EUR attach with only a USD slot does not match", () => {
 		const target = fixedPrice({
 			id: "pr_b",
+			isCustom: true,
 			config: { currencies: { eur: { amount: 25 } } },
 		});
 		const usdOnly = fixedPrice({
@@ -295,7 +298,7 @@ describe("findReusableStripeResources — fixed", () => {
 		).toBeNull();
 	});
 
-	test("catalog beats custom; newest custom wins among customs", () => {
+	test("catalog cannot reuse custom; custom can reuse catalog", () => {
 		const olderCustom = fixedPrice({
 			id: "pr_old",
 			isCustom: true,
@@ -316,22 +319,40 @@ describe("findReusableStripeResources — fixed", () => {
 
 		expect(
 			find({
-				target: fixedPrice({ id: "pr_b1" }),
+				target: fixedPrice({ id: "pr_catalog" }),
 				candidates: [
 					candidate({ price: olderCustom }),
 					candidate({ price: newerCustom }),
 				],
-			})?.id,
-		).toBe("pr_new");
+			}),
+		).toBeNull();
 		expect(
 			find({
-				target: fixedPrice({ id: "pr_b2" }),
+				target: fixedPrice({ id: "pr_catalog_mix" }),
 				candidates: [
 					candidate({ price: newerCustom }),
 					candidate({ price: catalog }),
 				],
 			})?.id,
 		).toBe("pr_cat");
+		expect(
+			find({
+				target: fixedPrice({ id: "pr_custom_mix", isCustom: true }),
+				candidates: [
+					candidate({ price: newerCustom }),
+					candidate({ price: catalog }),
+				],
+			})?.id,
+		).toBe("pr_cat");
+		expect(
+			find({
+				target: fixedPrice({ id: "pr_custom_only", isCustom: true }),
+				candidates: [
+					candidate({ price: olderCustom }),
+					candidate({ price: newerCustom }),
+				],
+			})?.id,
+		).toBe("pr_new");
 	});
 
 	test("usage target or candidate is ignored", () => {

--- a/server/tests/unit/products/has-empty-stripe-resource.test.ts
+++ b/server/tests/unit/products/has-empty-stripe-resource.test.ts
@@ -1,0 +1,161 @@
+/**
+ * hasEmptyStripeResource
+ *
+ * Contract:
+ *   paid fixed / consumable / allocated v2 with empty attach slot → true
+ *   prepaid V2 empty → true (V1 filled does not fill V2)
+ *   filled slot, $0 fixed, one-off prepaid, allocated v1 → false
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	AllocatedBillingBehavior,
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { hasEmptyStripeResource } from "@/internal/products/stripeResourceUtils/findReusableStripeResources/hasEmptyStripeResource.js";
+
+const ctx = {
+	org: { id: "org_1", default_currency: "usd" },
+	env: AppEnv.Sandbox,
+} as unknown as AutumnContext;
+
+const empty = ({
+	price,
+	currency = "usd",
+}: {
+	price: Price;
+	currency?: string;
+}) => hasEmptyStripeResource({ ctx, targetPrice: price, currency });
+
+const fixed = ({
+	amount = 25,
+	stripePriceId = null,
+}: {
+	amount?: number;
+	stripePriceId?: string | null;
+} = {}): Price => ({
+	id: "pr_fixed",
+	org_id: "org_1",
+	created_at: 1,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Fixed,
+		amount,
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_price_id: stripePriceId,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+	proration_config: null,
+});
+
+const usage = ({
+	overrides = {},
+	stripePriceId = null,
+}: {
+	overrides?: Partial<UsagePriceConfig>;
+	stripePriceId?: string | null;
+} = {}): Price => ({
+	id: "pr_usage",
+	org_id: "org_1",
+	created_at: 1,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Usage,
+		bill_when: BillWhen.EndOfPeriod,
+		billing_units: 1,
+		internal_feature_id: "ifeat_messages",
+		feature_id: "messages",
+		usage_tiers: [{ amount: 1, to: TierInfinite }],
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		should_prorate: false,
+		stripe_price_id: stripePriceId,
+		...overrides,
+	} satisfies UsagePriceConfig,
+	proration_config: null,
+});
+
+describe("hasEmptyStripeResource", () => {
+	test("true for empty paid fixed, consumable, and allocated v2 slots", () => {
+		expect(empty({ price: fixed() })).toBe(true);
+		expect(empty({ price: usage() })).toBe(true);
+		expect(
+			empty({
+				price: usage({
+					overrides: {
+						should_prorate: true,
+						allocated_billing_behavior: AllocatedBillingBehavior.Arrear,
+					},
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("true for empty prepaid V2 even when V1 is filled", () => {
+		expect(
+			empty({
+				price: usage({ overrides: { bill_when: BillWhen.InAdvance } }),
+			}),
+		).toBe(true);
+		expect(
+			empty({
+				price: usage({
+					overrides: {
+						bill_when: BillWhen.InAdvance,
+						stripe_price_id: "price_v1",
+					},
+				}),
+			}),
+		).toBe(true);
+	});
+
+	test("false when the attach slot is filled", () => {
+		expect(empty({ price: fixed({ stripePriceId: "price_1" }) })).toBe(false);
+		expect(empty({ price: usage({ stripePriceId: "price_1" }) })).toBe(false);
+		expect(
+			empty({
+				price: usage({
+					overrides: {
+						bill_when: BillWhen.InAdvance,
+						stripe_prepaid_price_v2_id: "price_v2",
+					},
+				}),
+			}),
+		).toBe(false);
+	});
+
+	test("false for $0 fixed, one-off prepaid, and allocated v1", () => {
+		expect(empty({ price: fixed({ amount: 0 }) })).toBe(false);
+		expect(
+			empty({
+				price: usage({
+					overrides: {
+						bill_when: BillWhen.InAdvance,
+						interval: BillingInterval.OneOff,
+					},
+				}),
+			}),
+		).toBe(false);
+		expect(
+			empty({
+				price: usage({
+					overrides: {
+						should_prorate: true,
+						allocated_billing_behavior: AllocatedBillingBehavior.Prorated,
+					},
+				}),
+			}),
+		).toBe(false);
+	});
+});

--- a/server/tests/unit/products/is-usable-stripe-price.test.ts
+++ b/server/tests/unit/products/is-usable-stripe-price.test.ts
@@ -4,7 +4,10 @@
  * Contract:
  *   retrieves the candidate's Stripe Price, then:
  *   live + same shape + currency → true
- *   missing / inactive / drift / wrong currency / usage autumn price → false
+ *   missing / inactive / drift / wrong currency → false
+ *   consumable matches the feature Stripe product (metered)
+ *   prepaid retrieves V2 with expand tiers; included 100 vs 0 → miss
+ *   usage without a paired entitlement → false after retrieve
  */
 
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -12,6 +15,8 @@ import {
 	AppEnv,
 	BillingInterval,
 	BillWhen,
+	type EntitlementWithFeature,
+	type Feature,
 	type FullProduct,
 	type Price,
 	PriceType,
@@ -22,15 +27,19 @@ import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
 import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
 
 const stripeProductId = "prod_pro";
+const featureStripeProductId = "prod_feat_messages";
 const currency = "usd";
 
 const mockState = {
 	retrieveCalls: [] as string[],
+	expandCalls: [] as (string[] | undefined)[],
 	stripePrice: null as {
 		id: string;
 		active: boolean;
 		currency?: string;
 		unitAmount?: number;
+		product?: string;
+		usageType?: "licensed" | "metered";
 	} | null,
 };
 
@@ -41,8 +50,15 @@ await mockModuleWithRestore("@/external/connect/createStripeCli.js", () => ({
 await mockModuleWithRestore(
 	"@/external/stripe/prices/operations/getStripePrice.js",
 	() => ({
-		getStripePrice: async ({ stripePriceId }: { stripePriceId: string }) => {
+		getStripePrice: async ({
+			stripePriceId,
+			expand,
+		}: {
+			stripePriceId: string;
+			expand?: string[];
+		}) => {
 			mockState.retrieveCalls.push(stripePriceId);
+			mockState.expandCalls.push(expand);
 			if (!mockState.stripePrice) return undefined;
 			return {
 				id: mockState.stripePrice.id,
@@ -52,11 +68,11 @@ await mockModuleWithRestore(
 				billing_scheme: "per_unit",
 				unit_amount: mockState.stripePrice.unitAmount ?? 2500,
 				unit_amount_decimal: String(mockState.stripePrice.unitAmount ?? 2500),
-				product: stripeProductId,
+				product: mockState.stripePrice.product ?? stripeProductId,
 				recurring: {
 					interval: "month",
 					interval_count: 1,
-					usage_type: "licensed",
+					usage_type: mockState.stripePrice.usageType ?? "licensed",
 				},
 				type: "recurring",
 			};
@@ -91,12 +107,17 @@ const autumnFixed = (): Price => ({
 	proration_config: null,
 });
 
-const autumnUsage = (): Price => ({
+const autumnUsage = ({
+	entitlementId = "ent_messages",
+}: {
+	entitlementId?: string;
+} = {}): Price => ({
 	id: "pr_usage",
 	org_id: "org_1",
 	created_at: 1_800_000_000_000,
 	internal_product_id: "ip_pro",
 	is_custom: true,
+	entitlement_id: entitlementId,
 	config: {
 		type: PriceType.Usage,
 		bill_when: BillWhen.EndOfPeriod,
@@ -106,7 +127,7 @@ const autumnUsage = (): Price => ({
 		usage_tiers: [{ amount: 25, to: TierInfinite }],
 		interval: BillingInterval.Month,
 		interval_count: 1,
-		stripe_price_id: "price_usage_25",
+		should_prorate: false,
 	} satisfies UsagePriceConfig,
 	proration_config: null,
 });
@@ -121,10 +142,37 @@ const candidateFixed = (): Price => ({
 	},
 });
 
+const candidateUsage = (): Price => ({
+	...autumnUsage(),
+	id: "pr_usage_a",
+	config: {
+		...autumnUsage().config,
+		stripe_price_id: "price_usage_25",
+		stripe_product_id: featureStripeProductId,
+	},
+});
+
+const messagesEntitlement = (): EntitlementWithFeature =>
+	({
+		id: "ent_messages",
+		created_at: 1,
+		internal_feature_id: "feat_messages",
+		internal_product_id: "ip_pro",
+		allowance: 0,
+		feature_id: "messages",
+		feature: {
+			id: "messages",
+			internal_id: "feat_messages",
+			stripe_product_id: featureStripeProductId,
+		} as Feature,
+	}) as EntitlementWithFeature;
+
 const product = ({
 	targetPrice = autumnFixed(),
+	entitlements = [],
 }: {
 	targetPrice?: Price;
+	entitlements?: EntitlementWithFeature[];
 } = {}): FullProduct =>
 	({
 		id: "pro",
@@ -133,27 +181,30 @@ const product = ({
 		env: AppEnv.Sandbox,
 		processor: { type: "stripe", id: stripeProductId },
 		prices: [targetPrice],
-		entitlements: [],
+		entitlements,
 	}) as unknown as FullProduct;
 
 const usable = ({
 	targetPrice = autumnFixed(),
 	candidate = candidateFixed(),
+	entitlements = [],
 }: {
 	targetPrice?: Price;
 	candidate?: Price;
+	entitlements?: EntitlementWithFeature[];
 } = {}) =>
 	isUsableStripePrice({
 		ctx,
 		targetPrice,
 		candidate,
-		product: product({ targetPrice }),
+		product: product({ targetPrice, entitlements }),
 		currency,
 	});
 
 describe("isUsableStripePrice", () => {
 	beforeEach(() => {
 		mockState.retrieveCalls = [];
+		mockState.expandCalls = [];
 		mockState.stripePrice = null;
 	});
 
@@ -183,9 +234,91 @@ describe("isUsableStripePrice", () => {
 		expect(await usable()).toBe(false);
 	});
 
-	test("returns false for a usage autumn price without retrieving", async () => {
-		expect(await usable({ targetPrice: autumnUsage() })).toBe(false);
-		expect(mockState.retrieveCalls).toEqual([]);
+	test("consumable matches a live metered Stripe Price on the feature product", async () => {
+		mockState.stripePrice = {
+			id: "price_usage_25",
+			active: true,
+			product: featureStripeProductId,
+			usageType: "metered",
+		};
+
+		expect(
+			await usable({
+				targetPrice: autumnUsage(),
+				candidate: candidateUsage(),
+				entitlements: [messagesEntitlement()],
+			}),
+		).toBe(true);
+		expect(mockState.retrieveCalls).toEqual(["price_usage_25"]);
+	});
+
+	test("prepaid retrieves the V2 slot with tiers and matches licensed shape", async () => {
+		const target = autumnUsage();
+		(target.config as UsagePriceConfig).bill_when = BillWhen.InAdvance;
+		const candidate = candidateUsage();
+		(candidate.config as UsagePriceConfig).bill_when = BillWhen.InAdvance;
+		(candidate.config as UsagePriceConfig).stripe_price_id = "price_v1";
+		(candidate.config as UsagePriceConfig).stripe_prepaid_price_v2_id =
+			"price_v2";
+		mockState.stripePrice = {
+			id: "price_v2",
+			active: true,
+			product: featureStripeProductId,
+			usageType: "licensed",
+		};
+
+		expect(
+			await usable({
+				targetPrice: target,
+				candidate,
+				entitlements: [messagesEntitlement()],
+			}),
+		).toBe(true);
+		expect(mockState.retrieveCalls).toEqual(["price_v2"]);
+		expect(mockState.expandCalls).toEqual([["tiers"]]);
+	});
+
+	test("prepaid included 100 misses a 0-included Stripe Price", async () => {
+		const target = autumnUsage();
+		(target.config as UsagePriceConfig).bill_when = BillWhen.InAdvance;
+		const candidate = candidateUsage();
+		(candidate.config as UsagePriceConfig).bill_when = BillWhen.InAdvance;
+		(candidate.config as UsagePriceConfig).stripe_prepaid_price_v2_id =
+			"price_v2_included0";
+		const entitlement = messagesEntitlement();
+		entitlement.allowance = 100;
+		mockState.stripePrice = {
+			id: "price_v2_included0",
+			active: true,
+			product: featureStripeProductId,
+			usageType: "licensed",
+		};
+
+		expect(
+			await usable({
+				targetPrice: target,
+				candidate,
+				entitlements: [entitlement],
+			}),
+		).toBe(false);
+		expect(mockState.retrieveCalls).toEqual(["price_v2_included0"]);
+	});
+
+	test("usage without a paired entitlement is unused after retrieve", async () => {
+		mockState.stripePrice = {
+			id: "price_usage_25",
+			active: true,
+			product: featureStripeProductId,
+			usageType: "metered",
+		};
+
+		expect(
+			await usable({
+				targetPrice: autumnUsage(),
+				candidate: candidateUsage(),
+			}),
+		).toBe(false);
+		expect(mockState.retrieveCalls).toEqual(["price_usage_25"]);
 	});
 });
 

--- a/server/tests/unit/products/stamp-attach-currency-stripe-slot.test.ts
+++ b/server/tests/unit/products/stamp-attach-currency-stripe-slot.test.ts
@@ -1,0 +1,198 @@
+/**
+ * stampAttachCurrencyStripeSlot
+ *
+ * Full usage reuse must persist stripe_product_id (+ meter for consumable)
+ * with the Price slot. createStripePriceIFNotExist sees an empty product
+ * slot and mints a new feature Product while the borrowed Price stays
+ * on the donor.
+ *
+ * Red (current):  stamp copies stripe_price_id + meter, not stripe_product_id
+ * Green (after):  same persist writes the donor feature Product id
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	AppEnv,
+	BillingInterval,
+	BillWhen,
+	type Price,
+	PriceType,
+	TierInfinite,
+	type UsagePriceConfig,
+} from "@autumn/shared";
+import type { AutumnContext } from "@/honoUtils/HonoEnv.js";
+import { mockModuleWithRestore } from "../utils/mockModuleWithRestore.js";
+
+const mockState = {
+	persistCalls: 0,
+};
+
+await mockModuleWithRestore(
+	"@/internal/products/prices/PriceService.js",
+	() => ({
+		PriceService: {
+			update: async () => {
+				mockState.persistCalls += 1;
+			},
+		},
+	}),
+);
+
+const { stampAttachCurrencyStripeSlot } = await import(
+	"@/internal/products/stripeResourceUtils/findReusableStripeResources/stampAttachCurrencyStripeSlot.js"
+);
+
+const ctx = {
+	db: {},
+	env: AppEnv.Sandbox,
+	org: { id: "org_1", default_currency: "usd" },
+} as unknown as AutumnContext;
+
+const consumable = ({
+	id,
+	stripePriceId,
+	stripeProductId,
+	stripeMeterId,
+	stripeEventName,
+}: {
+	id: string;
+	stripePriceId?: string;
+	stripeProductId?: string;
+	stripeMeterId?: string;
+	stripeEventName?: string;
+}): Price => ({
+	id,
+	org_id: "org_1",
+	created_at: 1,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Usage,
+		bill_when: BillWhen.EndOfPeriod,
+		billing_units: 1,
+		internal_feature_id: "ifeat_messages",
+		feature_id: "messages",
+		usage_tiers: [{ amount: 2, to: TierInfinite }],
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		should_prorate: false,
+		...(stripePriceId ? { stripe_price_id: stripePriceId } : {}),
+		...(stripeProductId ? { stripe_product_id: stripeProductId } : {}),
+		...(stripeMeterId ? { stripe_meter_id: stripeMeterId } : {}),
+		...(stripeEventName ? { stripe_event_name: stripeEventName } : {}),
+	} satisfies UsagePriceConfig,
+	proration_config: null,
+});
+
+const fixed = ({
+	id,
+	stripePriceId,
+	stripeProductId,
+}: {
+	id: string;
+	stripePriceId?: string;
+	stripeProductId?: string;
+}): Price => ({
+	id,
+	org_id: "org_1",
+	created_at: 1,
+	internal_product_id: "ip_pro",
+	is_custom: true,
+	config: {
+		type: PriceType.Fixed,
+		amount: 25,
+		interval: BillingInterval.Month,
+		interval_count: 1,
+		stripe_price_id: stripePriceId ?? null,
+		stripe_product_id: stripeProductId ?? null,
+		feature_id: null,
+		internal_feature_id: null,
+	},
+	proration_config: null,
+});
+
+describe("stampAttachCurrencyStripeSlot", () => {
+	beforeEach(() => {
+		mockState.persistCalls = 0;
+	});
+
+	test("consumable full reuse copies Price slot, feature Product, and meter in one persist", async () => {
+		const target = consumable({ id: "pr_b" });
+		const source = consumable({
+			id: "pr_a",
+			stripePriceId: "price_a",
+			stripeProductId: "prod_feat_a",
+			stripeMeterId: "mtr_a",
+			stripeEventName: "messages_used",
+		});
+
+		await stampAttachCurrencyStripeSlot({
+			ctx,
+			targetPrice: target,
+			sourcePrice: source,
+			currency: "usd",
+			slot: "stripe_price_id",
+		});
+
+		const config = target.config as UsagePriceConfig;
+		expect(config.stripe_price_id).toBe("price_a");
+		expect(config.stripe_product_id).toBe("prod_feat_a");
+		expect(config.stripe_meter_id).toBe("mtr_a");
+		expect(config.stripe_event_name).toBe("messages_used");
+		expect(mockState.persistCalls).toBe(1);
+	});
+
+	test("fixed reuse copies the Price slot only", async () => {
+		const target = fixed({ id: "pr_b" });
+		const source = fixed({
+			id: "pr_a",
+			stripePriceId: "price_a",
+			stripeProductId: "prod_plan_a",
+		});
+
+		await stampAttachCurrencyStripeSlot({
+			ctx,
+			targetPrice: target,
+			sourcePrice: source,
+			currency: "usd",
+			slot: "stripe_price_id",
+		});
+
+		expect(target.config.stripe_price_id).toBe("price_a");
+		expect(target.config.stripe_product_id).toBeNull();
+		expect(
+			(target.config as { stripe_meter_id?: string }).stripe_meter_id,
+		).toBeUndefined();
+		expect(mockState.persistCalls).toBe(1);
+	});
+
+	test("filled slot does not persist or overwrite a missing meter", async () => {
+		const target = consumable({
+			id: "pr_b",
+			stripePriceId: "price_already",
+		});
+		const source = consumable({
+			id: "pr_a",
+			stripePriceId: "price_a",
+			stripeMeterId: "mtr_a",
+			stripeEventName: "messages_used",
+		});
+
+		await stampAttachCurrencyStripeSlot({
+			ctx,
+			targetPrice: target,
+			sourcePrice: source,
+			currency: "usd",
+			slot: "stripe_price_id",
+		});
+
+		const config = target.config as UsagePriceConfig;
+		expect(config.stripe_price_id).toBe("price_already");
+		expect(config.stripe_meter_id).toBeUndefined();
+		expect(mockState.persistCalls).toBe(0);
+	});
+});
+
+afterAll(() => {
+	mock.restore();
+});

--- a/server/tests/utils/fixtures/itemsV2.ts
+++ b/server/tests/utils/fixtures/itemsV2.ts
@@ -239,7 +239,11 @@ const volumePrepaidMessages = ({
 }: {
 	included?: number;
 	billingUnits?: number;
-	tiers?: { to: number | typeof TierInfinite; amount: number }[];
+	tiers?: {
+		to: number | typeof TierInfinite;
+		amount: number;
+		flat_amount?: number;
+	}[];
 } = {}) => ({
 	feature_id: TestFeature.Messages,
 	included,

--- a/shared/utils/productUtils/priceUtils/comparePrice/priceToStripePriceIdempotencyShape.ts
+++ b/shared/utils/productUtils/priceUtils/comparePrice/priceToStripePriceIdempotencyShape.ts
@@ -1,0 +1,42 @@
+import { priceConfigForCurrency } from "@models/productModels/priceModels/priceConfig/priceCurrencyView";
+import { PriceType } from "@models/productModels/priceModels/priceEnums";
+import type { Price } from "@models/productModels/priceModels/priceModels";
+import { TierBehavior } from "@models/productModels/priceModels/priceConfig/usagePriceConfig";
+import { usageTiersToComparisonShape } from "./pricesAreSame.js";
+
+/**
+ * Stripe mint identity for one attach currency. Same normalizations as
+ * `pricesAreSame` for the fields that land on `prices.create`.
+ */
+export const priceToStripePriceIdempotencyShape = ({
+	price,
+	currency,
+	orgDefault,
+}: {
+	price: Price;
+	currency: string;
+	orgDefault: string;
+}) => {
+	const ccy = currency.toLowerCase();
+	const { amount, usage_tiers } = priceConfigForCurrency({
+		config: price.config,
+		currency: ccy,
+		orgDefault: orgDefault.toLowerCase(),
+	});
+	const usage = price.config.type === PriceType.Usage;
+	const billingUnits =
+		usage && "billing_units" in price.config
+			? (price.config.billing_units ?? 1)
+			: null;
+
+	return {
+		amount: amount ?? null,
+		usage_tiers: usageTiersToComparisonShape(usage_tiers ?? []),
+		interval: price.config.interval ?? null,
+		interval_count: price.config.interval_count ?? 1,
+		billing_units: billingUnits,
+		tier_behavior: usage
+			? (price.tier_behavior ?? TierBehavior.Graduated)
+			: null,
+	};
+};

--- a/shared/utils/productUtils/priceUtils/comparePrice/pricesAreSame.ts
+++ b/shared/utils/productUtils/priceUtils/comparePrice/pricesAreSame.ts
@@ -19,17 +19,26 @@ const normalizedAllocatedBillingBehavior = (usageConfig: UsagePriceConfig) =>
 		? AllocatedBillingBehavior.Prorated
 		: AllocatedBillingBehavior.Arrear);
 
+/** Last `to` is ignored; unset `flat_amount` is 0. */
+export const usageTiersToComparisonShape = (tiers: UsageTier[]) =>
+	tiers.map((tier, index) => ({
+		amount: tier.amount,
+		flat_amount: tier.flat_amount ?? 0,
+		to: index === tiers.length - 1 ? null : tier.to,
+	}));
+
 export const tiersAreSame = (tiers1: UsageTier[], tiers2: UsageTier[]) => {
 	if (tiers1.length !== tiers2.length) return false;
-	for (let i = 0; i < tiers1.length; i++) {
-		const tier1 = tiers1[i];
-		const tier2 = tiers2[i];
-
-		if (i !== tiers1.length - 1 && tier1.to !== tier2.to) return false;
-		if (tier1.amount !== tier2.amount) return false;
-		if ((tier1.flat_amount ?? 0) !== (tier2.flat_amount ?? 0)) return false;
-	}
-	return true;
+	const shape1 = usageTiersToComparisonShape(tiers1);
+	const shape2 = usageTiersToComparisonShape(tiers2);
+	return shape1.every((tier, index) => {
+		const other = shape2[index];
+		return (
+			tier.amount === other?.amount &&
+			tier.flat_amount === other.flat_amount &&
+			tier.to === other.to
+		);
+	});
 };
 
 const hasCatalogCurrencies = (

--- a/shared/utils/productUtils/priceUtils/index.ts
+++ b/shared/utils/productUtils/priceUtils/index.ts
@@ -6,6 +6,7 @@ import { priceToStripeTiersMode } from "./convertPrice/priceToStripeTiersMode.js
 export * from "./classifyPrice/priceIsTieredOneOff.js";
 export * from "./classifyPriceUtils.js";
 export * from "./comparePrice/pricesAreSame.js";
+export * from "./comparePrice/priceToStripePriceIdempotencyShape.js";
 export * from "./convertAmountUtils.js";
 export * from "./convertPrice/priceToRequiredStripeSlots.js";
 export * from "./convertPrice/priceToStripeNickname.js";

--- a/vite/src/components/compare-db-feature.test.ts
+++ b/vite/src/components/compare-db-feature.test.ts
@@ -112,3 +112,25 @@ test("rate-card comparison detects graduated tiers and invoice-credit changes", 
 		}),
 	).toBe(false);
 });
+
+test("detects stripe product changes and treats empty as unset", () => {
+	expect(
+		compareDbFeature({
+			curFeature: { ...creditSystem({ schema: [] }), stripe_product_id: null },
+			newFeature: { ...creditSystem({ schema: [] }), stripe_product_id: "" },
+		}),
+	).toBe(true);
+
+	expect(
+		compareDbFeature({
+			curFeature: {
+				...creditSystem({ schema: [] }),
+				stripe_product_id: "prod_123",
+			},
+			newFeature: {
+				...creditSystem({ schema: [] }),
+				stripe_product_id: "prod_456",
+			},
+		}),
+	).toBe(false);
+});

--- a/vite/src/components/compareDbFeature.ts
+++ b/vite/src/components/compareDbFeature.ts
@@ -108,6 +108,13 @@ export const compareDbFeature = ({
 				}),
 			message: `Event names different: ${curFeature.event_names} !== ${newFeature.event_names}`,
 		},
+
+		stripe_product_id: {
+			condition:
+				(curFeature.stripe_product_id || null) !==
+				(newFeature.stripe_product_id || null),
+			message: `Stripe product different: ${curFeature.stripe_product_id} !== ${newFeature.stripe_product_id}`,
+		},
 	};
 
 	const same = Object.values(diffs).every((d) => !d.condition);

--- a/vite/src/views/products/features/components/CreateFeatureSheet.tsx
+++ b/vite/src/views/products/features/components/CreateFeatureSheet.tsx
@@ -10,12 +10,14 @@ import {
 import { useUpdateCatalogMutation } from "@/hooks/queries/catalog/useUpdateCatalogMutation";
 import { useFeatureStore } from "@/hooks/stores/useFeatureStore";
 import { getBackendErr } from "@/utils/genUtils";
+import { FeatureStripeProductConfirmDialog } from "../../plan/components/new-feature/FeatureStripeProductConfirmDialog";
 import { NewFeatureAdvanced } from "../../plan/components/new-feature/NewFeatureAdvanced";
 import { NewFeatureBehaviour } from "../../plan/components/new-feature/NewFeatureBehaviour";
 import { NewFeatureDetails } from "../../plan/components/new-feature/NewFeatureDetails";
 import { NewFeatureType } from "../../plan/components/new-feature/NewFeatureType";
 import { validateCreditSystem } from "../credit-systems/utils/validateCreditSystem";
 import { featureToCatalogFeatureParams } from "../utils/buildFeatureMutationParams";
+import { featureStripeProductChanged } from "../utils/featureStripeProductChanged";
 import { getDefaultFeature } from "../utils/defaultFeature";
 
 function CreateFeatureSheet({
@@ -30,6 +32,7 @@ function CreateFeatureSheet({
 	isControlled?: boolean;
 } = {}) {
 	const [internalOpen, setInternalOpen] = useState(false);
+	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
 	const setOpen = controlledOnOpenChange || setInternalOpen;
@@ -39,6 +42,27 @@ function CreateFeatureSheet({
 	const reset = useFeatureStore((s) => s.reset);
 
 	const { mutateAsync: updateCatalog, isPending } = useUpdateCatalogMutation();
+
+	const persistFeature = async () => {
+		try {
+			await updateCatalog({
+				features: [featureToCatalogFeatureParams({ feature })],
+			});
+
+			toast.success("Feature created successfully");
+			setConfirmOpen(false);
+			setOpen(false);
+
+			if (onSuccess && feature.id) {
+				onSuccess(feature.id);
+			}
+		} catch (error: unknown) {
+			console.error("Error creating feature", error);
+			toast.error(
+				getBackendErr(error as AxiosError, "Failed to create feature"),
+			);
+		}
+	};
 
 	const handleCreateFeature = async () => {
 		// Validate credit system specific fields first
@@ -59,23 +83,17 @@ function CreateFeatureSheet({
 			return;
 		}
 
-		try {
-			await updateCatalog({
-				features: [featureToCatalogFeatureParams({ feature })],
-			});
-
-			toast.success("Feature created successfully");
-			setOpen(false);
-
-			if (onSuccess && feature.id) {
-				onSuccess(feature.id);
-			}
-		} catch (error: unknown) {
-			console.error("Error creating feature", error);
-			toast.error(
-				getBackendErr(error as AxiosError, "Failed to create feature"),
-			);
+		if (
+			featureStripeProductChanged({
+				from: null,
+				to: feature.stripe_product_id,
+			})
+		) {
+			setConfirmOpen(true);
+			return;
 		}
+
+		await persistFeature();
 	};
 
 	const handleCancel = () => {
@@ -123,6 +141,13 @@ function CreateFeatureSheet({
 						Create feature
 					</ShortcutButton>
 				</SheetFooter>
+				<FeatureStripeProductConfirmDialog
+					confirmLabel="Create feature"
+					isSaving={isPending}
+					onConfirm={() => void persistFeature()}
+					onOpenChange={setConfirmOpen}
+					open={confirmOpen}
+				/>
 			</SheetContent>
 		</Sheet>
 	);

--- a/vite/src/views/products/features/components/UpdateFeatureSheet.tsx
+++ b/vite/src/views/products/features/components/UpdateFeatureSheet.tsx
@@ -1,7 +1,7 @@
 import { type Feature, isAnyCreditSystem } from "@autumn/shared";
 import { Sheet, SheetContent, ShortcutButton } from "@autumn/ui";
 import type { AxiosError } from "axios";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
 	SheetFooter,
@@ -10,12 +10,14 @@ import {
 import { useUpdateCatalogMutation } from "@/hooks/queries/catalog/useUpdateCatalogMutation";
 import { useFeatureStore } from "@/hooks/stores/useFeatureStore";
 import { getBackendErr } from "@/utils/genUtils";
+import { FeatureStripeProductConfirmDialog } from "../../plan/components/new-feature/FeatureStripeProductConfirmDialog";
 import { NewFeatureAdvanced } from "../../plan/components/new-feature/NewFeatureAdvanced";
 import { NewFeatureBehaviour } from "../../plan/components/new-feature/NewFeatureBehaviour";
 import { NewFeatureDetails } from "../../plan/components/new-feature/NewFeatureDetails";
 import { NewFeatureType } from "../../plan/components/new-feature/NewFeatureType";
 import { validateCreditSystem } from "../credit-systems/utils/validateCreditSystem";
 import { featureToCatalogFeatureParams } from "../utils/buildFeatureMutationParams";
+import { featureStripeProductChanged } from "../utils/featureStripeProductChanged";
 
 interface UpdateFeatureSheetProps {
 	open: boolean;
@@ -35,6 +37,7 @@ function UpdateFeatureSheet({
 	const setBaseFeature = useFeatureStore((s) => s.setBaseFeature);
 
 	const { mutateAsync: updateCatalog, isPending } = useUpdateCatalogMutation();
+	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	// Initialize feature store when selectedFeature changes
 	useEffect(() => {
@@ -44,15 +47,8 @@ function UpdateFeatureSheet({
 		}
 	}, [open, selectedFeature, setFeature, setBaseFeature]);
 
-	const handleUpdateFeature = async () => {
+	const persistFeature = async () => {
 		if (!selectedFeature) return;
-		if (isAnyCreditSystem(feature.type)) {
-			const validationError = validateCreditSystem(feature);
-			if (validationError) {
-				toast.error(validationError);
-				return;
-			}
-		}
 
 		try {
 			await updateCatalog({
@@ -61,6 +57,7 @@ function UpdateFeatureSheet({
 						feature,
 						featureId: selectedFeature.id,
 						newFeatureId: feature.id,
+						originalStripeProductId: selectedFeature.stripe_product_id,
 					}),
 				],
 			});
@@ -72,6 +69,7 @@ function UpdateFeatureSheet({
 				onSuccess(selectedFeature.id, feature.id);
 			}
 
+			setConfirmOpen(false);
 			setOpen(false);
 		} catch (error: unknown) {
 			console.log(error);
@@ -79,6 +77,29 @@ function UpdateFeatureSheet({
 				getBackendErr(error as AxiosError, "Failed to update feature"),
 			);
 		}
+	};
+
+	const handleUpdateFeature = async () => {
+		if (!selectedFeature) return;
+		if (isAnyCreditSystem(feature.type)) {
+			const validationError = validateCreditSystem(feature);
+			if (validationError) {
+				toast.error(validationError);
+				return;
+			}
+		}
+
+		if (
+			featureStripeProductChanged({
+				from: selectedFeature.stripe_product_id,
+				to: feature.stripe_product_id,
+			})
+		) {
+			setConfirmOpen(true);
+			return;
+		}
+
+		await persistFeature();
 	};
 
 	const handleCancel = () => {
@@ -118,6 +139,13 @@ function UpdateFeatureSheet({
 						Update feature
 					</ShortcutButton>
 				</SheetFooter>
+				<FeatureStripeProductConfirmDialog
+					confirmLabel="Update feature"
+					isSaving={isPending}
+					onConfirm={() => void persistFeature()}
+					onOpenChange={setConfirmOpen}
+					open={confirmOpen}
+				/>
 			</SheetContent>
 		</Sheet>
 	);

--- a/vite/src/views/products/features/credit-systems/components/UpdateCreditSystemSheet.tsx
+++ b/vite/src/views/products/features/credit-systems/components/UpdateCreditSystemSheet.tsx
@@ -2,6 +2,7 @@ import type { Feature } from "@autumn/shared";
 import { Sheet, SheetContent, ShortcutButton } from "@autumn/ui";
 import { useStore } from "@tanstack/react-form";
 import type { AxiosError } from "axios";
+import { useState } from "react";
 import { toast } from "sonner";
 import {
 	SheetFooter,
@@ -9,7 +10,10 @@ import {
 } from "@/components/v2/sheets/SharedSheetComponents";
 import { useUpdateCatalogMutation } from "@/hooks/queries/catalog/useUpdateCatalogMutation";
 import { getBackendErr } from "@/utils/genUtils";
+import { FeatureStripeProductConfirmDialog } from "../../../plan/components/new-feature/FeatureStripeProductConfirmDialog";
+import { NewFeatureAdvanced } from "../../../plan/components/new-feature/NewFeatureAdvanced";
 import { featureToCatalogFeatureParams } from "../../utils/buildFeatureMutationParams";
+import { featureStripeProductChanged } from "../../utils/featureStripeProductChanged";
 import { useCreditSystemForm } from "../hooks/useCreditSystemForm";
 import { validateCreditSystem } from "../utils/validateCreditSystem";
 import { CreditSystemDetails } from "./CreditSystemDetails";
@@ -29,6 +33,7 @@ function UpdateCreditSystemSheet({
 	onSuccess,
 }: UpdateCreditSystemSheetProps) {
 	const { mutateAsync: updateCatalog } = useUpdateCatalogMutation();
+	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	const form = useCreditSystemForm({
 		feature: open ? selectedCreditSystem : null,
@@ -64,9 +69,11 @@ function UpdateCreditSystemSheet({
 							},
 							event_names: values.event_names,
 							model_markups: values.model_markups,
+							stripe_product_id: values.stripe_product_id,
 						},
 						featureId: selectedCreditSystem.id,
 						newFeatureId: values.id,
+						originalStripeProductId: selectedCreditSystem.stripe_product_id,
 					}),
 				],
 			});
@@ -76,11 +83,13 @@ function UpdateCreditSystemSheet({
 				selectedCreditSystem.id,
 				values.id || selectedCreditSystem.id,
 			);
+			setConfirmOpen(false);
 			setOpen(false);
 		},
 	});
 
 	const isSubmitting = useStore(form.store, (s) => s.isSubmitting);
+	const values = useStore(form.store, (s) => s.values);
 
 	return (
 		<Sheet open={open} onOpenChange={setOpen}>
@@ -96,6 +105,22 @@ function UpdateCreditSystemSheet({
 				<div className="flex-1 overflow-y-auto">
 					<CreditSystemDetails form={form} />
 					<CreditSystemSchema form={form} disableModeSwitch />
+					<NewFeatureAdvanced
+						feature={{
+							id: values.id,
+							name: values.name,
+							type: values.type,
+							config: values.config,
+							event_names: values.event_names,
+							stripe_product_id: values.stripe_product_id,
+						}}
+						setFeature={(next) =>
+							form.setFieldValue(
+								"stripe_product_id",
+								next.stripe_product_id ?? null,
+							)
+						}
+					/>
 				</div>
 
 				<SheetFooter>
@@ -109,19 +134,42 @@ function UpdateCreditSystemSheet({
 					</ShortcutButton>
 					<ShortcutButton
 						className="w-full"
-						onClick={() =>
+						onClick={() => {
+							if (
+								featureStripeProductChanged({
+									from: selectedCreditSystem?.stripe_product_id,
+									to: values.stripe_product_id,
+								})
+							) {
+								setConfirmOpen(true);
+								return;
+							}
+
 							form.handleSubmit().catch((err: AxiosError) => {
 								toast.error(
 									getBackendErr(err, "Failed to update credit system"),
 								);
-							})
-						}
+							});
+						}}
 						metaShortcut="enter"
 						isLoading={isSubmitting}
 					>
 						Update credit system
 					</ShortcutButton>
 				</SheetFooter>
+				<FeatureStripeProductConfirmDialog
+					confirmLabel="Update credit system"
+					isSaving={isSubmitting}
+					onConfirm={() =>
+						form.handleSubmit().catch((err: AxiosError) => {
+							toast.error(
+								getBackendErr(err, "Failed to update credit system"),
+							);
+						})
+					}
+					onOpenChange={setConfirmOpen}
+					open={confirmOpen}
+				/>
 			</SheetContent>
 		</Sheet>
 	);

--- a/vite/src/views/products/features/credit-systems/hooks/useCreditSystemForm.ts
+++ b/vite/src/views/products/features/credit-systems/hooks/useCreditSystemForm.ts
@@ -16,6 +16,7 @@ export interface CreditSystemFormValues {
 	defaultMarkup: number;
 	/** Per-provider default markups (persisted to config.provider_markups). */
 	provider_markups: Record<string, { markup: number }>;
+	stripe_product_id: string | null;
 }
 
 export function useCreditSystemForm({
@@ -43,6 +44,7 @@ export function useCreditSystemForm({
 				(feature?.config
 					?.provider_markups as CreditSystemFormValues["provider_markups"]) ??
 				{},
+			stripe_product_id: feature?.stripe_product_id ?? null,
 		} satisfies CreditSystemFormValues,
 		onSubmit: onSubmit ? ({ value }) => onSubmit(value) : undefined,
 	});

--- a/vite/src/views/products/features/utils/build-feature-mutation-params.test.ts
+++ b/vite/src/views/products/features/utils/build-feature-mutation-params.test.ts
@@ -90,4 +90,37 @@ test("catalog feature params include invoice-credit configuration", () => {
 			credit_cost: 1,
 		},
 	]);
+	expect(result.processors).toBeUndefined();
+});
+
+const creditFeature = {
+	id: "credits",
+	name: "Credits",
+	type: FeatureType.CreditSystem,
+	config: { usage_type: FeatureUsageType.Single, schema: [] },
+	event_names: [],
+};
+
+test("omits processors when the stripe product is unchanged", () => {
+	const result = featureToCatalogFeatureParams({
+		feature: { ...creditFeature, stripe_product_id: "prod_1" },
+		originalStripeProductId: "prod_1",
+	});
+
+	expect(result.processors).toBeUndefined();
+});
+
+test("sends processors when a stripe product is set or cleared", () => {
+	expect(
+		featureToCatalogFeatureParams({
+			feature: { ...creditFeature, stripe_product_id: "prod_1" },
+		}).processors,
+	).toEqual({ stripe: { product_id: "prod_1" } });
+
+	expect(
+		featureToCatalogFeatureParams({
+			feature: { ...creditFeature, stripe_product_id: null },
+			originalStripeProductId: "prod_1",
+		}).processors,
+	).toEqual({ stripe: { product_id: "" } });
 });

--- a/vite/src/views/products/features/utils/buildFeatureMutationParams.ts
+++ b/vite/src/views/products/features/utils/buildFeatureMutationParams.ts
@@ -10,6 +10,10 @@ import {
 	type UpdateCatalogFeatureParams,
 } from "@autumn/shared";
 import { creditSchemaToApi } from "../credit-systems/utils/creditSchemaUtils";
+import {
+	featureStripeProductChanged,
+	normalizeFeatureStripeProductId,
+} from "./featureStripeProductChanged";
 
 interface BuildFeatureMarkupParamsArgs {
 	type: FeatureType;
@@ -57,18 +61,30 @@ export const featureToCatalogFeatureParams = ({
 	featureId = feature.id,
 	newFeatureId,
 	archived,
+	originalStripeProductId,
 }: {
 	feature: Pick<Feature, "id" | "name" | "type" | "config" | "event_names"> & {
 		model_markups?: Feature["model_markups"];
+		stripe_product_id?: string | null;
 	};
 	featureId?: string;
 	newFeatureId?: string;
 	archived?: boolean;
+	originalStripeProductId?: string | null;
 }): UpdateCatalogFeatureParams => {
 	const renamed =
 		newFeatureId !== undefined && newFeatureId !== featureId
 			? newFeatureId
 			: undefined;
+	const nextProductId = normalizeFeatureStripeProductId(
+		feature.stripe_product_id,
+	);
+	const processors = featureStripeProductChanged({
+		from: originalStripeProductId,
+		to: nextProductId,
+	})
+		? { stripe: { product_id: nextProductId ?? "" } }
+		: undefined;
 
 	return {
 		feature_id: featureId,
@@ -86,5 +102,6 @@ export const featureToCatalogFeatureParams = ({
 			invoiceCredit: feature.config?.invoice_credit,
 		}),
 		...(archived !== undefined ? { archived } : {}),
+		...(processors ? { processors } : {}),
 	};
 };

--- a/vite/src/views/products/features/utils/featureStripeProductChanged.ts
+++ b/vite/src/views/products/features/utils/featureStripeProductChanged.ts
@@ -1,0 +1,13 @@
+export const normalizeFeatureStripeProductId = (
+	stripeProductId?: string | null,
+) => stripeProductId?.trim() || null;
+
+export const featureStripeProductChanged = ({
+	from,
+	to,
+}: {
+	from?: string | null;
+	to?: string | null;
+}) =>
+	normalizeFeatureStripeProductId(from) !==
+	normalizeFeatureStripeProductId(to);

--- a/vite/src/views/products/plan/components/new-feature/FeatureStripeProductConfirmDialog.tsx
+++ b/vite/src/views/products/plan/components/new-feature/FeatureStripeProductConfirmDialog.tsx
@@ -1,0 +1,61 @@
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	ShortcutButton,
+} from "@autumn/ui";
+import { InfoBox } from "@/views/onboarding2/integrate/components/InfoBox";
+
+export function FeatureStripeProductConfirmDialog({
+	open,
+	isSaving,
+	confirmLabel,
+	onOpenChange,
+	onConfirm,
+}: {
+	open: boolean;
+	isSaving: boolean;
+	confirmLabel: string;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+}) {
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Save Stripe product?</DialogTitle>
+					<DialogDescription>
+						Confirm this Stripe product before Autumn updates the feature.
+					</DialogDescription>
+				</DialogHeader>
+
+				<InfoBox variant="warning">
+					Existing customers' Stripe state is unchanged; this Stripe product is
+					used for new usage prices going forward.
+				</InfoBox>
+
+				<DialogFooter>
+					<ShortcutButton
+						disabled={isSaving}
+						onClick={() => onOpenChange(false)}
+						singleShortcut="escape"
+						variant="secondary"
+					>
+						Cancel
+					</ShortcutButton>
+					<ShortcutButton
+						disabled={isSaving}
+						isLoading={isSaving}
+						metaShortcut="enter"
+						onClick={onConfirm}
+					>
+						{confirmLabel}
+					</ShortcutButton>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/vite/src/views/products/plan/components/new-feature/FeatureStripeProductField.tsx
+++ b/vite/src/views/products/plan/components/new-feature/FeatureStripeProductField.tsx
@@ -1,0 +1,59 @@
+import { FormLabel, IconTooltipButton } from "@autumn/ui";
+import { StripeIcon } from "@/components/v2/icons/AutumnIcons";
+import { useStripeProductsResolveQuery } from "@/hooks/queries/useStripeProductsResolveQuery";
+import { StripeProductSelect } from "@/views/developer/configure-stripe/mappings/StripeProductSelect";
+import { useStripeProductLink } from "@/views/developer/configure-stripe/mappings/useStripeProductLink";
+import { useStripeProductSearch } from "@/views/developer/configure-stripe/mappings/useStripeProductSearch";
+
+export function FeatureStripeProductField({
+	stripeProductId,
+	onChange,
+}: {
+	stripeProductId: string | null;
+	onChange: (stripeProductId: string | null) => void;
+}) {
+	const { stripeProducts } = useStripeProductsResolveQuery({
+		stripeProductIds: stripeProductId ? [stripeProductId] : [],
+	});
+	const { setSearch, knownStripeProducts, selectStripeProducts, isSearching } =
+		useStripeProductSearch({
+			knownProducts: stripeProducts,
+			enabled: true,
+		});
+	const getStripeProductHref = useStripeProductLink();
+
+	return (
+		<div className="flex flex-col w-full gap-1">
+			<FormLabel>Stripe Product (optional)</FormLabel>
+			<div className="flex items-center gap-2">
+				<div className="min-w-0 flex-1">
+					<StripeProductSelect
+						isLoading={isSearching}
+						knownProducts={knownStripeProducts}
+						onChange={onChange}
+						onSearchChange={setSearch}
+						products={selectStripeProducts}
+						value={stripeProductId}
+					/>
+				</div>
+				{stripeProductId && (
+					<IconTooltipButton
+						icon={<StripeIcon size={14} />}
+						onClick={() =>
+							window.open(
+								getStripeProductHref(stripeProductId),
+								"_blank",
+								"noopener,noreferrer",
+							)
+						}
+						tooltip="Open in Stripe"
+					/>
+				)}
+			</div>
+			<span className="text-tiny text-tertiary-foreground">
+				Usage prices for this feature bill under this Stripe product. Leave
+				empty to let Autumn create one.
+			</span>
+		</div>
+	);
+}

--- a/vite/src/views/products/plan/components/new-feature/NewFeatureAdvanced.tsx
+++ b/vite/src/views/products/plan/components/new-feature/NewFeatureAdvanced.tsx
@@ -5,6 +5,7 @@ import {
 	SheetAccordionItem,
 	TagInput,
 } from "@autumn/ui";
+import { FeatureStripeProductField } from "./FeatureStripeProductField";
 
 export function NewFeatureAdvanced({
 	feature,
@@ -13,19 +14,18 @@ export function NewFeatureAdvanced({
 	feature: CreateFeature;
 	setFeature: (feature: CreateFeature) => void;
 }) {
-	const showAdvanced =
-		feature.type &&
-		feature.config?.usage_type &&
-		feature.type !== FeatureType.Boolean &&
-		feature.type !== FeatureType.CreditSystem;
+	const showEventNames =
+		feature.type === FeatureType.Metered && Boolean(feature.config?.usage_type);
+	const showStripeProduct =
+		Boolean(feature.type) && feature.type !== FeatureType.Boolean;
 
-	if (!showAdvanced) return null;
+	if (!showEventNames && !showStripeProduct) return null;
 
 	return (
 		<SheetAccordion type="single" withSeparator={false} collapsible={true}>
 			<SheetAccordionItem value="advanced" title="Advanced">
 				<div className="space-y-4">
-					<div className="space-y-4">
+					{showEventNames && (
 						<div className="flex flex-col w-full gap-1">
 							<FormLabel>Event Names (optional)</FormLabel>
 							<TagInput
@@ -51,7 +51,18 @@ export function NewFeatureAdvanced({
 								</a>
 							</span>
 						</div>
-					</div>
+					)}
+					{showStripeProduct && (
+						<FeatureStripeProductField
+							onChange={(stripeProductId) =>
+								setFeature({
+									...feature,
+									stripe_product_id: stripeProductId,
+								})
+							}
+							stripeProductId={feature.stripe_product_id ?? null}
+						/>
+					)}
 				</div>
 			</SheetAccordionItem>
 		</SheetAccordion>

--- a/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
+++ b/vite/src/views/products/plan/components/new-feature/NewFeatureSheet.tsx
@@ -4,6 +4,7 @@ import {
 	featureV1ToDbFeature,
 } from "@autumn/shared";
 import type { AxiosError } from "axios";
+import { useState } from "react";
 import { toast } from "sonner";
 import {
 	useProduct,
@@ -17,8 +18,10 @@ import { getBackendErr } from "@/utils/genUtils";
 import { getItemId } from "@/utils/product/productItemUtils";
 import { validateCreditSystem } from "@/views/products/features/credit-systems/utils/validateCreditSystem";
 import { featureToCatalogFeatureParams } from "@/views/products/features/utils/buildFeatureMutationParams";
+import { featureStripeProductChanged } from "@/views/products/features/utils/featureStripeProductChanged";
 import { useSaveRestoreFeature } from "../../hooks/useSaveRestoreFeature";
 import { getDefaultItem } from "../../utils/getDefaultItem";
+import { FeatureStripeProductConfirmDialog } from "./FeatureStripeProductConfirmDialog";
 import { NewFeatureAdvanced } from "./NewFeatureAdvanced";
 import { NewFeatureBehaviour } from "./NewFeatureBehaviour";
 import { NewFeatureDetails } from "./NewFeatureDetails";
@@ -33,28 +36,11 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 	const { product, setProduct } = useProduct();
 	const { setSheet } = useSheet();
 	const { mutateAsync: updateCatalog, isPending } = useUpdateCatalogMutation();
+	const [confirmOpen, setConfirmOpen] = useState(false);
 
 	const isDirty = !!feature.name || !!feature.id || feature.type !== null;
 
-	const handleCreateFeature = async () => {
-		if (feature.type === FeatureType.CreditSystem) {
-			const validationError = validateCreditSystem(feature);
-			if (validationError) {
-				toast.error(validationError);
-				return;
-			}
-		}
-
-		const result = CreateFeatureSchema.safeParse(feature);
-		if (result.error) {
-			toast.error("Invalid feature", {
-				description: result.error.issues
-					.map((issue) => issue.message)
-					.join(".\n"),
-			});
-			return;
-		}
-
+	const persistFeature = async () => {
 		try {
 			const response = await updateCatalog({
 				features: [featureToCatalogFeatureParams({ feature })],
@@ -77,6 +63,7 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 			const itemIndex = newItems.length - 1;
 			const itemId = getItemId({ item: newItem, itemIndex });
 
+			setConfirmOpen(false);
 			setTimeout(() => {
 				setSheet({ type: "edit-feature", itemId });
 			}, 0);
@@ -85,6 +72,38 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 				getBackendErr(error as AxiosError, "Failed to create feature"),
 			);
 		}
+	};
+
+	const handleCreateFeature = async () => {
+		if (feature.type === FeatureType.CreditSystem) {
+			const validationError = validateCreditSystem(feature);
+			if (validationError) {
+				toast.error(validationError);
+				return;
+			}
+		}
+
+		const result = CreateFeatureSchema.safeParse(feature);
+		if (result.error) {
+			toast.error("Invalid feature", {
+				description: result.error.issues
+					.map((issue) => issue.message)
+					.join(".\n"),
+			});
+			return;
+		}
+
+		if (
+			featureStripeProductChanged({
+				from: null,
+				to: feature.stripe_product_id,
+			})
+		) {
+			setConfirmOpen(true);
+			return;
+		}
+
+		await persistFeature();
 	};
 
 	const handleClose = () => {
@@ -122,6 +141,14 @@ export function NewFeatureSheet({ isOnboarding }: { isOnboarding?: boolean }) {
 				confirmLabel="Create"
 				closeLabel="Cancel"
 				isLoading={isPending}
+			/>
+
+			<FeatureStripeProductConfirmDialog
+				confirmLabel="Create"
+				isSaving={isPending}
+				onConfirm={() => void persistFeature()}
+				onOpenChange={setConfirmOpen}
+				open={confirmOpen}
 			/>
 		</div>
 	);


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses matching usage and prepaid Stripe Prices across customers on the same plan. Previously only fixed prices were reused; usage and prepaid prices were minted per customer.

- Adds newest-reusable finders for usage (consumable + allocated v2) and recurring prepaid Stripe Prices; candidates rank catalog-first, then newest.
- Custom customers can reuse catalog Stripe Prices, but catalog customers cannot borrow custom ones.
- Prepaid reuse stamps `stripe_prepaid_price_v2_id`, leaves the V1 slot untouched, and retrieves V2 prices with `tiers` expanded; one-off prepaid and allocated v1 are excluded.
- Validates candidates against the target's Stripe shape, product, and live status; reused usage prices also copy the donor's meter and feature product so usage billing keeps working.
- Hashes the mint shape into the Stripe idempotency key so changing an amount or tier mints a fresh Stripe Price instead of being rejected.
- Adds a dashboard confirm dialog for setting a feature's Stripe product, plus integration and unit tests for shared reuse, diverging prices, custom/catalog scoping, empty-slot detection, and Stripe shape matching.

<sup>Written for commit 29f54338601f74689fcec034268d4f239ca8d2e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR expands Stripe Price reuse to matching usage and recurring prepaid prices across customers on the same plan, with shape validation and resource propagation.

- **[Improvements]** Adds reusable-candidate discovery and Stripe-shape matching for consumable, allocated-v2, and recurring prepaid prices.
- **[Bug fixes]** Copies the reused consumable Price’s meter and event metadata so usage billing retains its Stripe linkage.
- **[Improvements]** Adds custom-versus-catalog scoping, currency-aware slot handling, diagnostics, and broader integration and unit coverage.
- **[API changes, Improvements]** Updates Stripe Price retrieval to optionally request expanded fields and makes idempotency keys depend on the normalized price shape.
</details>


<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because valid reusable prices can still be missed after candidate truncation, and a candidate from the wrong Stripe product can still be attached.

The current usage and prepaid finders limit coarse candidates before exact comparison, so an older exact match can be missed and duplicated; product validation also treats the candidate’s own Stripe product as the expected target product, allowing a mismatched Price to pass validation.

**Files Needing Attention:** server/src/internal/products/prices/repos/findNewestReusableUsagePrice.ts, server/src/internal/products/prices/repos/findNewestReusablePrepaidPrice.ts, server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/internal/products/prices/repos/findNewestReusableUsagePrice.ts | Adds usage-price candidate reuse, but exact matching still occurs after a hard 1,000-row truncation. |
| server/src/internal/products/prices/repos/findNewestReusablePrepaidPrice.ts | Adds recurring prepaid-price reuse with the same outstanding candidate-truncation behavior. |
| server/src/internal/products/stripeResourceUtils/findReusableStripeResources/isUsableStripePrice.ts | Extends live Stripe shape validation, but usage and prepaid validation still derives the expected product from the candidate. |
| server/src/internal/products/stripeResourceUtils/findReusableStripeResources/copyReusableUsageMeter.ts | Copies missing meter and event metadata between matching consumable prices, addressing the previously missing linkage. |
| server/src/internal/products/stripeResourceUtils/findReusableStripeResources/findReusableStripePrice.ts | Coordinates fixed, usage, and prepaid candidate lookup, validation, logging, and target-slot stamping. |
| server/src/external/stripe/prices/utils/buildIdempotencyKey.ts | Adds a normalized price-shape hash to Stripe Price idempotency keys so materially changed configurations can mint new prices. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Target Autumn price] --> B{Reusable kind?}
  B -->|Fixed| C[Find matching fixed candidate]
  B -->|Usage| D[Find matching usage candidate]
  B -->|Recurring prepaid| E[Find matching prepaid candidate]
  C --> F[Retrieve and validate Stripe Price]
  D --> F
  E --> F
  F -->|Valid| G[Copy currency-specific Stripe Price ID]
  G --> H[Copy Stripe product metadata]
  H --> I{Consumable usage?}
  I -->|Yes| J[Copy meter and event metadata]
  I -->|No| K[Persist target configuration]
  J --> K
  F -->|No match| L[Continue normal Stripe Price creation]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Pin bun dw off a fresh install, and poin..."](https://github.com/useautumn/autumn/commit/29f54338601f74689fcec034268d4f239ca8d2e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57535588)</sub>

**Context used:**

- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)

<!-- /greptile_comment -->