### PR TITLE
perf(logging): compact additional high-volume responses

### DIFF
--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -122,10 +122,12 @@ export const logRequestResult = async ({
 
 		const excludeResponseBody =
 			isSuccess && RESPONSE_BODY_EXCLUDED_ROUTES.has(c.req.path);
+		const isFastHighVolumeSuccess =
+			isHighVolumeSuccess && durationMs < SLOW_REQUEST_BODY_THRESHOLD_MS;
+		const keepFullSampledResponseBody =
+			isFastHighVolumeSuccess && shouldSampleSuccessResponseBody();
 		const compactResponseBody =
-			isHighVolumeSuccess &&
-			durationMs < SLOW_REQUEST_BODY_THRESHOLD_MS &&
-			!shouldSampleSuccessResponseBody();
+			isFastHighVolumeSuccess && !keepFullSampledResponseBody;
 
 		let originalResponseBodyBytes: number | undefined;
 		let responseBodyWasCompacted = false;
@@ -162,7 +164,10 @@ export const logRequestResult = async ({
 					originalResponseBodyBytes > MAX_LOGGED_RESPONSE_BODY_BYTES)
 					? Buffer.byteLength(JSON.stringify(finalResponseBody))
 					: originalResponseBodyBytes;
-			if (loggedResponseBodyBytes > MAX_LOGGED_RESPONSE_BODY_BYTES) {
+			if (
+				!keepFullSampledResponseBody &&
+				loggedResponseBodyBytes > MAX_LOGGED_RESPONSE_BODY_BYTES
+			) {
 				finalResponseBody = {
 					truncated: true,
 					original_bytes: originalResponseBodyBytes ?? loggedResponseBodyBytes,

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import type { Context } from "hono";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { isAxiomResponseBodyReductionEnabled } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { addExtrasToLogs } from "@/utils/logging/addContextToLogs.js";
 import { maskExtraLogs } from "@/utils/logging/maskExtraLogs.js";
 
@@ -114,8 +115,11 @@ export const logRequestResult = async ({
 		}
 
 		const isSuccess = statusCode >= 200 && statusCode < 300;
+		const reduceResponseBodyIngest = isAxiomResponseBodyReductionEnabled();
 		const isHighVolumeSuccess =
-			isSuccess && HIGH_VOLUME_SUCCESS_ROUTES.has(c.req.path);
+			reduceResponseBodyIngest &&
+			isSuccess &&
+			HIGH_VOLUME_SUCCESS_ROUTES.has(c.req.path);
 
 		ctx.logger = addExtrasToLogs({
 			logger: ctx.logger,
@@ -170,6 +174,7 @@ export const logRequestResult = async ({
 					? Buffer.byteLength(JSON.stringify(finalResponseBody))
 					: originalResponseBodyBytes;
 			if (
+				reduceResponseBodyIngest &&
 				!keepFullSampledResponseBody &&
 				loggedResponseBodyBytes > MAX_LOGGED_RESPONSE_BODY_BYTES
 			) {

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -19,6 +19,8 @@ const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
 const SLOW_REQUEST_BODY_THRESHOLD_MS = 500;
 const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = 0.01;
 const MAX_LOGGED_RESPONSE_BODY_BYTES = 32 * 1024;
+const MAX_LOGGED_RESPONSE_BODY_KEYS = 50;
+const MAX_LOGGED_RESPONSE_BODY_KEY_LENGTH = 128;
 
 const LIST_RESPONSE_ROUTES = new Set<string>([
 	"/v1/events.aggregate",
@@ -148,6 +150,9 @@ export const logRequestResult = async ({
 				}
 			}
 		}
+		const originalTopLevelKeys = isRecord(finalResponseBody)
+			? Object.keys(finalResponseBody)
+			: undefined;
 
 		if (compactResponseBody && isRecord(finalResponseBody)) {
 			finalResponseBody = compactHighVolumeResponseBody({
@@ -157,7 +162,7 @@ export const logRequestResult = async ({
 			responseBodyWasCompacted = true;
 		}
 
-		if (isRecord(finalResponseBody)) {
+		if (finalResponseBody !== null && finalResponseBody !== undefined) {
 			const loggedResponseBodyBytes =
 				originalResponseBodyBytes === undefined ||
 				(responseBodyWasCompacted &&
@@ -168,11 +173,29 @@ export const logRequestResult = async ({
 				!keepFullSampledResponseBody &&
 				loggedResponseBodyBytes > MAX_LOGGED_RESPONSE_BODY_BYTES
 			) {
-				finalResponseBody = {
+				const truncatedResponseBody = {
 					truncated: true,
 					original_bytes: originalResponseBodyBytes ?? loggedResponseBodyBytes,
-					top_level_keys: Object.keys(finalResponseBody),
+					...(originalTopLevelKeys
+						? {
+								top_level_keys: originalTopLevelKeys
+									.slice(0, MAX_LOGGED_RESPONSE_BODY_KEYS)
+									.map((key) =>
+										key.slice(0, MAX_LOGGED_RESPONSE_BODY_KEY_LENGTH),
+									),
+								top_level_key_count: originalTopLevelKeys.length,
+							}
+						: {}),
 				};
+				finalResponseBody =
+					Buffer.byteLength(JSON.stringify(truncatedResponseBody)) <=
+					MAX_LOGGED_RESPONSE_BODY_BYTES
+						? truncatedResponseBody
+						: {
+								truncated: true,
+								original_bytes:
+									originalResponseBodyBytes ?? loggedResponseBodyBytes,
+							};
 			}
 		}
 

--- a/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
+++ b/server/src/honoMiddlewares/requestLogging/logRequestResult.ts
@@ -9,10 +9,21 @@ const HIGH_VOLUME_SUCCESS_ROUTES = new Set<string>([
 	"/v1/balances.check",
 	"/v1/check",
 	"/v1/track",
+	"/v1/entities.get",
+	"/v1/customers.get",
+	"/v1/customers.get_or_create",
+	"/v1/events.aggregate",
+	"/v1/plans.list",
 ]);
 
 const SLOW_REQUEST_BODY_THRESHOLD_MS = 500;
 const SUCCESS_RESPONSE_BODY_SAMPLE_RATE = 0.01;
+const MAX_LOGGED_RESPONSE_BODY_BYTES = 32 * 1024;
+
+const LIST_RESPONSE_ROUTES = new Set<string>([
+	"/v1/events.aggregate",
+	"/v1/plans.list",
+]);
 
 // Event pages run to megabytes each, dwarfing every other route's ingest.
 const RESPONSE_BODY_EXCLUDED_ROUTES = new Set<string>([
@@ -35,9 +46,13 @@ const stripLargeFields = (value: unknown) => {
 	return compactValue;
 };
 
-const compactHighVolumeResponseBody = (
-	responseBody: Record<string, unknown>,
-) => {
+const compactHighVolumeResponseBody = ({
+	path,
+	responseBody,
+}: {
+	path: string;
+	responseBody: Record<string, unknown>;
+}) => {
 	const compactResponseBody = { ...responseBody };
 	delete compactResponseBody.preview;
 	if ("balance" in compactResponseBody) {
@@ -53,6 +68,25 @@ const compactHighVolumeResponseBody = (
 	}
 	if ("flag" in compactResponseBody) {
 		compactResponseBody.flag = stripLargeFields(responseBody.flag);
+	}
+	if (Array.isArray(responseBody.subscriptions)) {
+		compactResponseBody.subscriptions_count = responseBody.subscriptions.length;
+		delete compactResponseBody.subscriptions;
+	}
+	if (Array.isArray(responseBody.purchases)) {
+		compactResponseBody.purchases_count = responseBody.purchases.length;
+		delete compactResponseBody.purchases;
+	}
+	if (LIST_RESPONSE_ROUTES.has(path) && Array.isArray(responseBody.list)) {
+		compactResponseBody.list_count = responseBody.list.length;
+		delete compactResponseBody.list;
+	}
+	if (
+		path === "/v1/events.aggregate" &&
+		Array.isArray(responseBody.deductions)
+	) {
+		compactResponseBody.deductions_count = responseBody.deductions.length;
+		delete compactResponseBody.deductions;
 	}
 	return compactResponseBody;
 };
@@ -93,6 +127,8 @@ export const logRequestResult = async ({
 			durationMs < SLOW_REQUEST_BODY_THRESHOLD_MS &&
 			!shouldSampleSuccessResponseBody();
 
+		let originalResponseBodyBytes: number | undefined;
+		let responseBodyWasCompacted = false;
 		let finalResponseBody = excludeResponseBody ? null : responseBody;
 		if (
 			!excludeResponseBody &&
@@ -102,7 +138,9 @@ export const logRequestResult = async ({
 			const contentType = c.res.headers.get("content-type");
 			if (contentType?.includes("application/json")) {
 				try {
-					finalResponseBody = await c.res.clone().json();
+					const responseText = await c.res.clone().text();
+					originalResponseBodyBytes = Buffer.byteLength(responseText);
+					finalResponseBody = JSON.parse(responseText);
 				} catch (_error) {
 					finalResponseBody = null;
 				}
@@ -110,7 +148,27 @@ export const logRequestResult = async ({
 		}
 
 		if (compactResponseBody && isRecord(finalResponseBody)) {
-			finalResponseBody = compactHighVolumeResponseBody(finalResponseBody);
+			finalResponseBody = compactHighVolumeResponseBody({
+				path: c.req.path,
+				responseBody: finalResponseBody,
+			});
+			responseBodyWasCompacted = true;
+		}
+
+		if (isRecord(finalResponseBody)) {
+			const loggedResponseBodyBytes =
+				originalResponseBodyBytes === undefined ||
+				(responseBodyWasCompacted &&
+					originalResponseBodyBytes > MAX_LOGGED_RESPONSE_BODY_BYTES)
+					? Buffer.byteLength(JSON.stringify(finalResponseBody))
+					: originalResponseBodyBytes;
+			if (loggedResponseBodyBytes > MAX_LOGGED_RESPONSE_BODY_BYTES) {
+				finalResponseBody = {
+					truncated: true,
+					original_bytes: originalResponseBodyBytes ?? loggedResponseBodyBytes,
+					top_level_keys: Object.keys(finalResponseBody),
+				};
+			}
 		}
 
 		const log = isSuccess ? ctx.logger.info : ctx.logger.warn;

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts
@@ -23,6 +23,8 @@ export const MiscellaneousEdgeConfigSchema = z.object({
 	/** Kill switch for the MotherDuck balance-cache refresh cron. Refresh runs
 	 *  by default wherever the RW token exists; flip this to stop it. */
 	disableMotherduckCacheRefresh: z.boolean().default(false),
+	/** Global switch for Axiom response-body compaction and size caps. */
+	axiomResponseBodyReduction: z.boolean().default(true),
 });
 
 export type MiscellaneousEdgeConfig = z.infer<

--- a/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
+++ b/server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts
@@ -74,3 +74,7 @@ export const isSubjectReadSingleflightEnabled = (): boolean =>
 /** Kill switch for the MotherDuck balance-cache refresh cron. */
 export const isMotherduckCacheRefreshDisabled = (): boolean =>
 	store.get().disableMotherduckCacheRefresh;
+
+/** Global gate for Axiom response-body compaction and size caps. */
+export const isAxiomResponseBodyReductionEnabled = (): boolean =>
+	store.get().axiomResponseBodyReduction;

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -419,13 +419,12 @@ describe("logRequestResult", () => {
 	});
 
 	test("summarizes any response body larger than the logging cap", async () => {
-		spyOn(Math, "random").mockReturnValue(0);
 		const responseBody = {
 			id: "cus_123",
 			payload: "x".repeat(32 * 1024),
 		};
 		const { captured } = await captureJsonResponse({
-			path: "/v1/balances.check",
+			path: "/v1/customers.list",
 			durationMs: 10,
 			responseBody,
 		});
@@ -438,6 +437,25 @@ describe("logRequestResult", () => {
 				original_bytes: Buffer.byteLength(JSON.stringify(responseBody)),
 				top_level_keys: ["id", "payload"],
 			},
+		});
+	});
+
+	test("keeps the one-percent sampled response in full above the logging cap", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const responseBody = {
+			allowed: true,
+			payload: "x".repeat(32 * 1024),
+		};
+		const { captured } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: responseBody,
 		});
 	});
 

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -54,7 +54,7 @@ const captureJsonResponse = async ({
 }: {
 	path: string;
 	durationMs: number;
-	responseBody: Record<string, unknown>;
+	responseBody: unknown;
 }) => {
 	const captured: CapturedLog[] = [];
 	let cloneCount = 0;
@@ -418,7 +418,7 @@ describe("logRequestResult", () => {
 		});
 	});
 
-	test("summarizes any response body larger than the logging cap", async () => {
+	test("summarizes an object response larger than the logging cap", async () => {
 		const responseBody = {
 			id: "cus_123",
 			payload: "x".repeat(32 * 1024),
@@ -436,6 +436,79 @@ describe("logRequestResult", () => {
 				truncated: true,
 				original_bytes: Buffer.byteLength(JSON.stringify(responseBody)),
 				top_level_keys: ["id", "payload"],
+				top_level_key_count: 2,
+			},
+		});
+	});
+
+	test("summarizes a top-level array larger than the logging cap", async () => {
+		const responseBody = [{ payload: "x".repeat(32 * 1024) }];
+		const { captured } = await captureJsonResponse({
+			path: "/v1/customers.list",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: {
+				truncated: true,
+				original_bytes: Buffer.byteLength(JSON.stringify(responseBody)),
+			},
+		});
+	});
+
+	test("bounds oversized response key diagnostics", async () => {
+		const responseBody = Object.fromEntries(
+			Array.from({ length: 100 }, (_, index) => [
+				`key_${index}_${"x".repeat(160)}`,
+				"value".repeat(100),
+			]),
+		);
+		const { captured } = await captureJsonResponse({
+			path: "/v1/customers.list",
+			durationMs: 10,
+			responseBody,
+		});
+		const loggedResponse = captured[0]?.args[1] as {
+			res: {
+				top_level_keys: string[];
+				top_level_key_count: number;
+			};
+		};
+
+		expect(loggedResponse.res.top_level_keys).toHaveLength(50);
+		expect(loggedResponse.res.top_level_key_count).toBe(100);
+		expect(
+			loggedResponse.res.top_level_keys.every((key) => key.length <= 128),
+		).toBe(true);
+		expect(
+			Buffer.byteLength(JSON.stringify(loggedResponse.res)),
+		).toBeLessThanOrEqual(32 * 1024);
+	});
+
+	test("reports original keys when a compacted response still exceeds the cap", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = {
+			id: "cus_123",
+			subscriptions: [{ id: "sub_123" }],
+			payload: "x".repeat(32 * 1024),
+		};
+		const { captured } = await captureJsonResponse({
+			path: "/v1/customers.get",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: {
+				truncated: true,
+				original_bytes: Buffer.byteLength(JSON.stringify(responseBody)),
+				top_level_keys: ["id", "subscriptions", "payload"],
+				top_level_key_count: 3,
 			},
 		});
 	});

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -3,6 +3,8 @@ import type { Context } from "hono";
 import type { Logger } from "@/external/logtail/logtailUtils.js";
 import { logRequestResult } from "@/honoMiddlewares/requestLogging/logRequestResult.js";
 import type { AutumnContext, HonoEnv } from "@/honoUtils/HonoEnv.js";
+import { MiscellaneousEdgeConfigSchema } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.js";
+import { _setMiscellaneousEdgeConfigForTesting } from "@/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.js";
 import { addRequestToLogs } from "@/utils/logging/addContextToLogs.js";
 import type { LogRequestContext } from "@/utils/logging/loggerTypes.js";
 
@@ -82,6 +84,9 @@ const captureJsonResponse = async ({
 
 afterEach(() => {
 	mock.restore();
+	_setMiscellaneousEdgeConfigForTesting({
+		config: MiscellaneousEdgeConfigSchema.parse({}),
+	});
 });
 
 describe("logRequestResult", () => {
@@ -532,6 +537,34 @@ describe("logRequestResult", () => {
 		});
 	});
 
+	test("keeps full response bodies when Axiom reduction is disabled", async () => {
+		_setMiscellaneousEdgeConfigForTesting({
+			config: MiscellaneousEdgeConfigSchema.parse({
+				axiomResponseBodyReduction: false,
+			}),
+		});
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const responseBody = {
+			allowed: true,
+			balance: {
+				remaining: 90,
+				breakdown: [{ id: "cus_ent_123" }],
+			},
+			payload: "x".repeat(32 * 1024),
+		};
+		const { captured } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: responseBody,
+		});
+	});
+
 	test("keeps a sampled fast high-volume response in full", async () => {
 		spyOn(Math, "random").mockReturnValue(0);
 		const responseBody = { allowed: true, balance: { remaining: 90 } };
@@ -600,7 +633,12 @@ describe("logRequestResult", () => {
 		});
 	});
 
-	test("drops the response body on the legacy events list route", async () => {
+	test("keeps the legacy events list exclusion when reduction is disabled", async () => {
+		_setMiscellaneousEdgeConfigForTesting({
+			config: MiscellaneousEdgeConfigSchema.parse({
+				axiomResponseBodyReduction: false,
+			}),
+		});
 		const captured: CapturedLog[] = [];
 		let cloneCount = 0;
 		const ctx = {

--- a/server/tests/unit/logging/logRequestResult.test.ts
+++ b/server/tests/unit/logging/logRequestResult.test.ts
@@ -71,7 +71,7 @@ const captureJsonResponse = async ({
 			headers: new Headers({ "content-type": "application/json" }),
 			clone: () => {
 				cloneCount++;
-				return { json: async () => responseBody };
+				return { text: async () => JSON.stringify(responseBody) };
 			},
 		},
 	} as unknown as Context<HonoEnv>;
@@ -343,6 +343,104 @@ describe("logRequestResult", () => {
 		});
 	});
 
+	test("compacts additional high-volume response shapes", async () => {
+		spyOn(Math, "random").mockReturnValue(0.5);
+		const subjectResponseBody = {
+			id: "cus_123",
+			name: "Acme",
+			balances: {
+				messages: {
+					remaining: 90,
+					breakdown: [
+						{
+							id: "cus_ent_123",
+							remaining: 90,
+							metadata: "x".repeat(32 * 1024),
+						},
+					],
+					feature: { id: "messages", name: "Messages" },
+				},
+			},
+			subscriptions: [{ id: "sub_123", plan_id: "pro" }],
+			purchases: [{ id: "purchase_123", plan_id: "credits" }],
+		};
+
+		for (const path of [
+			"/v1/entities.get",
+			"/v1/customers.get",
+			"/v1/customers.get_or_create",
+		]) {
+			const { captured } = await captureJsonResponse({
+				path,
+				durationMs: 10,
+				responseBody: subjectResponseBody,
+			});
+
+			expect(captured[0]?.args[1]).toEqual({
+				statusCode: 200,
+				durationMs: 10,
+				res: {
+					id: "cus_123",
+					name: "Acme",
+					balances: { messages: { remaining: 90 } },
+					subscriptions_count: 1,
+					purchases_count: 1,
+				},
+			});
+		}
+
+		const { captured: aggregateCaptured } = await captureJsonResponse({
+			path: "/v1/events.aggregate",
+			durationMs: 10,
+			responseBody: {
+				list: [{ period: 1, values: { messages: 10 } }],
+				total: 10,
+				deductions: [{ period: 1, values: { messages: 4 } }],
+			},
+		});
+		expect(aggregateCaptured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: { total: 10, list_count: 1, deductions_count: 1 },
+		});
+
+		const { captured: plansCaptured } = await captureJsonResponse({
+			path: "/v1/plans.list",
+			durationMs: 10,
+			responseBody: {
+				list: [{ id: "pro", items: [{ feature_id: "messages" }] }],
+			},
+		});
+		expect(plansCaptured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: { list_count: 1 },
+		});
+	});
+
+	test("summarizes any response body larger than the logging cap", async () => {
+		spyOn(Math, "random").mockReturnValue(0);
+		const responseBody = {
+			id: "cus_123",
+			payload: "x".repeat(32 * 1024),
+		};
+		const { captured } = await captureJsonResponse({
+			path: "/v1/balances.check",
+			durationMs: 10,
+			responseBody,
+		});
+
+		expect(captured[0]?.args[1]).toEqual({
+			statusCode: 200,
+			durationMs: 10,
+			res: {
+				truncated: true,
+				original_bytes: Buffer.byteLength(JSON.stringify(responseBody)),
+				top_level_keys: ["id", "payload"],
+			},
+		});
+	});
+
 	test("keeps a sampled fast high-volume response in full", async () => {
 		spyOn(Math, "random").mockReturnValue(0);
 		const responseBody = { allowed: true, balance: { remaining: 90 } };
@@ -393,7 +491,7 @@ describe("logRequestResult", () => {
 				clone: () => {
 					cloneCount++;
 					return {
-						json: async () => responseBody,
+						text: async () => JSON.stringify(responseBody),
 					};
 				},
 			},
@@ -427,7 +525,9 @@ describe("logRequestResult", () => {
 				headers: new Headers({ "content-type": "application/json" }),
 				clone: () => {
 					cloneCount++;
-					return { json: async () => ({ events: [{ id: "evt_1" }] }) };
+					return {
+						text: async () => JSON.stringify({ events: [{ id: "evt_1" }] }),
+					};
 				},
 			},
 		} as unknown as Context<HonoEnv>;

--- a/vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx
+++ b/vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx
@@ -37,6 +37,7 @@ export function MiscellaneousEdgeConfigDialog({
 				syncCoalesce: data.syncCoalesce ?? false,
 				subjectLookupDbOnly: data.subjectLookupDbOnly ?? false,
 				idempotencyDynamoRead: data.idempotencyDynamoRead ?? false,
+				axiomResponseBodyReduction: data.axiomResponseBodyReduction ?? true,
 			};
 		},
 		enabled: open,

--- a/vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx
+++ b/vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx
@@ -70,6 +70,8 @@ export const MiscellaneousEdgeConfigForm = ({
 				idempotencyDynamoRead:
 					parsed.idempotencyDynamoRead ?? prev.idempotencyDynamoRead,
 				redisFallbackToDb: parsed.redisFallbackToDb ?? prev.redisFallbackToDb,
+				axiomResponseBodyReduction:
+					parsed.axiomResponseBodyReduction ?? prev.axiomResponseBodyReduction,
 			}));
 			setJsonError(null);
 		} catch {
@@ -187,6 +189,20 @@ export const MiscellaneousEdgeConfigForm = ({
 						</div>
 					</div>
 					<div className="rounded-lg border border-border divide-y divide-border">
+						<MiscellaneousEdgeConfigSwitch
+							title="Axiom response-body reduction"
+							hint="Compacts 99% of selected fast-success bodies and caps other non-sampled JSON bodies at 32 KB. Request metadata is unaffected; disable to restore full bodies."
+							ariaLabel="Enable Axiom response-body reduction"
+							checked={config.axiomResponseBodyReduction}
+							onCheckedChange={(axiomResponseBodyReduction) => {
+								setSyncSource("form");
+								setConfig((prev) => ({
+									...prev,
+									axiomResponseBodyReduction,
+								}));
+							}}
+						/>
+
 						<MiscellaneousEdgeConfigSwitch
 							title="Sync coalescing"
 							ariaLabel="Enable sync coalescing"

--- a/vite/src/views/admin/components/edgeConfigCards.ts
+++ b/vite/src/views/admin/components/edgeConfigCards.ts
@@ -364,9 +364,14 @@ export const EDGE_CONFIG_SECTIONS: EdgeConfigSectionDef[] = [
 					const allowlistCount = Array.isArray(allowlist)
 						? allowlist.length
 						: 0;
+					const axiomResponseBodyReductionDisabled =
+						config.axiomResponseBodyReduction === false;
 					const parts: string[] = [];
 
 					if (config.syncCoalesce === true) parts.push("Sync coalesce on");
+					if (axiomResponseBodyReductionDisabled) {
+						parts.push("Axiom response reduction off");
+					}
 					if (allowlistCount > 0) {
 						parts.push(
 							`${pluralize({ count: allowlistCount, noun: "flat-model customer" })}`,
@@ -375,7 +380,10 @@ export const EDGE_CONFIG_SECTIONS: EdgeConfigSectionDef[] = [
 
 					return parts.length === 0
 						? { label: "Defaults", tone: "neutral" }
-						: { label: parts.join(" | "), tone: "active" };
+						: {
+								label: parts.join(" | "),
+								tone: axiomResponseBodyReductionDisabled ? "warning" : "active",
+							};
 				},
 			},
 		],

--- a/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.test.ts
+++ b/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildMiscellaneousJsonText,
+	getStatusMessage,
+	MISCELLANEOUS_DEFAULT_CONFIG,
+} from "./miscellaneousEdgeConfigTypes";
+
+describe("Miscellaneous edge config admin defaults", () => {
+	test("keeps Axiom response-body reduction enabled by default", () => {
+		expect(MISCELLANEOUS_DEFAULT_CONFIG.axiomResponseBodyReduction).toBe(true);
+		expect(
+			JSON.parse(
+				buildMiscellaneousJsonText({
+					config: MISCELLANEOUS_DEFAULT_CONFIG,
+				}),
+			),
+		).toMatchObject({ axiomResponseBodyReduction: true });
+	});
+
+	test("describes missing S3 config as using defaults", () => {
+		expect(
+			getStatusMessage({ config: MISCELLANEOUS_DEFAULT_CONFIG }),
+		).toContain("defaults shown below apply");
+	});
+});

--- a/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts
+++ b/vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts
@@ -4,6 +4,7 @@ export type MiscellaneousEdgeConfig = {
 	subjectLookupDbOnly: boolean;
 	idempotencyDynamoRead: boolean;
 	redisFallbackToDb: boolean;
+	axiomResponseBodyReduction: boolean;
 	configHealthy: boolean;
 	configConfigured: boolean;
 	lastSuccessAt: string | null;
@@ -16,6 +17,7 @@ export const MISCELLANEOUS_DEFAULT_CONFIG: MiscellaneousEdgeConfig = {
 	subjectLookupDbOnly: false,
 	idempotencyDynamoRead: false,
 	redisFallbackToDb: false,
+	axiomResponseBodyReduction: true,
 	configHealthy: false,
 	configConfigured: false,
 	lastSuccessAt: null,
@@ -48,7 +50,7 @@ export const getStatusMessage = ({
 	config: MiscellaneousEdgeConfig;
 }) => {
 	if (config.configConfigured === false) {
-		return "Miscellaneous config is missing in S3, so every switch below stays off.";
+		return "Miscellaneous config is missing in S3, so the defaults shown below apply.";
 	}
 
 	return config.error ?? "Saved changes reach all servers within 10 seconds.";


### PR DESCRIPTION
## Summary
- extend fast-success response compaction to `entities.get`, `customers.get`, `customers.get_or_create`, `events.aggregate`, and `plans.list`
- keep the selected 1% sample fully intact regardless of size; cap other logged JSON responses at 32 KB with bounded diagnostics
- add a default-on `axiomResponseBodyReduction` edge-config switch that controls both the existing check/track reduction and this PR's additional routes and size cap
- expose the switch in the Miscellaneous Edge Config admin UI and surface its disabled state on the config card

## Visibility retained
- every terminal request record, status code, latency, and request context
- the full 1% sample, including responses above 32 KB
- errors and slow responses in full while under the cap when reduction is enabled
- disabling the switch restores full response bodies for both reduction changes; the older events-list exclusion remains unchanged

## Verification
- 18 focused `logRequestResult` unit tests
- 2 focused admin-config unit tests
- server and Vite typechecks
- scoped Biome check
- React Doctor changed-file scan; no new actionable UI diagnostics
- `git diff --check`


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces Axiom ingestion from large and frequently logged JSON responses while retaining complete sampled responses and providing an administrative kill switch.
- **Improvements:** Extends fast-success response compaction to customer, entity, aggregate-event, and plan-list routes.
- **Improvements:** Replaces non-sampled JSON responses larger than 32 KB with bounded size and top-level-key diagnostics.
- **Improvements:** Adds a default-on edge-config switch for response-body reduction and exposes its state in the admin interface.
- **Improvements:** Adds focused server logging and admin default tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/src/honoMiddlewares/requestLogging/logRequestResult.ts | Adds config-gated route compaction, complete-response sampling, and bounded diagnostics for oversized JSON log bodies. |
| server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigSchemas.ts | Defines the response-body-reduction switch as enabled by default. |
| server/src/internal/misc/miscellaneousEdgeConfig/miscellaneousEdgeConfigStore.ts | Exposes the new edge-config value to request logging. |
| server/tests/unit/logging/logRequestResult.test.ts | Covers new route shapes, oversized objects and arrays, bounded diagnostics, sampling, and switch behavior. |
| vite/src/views/admin/components/MiscellaneousEdgeConfigDialog.tsx | Applies the enabled default when loading legacy or partial configuration. |
| vite/src/views/admin/components/MiscellaneousEdgeConfigForm.tsx | Adds form and raw-JSON synchronization for the new switch. |
| vite/src/views/admin/components/edgeConfigCards.ts | Surfaces disabled response reduction as a warning on the miscellaneous-config card. |
| vite/src/views/admin/components/miscellaneousEdgeConfigTypes.ts | Extends the client-side config contract and defaults with the new option. |
| vite/src/views/admin/components/miscellaneousEdgeConfigTypes.test.ts | Verifies the default-on value and updated missing-config status message. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Completed HTTP request] --> B{JSON response body?}
    B -- No --> L[Log request result]
    B -- Yes --> C{Reduction enabled?}
    C -- No --> L
    C -- Yes --> D{Fast successful high-volume route?}
    D -- Yes --> E{Selected for full sample?}
    E -- Yes --> L
    E -- No --> F[Compact large response fields]
    D -- No --> G[Keep original body candidate]
    F --> H{Logged body exceeds 32 KB?}
    G --> H
    H -- Yes --> I[Log bounded truncation diagnostics]
    H -- No --> L
    I --> L
```
</details>

<sub>Reviews (3): Last reviewed commit: ["feat(logging): add Axiom response reduct..."](https://github.com/useautumn/autumn/commit/103e44b18d3a59d1757161744f9fd719e98b64d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57535798)</sub>

<!-- /greptile_comment -->