### PR TITLE
release

### DIFF
--- a/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
+++ b/apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts
@@ -291,15 +291,16 @@ export const consumeAgentTurn = async ({
 				});
 			}
 
-			const quietTooLong =
-				activity.activeChildren() === 0 &&
-				activity.msSinceActivity() >= MAX_QUIET_MS;
+			// A child streams on its own session, so a quiet parent is not
+			// evidence the turn is done — children have completed well after the
+			// deadline. MAX_TURN_DURATION_MS still bounds a runaway turn.
+			const childIsWorking = activity.activeChildren() > 0;
+			const quietTooLong = activity.msSinceActivity() >= MAX_QUIET_MS;
 			const deadlineReached =
 				deadlineAt !== undefined && Date.now() >= deadlineAt;
 			if (
 				activity.msSinceStart() >= MAX_TURN_DURATION_MS ||
-				quietTooLong ||
-				deadlineReached
+				(!childIsWorking && (quietTooLong || deadlineReached))
 			) {
 				return settleExhaustedTurn({ activity, logger, turn });
 			}

--- a/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
+++ b/apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts
@@ -223,9 +223,10 @@ describe("a parent quiet past the cap settles on the clock", () => {
 		expect(log.quiet_ms).toBeLessThan(QUIET_CAP_MS + PASS_ADVANCE_MS);
 	});
 
-	test("a caller deadline settles the turn before its own backstop", async () => {
-		// A live child suppresses the quiet cap, so without a deadline the turn
-		// runs to the 15 min ceiling -- long past the caller's 3m20s wall.
+	test("a caller deadline does not settle a turn whose child is working", async () => {
+		// Prod 2026-08-27 17:30:40 wrun_01M1247EP8R8ZBDA5QXXFSZQPG: the deadline
+		// fired with quiet_ms 299 while the investigator had 46 events in flight.
+		// The child completed 2m44s later, into a turn already reported failed.
 		childKeepsStreaming = true;
 		childEvents = Array.from({ length: 3 }, () =>
 			event({
@@ -233,15 +234,29 @@ describe("a parent quiet past the cap settles on the clock", () => {
 				type: "actions.requested",
 			}),
 		);
-		streamPasses = nineQuietPasses([
-			event({ type: "turn.started" }),
-			event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
-			event({
-				finishReason: "stop",
-				message: "Partial answer so far.",
-				type: "message.completed",
-			}),
-		]);
+		// Quiet passes carry the turn past the deadline, then eve resumes and
+		// finishes -- exactly what prod's child did 2m44s after being cut off.
+		streamPasses = [
+			{
+				events: [
+					event({ type: "turn.started" }),
+					event({ childSessionId: "wrun_child_1", type: "subagent.called" }),
+				],
+				thenThrow: "idle",
+			},
+			{ events: [], thenThrow: "idle" },
+			{ events: [], thenThrow: "idle" },
+			{
+				events: [
+					event({
+						finishReason: "stop",
+						message: "The delegated answer.",
+						type: "message.completed",
+					}),
+					event({ type: "session.waiting" }),
+				],
+			},
+		];
 
 		const abandoned: AbandonedLog[] = [];
 		const logger = {
@@ -268,9 +283,11 @@ describe("a parent quiet past the cap settles on the clock", () => {
 			token: "t",
 		} as never);
 
-		expect(outcome).toMatchObject({ kind: "answered" });
-		expect(abandoned).toHaveLength(1);
-		expect(parentStreamCalls).toBeLessThan(5);
+		expect(abandoned).toHaveLength(0);
+		expect(outcome).toMatchObject({
+			kind: "answered",
+			text: "The delegated answer.",
+		});
 	});
 
 	test("a live child suppresses the quiet cap even when the parent is silent", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
The caller deadline no longer settles a turn whose child agent is still working, so delegated work can finish instead of being reported as failed mid-flight.

- The deadline and quiet cap now both respect an active child; `MAX_TURN_DURATION_MS` still bounds a runaway turn.
- Fixes prod failures where a child completed minutes after the parent was abandoned.

<sup>Written for commit 670d36a925d7c3fa1a901c2343952aa5f59d40f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This release changes agent-turn timeout handling so an active delegated child can continue past the parent’s quiet cap and caller deadline.
- **Bug fixes, Improvements:** Keep a parent agent turn alive while a child agent is actively working, while retaining the absolute 15-minute turn cap.
- **Bug fixes:** Add a regression test showing that a delegated answer can complete after the caller deadline.
</details>


<h3>Confidence Score: 4/5</h3>

The reconnecting-child timeout path should be fixed before merging because a failed child can leave an agent turn running long after its caller has timed out.

The new condition equates a relay that is still reconnecting with productive child work and suppresses both normal settlement mechanisms, while the surrounding caller timeout does not cancel the underlying turn.

**Files Needing Attention:** apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts | Defers quiet and caller-deadline settlement for active children, but reconnecting child relays can now keep timed-out turns running in the background. |
| apps/leaf/tests/unit/harness/quiet-turn-cap.test.ts | Replaces the deadline-settlement expectation with coverage for a genuinely active child completing after the deadline. |


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Parent as Parent turn
    participant Child as Child relay
    Caller->>Parent: Start turn with deadline
    Parent->>Child: Delegate work
    Child--xParent: Stream becomes quiet/disconnected
    Note over Parent,Child: activeChildren remains positive during reconnects
    Caller--xCaller: Caller timeout fires
    Note over Parent: Parent ignores deadline and continues
    Parent-->>Parent: Settle at child completion or 15-minute cap
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/leaf/src/internal/agentRuntime/actions/runAgentTurn/execute/consumeAgentTurn.ts:297-306
**Stale children bypass deadlines**

When a child stream stops producing events but its relay remains in the reconnect loop, `activeChildren()` stays positive and bypasses both the quiet cap and caller deadline, causing Slack to report a timeout while the parent turn continues consuming stream and session resources until the child relay exits or the 15-minute cap is reached.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #3130 from useautumn/..."](https://github.com/useautumn/autumn/commit/670d36a925d7c3fa1a901c2343952aa5f59d40f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57605178)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->