### PR TITLE
fix: the caller deadline no longer kills a turn whose child is working

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -291,15 +291,16 @@ export const consumeAgentTurn = async ({
 				});
 			}
 
-			const quietTooLong =
-				activity.activeChildren() === 0 &&
-				activity.msSinceActivity() >= MAX_QUIET_MS;
+			// A child streams on its own session, so a quiet parent is not
+			// evidence the turn is done — children have completed well after the
+			// deadline. MAX_TURN_DURATION_MS still bounds a runaway turn.
+			const childIsWorking = activity.activeChildren() > 0;
+			const quietTooLong = activity.msSinceActivity() >= MAX_QUIET_MS;
 			const deadlineReached =
 				deadlineAt !== undefined && Date.now() >= deadlineAt;
 			if (
 				activity.msSinceStart() >= MAX_TURN_DURATION_MS ||
-				quietTooLong ||
-				deadlineReached
+				(!childIsWorking && (quietTooLong || deadlineReached))
 			) {
 				return settleExhaustedTurn({ activity, logger, turn });
 			}

--- a/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
+++ b/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
@@ -223,9 +223,10 @@ describe("a parent quiet past the cap settles on the clock", () => {
 		expect(log.quiet_ms).toBeLessThan(QUIET_CAP_MS + PASS_ADVANCE_MS);
 	});
 
-	test("a caller deadline settles the turn before its own backstop", async () => {
-		// A live child suppresses the quiet cap, so without a deadline the turn
-		// runs to the 15 min ceiling -- long past the caller's 3m20s wall.
+	test("a caller deadline does not settle a turn whose child is working", async () => {
+		// Prod 2026-08-27 17:30:40 wrun_01M1247EP8R8ZBDA5QXXFSZQPG: the deadline
+		// fired with quiet_ms 299 while the investigator had 46 events in flight.
+		// The child completed 2m44s later, into a turn already reported failed.
 		childKeepsStreaming = true;
 		childEvents = Array.from({ length: 3 }, () =>
 			event({
@@ -233,15 +234,29 @@ describe("a parent quiet past the cap settles on the clock", () => {
 				type: "actions.requested",
 			}),
 		);
-		streamPasses = nineQuietPasses([
-			event({ type: "turn.started" }),
-			event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
-			event({
-				finishReason: "stop",
-				message: "Partial answer so far.",
-				type: "message.completed",
-			}),
-		]);
+		// Quiet passes carry the turn past the deadline, then eve resumes and
+		// finishes -- exactly what prod's child did 2m44s after being cut off.
+		streamPasses = [
+			{
+				events: [
+					event({ type: "turn.started" }),
+					event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
+				],
+				thenThrow: "idle",
+			},
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{
+				events: [
+					event({
+						finishReason: "stop",
+						message: "The delegated answer.",
+						type: "message.completed",
+					}),
+					event({ type: "session.waiting" }),
+				],
+			},
+		];
 
 		const abandoned: AbandonedLog[] = [];
 		const logger = {
@@ -268,9 +283,11 @@ describe("a parent quiet past the cap settles on the clock", () => {
 			token: "t",
 		} as never);
 
-		expect(outcome).toMatchObject({ kind: "answered" });
-		expect(abandoned).toHaveLength(1);
-		expect(parentStreamCalls).toBeLessThan(5);
+		expect(abandoned).toHaveLength(0);
+		expect(outcome).toMatchObject({
+			kind: "answered",
+			text: "The delegated answer.",
+		});
 	});
 
 	test("a live child suppresses the quiet cap even when the parent is silent", async () => {


### PR DESCRIPTION
## The failure

Prod `wrun_01M1247EP8R8ZBDA5QXXFSZQPG`, 17:30:40, live env:

```
17:28:39  investigator spawned
17:29–17:30  child streaming normally
17:30:40.114  eve_turn_abandoned   quiet_ms: 299   turn_ms: 154934
17:30:40.115  "Eve stopped responding mid-turn — please send your message again."
17:30:40.119  child_relay_ended    events_seen: 46   reason: stream_closed
17:33:24.672  eve_subagent_completed  ← 2m44s later, into a dead turn
```

Eve had not stopped responding. `quiet_ms: 299` means activity was 0.3s old — the child relay was calling `activity.touch()` continuously across 46 events.

## Cause

`consumeAgentTurn.ts`, one condition, two budget terms — only one of them child-aware:

```ts
const quietTooLong =
  activity.activeChildren() === 0 &&        // ← guarded
  activity.msSinceActivity() >= MAX_QUIET_MS;
const deadlineReached =
  deadlineAt !== undefined && Date.now() >= deadlineAt;   // ← not guarded
if (msSinceStart() >= MAX_TURN_DURATION_MS || quietTooLong || deadlineReached)
```

With `quiet_ms: 299` and `turn_ms` far under the 15m ceiling, `deadlineReached` is the only term that could have fired. `deadlineAt` is `MESSAGE_TIMEOUT_MS - 30s` = 2m30s; the turn died at 2m35s.

The fix hoists the liveness check so it guards both terms:

```ts
const childIsWorking = activity.activeChildren() > 0;
const quietTooLong = activity.msSinceActivity() >= MAX_QUIET_MS;
if (msSinceStart() >= MAX_TURN_DURATION_MS ||
    (!childIsWorking && (quietTooLong || deadlineReached)))
```

`MAX_TURN_DURATION_MS` still bounds a runaway turn, and Slack's own 3m20s backstop still bounds the user-facing wait — so a live child cannot hold a Slack turn open indefinitely.

## Scale (Axiom, today)

- **17** `slack_message_failed`; **5** killed a child that was still producing events (`events_seen` 46, 13, 13, 7, 7 — healthy children average 43)
- Parent→child kill ordering is provable to the millisecond in four cases
- `has_partial_text: false` on **all 10** abandonments — every killed turn discarded its work
- Slowest turn that **ever succeeded**: 193.6s against a ~240s wall. Under 20% headroom.

## Red/green

`quiet-turn-cap.test.ts` — the deadline case now drives a live child past the deadline and lets eve finish, as prod's child did:

| | old condition | with fix |
|---|---|---|
| deadline + working child | **abandons** ✗ | completes ✓ |
| no child, past deadline | settles ✓ | settles ✓ |
| no child, quiet too long | settles ✓ | settles ✓ |

1 fail / 2 pass before, 3 pass after — the two controls pin the behaviour that must not change. Full suite 489 pass, typecheck and biome clean.

## Note on the changed expectation

This test previously asserted the deadline **should** settle a turn with a live child, to stop it running to the 15m ceiling. Today's data says that was the wrong call — it is the mechanism behind 5 of 17 failures. The expectation is changed deliberately, not incidentally.

## Follow-up

This is the narrow fix. The audit found **15 timeout constants across 6 layers**, three unreachable under the Slack wall, and six different user-facing strings for one event chosen partly by regex over error text. Two of the three consume paths have no lifecycle bounding at all. That consolidation is separate and worth doing properly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the caller deadline from abandoning a turn while a child agent is still streaming, so parents no longer report failure while the child completes into a dead turn.

**Bug Fixes**
- The deadline condition now only fires when no child is working; a live child no longer triggers abandonment.
- `MAX_TURN_DURATION_MS` still bounds a runaway turn.
- Updated the quiet-turn-cap test to expect completion when a live child crosses the deadline; the two control cases still settle as before.

<sup>Written for commit 8096a09d3a8e036f618a00aa02dad6954bf12c90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents Leaf from abandoning an agent turn at the caller deadline while a child agent remains active.
- **Bug fixes:** Applies child-liveness protection to both quiet-time and caller-deadline settlement.
- **Improvements:** Updates the turn-cap test to verify that a working child can finish after the caller deadline while preserving no-child timeout behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the intended caller-deadline behavior covered by focused regression tests.

The change narrowly defers deadline and quiet-time settlement while a child is active, retains the unconditional maximum turn duration, and preserves settlement once no child is working.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts | Extends the active-child guard to prevent caller-deadline settlement while delegated work remains active. |
| apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts | Replaces the prior deadline-settlement expectation with regression coverage for child completion after the deadline. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Parent as Parent turn
    participant Child as Child agent
    Caller->>Parent: Start turn with deadline
    Parent->>Child: Delegate work
    Child-->>Parent: Stream activity
    Note over Parent: Caller deadline reached
    Parent->>Parent: Child active, continue turn
    Child-->>Parent: Complete delegated answer
    Parent-->>Caller: Return answer
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: the caller deadline no longer kills..."](https://github.com/useautumn/autumn/commit/8096a09d3a8e036f618a00aa02dad6954bf12c90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57603216)</sub>

<!-- /greptile_comment -->