### PR TITLE
Move multi-update refund and subscription_params to the request root

### DIFF
--- a/apps/docs/mintlify/api-reference/billing/multiUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/multiUpdate.mdx
@@ -59,6 +59,14 @@ const response = await autumn.billing.multiUpdate({
   The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
 </DynamicParamField>
 
+<DynamicParamField body="refund_last_payment" type="'prorated' | 'full'">
+  Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+</DynamicParamField>
+
+<DynamicParamField body="subscription_params" type="object">
+  Additional parameters to pass into the Stripe subscription update or cancel call.
+</DynamicParamField>
+
 <DynamicParamField body="updates" type="object[]" required>
   The list of plan updates to apply to the customer.
   <Expandable title="properties">
@@ -80,14 +88,6 @@ const response = await autumn.billing.multiUpdate({
 
     <DynamicParamField body="proration_behavior" type="'prorate_immediately' | 'none'">
       How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.
-    </DynamicParamField>
-
-    <DynamicParamField body="refund_last_payment" type="'prorated' | 'full'">
-      Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
-    </DynamicParamField>
-
-    <DynamicParamField body="subscription_params" type="object">
-      Additional parameters to pass into the Stripe subscription update or cancel call.
     </DynamicParamField>
 
   </Expandable>

--- a/apps/docs/mintlify/api-reference/billing/previewMultiUpdate.mdx
+++ b/apps/docs/mintlify/api-reference/billing/previewMultiUpdate.mdx
@@ -17,6 +17,14 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
   The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
 </DynamicParamField>
 
+<DynamicParamField body="refund_last_payment" type="'prorated' | 'full'">
+  Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+</DynamicParamField>
+
+<DynamicParamField body="subscription_params" type="object">
+  Additional parameters to pass into the Stripe subscription update or cancel call.
+</DynamicParamField>
+
 <DynamicParamField body="updates" type="object[]" required>
   The list of plan updates to apply to the customer.
   <Expandable title="properties">
@@ -38,14 +46,6 @@ import { DynamicResponseExample } from "/snippets/dynamic-response-example.jsx";
 
     <DynamicParamField body="proration_behavior" type="'prorate_immediately' | 'none'">
       How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.
-    </DynamicParamField>
-
-    <DynamicParamField body="refund_last_payment" type="'prorated' | 'full'">
-      Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
-    </DynamicParamField>
-
-    <DynamicParamField body="subscription_params" type="object">
-      Additional parameters to pass into the Stripe subscription update or cancel call.
     </DynamicParamField>
 
   </Expandable>

--- a/apps/docs/mintlify/api/openapi.yml
+++ b/apps/docs/mintlify/api/openapi.yml
@@ -28894,6 +28894,23 @@ paths:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can
                     override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate
+                    cancellation. 'prorated' refunds the unused portion, 'full'
+                    refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update
+                    or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -28931,23 +28948,6 @@ paths:
                         description: How to handle proration for this update. 'prorate_immediately'
                           charges/credits prorated amounts now, 'none' skips
                           creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate
-                          cancellation. 'prorated' refunds the unused portion,
-                          'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update
-                          or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.
@@ -29118,6 +29118,23 @@ paths:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can
                     override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate
+                    cancellation. 'prorated' refunds the unused portion, 'full'
+                    refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update
+                    or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -29155,23 +29172,6 @@ paths:
                         description: How to handle proration for this update. 'prorate_immediately'
                           charges/credits prorated amounts now, 'none' skips
                           creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate
-                          cancellation. 'prorated' refunds the unused portion,
-                          'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update
-                          or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.

--- a/others/python-sdk/.speakeasy/gen.lock
+++ b/others/python-sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 05940b80-1ef8-40f4-9878-822fb2792070
 management:
-  docChecksum: e4c672987eccc63ed1ec3647eaab2574
+  docChecksum: 6e1535d8d3a4d1f1f3fe9850b74a51ab
   docVersion: 2.3.0
-  speakeasyVersion: 1.763.3
-  generationVersion: 2.884.7
+  speakeasyVersion: 1.762.0
+  generationVersion: 2.882.0
   releaseVersion: 1.0.2
   configChecksum: f4e1f05a41ffbdd2d471149ad34b3cf6
 persistentEdits:
-  generation_id: 6c60ae0d-a810-4005-a199-8bfd0a618332
-  pristine_commit_hash: 3907ba839b15138782b38db6c33d85581c95026a
-  pristine_tree_hash: 288e1d69246d151799536e090da9dec7c53bb9e2
+  generation_id: fc1b705e-9c35-4b8f-b851-1baa973b7b50
+  pristine_commit_hash: f306f0f22a0935a666983278d6142e3964dc7ede
+  pristine_tree_hash: 33a6feb059b8b42fbe737e9a27ed3118713a4166
 features:
   python:
     additionalDependencies: 1.0.0
@@ -5572,8 +5572,8 @@ trackedFiles:
     pristine_git_object: ea17ec50caa5816b9f017df93fa029397d918ff4
   docs/models/multiupdateparams.md:
     id: 9ef93cd26c23
-    last_write_checksum: sha1:7c85e0dab08d7af85c406e2df6479436045396ad
-    pristine_git_object: 9b852ab4aa373656758a3480ff35cd6618bba5be
+    last_write_checksum: sha1:2993ba9256151b7ffa022e97b45f5ad563627175
+    pristine_git_object: 7b12c78e19e97160fb8af8c640d94c5336ddf632
   docs/models/multiupdatepreviewresponse.md:
     id: eb77c6b66eed
     last_write_checksum: sha1:5ac2b5727fc88026e6ecc1573b72bf6f46c4189f
@@ -5596,8 +5596,8 @@ trackedFiles:
     pristine_git_object: 0a124ba1df254db94ee8fe6489e6fdee111b7349
   docs/models/multiupdateupdate.md:
     id: 328c4da29465
-    last_write_checksum: sha1:d27d88999c7530de25e851d132fcc00aae82a9bd
-    pristine_git_object: 4dde5f227653d8ab29b7b7214ecbab33dc524991
+    last_write_checksum: sha1:e32a57e02be469d8ccc4492e648f8c9cb5fe0669
+    pristine_git_object: 4e6e6071a908cd1914cfb6f8764a13d31db9546f
   docs/models/ondecrease.md:
     id: 64eee91e295e
     last_write_checksum: sha1:ba69bee1e594ed15b8cffbdecefa34e17a4d7f99
@@ -6940,8 +6940,8 @@ trackedFiles:
     pristine_git_object: d7c71217ee3dd8b1f5be97f6cc7dd54085eced3e
   docs/models/previewmultiupdateparams.md:
     id: 884f92bcbe2d
-    last_write_checksum: sha1:fae038c8dbfd358f0641a9acf7623d34b31572aa
-    pristine_git_object: ce630296ddbeac083f1dd808e47072d136b0db4a
+    last_write_checksum: sha1:33fdfb8e656e59a1f4cddc9f42df62209112986e
+    pristine_git_object: 92ffd5bb0276fbc34d48bd6bf7dd127066f4e562
   docs/models/previewmultiupdateprorationbehavior.md:
     id: bc0e5824798f
     last_write_checksum: sha1:90113d6da608c298d3248aa70c7c974adae99561
@@ -6956,8 +6956,8 @@ trackedFiles:
     pristine_git_object: 03645fb9d10e014d9f1b94ecbdfae56d27a66588
   docs/models/previewmultiupdateupdate.md:
     id: 5f7629bf729b
-    last_write_checksum: sha1:594352dd00b63e9f240bda014970682cf4482164
-    pristine_git_object: e7b2da68ed646fa9675e6b40e744c3651e8732b8
+    last_write_checksum: sha1:f5b8bad48a141037621ce309709d1c79be3f16f8
+    pristine_git_object: 74dcf1a85833c264f24289425e103176e580f63e
   docs/models/previewmultiupdateusagelineitem.md:
     id: 7dde0268cea5
     last_write_checksum: sha1:23365b06dc5704129b97a0a154e5a678200a4385
@@ -10016,8 +10016,8 @@ trackedFiles:
     pristine_git_object: 212a318100919a8730520424aacbc95fe5e5b3ce
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:2b1ec495706fe4cc9b94e89c02e4a9dab95aee4e
-    pristine_git_object: b71ffa7fab9d66e6312aa3822bccbc4d26aa94ee
+    last_write_checksum: sha1:8646abce8314d4e83ef46ff2d417fc0b812527da
+    pristine_git_object: 4ae3a7ea8c41a68b2a144b64da50fbca4430edae
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:adb6d370f8b2d915bf7562bdc1cf2fa05def631e
@@ -10096,8 +10096,8 @@ trackedFiles:
     pristine_git_object: 3e604651c1eae73d815b276806e73b2f1334bb79
   src/autumn_sdk/_version.py:
     id: a98babfdf4fc
-    last_write_checksum: sha1:02a3890fc77fa341946292fd6ec503dce8d458b3
-    pristine_git_object: 2459bfe9e71d9c8efd948f11fdc846fb10de593e
+    last_write_checksum: sha1:32e3e5ae5d89bc2b49b357d33af0f2c6a9fa9e18
+    pristine_git_object: 757746145237df7bec1643fa3cc0be0d6859d595
   src/autumn_sdk/balances.py:
     id: 0a15be654dad
     last_write_checksum: sha1:71f71c0e93f4df6f2555f6a43c51cc3e44d7b17c
@@ -10108,8 +10108,8 @@ trackedFiles:
     pristine_git_object: 4db96641966f6337a1a1613ea731050ed25a1fb9
   src/autumn_sdk/billing.py:
     id: e6cffdbf2221
-    last_write_checksum: sha1:1af888569c9a9dc2aa51ae35f4a1b3418725a82d
-    pristine_git_object: ef4055f4d77b9f6a11f529e3024f350695d87ae2
+    last_write_checksum: sha1:c424ffab895b1d4da3981c74d86d0836f7acf85b
+    pristine_git_object: 266fd750394599e2a15f0eb3a8a2f484749a2d83
   src/autumn_sdk/customers.py:
     id: 5c5a0a07a433
     last_write_checksum: sha1:4927aac4111a01e0e631d75f6bbb4d37edd54968
@@ -10364,8 +10364,8 @@ trackedFiles:
     pristine_git_object: e8819c2050f477d749235399b1af91ea3cc72b85
   src/autumn_sdk/models/multiupdateop.py:
     id: 46b9952f7400
-    last_write_checksum: sha1:5acbac818d4b9cd160ef64d28c893ec07bb889d6
-    pristine_git_object: d1942bb1182ce1bf47d1c3b3d060049b83342b25
+    last_write_checksum: sha1:5f6a37274f86e4a46ea31751284f7266122eb7b6
+    pristine_git_object: e6e2b9833d85bccbfc209d7956a70ba01c985840
   src/autumn_sdk/models/opencustomerportalop.py:
     id: 004cc9a6466f
     last_write_checksum: sha1:e32037dcfea1c4bd953f749f74775b3d7d1d83c3
@@ -10384,8 +10384,8 @@ trackedFiles:
     pristine_git_object: 156c1a3a7c663fb1bab5343bf30781179d3ef587
   src/autumn_sdk/models/previewmultiupdateop.py:
     id: cbd62f0afc6d
-    last_write_checksum: sha1:1a111f4de27e2a4d749c0c672bb681230809d8c5
-    pristine_git_object: be34d2b8bcfa53687f2639cb8ced658b39446ece
+    last_write_checksum: sha1:aa6f47b61865e7ab1304012fcb0eabb42f2c4cfb
+    pristine_git_object: 5ee28fe7d7f93015c52e2084ade97dc383d5a235
   src/autumn_sdk/models/previewupdateop.py:
     id: 081d5f08508d
     last_write_checksum: sha1:5c8ec1d15acca08c97194f24dcaa3f8f967a6526

--- a/others/python-sdk/src/autumn_sdk/_version.py
+++ b/others/python-sdk/src/autumn_sdk/_version.py
@@ -5,8 +5,8 @@ import importlib.metadata
 __title__: str = "autumn-sdk"
 __version__: str = "1.0.2"
 __openapi_doc_version__: str = "2.3.0"
-__gen_version__: str = "2.884.7"
-__user_agent__: str = "speakeasy-sdk/python 1.0.2 2.884.7 2.3.0 autumn-sdk"
+__gen_version__: str = "2.882.0"
+__user_agent__: str = "speakeasy-sdk/python 1.0.2 2.882.0 2.3.0 autumn-sdk"
 
 try:
     if __package__ is not None:

--- a/others/python-sdk/src/autumn_sdk/billing.py
+++ b/others/python-sdk/src/autumn_sdk/billing.py
@@ -2813,6 +2813,8 @@ class Billing(BaseSDK):
             List[models.MultiUpdateUpdate], List[models.MultiUpdateUpdateTypedDict]
         ],
         entity_id: Optional[str] = None,
+        refund_last_payment: Optional[models.MultiUpdateRefundLastPayment] = None,
+        subscription_params: Optional[Dict[str, Any]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -2825,6 +2827,8 @@ class Billing(BaseSDK):
         :param customer_id: The ID of the customer to update plans for.
         :param updates: The list of plan updates to apply to the customer.
         :param entity_id: The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
+        :param refund_last_payment: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+        :param subscription_params: Additional parameters to pass into the Stripe subscription update or cancel call.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -2843,6 +2847,8 @@ class Billing(BaseSDK):
         request = models.MultiUpdateParams(
             customer_id=customer_id,
             entity_id=entity_id,
+            refund_last_payment=refund_last_payment,
+            subscription_params=subscription_params,
             updates=utils.get_pydantic_model(updates, List[models.MultiUpdateUpdate]),
         )
 
@@ -2913,6 +2919,8 @@ class Billing(BaseSDK):
             List[models.MultiUpdateUpdate], List[models.MultiUpdateUpdateTypedDict]
         ],
         entity_id: Optional[str] = None,
+        refund_last_payment: Optional[models.MultiUpdateRefundLastPayment] = None,
+        subscription_params: Optional[Dict[str, Any]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -2925,6 +2933,8 @@ class Billing(BaseSDK):
         :param customer_id: The ID of the customer to update plans for.
         :param updates: The list of plan updates to apply to the customer.
         :param entity_id: The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
+        :param refund_last_payment: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+        :param subscription_params: Additional parameters to pass into the Stripe subscription update or cancel call.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -2943,6 +2953,8 @@ class Billing(BaseSDK):
         request = models.MultiUpdateParams(
             customer_id=customer_id,
             entity_id=entity_id,
+            refund_last_payment=refund_last_payment,
+            subscription_params=subscription_params,
             updates=utils.get_pydantic_model(updates, List[models.MultiUpdateUpdate]),
         )
 
@@ -3014,6 +3026,10 @@ class Billing(BaseSDK):
             List[models.PreviewMultiUpdateUpdateTypedDict],
         ],
         entity_id: Optional[str] = None,
+        refund_last_payment: Optional[
+            models.PreviewMultiUpdateRefundLastPayment
+        ] = None,
+        subscription_params: Optional[Dict[str, Any]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -3026,6 +3042,8 @@ class Billing(BaseSDK):
         :param customer_id: The ID of the customer to update plans for.
         :param updates: The list of plan updates to apply to the customer.
         :param entity_id: The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
+        :param refund_last_payment: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+        :param subscription_params: Additional parameters to pass into the Stripe subscription update or cancel call.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -3044,6 +3062,8 @@ class Billing(BaseSDK):
         request = models.PreviewMultiUpdateParams(
             customer_id=customer_id,
             entity_id=entity_id,
+            refund_last_payment=refund_last_payment,
+            subscription_params=subscription_params,
             updates=utils.get_pydantic_model(
                 updates, List[models.PreviewMultiUpdateUpdate]
             ),
@@ -3117,6 +3137,10 @@ class Billing(BaseSDK):
             List[models.PreviewMultiUpdateUpdateTypedDict],
         ],
         entity_id: Optional[str] = None,
+        refund_last_payment: Optional[
+            models.PreviewMultiUpdateRefundLastPayment
+        ] = None,
+        subscription_params: Optional[Dict[str, Any]] = None,
         retries: OptionalNullable[utils.RetryConfig] = UNSET,
         server_url: Optional[str] = None,
         timeout_ms: Optional[int] = None,
@@ -3129,6 +3153,8 @@ class Billing(BaseSDK):
         :param customer_id: The ID of the customer to update plans for.
         :param updates: The list of plan updates to apply to the customer.
         :param entity_id: The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
+        :param refund_last_payment: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+        :param subscription_params: Additional parameters to pass into the Stripe subscription update or cancel call.
         :param retries: Override the default retry configuration for this method
         :param server_url: Override the default server URL for this method
         :param timeout_ms: Override the default request timeout configuration for this method in milliseconds
@@ -3147,6 +3173,8 @@ class Billing(BaseSDK):
         request = models.PreviewMultiUpdateParams(
             customer_id=customer_id,
             entity_id=entity_id,
+            refund_last_payment=refund_last_payment,
+            subscription_params=subscription_params,
             updates=utils.get_pydantic_model(
                 updates, List[models.PreviewMultiUpdateUpdate]
             ),

--- a/others/python-sdk/src/autumn_sdk/models/multiupdateop.py
+++ b/others/python-sdk/src/autumn_sdk/models/multiupdateop.py
@@ -37,6 +37,13 @@ class MultiUpdateGlobals(BaseModel):
         return m
 
 
+MultiUpdateRefundLastPayment = Literal[
+    "prorated",
+    "full",
+]
+r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
+
+
 MultiUpdateCancelAction = Literal[
     "cancel_immediately",
     "cancel_end_of_cycle",
@@ -52,13 +59,6 @@ MultiUpdateProrationBehavior = Literal[
 r"""How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges."""
 
 
-MultiUpdateRefundLastPayment = Literal[
-    "prorated",
-    "full",
-]
-r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
-
-
 class MultiUpdateUpdateTypedDict(TypedDict):
     cancel_action: MultiUpdateCancelAction
     r"""Action to perform for cancellation. 'cancel_immediately' cancels now with prorated refund, 'cancel_end_of_cycle' cancels at period end, 'uncancel' reverses a pending cancellation."""
@@ -70,10 +70,6 @@ class MultiUpdateUpdateTypedDict(TypedDict):
     r"""The ID of the entity this update targets. Overrides the top-level entity_id for this update."""
     proration_behavior: NotRequired[MultiUpdateProrationBehavior]
     r"""How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges."""
-    refund_last_payment: NotRequired[MultiUpdateRefundLastPayment]
-    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
-    subscription_params: NotRequired[Dict[str, Any]]
-    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
 
 
 class MultiUpdateUpdate(BaseModel):
@@ -92,23 +88,10 @@ class MultiUpdateUpdate(BaseModel):
     proration_behavior: Optional[MultiUpdateProrationBehavior] = None
     r"""How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges."""
 
-    refund_last_payment: Optional[MultiUpdateRefundLastPayment] = None
-    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
-
-    subscription_params: Optional[Dict[str, Any]] = None
-    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
-
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = set(
-            [
-                "plan_id",
-                "subscription_id",
-                "entity_id",
-                "proration_behavior",
-                "refund_last_payment",
-                "subscription_params",
-            ]
+            ["plan_id", "subscription_id", "entity_id", "proration_behavior"]
         )
         serialized = handler(self)
         m = {}
@@ -131,6 +114,10 @@ class MultiUpdateParamsTypedDict(TypedDict):
     r"""The list of plan updates to apply to the customer."""
     entity_id: NotRequired[str]
     r"""The ID of the entity to update plans for. Individual updates can override this with their own entity_id."""
+    refund_last_payment: NotRequired[MultiUpdateRefundLastPayment]
+    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
+    subscription_params: NotRequired[Dict[str, Any]]
+    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
 
 
 class MultiUpdateParams(BaseModel):
@@ -143,9 +130,17 @@ class MultiUpdateParams(BaseModel):
     entity_id: Optional[str] = None
     r"""The ID of the entity to update plans for. Individual updates can override this with their own entity_id."""
 
+    refund_last_payment: Optional[MultiUpdateRefundLastPayment] = None
+    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
+
+    subscription_params: Optional[Dict[str, Any]] = None
+    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["entity_id"])
+        optional_fields = set(
+            ["entity_id", "refund_last_payment", "subscription_params"]
+        )
         serialized = handler(self)
         m = {}
 

--- a/others/python-sdk/src/autumn_sdk/models/previewmultiupdateop.py
+++ b/others/python-sdk/src/autumn_sdk/models/previewmultiupdateop.py
@@ -38,6 +38,13 @@ class PreviewMultiUpdateGlobals(BaseModel):
         return m
 
 
+PreviewMultiUpdateRefundLastPayment = Literal[
+    "prorated",
+    "full",
+]
+r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
+
+
 PreviewMultiUpdateCancelAction = Literal[
     "cancel_immediately",
     "cancel_end_of_cycle",
@@ -53,13 +60,6 @@ PreviewMultiUpdateProrationBehavior = Literal[
 r"""How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges."""
 
 
-PreviewMultiUpdateRefundLastPayment = Literal[
-    "prorated",
-    "full",
-]
-r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
-
-
 class PreviewMultiUpdateUpdateTypedDict(TypedDict):
     cancel_action: PreviewMultiUpdateCancelAction
     r"""Action to perform for cancellation. 'cancel_immediately' cancels now with prorated refund, 'cancel_end_of_cycle' cancels at period end, 'uncancel' reverses a pending cancellation."""
@@ -71,10 +71,6 @@ class PreviewMultiUpdateUpdateTypedDict(TypedDict):
     r"""The ID of the entity this update targets. Overrides the top-level entity_id for this update."""
     proration_behavior: NotRequired[PreviewMultiUpdateProrationBehavior]
     r"""How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges."""
-    refund_last_payment: NotRequired[PreviewMultiUpdateRefundLastPayment]
-    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
-    subscription_params: NotRequired[Dict[str, Any]]
-    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
 
 
 class PreviewMultiUpdateUpdate(BaseModel):
@@ -93,23 +89,10 @@ class PreviewMultiUpdateUpdate(BaseModel):
     proration_behavior: Optional[PreviewMultiUpdateProrationBehavior] = None
     r"""How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges."""
 
-    refund_last_payment: Optional[PreviewMultiUpdateRefundLastPayment] = None
-    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
-
-    subscription_params: Optional[Dict[str, Any]] = None
-    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
-
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
         optional_fields = set(
-            [
-                "plan_id",
-                "subscription_id",
-                "entity_id",
-                "proration_behavior",
-                "refund_last_payment",
-                "subscription_params",
-            ]
+            ["plan_id", "subscription_id", "entity_id", "proration_behavior"]
         )
         serialized = handler(self)
         m = {}
@@ -132,6 +115,10 @@ class PreviewMultiUpdateParamsTypedDict(TypedDict):
     r"""The list of plan updates to apply to the customer."""
     entity_id: NotRequired[str]
     r"""The ID of the entity to update plans for. Individual updates can override this with their own entity_id."""
+    refund_last_payment: NotRequired[PreviewMultiUpdateRefundLastPayment]
+    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
+    subscription_params: NotRequired[Dict[str, Any]]
+    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
 
 
 class PreviewMultiUpdateParams(BaseModel):
@@ -144,9 +131,17 @@ class PreviewMultiUpdateParams(BaseModel):
     entity_id: Optional[str] = None
     r"""The ID of the entity to update plans for. Individual updates can override this with their own entity_id."""
 
+    refund_last_payment: Optional[PreviewMultiUpdateRefundLastPayment] = None
+    r"""Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment."""
+
+    subscription_params: Optional[Dict[str, Any]] = None
+    r"""Additional parameters to pass into the Stripe subscription update or cancel call."""
+
     @model_serializer(mode="wrap")
     def serialize_model(self, handler):
-        optional_fields = set(["entity_id"])
+        optional_fields = set(
+            ["entity_id", "refund_last_payment", "subscription_params"]
+        )
         serialized = handler(self)
         m = {}
 

--- a/packages/openapi/openapi-stripped.yml
+++ b/packages/openapi/openapi-stripped.yml
@@ -28254,6 +28254,23 @@ paths:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can
                     override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate
+                    cancellation. 'prorated' refunds the unused portion, 'full'
+                    refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update
+                    or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -28291,23 +28308,6 @@ paths:
                         description: How to handle proration for this update. 'prorate_immediately'
                           charges/credits prorated amounts now, 'none' skips
                           creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate
-                          cancellation. 'prorated' refunds the unused portion,
-                          'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update
-                          or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.
@@ -28437,6 +28437,23 @@ paths:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can
                     override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate
+                    cancellation. 'prorated' refunds the unused portion, 'full'
+                    refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update
+                    or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -28474,23 +28491,6 @@ paths:
                         description: How to handle proration for this update. 'prorate_immediately'
                           charges/credits prorated amounts now, 'none' skips
                           creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate
-                          cancellation. 'prorated' refunds the unused portion,
-                          'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update
-                          or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -29165,6 +29165,8 @@ paths:
 
         @param customerId - The ID of the customer to update plans for.
         @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+        @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+        @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
         @param updates - The list of plan updates to apply to the customer.
 
         @returns A billing response with the resulting invoice summary (one credit invoice per affected subscription for immediate cancels).
@@ -29184,6 +29186,23 @@ paths:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can
                     override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate
+                    cancellation. 'prorated' refunds the unused portion, 'full'
+                    refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update
+                    or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -29221,23 +29240,6 @@ paths:
                         description: How to handle proration for this update. 'prorate_immediately'
                           charges/credits prorated amounts now, 'none' skips
                           creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate
-                          cancellation. 'prorated' refunds the unused portion,
-                          'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update
-                          or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.
@@ -29353,6 +29355,8 @@ paths:
 
         @param customerId - The ID of the customer to update plans for.
         @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+        @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+        @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
         @param updates - The list of plan updates to apply to the customer.
 
         @returns A preview with the combined total plus one entry per subscription, each with its own line items, totals, and next-cycle preview.
@@ -29372,6 +29376,23 @@ paths:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can
                     override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate
+                    cancellation. 'prorated' refunds the unused portion, 'full'
+                    refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update
+                    or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -29409,23 +29430,6 @@ paths:
                         description: How to handle proration for this update. 'prorate_immediately'
                           charges/credits prorated amounts now, 'none' skips
                           creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate
-                          cancellation. 'prorated' refunds the unused portion,
-                          'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update
-                          or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.

--- a/packages/sdk/.speakeasy/gen.lock
+++ b/packages/sdk/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 7b300647-cd76-49e9-bf77-7d1bf5446d66
 management:
-  docChecksum: e8c4c193669e91b773c5a3b032a91ee0
+  docChecksum: 5c1db69a01f7ae1d0f0bf1e3728ad6d7
   docVersion: 2.3.0
-  speakeasyVersion: 1.763.3
-  generationVersion: 2.884.7
+  speakeasyVersion: 1.762.0
+  generationVersion: 2.882.0
   releaseVersion: 0.10.18
   configChecksum: a05ee9fa7bf0a40d4f216cac1903f122
 persistentEdits:
-  generation_id: 124beb1a-1509-4c43-a5f6-055b90d0acdb
-  pristine_commit_hash: eb07ad49928b5083d0c3962b9ac54f60a911ca44
-  pristine_tree_hash: 32a276b176bf02896451a9eaf73f241b34a5f334
+  generation_id: b89c345c-94ff-49e4-8f19-f0cd882ecb8d
+  pristine_commit_hash: 37880a7a1e039780ca654728e418866fc5ffd2bc
+  pristine_tree_hash: c222fe468c73be0353bfcc40a0164854161c7297
 features:
   typescript:
     additionalDependencies: 0.1.0
@@ -5591,8 +5591,8 @@ trackedFiles:
     pristine_git_object: fdaf29cda6b3a5c34222e520814f4a594e52edf2
   docs/models/multi-update-params.md:
     id: e307560d2161
-    last_write_checksum: sha1:40f59d776e34260f1e47bd7822849cc880685618
-    pristine_git_object: bb804f1acb18438dfb2a42cbe48839955f433b98
+    last_write_checksum: sha1:8f4d5858e67641132400c71b6c8f234421479e66
+    pristine_git_object: 2a9b58608ee3d9033d16e2d5add158f55e02fef0
   docs/models/multi-update-preview-response.md:
     id: f55e4b81e76c
     last_write_checksum: sha1:38f5f7b0dcfbb50fbfb2bca039e24155a1d531c9
@@ -5615,8 +5615,8 @@ trackedFiles:
     pristine_git_object: 00e7afbe70176cf59ede9e5567190f4efb3be2b0
   docs/models/multi-update-update.md:
     id: 83625c0d3000
-    last_write_checksum: sha1:c532caf987387251e105eb44df394fa34ee9dc9c
-    pristine_git_object: 7a11e685cb15d603f4bfd00cd9d9ed16ae488eda
+    last_write_checksum: sha1:f8ad54689584ffe295a29d2f47699495ca70865f
+    pristine_git_object: 2f66e977252fa2088d14f3e533b386c744c58f8e
   docs/models/on-decrease.md:
     id: 101f3c344c1f
     last_write_checksum: sha1:f1d0801b9a5bd2841b228a84405cb509248577e2
@@ -6951,8 +6951,8 @@ trackedFiles:
     pristine_git_object: 08574d31bd80b64743bb69304cc9a95c5df8d8d0
   docs/models/preview-multi-update-params.md:
     id: b6c8ebb7b87a
-    last_write_checksum: sha1:6e57e828e73e72d36d568dc056fe6f2044333f05
-    pristine_git_object: 988e97debcd8a03e5c6b56700a2f44870c80e100
+    last_write_checksum: sha1:e5db6442222e9e72b01a43de04c0f7f5b26ba896
+    pristine_git_object: a4975a75b642ccde72ce3d13a0cf990e30504bc4
   docs/models/preview-multi-update-proration-behavior.md:
     id: 95c84df7735c
     last_write_checksum: sha1:79872707c92a40e2a83dcbbbba13fb7ccb7270a2
@@ -6967,8 +6967,8 @@ trackedFiles:
     pristine_git_object: 542a0ef162d109d45baee0100e90ec613e90c17d
   docs/models/preview-multi-update-update.md:
     id: 9b26db3dce91
-    last_write_checksum: sha1:4ff7fd0fb6795c6a5e4ccc895ab8896b9b2957db
-    pristine_git_object: 6a8064a008872048c67972e6b8b791055e1ab30b
+    last_write_checksum: sha1:570a9ee0117452bba09d335e3e48c73affe92609
+    pristine_git_object: 38f7e071ebb10482d0f338ca45ec98232474366a
   docs/models/preview-multi-update-usage-line-item-period.md:
     id: f326b6282141
     last_write_checksum: sha1:77ac24d64a5f72811089a44c2ff15c8a4d511e94
@@ -10031,8 +10031,8 @@ trackedFiles:
     pristine_git_object: 0ebe5146cd24c153cb9b7655e4f502c09f7d4abd
   docs/sdks/billing/README.md:
     id: dc915331dd9d
-    last_write_checksum: sha1:2e7fc5ad0cb827e1c66616aac884c98675f26180
-    pristine_git_object: fcf96755e85348131271ae4c8cb7f86128667733
+    last_write_checksum: sha1:7f087a324032fede628c854bb2e21e1317ced28b
+    pristine_git_object: 450e4709276337a78150c38654d1182eff0b831b
   docs/sdks/customers/README.md:
     id: 9332759cffc2
     last_write_checksum: sha1:9ef975ed7a810cead53f98391be01f8aafd67d7d
@@ -10147,8 +10147,8 @@ trackedFiles:
     pristine_git_object: a15c30aa8c62eb2cc1031cc33923efed2c0ab8c7
   src/funcs/billing-multi-update.ts:
     id: 806822a26e84
-    last_write_checksum: sha1:697125dfc609367badc0dc98f019bb59060ff12f
-    pristine_git_object: 97776e2d675e7290ff3b7a3700b76cba31215156
+    last_write_checksum: sha1:a57b4d0328dab28fb36d157d6d64b7d32dd13138
+    pristine_git_object: 9ac03047b9f8263f60c9f609dd789d0f4d5ba4c4
   src/funcs/billing-open-customer-portal.ts:
     id: bb88a88dc0c5
     last_write_checksum: sha1:3e8a3ac6667dca9207ab7d38ccfc3a418c759003
@@ -10163,8 +10163,8 @@ trackedFiles:
     pristine_git_object: bd3a8935acbfa1e0531173c6712babebb0f79eaa
   src/funcs/billing-preview-multi-update.ts:
     id: d39dc9ea703b
-    last_write_checksum: sha1:e7e050b928c6968e734b72d279d407790e881ff0
-    pristine_git_object: 47e1e883cc3d64d79b42d858d941d5aa916918d1
+    last_write_checksum: sha1:fd3d02f4932bc18bd6025cb837bc42586fb67d01
+    pristine_git_object: cf4ca6124ec607c6b309ca37b3f0e01b1f5bfe69
   src/funcs/billing-preview-update.ts:
     id: cd3a375787c5
     last_write_checksum: sha1:4bf281f7236df1c252aae24569992b2a4b01ab79
@@ -10391,8 +10391,8 @@ trackedFiles:
     pristine_git_object: 44be0eae8246521b230e8e711a88eff738fc015d
   src/lib/config.ts:
     id: 320761608fb3
-    last_write_checksum: sha1:a30adea3ea810f644e940b74baa021e904ace450
-    pristine_git_object: 5f6865f42c15c7b13cee33bfa273a79d418f6f74
+    last_write_checksum: sha1:f64bb0bd2dcb34652f3c8d474ef882842f6bf305
+    pristine_git_object: 73e1b83d9ffb793312cb10b5255fc71fc87fd175
   src/lib/dlv.ts:
     id: b1988214835a
     last_write_checksum: sha1:1dd3e3fbb4550c4bf31f5ef997faff355d6f3250
@@ -10655,8 +10655,8 @@ trackedFiles:
     pristine_git_object: fac09266dd9331c7181d10c854baa10a5024437d
   src/models/multi-update-op.ts:
     id: dadd2a33fd11
-    last_write_checksum: sha1:e8d73e983818545ffa1d232cefd3ecc2b9a4fb5c
-    pristine_git_object: c78f45d5a3c53ad1fd8ac5be4788872352ccf996
+    last_write_checksum: sha1:e0c99efd74fc86c91f7cc565caabc738f6b2e656
+    pristine_git_object: 791522494864fd376fc48fbfc22b94814774952d
   src/models/open-customer-portal-op.ts:
     id: a003eb4172a9
     last_write_checksum: sha1:5e672fc975a0336c963181042a770c2a43cbc0e3
@@ -10675,8 +10675,8 @@ trackedFiles:
     pristine_git_object: 17e6657680724f825076d8838907f242dee30ada
   src/models/preview-multi-update-op.ts:
     id: f7d681281cae
-    last_write_checksum: sha1:40764b096c6c49ee46794aaf3f78aec7800b480b
-    pristine_git_object: 985e3215c2267350f489d8ba35c0557d0f4c2f1d
+    last_write_checksum: sha1:5890ddc20be76f857cfd9957e2369b5c2ac48721
+    pristine_git_object: 35755b8b1bc1e66930d5cc500e53d8f6db3e53f5
   src/models/preview-update-op.ts:
     id: fcbbbf3b22ac
     last_write_checksum: sha1:2e4d561e952a698f2990ac76071d0c7e213a252d
@@ -10767,8 +10767,8 @@ trackedFiles:
     pristine_git_object: 571de419ea3321d79acec4bddbb46b1580007115
   src/sdk/billing.ts:
     id: 10905058c4ad
-    last_write_checksum: sha1:a1389be5240a1d6b37c6f51285eadc96e236d349
-    pristine_git_object: 24798a82468f256d3b70342f7e1c487d8d3521a1
+    last_write_checksum: sha1:23d16a8a8596a93ad3df92766d8332e479229cd2
+    pristine_git_object: 084f4744de9411fc4c276bfaada65f53221c2d56
   src/sdk/customers.ts:
     id: d33e193e0c00
     last_write_checksum: sha1:9363c51bdf5a65a291f6ab33d70cf3742f5d3bbe

--- a/packages/sdk/.speakeasy/out.openapi.yaml
+++ b/packages/sdk/.speakeasy/out.openapi.yaml
@@ -26220,6 +26220,8 @@ paths:
 
         @param customerId - The ID of the customer to update plans for.
         @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+        @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+        @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
         @param updates - The list of plan updates to apply to the customer.
 
         @returns A billing response with the resulting invoice summary (one credit invoice per affected subscription for immediate cancels).
@@ -26238,6 +26240,20 @@ paths:
                 entity_id:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -26267,20 +26283,6 @@ paths:
                           - none
                         type: string
                         description: How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.
@@ -26392,6 +26394,8 @@ paths:
 
         @param customerId - The ID of the customer to update plans for.
         @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+        @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+        @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
         @param updates - The list of plan updates to apply to the customer.
 
         @returns A preview with the combined total plus one entry per subscription, each with its own line items, totals, and next-cycle preview.
@@ -26410,6 +26414,20 @@ paths:
                 entity_id:
                   type: string
                   description: The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
+                refund_last_payment:
+                  enum:
+                    - prorated
+                    - full
+                  type: string
+                  title: RefundLastPayment
+                  description: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+                subscription_params:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
+                  title: SubscriptionParams
+                  description: Additional parameters to pass into the Stripe subscription update or cancel call.
                 updates:
                   type: array
                   minItems: 1
@@ -26439,20 +26457,6 @@ paths:
                           - none
                         type: string
                         description: How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.
-                      refund_last_payment:
-                        enum:
-                          - prorated
-                          - full
-                        type: string
-                        title: RefundLastPayment
-                        description: Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
-                      subscription_params:
-                        type: object
-                        propertyNames:
-                          type: string
-                        additionalProperties: {}
-                        title: SubscriptionParams
-                        description: Additional parameters to pass into the Stripe subscription update or cancel call.
                     required:
                       - cancel_action
                   description: The list of plan updates to apply to the customer.

--- a/packages/sdk/.speakeasy/workflow.lock
+++ b/packages/sdk/.speakeasy/workflow.lock
@@ -1,16 +1,16 @@
-speakeasyVersion: 1.763.3
+speakeasyVersion: 1.762.0
 sources:
     Autumn API:
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:3f2bdb082c448763b2ce428d074daa314fb3f59010cc5117f67a54bd3fc67c59
-        sourceBlobDigest: sha256:ad498217bff326b32b569340762f61082a87570d80aab7f024b75ed3a4e85220
+        sourceRevisionDigest: sha256:ecaffb1fbaad94513e515b0c3a985b470ebb12fc681ad14fce57ffdef5b9c38b
+        sourceBlobDigest: sha256:3927f3519d1d3b56db2eae39348d9d68a46c1d7742e09ba5bf13ac822e39f5df
         tags:
             - latest
             - 2.3.0
     Autumn API Stripped:
         sourceNamespace: autumn-api-stripped
-        sourceRevisionDigest: sha256:6953a26ffaa331c82b16f4d6b251a0d2c13366b1a50f281fa496e195e03b2048
-        sourceBlobDigest: sha256:48482162ce411b4560743bdbe0481cda1a4f5f10972592524313d1ede937755d
+        sourceRevisionDigest: sha256:5c89730d9428c9e81f7e9ba20b0160e85c3f2161a9f57f8c9f7b08ec64a10f68
+        sourceBlobDigest: sha256:faaf96a65b3532c92bc1800ce1d1d22d0e8696e8f9129a93b8ee3f516b0c08a6
         tags:
             - latest
             - 2.3.0
@@ -18,17 +18,17 @@ targets:
     autumn:
         source: Autumn API
         sourceNamespace: autumn-api
-        sourceRevisionDigest: sha256:3f2bdb082c448763b2ce428d074daa314fb3f59010cc5117f67a54bd3fc67c59
-        sourceBlobDigest: sha256:ad498217bff326b32b569340762f61082a87570d80aab7f024b75ed3a4e85220
+        sourceRevisionDigest: sha256:ecaffb1fbaad94513e515b0c3a985b470ebb12fc681ad14fce57ffdef5b9c38b
+        sourceBlobDigest: sha256:3927f3519d1d3b56db2eae39348d9d68a46c1d7742e09ba5bf13ac822e39f5df
         codeSamplesNamespace: autumn-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:d18789f8c65e4f9720386c5221c86811305641492fa8be6c2ead168f6de89fe0
+        codeSamplesRevisionDigest: sha256:9e079d02d78993ac3be686b1d0cf6b61146d87b0ac3583e39e2c9fe5eecf7ca3
     autumn-python:
         source: Autumn API Stripped
         sourceNamespace: autumn-api-stripped
-        sourceRevisionDigest: sha256:6953a26ffaa331c82b16f4d6b251a0d2c13366b1a50f281fa496e195e03b2048
-        sourceBlobDigest: sha256:48482162ce411b4560743bdbe0481cda1a4f5f10972592524313d1ede937755d
+        sourceRevisionDigest: sha256:5c89730d9428c9e81f7e9ba20b0160e85c3f2161a9f57f8c9f7b08ec64a10f68
+        sourceBlobDigest: sha256:faaf96a65b3532c92bc1800ce1d1d22d0e8696e8f9129a93b8ee3f516b0c08a6
         codeSamplesNamespace: autumn-api-python-code-samples
-        codeSamplesRevisionDigest: sha256:8b9aaf7de4fe783cdab9bae2f785940184fa19f61b64a408a3272671c362a733
+        codeSamplesRevisionDigest: sha256:9da317e93e5a5958aeb3f18f588ab9e883709a8509781ec096ae52bf95778f33
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.762.0

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -539,6 +539,8 @@ const response = await client.billing.multiUpdate({ customerId: "cus_123", updat
 
 @param customerId - The ID of the customer to update plans for.
 @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+@param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+@param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
 @param updates - The list of plan updates to apply to the customer.
 
 @returns A billing response with the resulting invoice summary (one credit invoice per affected subscription for immediate cancels).
@@ -554,6 +556,8 @@ const response = await client.billing.previewMultiUpdate({ customerId: "cus_123"
 
 @param customerId - The ID of the customer to update plans for.
 @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+@param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+@param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
 @param updates - The list of plan updates to apply to the customer.
 
 @returns A preview with the combined total plus one entry per subscription, each with its own line items, totals, and next-cycle preview.
@@ -1025,6 +1029,8 @@ const response = await client.billing.multiUpdate({ customerId: "cus_123", updat
 
 @param customerId - The ID of the customer to update plans for.
 @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+@param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+@param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
 @param updates - The list of plan updates to apply to the customer.
 
 @returns A billing response with the resulting invoice summary (one credit invoice per affected subscription for immediate cancels).
@@ -1111,6 +1117,8 @@ const response = await client.billing.previewMultiUpdate({ customerId: "cus_123"
 
 @param customerId - The ID of the customer to update plans for.
 @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+@param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+@param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
 @param updates - The list of plan updates to apply to the customer.
 
 @returns A preview with the combined total plus one entry per subscription, each with its own line items, totals, and next-cycle preview.

--- a/packages/sdk/src/funcs/billing-multi-update.ts
+++ b/packages/sdk/src/funcs/billing-multi-update.ts
@@ -45,6 +45,8 @@ import { Result } from "../types/fp.js";
  *
  * @param customerId - The ID of the customer to update plans for.
  * @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+ * @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+ * @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
  * @param updates - The list of plan updates to apply to the customer.
  *
  * @returns A billing response with the resulting invoice summary (one credit invoice per affected subscription for immediate cancels).

--- a/packages/sdk/src/funcs/billing-preview-multi-update.ts
+++ b/packages/sdk/src/funcs/billing-preview-multi-update.ts
@@ -39,6 +39,8 @@ import { Result } from "../types/fp.js";
  *
  * @param customerId - The ID of the customer to update plans for.
  * @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+ * @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+ * @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
  * @param updates - The list of plan updates to apply to the customer.
  *
  * @returns A preview with the combined total plus one entry per subscription, each with its own line items, totals, and next-cycle preview.

--- a/packages/sdk/src/lib/config.ts
+++ b/packages/sdk/src/lib/config.ts
@@ -72,6 +72,6 @@ export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "2.3.0",
   sdkVersion: "0.10.18",
-  genVersion: "2.884.7",
-  userAgent: "speakeasy-sdk/typescript 0.10.18 2.884.7 2.3.0 @useautumn/sdk",
+  genVersion: "2.882.0",
+  userAgent: "speakeasy-sdk/typescript 0.10.18 2.882.0 2.3.0 @useautumn/sdk",
 } as const;

--- a/packages/sdk/src/models/multi-update-op.ts
+++ b/packages/sdk/src/models/multi-update-op.ts
@@ -16,6 +16,20 @@ export type MultiUpdateGlobals = {
 };
 
 /**
+ * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+ */
+export const MultiUpdateRefundLastPayment = {
+  Prorated: "prorated",
+  Full: "full",
+} as const;
+/**
+ * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+ */
+export type MultiUpdateRefundLastPayment = ClosedEnum<
+  typeof MultiUpdateRefundLastPayment
+>;
+
+/**
  * Action to perform for cancellation. 'cancel_immediately' cancels now with prorated refund, 'cancel_end_of_cycle' cancels at period end, 'uncancel' reverses a pending cancellation.
  */
 export const MultiUpdateCancelAction = {
@@ -44,20 +58,6 @@ export type MultiUpdateProrationBehavior = ClosedEnum<
   typeof MultiUpdateProrationBehavior
 >;
 
-/**
- * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
- */
-export const MultiUpdateRefundLastPayment = {
-  Prorated: "prorated",
-  Full: "full",
-} as const;
-/**
- * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
- */
-export type MultiUpdateRefundLastPayment = ClosedEnum<
-  typeof MultiUpdateRefundLastPayment
->;
-
 export type MultiUpdateUpdate = {
   /**
    * The ID of the plan to update. Optional if subscription_id is provided.
@@ -79,14 +79,6 @@ export type MultiUpdateUpdate = {
    * How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.
    */
   prorationBehavior?: MultiUpdateProrationBehavior | undefined;
-  /**
-   * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
-   */
-  refundLastPayment?: MultiUpdateRefundLastPayment | undefined;
-  /**
-   * Additional parameters to pass into the Stripe subscription update or cancel call.
-   */
-  subscriptionParams?: { [k: string]: any } | undefined;
 };
 
 export type MultiUpdateParams = {
@@ -98,6 +90,14 @@ export type MultiUpdateParams = {
    * The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
    */
   entityId?: string | undefined;
+  /**
+   * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+   */
+  refundLastPayment?: MultiUpdateRefundLastPayment | undefined;
+  /**
+   * Additional parameters to pass into the Stripe subscription update or cancel call.
+   */
+  subscriptionParams?: { [k: string]: any } | undefined;
   /**
    * The list of plan updates to apply to the customer.
    */
@@ -185,6 +185,11 @@ export type MultiUpdateResponse = {
 };
 
 /** @internal */
+export const MultiUpdateRefundLastPayment$outboundSchema: z.ZodMiniEnum<
+  typeof MultiUpdateRefundLastPayment
+> = z.enum(MultiUpdateRefundLastPayment);
+
+/** @internal */
 export const MultiUpdateCancelAction$outboundSchema: z.ZodMiniEnum<
   typeof MultiUpdateCancelAction
 > = z.enum(MultiUpdateCancelAction);
@@ -195,19 +200,12 @@ export const MultiUpdateProrationBehavior$outboundSchema: z.ZodMiniEnum<
 > = z.enum(MultiUpdateProrationBehavior);
 
 /** @internal */
-export const MultiUpdateRefundLastPayment$outboundSchema: z.ZodMiniEnum<
-  typeof MultiUpdateRefundLastPayment
-> = z.enum(MultiUpdateRefundLastPayment);
-
-/** @internal */
 export type MultiUpdateUpdate$Outbound = {
   plan_id?: string | undefined;
   subscription_id?: string | undefined;
   entity_id?: string | undefined;
   cancel_action: string;
   proration_behavior?: string | undefined;
-  refund_last_payment?: string | undefined;
-  subscription_params?: { [k: string]: any } | undefined;
 };
 
 /** @internal */
@@ -221,8 +219,6 @@ export const MultiUpdateUpdate$outboundSchema: z.ZodMiniType<
     entityId: z.optional(z.string()),
     cancelAction: MultiUpdateCancelAction$outboundSchema,
     prorationBehavior: z.optional(MultiUpdateProrationBehavior$outboundSchema),
-    refundLastPayment: z.optional(MultiUpdateRefundLastPayment$outboundSchema),
-    subscriptionParams: z.optional(z.record(z.string(), z.any())),
   }),
   z.transform((v) => {
     return remap$(v, {
@@ -231,8 +227,6 @@ export const MultiUpdateUpdate$outboundSchema: z.ZodMiniType<
       entityId: "entity_id",
       cancelAction: "cancel_action",
       prorationBehavior: "proration_behavior",
-      refundLastPayment: "refund_last_payment",
-      subscriptionParams: "subscription_params",
     });
   }),
 );
@@ -249,6 +243,8 @@ export function multiUpdateUpdateToJSON(
 export type MultiUpdateParams$Outbound = {
   customer_id: string;
   entity_id?: string | undefined;
+  refund_last_payment?: string | undefined;
+  subscription_params?: { [k: string]: any } | undefined;
   updates: Array<MultiUpdateUpdate$Outbound>;
 };
 
@@ -260,12 +256,16 @@ export const MultiUpdateParams$outboundSchema: z.ZodMiniType<
   z.object({
     customerId: z.string(),
     entityId: z.optional(z.string()),
+    refundLastPayment: z.optional(MultiUpdateRefundLastPayment$outboundSchema),
+    subscriptionParams: z.optional(z.record(z.string(), z.any())),
     updates: z.array(z.lazy(() => MultiUpdateUpdate$outboundSchema)),
   }),
   z.transform((v) => {
     return remap$(v, {
       customerId: "customer_id",
       entityId: "entity_id",
+      refundLastPayment: "refund_last_payment",
+      subscriptionParams: "subscription_params",
     });
   }),
 );

--- a/packages/sdk/src/models/preview-multi-update-op.ts
+++ b/packages/sdk/src/models/preview-multi-update-op.ts
@@ -16,6 +16,20 @@ export type PreviewMultiUpdateGlobals = {
 };
 
 /**
+ * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+ */
+export const PreviewMultiUpdateRefundLastPayment = {
+  Prorated: "prorated",
+  Full: "full",
+} as const;
+/**
+ * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+ */
+export type PreviewMultiUpdateRefundLastPayment = ClosedEnum<
+  typeof PreviewMultiUpdateRefundLastPayment
+>;
+
+/**
  * Action to perform for cancellation. 'cancel_immediately' cancels now with prorated refund, 'cancel_end_of_cycle' cancels at period end, 'uncancel' reverses a pending cancellation.
  */
 export const PreviewMultiUpdateCancelAction = {
@@ -44,20 +58,6 @@ export type PreviewMultiUpdateProrationBehavior = ClosedEnum<
   typeof PreviewMultiUpdateProrationBehavior
 >;
 
-/**
- * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
- */
-export const PreviewMultiUpdateRefundLastPayment = {
-  Prorated: "prorated",
-  Full: "full",
-} as const;
-/**
- * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
- */
-export type PreviewMultiUpdateRefundLastPayment = ClosedEnum<
-  typeof PreviewMultiUpdateRefundLastPayment
->;
-
 export type PreviewMultiUpdateUpdate = {
   /**
    * The ID of the plan to update. Optional if subscription_id is provided.
@@ -79,14 +79,6 @@ export type PreviewMultiUpdateUpdate = {
    * How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.
    */
   prorationBehavior?: PreviewMultiUpdateProrationBehavior | undefined;
-  /**
-   * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
-   */
-  refundLastPayment?: PreviewMultiUpdateRefundLastPayment | undefined;
-  /**
-   * Additional parameters to pass into the Stripe subscription update or cancel call.
-   */
-  subscriptionParams?: { [k: string]: any } | undefined;
 };
 
 export type PreviewMultiUpdateParams = {
@@ -98,6 +90,14 @@ export type PreviewMultiUpdateParams = {
    * The ID of the entity to update plans for. Individual updates can override this with their own entity_id.
    */
   entityId?: string | undefined;
+  /**
+   * Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment.
+   */
+  refundLastPayment?: PreviewMultiUpdateRefundLastPayment | undefined;
+  /**
+   * Additional parameters to pass into the Stripe subscription update or cancel call.
+   */
+  subscriptionParams?: { [k: string]: any } | undefined;
   /**
    * The list of plan updates to apply to the customer.
    */
@@ -423,6 +423,11 @@ export type MultiUpdatePreviewResponse = {
 };
 
 /** @internal */
+export const PreviewMultiUpdateRefundLastPayment$outboundSchema: z.ZodMiniEnum<
+  typeof PreviewMultiUpdateRefundLastPayment
+> = z.enum(PreviewMultiUpdateRefundLastPayment);
+
+/** @internal */
 export const PreviewMultiUpdateCancelAction$outboundSchema: z.ZodMiniEnum<
   typeof PreviewMultiUpdateCancelAction
 > = z.enum(PreviewMultiUpdateCancelAction);
@@ -433,19 +438,12 @@ export const PreviewMultiUpdateProrationBehavior$outboundSchema: z.ZodMiniEnum<
 > = z.enum(PreviewMultiUpdateProrationBehavior);
 
 /** @internal */
-export const PreviewMultiUpdateRefundLastPayment$outboundSchema: z.ZodMiniEnum<
-  typeof PreviewMultiUpdateRefundLastPayment
-> = z.enum(PreviewMultiUpdateRefundLastPayment);
-
-/** @internal */
 export type PreviewMultiUpdateUpdate$Outbound = {
   plan_id?: string | undefined;
   subscription_id?: string | undefined;
   entity_id?: string | undefined;
   cancel_action: string;
   proration_behavior?: string | undefined;
-  refund_last_payment?: string | undefined;
-  subscription_params?: { [k: string]: any } | undefined;
 };
 
 /** @internal */
@@ -461,10 +459,6 @@ export const PreviewMultiUpdateUpdate$outboundSchema: z.ZodMiniType<
     prorationBehavior: z.optional(
       PreviewMultiUpdateProrationBehavior$outboundSchema,
     ),
-    refundLastPayment: z.optional(
-      PreviewMultiUpdateRefundLastPayment$outboundSchema,
-    ),
-    subscriptionParams: z.optional(z.record(z.string(), z.any())),
   }),
   z.transform((v) => {
     return remap$(v, {
@@ -473,8 +467,6 @@ export const PreviewMultiUpdateUpdate$outboundSchema: z.ZodMiniType<
       entityId: "entity_id",
       cancelAction: "cancel_action",
       prorationBehavior: "proration_behavior",
-      refundLastPayment: "refund_last_payment",
-      subscriptionParams: "subscription_params",
     });
   }),
 );
@@ -491,6 +483,8 @@ export function previewMultiUpdateUpdateToJSON(
 export type PreviewMultiUpdateParams$Outbound = {
   customer_id: string;
   entity_id?: string | undefined;
+  refund_last_payment?: string | undefined;
+  subscription_params?: { [k: string]: any } | undefined;
   updates: Array<PreviewMultiUpdateUpdate$Outbound>;
 };
 
@@ -502,12 +496,18 @@ export const PreviewMultiUpdateParams$outboundSchema: z.ZodMiniType<
   z.object({
     customerId: z.string(),
     entityId: z.optional(z.string()),
+    refundLastPayment: z.optional(
+      PreviewMultiUpdateRefundLastPayment$outboundSchema,
+    ),
+    subscriptionParams: z.optional(z.record(z.string(), z.any())),
     updates: z.array(z.lazy(() => PreviewMultiUpdateUpdate$outboundSchema)),
   }),
   z.transform((v) => {
     return remap$(v, {
       customerId: "customer_id",
       entityId: "entity_id",
+      refundLastPayment: "refund_last_payment",
+      subscriptionParams: "subscription_params",
     });
   }),
 );

--- a/packages/sdk/src/sdk/billing.ts
+++ b/packages/sdk/src/sdk/billing.ts
@@ -397,6 +397,8 @@ export class Billing extends ClientSDK {
    *
    * @param customerId - The ID of the customer to update plans for.
    * @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+   * @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+   * @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
    * @param updates - The list of plan updates to apply to the customer.
    *
    * @returns A billing response with the resulting invoice summary (one credit invoice per affected subscription for immediate cancels).
@@ -425,6 +427,8 @@ export class Billing extends ClientSDK {
    *
    * @param customerId - The ID of the customer to update plans for.
    * @param entityId - The ID of the entity to update plans for. Individual updates can override this with their own entity_id. (optional)
+   * @param refundLastPayment - Controls how the last payment is refunded on immediate cancellation. 'prorated' refunds the unused portion, 'full' refunds the entire last payment. (optional)
+   * @param subscriptionParams - Additional parameters to pass into the Stripe subscription update or cancel call. (optional)
    * @param updates - The list of plan updates to apply to the customer.
    *
    * @returns A preview with the combined total plus one entry per subscription, each with its own line items, totals, and next-cycle preview.

--- a/server/src/internal/billing/v2/actions/multiUpdate/setup/setupMultiUpdateItemParams.ts
+++ b/server/src/internal/billing/v2/actions/multiUpdate/setup/setupMultiUpdateItemParams.ts
@@ -21,8 +21,8 @@ export const multiUpdateItemToParams = ({
 	customer_product_id: item.customer_product_id,
 	cancel_action: item.cancel_action,
 	proration_behavior: item.proration_behavior,
-	refund_last_payment: item.refund_last_payment,
-	subscription_params: item.subscription_params,
+	refund_last_payment: params.refund_last_payment,
+	subscription_params: params.subscription_params,
 });
 
 export const narrowFullCustomerToEntity = ({

--- a/server/tests/_groups/temp.ts
+++ b/server/tests/_groups/temp.ts
@@ -14,7 +14,6 @@ const activeTempPaths: string[] = [
 	"integration/billing/update-subscription/free-trial/update-quantity-with-trial.test.ts",
 	"integration/catalog-v2/plans/update/stripe-price-immutability.test.ts",
 	"integration/catalog-v2/plans/update/update-plan-free-trial.test.ts",
-	"integration/crud/plans/update/update-plan-allocated-v1-compat.test.ts",
 	"integration/crud/plans/variants/rollover-disambiguation.test.ts",
 ];
 

--- a/server/tests/integration/billing/multi-update/cancel-params/multi-update-cancel-params.test.ts
+++ b/server/tests/integration/billing/multi-update/cancel-params/multi-update-cancel-params.test.ts
@@ -3,8 +3,8 @@
  *
  * Contract:
  *   New types/fields:
- *     updates[].refund_last_payment: "prorated" | "full"
- *     updates[].subscription_params.cancellation_details.{feedback,comment}
+ *     refund_last_payment: "prorated" | "full"
+ *     subscription_params.cancellation_details.{feedback,comment}
  *   New behaviors:
  *     refund_last_payment on cancel_immediately refunds the last Stripe payment
  *     cancellation_details reach Stripe on cancel_immediately (subscriptions.cancel)
@@ -65,11 +65,11 @@ test.concurrent(
 
 		await autumnV2_3.billing.multiUpdate<MultiUpdateParamsV0Input>({
 			customer_id: customerId,
+			refund_last_payment: "full",
 			updates: [
 				{
 					plan_id: pro.id,
 					cancel_action: "cancel_immediately",
-					refund_last_payment: "full",
 				},
 			],
 		});
@@ -119,13 +119,13 @@ test.concurrent(
 
 		await autumnV2_3.billing.multiUpdate<MultiUpdateParamsV0Input>({
 			customer_id: customerId,
+			subscription_params: {
+				cancellation_details: stripeCancellationDetails,
+			},
 			updates: [
 				{
 					plan_id: pro.id,
 					cancel_action: "cancel_immediately",
-					subscription_params: {
-						cancellation_details: stripeCancellationDetails,
-					},
 				},
 			],
 		});
@@ -157,13 +157,13 @@ test.concurrent(
 
 		await autumnV2_3.billing.multiUpdate<MultiUpdateParamsV0Input>({
 			customer_id: customerId,
+			subscription_params: {
+				cancellation_details: stripeCancellationDetails,
+			},
 			updates: [
 				{
 					plan_id: pro.id,
 					cancel_action: "cancel_end_of_cycle",
-					subscription_params: {
-						cancellation_details: stripeCancellationDetails,
-					},
 				},
 			],
 		});

--- a/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts
+++ b/server/tests/integration/billing/stripe-webhooks/subscription-created/licenses/sub-created-parent-product-license-backsync.test.ts
@@ -10,6 +10,7 @@ import {
 import {
 	createExternalStripeSubscription,
 	stampStripeSlotsViaV1Attach,
+	stripePriceIdForPrice,
 } from "@tests/integration/billing/stripe-webhooks/utils/sharedStripeProductAutoSyncUtils";
 import { createStripeFixedPriceUnderProduct } from "@tests/integration/billing/sync/utils/syncProductHelpers";
 import {
@@ -87,10 +88,11 @@ const expectCustomizedPriceUnderLicenseProduct = async ({
 	expect(customized.planLicense.customized).toBe(true);
 	expect(price?.is_custom).toBe(true);
 	expect(price?.config.stripe_product_id).toBe(licenseStripeProductId);
-	expect(price?.config.stripe_price_id).toBeDefined();
+	if (!price) throw new Error(`License ${licensePlanId} has no base price`);
+	const stampedStripePriceId = stripePriceIdForPrice({ price });
 
 	const stripePrice = await ctx.stripeCli.prices.retrieve(
-		price!.config.stripe_price_id!,
+		stampedStripePriceId,
 	);
 	expect(stripeProductId({ price: stripePrice })).toBe(licenseStripeProductId);
 

--- a/server/tests/integration/billing/stripe-webhooks/utils/sharedStripeProductAutoSyncUtils.ts
+++ b/server/tests/integration/billing/stripe-webhooks/utils/sharedStripeProductAutoSyncUtils.ts
@@ -91,8 +91,13 @@ export const requireUsagePrice = ({ fullProduct }: { fullProduct: FullProduct })
 };
 
 export const stripePriceIdForPrice = ({ price }: { price: Price }) => {
+	const config = price.config;
 	const stripePriceId =
-		price.config.stripe_price_id ?? price.config.stripe_empty_price_id;
+		config.stripe_price_id ??
+		("stripe_prepaid_price_v2_id" in config
+			? config.stripe_prepaid_price_v2_id
+			: undefined) ??
+		config.stripe_empty_price_id;
 	if (!stripePriceId) throw new Error(`Price ${price.id} has no Stripe price`);
 	return stripePriceId;
 };

--- a/server/tests/integration/catalog-v2/plans/update/stripe-price-immutability.test.ts
+++ b/server/tests/integration/catalog-v2/plans/update/stripe-price-immutability.test.ts
@@ -61,12 +61,12 @@ const prepaidMessagesItem = ({
 	},
 });
 
-const stripePriceIdOf = (price: { config: unknown }): string => {
+const stripePriceIdOf = (price: { config: unknown }): string | undefined => {
 	const config = price.config as {
 		stripe_prepaid_price_v2_id?: string | null;
 		stripe_price_id?: string | null;
 	};
-	return (config.stripe_prepaid_price_v2_id || config.stripe_price_id)!;
+	return config.stripe_prepaid_price_v2_id || config.stripe_price_id || undefined;
 };
 
 test.concurrent(
@@ -98,7 +98,9 @@ test.concurrent(
 						items: [
 							prepaidMessagesItem({
 								amount: 500,
-								stripePriceId: stripePriceIdOf(beforePrice),
+								...(stripePriceIdOf(beforePrice)
+									? { stripePriceId: stripePriceIdOf(beforePrice) }
+									: {}),
 							}),
 						],
 					},

--- a/server/tests/integration/crud/plans/variants/rollover-disambiguation.test.ts
+++ b/server/tests/integration/crud/plans/variants/rollover-disambiguation.test.ts
@@ -29,7 +29,9 @@ import {
 	BillingInterval,
 	BillingMethod,
 	type CreatePlanParamsV2Input,
+	findPriceByFeatureId,
 	type PlanUpdatePreview,
+	type Price,
 	ResetInterval,
 	RolloverExpiryDurationType,
 } from "@autumn/shared";
@@ -40,6 +42,7 @@ import { AutumnRpcCli } from "@/external/autumn/autumnRpcCli.js";
 import { ProductService } from "@/internal/products/ProductService.js";
 import ctx from "@tests/utils/testInitUtils/createTestContext.js";
 import { initScenario, s } from "@tests/utils/testInitUtils/initScenario.js";
+import { stripeConfigValue } from "@tests/integration/utils/expectStripePriceResources.js";
 import {
 	expectStripeResourcesCarriedToVariant,
 	expectVariantProductCorrect,
@@ -584,12 +587,17 @@ test.concurrent(
 		await autumnV1.attach({ customer_id: customerId, product_id: variantId, options: [{ feature_id: TestFeature.Credits, quantity: 500 }] });
 		await wait(4000);
 
+		const prepaidStripeId = (price: Price | undefined) =>
+			stripeConfigValue({ price, field: "stripe_prepaid_price_v2_id" }) ??
+			stripeConfigValue({ price, field: "stripe_price_id" });
+
 		const variantV1 = await ProductService.getFull({ db, idOrInternalId: variantId, orgId: org.id, env });
-		const v1PrepaidPrice = variantV1.prices.find(
-			(p: any) => p.config?.feature_id === TestFeature.Credits && p.config?.stripe_price_id,
-		);
+		const v1PrepaidPrice = findPriceByFeatureId({
+			prices: variantV1.prices,
+			featureId: TestFeature.Credits,
+		});
 		expect(v1PrepaidPrice).toBeDefined();
-		expect((v1PrepaidPrice!.config as any)?.stripe_price_id).toBeTruthy();
+		expect(prepaidStripeId(v1PrepaidPrice)).toBeTruthy();
 
 		await autumnRpc.plans.update<ApiPlanV1>(baseId, {
 			items: rolloverPrepaidItems(500),
@@ -599,12 +607,13 @@ test.concurrent(
 		const variantVersions = await getAllVersions(variantId);
 		expect(variantVersions.length).toBe(2);
 
-		const v2 = variantVersions.find((v: any) => v.version === 2)!;
-		const v2PrepaidPrice = v2.prices.find(
-			(p: any) => p.config?.feature_id === TestFeature.Credits && p.config?.stripe_price_id,
-		);
+		const v2 = variantVersions.find((v: { version: number }) => v.version === 2)!;
+		const v2PrepaidPrice = findPriceByFeatureId({
+			prices: v2.prices,
+			featureId: TestFeature.Credits,
+		});
 		expect(v2PrepaidPrice).toBeDefined();
-		expect((v2PrepaidPrice!.config as any)?.stripe_price_id).toBeTruthy();
+		expect(prepaidStripeId(v2PrepaidPrice)).toBeTruthy();
 
 		await cleanup(baseId, variantId);
 	},

--- a/server/tests/unit/billing/multi-update/multi-update-cancel-params-schema.test.ts
+++ b/server/tests/unit/billing/multi-update/multi-update-cancel-params-schema.test.ts
@@ -4,13 +4,15 @@
  *
  * Contract:
  *   New types/fields:
- *     updates[].subscription_params?: Record<string, unknown>
+ *     multiUpdate.subscription_params?: Record<string, unknown>
+ *     multiUpdate.refund_last_payment?: "prorated" | "full"
  *     update.subscription_params?: Record<string, unknown>
  *   Kept:
- *     refund_last_payment cannot pair with proration_behavior
- *     refund_last_payment requires cancel_immediately
+ *     refund_last_payment cannot pair with any update's proration_behavior
+ *     refund_last_payment requires every update to be cancel_immediately
  *   Removed:
  *     cancellation_details / Autumn reason+details rename
+ *     per-update subscription_params / refund_last_payment
  */
 
 import { describe, expect, test } from "bun:test";
@@ -24,9 +26,19 @@ import {
 import { multiUpdateItemToParams } from "@/internal/billing/v2/actions/multiUpdate/setup/setupMultiUpdateItemParams";
 import chalk from "chalk";
 
-const parseMultiUpdate = (updates: Array<Record<string, unknown>>) =>
+const parseMultiUpdate = ({
+	updates,
+	refundLastPayment,
+	subscriptionParams,
+}: {
+	updates: Array<Record<string, unknown>>;
+	refundLastPayment?: "prorated" | "full";
+	subscriptionParams?: Record<string, unknown>;
+}) =>
 	ExtMultiUpdateParamsV0Schema.safeParse({
 		customer_id: "cus_123",
+		refund_last_payment: refundLastPayment,
+		subscription_params: subscriptionParams,
 		updates,
 	});
 
@@ -39,14 +51,16 @@ const stripeSubscriptionParams = {
 
 describe(chalk.yellowBright("multiUpdate cancel param schema"), () => {
 	test("rejects refund_last_payment with proration_behavior", () => {
-		const result = parseMultiUpdate([
-			{
-				plan_id: "pro",
-				cancel_action: "cancel_immediately",
-				refund_last_payment: "full",
-				proration_behavior: "prorate_immediately",
-			},
-		]);
+		const result = parseMultiUpdate({
+			refundLastPayment: "full",
+			updates: [
+				{
+					plan_id: "pro",
+					cancel_action: "cancel_immediately",
+					proration_behavior: "prorate_immediately",
+				},
+			],
+		});
 
 		expect(result.success).toBe(false);
 		if (result.success) return;
@@ -56,13 +70,15 @@ describe(chalk.yellowBright("multiUpdate cancel param schema"), () => {
 	});
 
 	test("rejects refund_last_payment unless cancel_immediately", () => {
-		const result = parseMultiUpdate([
-			{
-				plan_id: "pro",
-				cancel_action: "cancel_end_of_cycle",
-				refund_last_payment: "full",
-			},
-		]);
+		const result = parseMultiUpdate({
+			refundLastPayment: "full",
+			updates: [
+				{
+					plan_id: "pro",
+					cancel_action: "cancel_end_of_cycle",
+				},
+			],
+		});
 
 		expect(result.success).toBe(false);
 		if (result.success) return;
@@ -72,48 +88,52 @@ describe(chalk.yellowBright("multiUpdate cancel param schema"), () => {
 	});
 
 	test("accepts refund_last_payment on immediate cancel", () => {
-		const result = parseMultiUpdate([
-			{
-				plan_id: "pro",
-				cancel_action: "cancel_immediately",
-				refund_last_payment: "full",
-			},
-		]);
+		const result = parseMultiUpdate({
+			refundLastPayment: "full",
+			updates: [
+				{
+					plan_id: "pro",
+					cancel_action: "cancel_immediately",
+				},
+			],
+		});
 
 		expect(result.success).toBe(true);
+		if (!result.success) return;
+		expect(result.data.refund_last_payment).toBe("full");
 	});
 
 	test("accepts subscription_params on end-of-cycle cancel", () => {
-		const result = parseMultiUpdate([
-			{
-				plan_id: "pro",
-				cancel_action: "cancel_end_of_cycle",
-				subscription_params: stripeSubscriptionParams,
-			},
-		]);
+		const result = parseMultiUpdate({
+			subscriptionParams: stripeSubscriptionParams,
+			updates: [
+				{
+					plan_id: "pro",
+					cancel_action: "cancel_end_of_cycle",
+				},
+			],
+		});
 
 		expect(result.success).toBe(true);
 		if (!result.success) return;
-		expect(result.data.updates[0]?.subscription_params).toEqual(
-			stripeSubscriptionParams,
-		);
+		expect(result.data.subscription_params).toEqual(stripeSubscriptionParams);
 	});
 
 	test("accepts subscription_params on immediate cancel", () => {
-		const result = parseMultiUpdate([
-			{
-				plan_id: "pro",
-				cancel_action: "cancel_immediately",
-				refund_last_payment: "prorated",
-				subscription_params: stripeSubscriptionParams,
-			},
-		]);
+		const result = parseMultiUpdate({
+			refundLastPayment: "prorated",
+			subscriptionParams: stripeSubscriptionParams,
+			updates: [
+				{
+					plan_id: "pro",
+					cancel_action: "cancel_immediately",
+				},
+			],
+		});
 
 		expect(result.success).toBe(true);
 		if (!result.success) return;
-		expect(result.data.updates[0]?.subscription_params).toEqual(
-			stripeSubscriptionParams,
-		);
+		expect(result.data.subscription_params).toEqual(stripeSubscriptionParams);
 	});
 });
 
@@ -146,18 +166,21 @@ describe(chalk.yellowBright("update subscription param schema"), () => {
 });
 
 describe(chalk.yellowBright("multiUpdateItemToParams"), () => {
-	test("copies subscription_params onto update params", () => {
-		const params = {
-			customer_id: "cus_123",
-		} as MultiUpdateParamsV0;
+	test("copies top-level subscription_params and refund_last_payment onto update params", () => {
 		const item = {
 			plan_id: "pro",
 			cancel_action: "cancel_end_of_cycle",
-			subscription_params: stripeSubscriptionParams,
 		} as MultiUpdateItemV0;
+		const params = {
+			customer_id: "cus_123",
+			refund_last_payment: "full" as const,
+			subscription_params: stripeSubscriptionParams,
+			updates: [item],
+		} satisfies MultiUpdateParamsV0;
 
-		expect(
-			multiUpdateItemToParams({ params, item }).subscription_params,
-		).toEqual(stripeSubscriptionParams);
+		expect(multiUpdateItemToParams({ params, item })).toMatchObject({
+			refund_last_payment: "full",
+			subscription_params: stripeSubscriptionParams,
+		});
 	});
 });

--- a/server/tests/unit/catalogV2/comparators/price-to-stripe-price-idempotency-shape.test.ts
+++ b/server/tests/unit/catalogV2/comparators/price-to-stripe-price-idempotency-shape.test.ts
@@ -1,15 +1,21 @@
 /**
- * Stripe Price idempotency shape — only fields that land on prices.create
+ * Stripe Price idempotency shape — fields that change prices.create
  * for THIS currency. Same normalizations as pricesAreSame for those fields.
  *
  * In:  amount (this currency), usage_tiers (this currency), interval,
- *      interval_count, billing_units (usage), tier_behavior (usage)
+ *      interval_count, billing_units (usage), tier_behavior (usage),
+ *      bill_when, should_prorate, allocated_billing_behavior
  * Out: entitlement, feature ids, proration, other-currency overlays,
- *      stripe ids, should_prorate, bill_when
+ *      stripe ids
+ *
+ * Red (current):  bill_when / should_prorate collide so allocated→arrear remint
+ *                 reuses autumn:price:{id}:stripe_price_id:{ccy}:{hash}
+ * Green (after):  those config fields change the hash
  */
 
 import { describe, expect, test } from "bun:test";
 import {
+	AllocatedBillingBehavior,
 	BillingInterval,
 	BillWhen,
 	type FixedPriceConfig,
@@ -279,8 +285,34 @@ describe("priceToStripePriceIdempotencyShape", () => {
 		});
 	});
 
+	describe("usage — billing path (in-place config update remints the same slot)", () => {
+		test("bill_when", () => {
+			expectShapeSame(
+				usage({ bill_when: BillWhen.EndOfPeriod }),
+				usage({ bill_when: BillWhen.InAdvance }),
+				false,
+			);
+		});
+
+		test("should_prorate", () => {
+			expectShapeSame(
+				usage({ should_prorate: false }),
+				usage({ should_prorate: true }),
+				false,
+			);
+		});
+
+		test("allocated_billing_behavior", () => {
+			expectShapeSame(
+				usage({ allocated_billing_behavior: AllocatedBillingBehavior.Prorated }),
+				usage({ allocated_billing_behavior: AllocatedBillingBehavior.Arrear }),
+				false,
+			);
+		});
+	});
+
 	describe("ignored (differ but still same shape)", () => {
-		test("stripe ids, feature ids, bill_when, should_prorate, entitlement", () => {
+		test("stripe ids, feature ids, entitlement", () => {
 			expectShapeSame(
 				usage({
 					stripe_price_id: "a",
@@ -288,8 +320,6 @@ describe("priceToStripePriceIdempotencyShape", () => {
 					stripe_meter_id: "a",
 					feature_id: "messages",
 					internal_feature_id: "ifeat_1",
-					bill_when: BillWhen.EndOfPeriod,
-					should_prorate: false,
 				}),
 				usage({
 					stripe_price_id: "b",
@@ -297,8 +327,6 @@ describe("priceToStripePriceIdempotencyShape", () => {
 					stripe_meter_id: "b",
 					feature_id: "seats",
 					internal_feature_id: "ifeat_2",
-					bill_when: BillWhen.InAdvance,
-					should_prorate: true,
 				}),
 				true,
 			);

--- a/server/tests/unit/external/stripe/build-stripe-price-idempotency-key.test.ts
+++ b/server/tests/unit/external/stripe/build-stripe-price-idempotency-key.test.ts
@@ -6,7 +6,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { BillingInterval, type Price, PriceType } from "@autumn/shared";
+import {
+	BillingInterval,
+	BillWhen,
+	type Price,
+	PriceType,
+} from "@autumn/shared";
 import { buildStripePriceIdempotencyKey } from "@/external/stripe/prices/utils/buildIdempotencyKey.js";
 
 const fixed = ({ amount }: { amount: number }): Price => ({
@@ -43,5 +48,31 @@ describe("buildStripePriceIdempotencyKey", () => {
 		expect(key({ price: ten })).toBe(key({ price: tenAgain }));
 		expect(key({ price: ten })).not.toBe(key({ price: twenty }));
 		expect(key({ price: ten })).toMatch(/^autumn:price:pr_abc:stripe_price_id:usd:[a-f0-9]{16}$/);
+	});
+
+	test("same id + amount, prorated → arrear, gets a new key", () => {
+		const usage = ({ shouldProrate }: { shouldProrate: boolean }): Price => ({
+			id: "pr_abc",
+			org_id: "org_1",
+			created_at: 1,
+			internal_product_id: "ip_pro",
+			is_custom: false,
+			proration_config: null,
+			config: {
+				type: PriceType.Usage,
+				bill_when: BillWhen.EndOfPeriod,
+				should_prorate: shouldProrate,
+				interval: BillingInterval.Month,
+				interval_count: 1,
+				billing_units: 1,
+				usage_tiers: [{ to: "inf", amount: 1 }],
+				feature_id: "messages",
+				internal_feature_id: "feat_1",
+			},
+		});
+
+		expect(key({ price: usage({ shouldProrate: true }) })).not.toBe(
+			key({ price: usage({ shouldProrate: false }) }),
+		);
 	});
 });

--- a/shared/api/billing/multiUpdate/multiUpdateParamsV0.ts
+++ b/shared/api/billing/multiUpdate/multiUpdateParamsV0.ts
@@ -4,26 +4,36 @@ import { CancelActionSchema } from "../common/cancelAction";
 import { RefundLastPaymentSchema } from "../common/refundLastPayment";
 import { SubscriptionParamsSchema } from "../common/subscriptionParams";
 
-const applyMultiUpdateItemRefinements = <
+const applyMultiUpdateParamsRefinements = <
 	Schema extends z.ZodType<{
-		cancel_action: z.infer<typeof CancelActionSchema>;
-		proration_behavior?: z.infer<typeof BillingBehaviorSchema>;
 		refund_last_payment?: z.infer<typeof RefundLastPaymentSchema>;
-		subscription_params?: z.infer<typeof SubscriptionParamsSchema>;
+		updates: Array<{
+			cancel_action: z.infer<typeof CancelActionSchema>;
+			proration_behavior?: z.infer<typeof BillingBehaviorSchema>;
+		}>;
 	}>,
 >(
 	schema: Schema,
 ) =>
 	schema
-		.refine((data) => !(data.refund_last_payment && data.proration_behavior), {
-			message:
-				"Cannot pass both proration_behavior and refund_last_payment. Use proration_behavior for invoice credits/proration, or refund_last_payment for direct refunds.",
-		})
 		.refine(
 			(data) =>
 				!(
 					data.refund_last_payment &&
-					data.cancel_action !== "cancel_immediately"
+					data.updates.some((update) => update.proration_behavior)
+				),
+			{
+				message:
+					"Cannot pass both proration_behavior and refund_last_payment. Use proration_behavior for invoice credits/proration, or refund_last_payment for direct refunds.",
+			},
+		)
+		.refine(
+			(data) =>
+				!(
+					data.refund_last_payment &&
+					data.updates.some(
+						(update) => update.cancel_action !== "cancel_immediately",
+					)
 				),
 			{
 				message:
@@ -53,21 +63,15 @@ const extMultiUpdateItemShape = z.object({
 		description:
 			"How to handle proration for this update. 'prorate_immediately' charges/credits prorated amounts now, 'none' skips creating any charges.",
 	}),
-	refund_last_payment: RefundLastPaymentSchema.optional(),
-	subscription_params: SubscriptionParamsSchema.optional(),
 });
 
-export const ExtMultiUpdateItemV0Schema = applyMultiUpdateItemRefinements(
-	extMultiUpdateItemShape,
-);
+export const ExtMultiUpdateItemV0Schema = extMultiUpdateItemShape;
 
-export const MultiUpdateItemV0Schema = applyMultiUpdateItemRefinements(
-	extMultiUpdateItemShape.extend({
-		customer_product_id: z.string().optional().meta({
-			internal: true,
-		}),
+export const MultiUpdateItemV0Schema = extMultiUpdateItemShape.extend({
+	customer_product_id: z.string().optional().meta({
+		internal: true,
 	}),
-);
+});
 
 const multiUpdateParamsBase = {
 	customer_id: z.string().meta({
@@ -77,27 +81,33 @@ const multiUpdateParamsBase = {
 		description:
 			"The ID of the entity to update plans for. Individual updates can override this with their own entity_id.",
 	}),
+	refund_last_payment: RefundLastPaymentSchema.optional(),
+	subscription_params: SubscriptionParamsSchema.optional(),
 };
 
 const updatesMeta = {
 	description: "The list of plan updates to apply to the customer.",
 };
 
-export const ExtMultiUpdateParamsV0Schema = z.object({
-	...multiUpdateParamsBase,
-	updates: z
-		.array(ExtMultiUpdateItemV0Schema)
-		.min(1, "At least one update must be provided")
-		.meta(updatesMeta),
-});
+export const ExtMultiUpdateParamsV0Schema = applyMultiUpdateParamsRefinements(
+	z.object({
+		...multiUpdateParamsBase,
+		updates: z
+			.array(ExtMultiUpdateItemV0Schema)
+			.min(1, "At least one update must be provided")
+			.meta(updatesMeta),
+	}),
+);
 
-export const MultiUpdateParamsV0Schema = z.object({
-	...multiUpdateParamsBase,
-	updates: z
-		.array(MultiUpdateItemV0Schema)
-		.min(1, "At least one update must be provided")
-		.meta(updatesMeta),
-});
+export const MultiUpdateParamsV0Schema = applyMultiUpdateParamsRefinements(
+	z.object({
+		...multiUpdateParamsBase,
+		updates: z
+			.array(MultiUpdateItemV0Schema)
+			.min(1, "At least one update must be provided")
+			.meta(updatesMeta),
+	}),
+);
 
 export type MultiUpdateItemV0 = z.infer<typeof MultiUpdateItemV0Schema>;
 export type MultiUpdateParamsV0 = z.infer<typeof MultiUpdateParamsV0Schema>;

--- a/shared/utils/productUtils/priceUtils/comparePrice/priceToStripePriceIdempotencyShape.ts
+++ b/shared/utils/productUtils/priceUtils/comparePrice/priceToStripePriceIdempotencyShape.ts
@@ -1,8 +1,14 @@
 import { priceConfigForCurrency } from "@models/productModels/priceModels/priceConfig/priceCurrencyView";
 import { PriceType } from "@models/productModels/priceModels/priceEnums";
 import type { Price } from "@models/productModels/priceModels/priceModels";
-import { TierBehavior } from "@models/productModels/priceModels/priceConfig/usagePriceConfig";
-import { usageTiersToComparisonShape } from "./pricesAreSame.js";
+import {
+	TierBehavior,
+	type UsagePriceConfig,
+} from "@models/productModels/priceModels/priceConfig/usagePriceConfig";
+import {
+	normalizedAllocatedBillingBehavior,
+	usageTiersToComparisonShape,
+} from "./pricesAreSame.js";
 
 /**
  * Stripe mint identity for one attach currency. Same normalizations as
@@ -23,11 +29,11 @@ export const priceToStripePriceIdempotencyShape = ({
 		currency: ccy,
 		orgDefault: orgDefault.toLowerCase(),
 	});
-	const usage = price.config.type === PriceType.Usage;
-	const billingUnits =
-		usage && "billing_units" in price.config
-			? (price.config.billing_units ?? 1)
+	const usageConfig =
+		price.config.type === PriceType.Usage
+			? (price.config as UsagePriceConfig)
 			: null;
+	const billingUnits = usageConfig ? (usageConfig.billing_units ?? 1) : null;
 
 	return {
 		amount: amount ?? null,
@@ -35,8 +41,13 @@ export const priceToStripePriceIdempotencyShape = ({
 		interval: price.config.interval ?? null,
 		interval_count: price.config.interval_count ?? 1,
 		billing_units: billingUnits,
-		tier_behavior: usage
+		tier_behavior: usageConfig
 			? (price.tier_behavior ?? TierBehavior.Graduated)
+			: null,
+		bill_when: usageConfig?.bill_when ?? null,
+		should_prorate: usageConfig ? (usageConfig.should_prorate ?? false) : null,
+		allocated_billing_behavior: usageConfig
+			? normalizedAllocatedBillingBehavior(usageConfig)
 			: null,
 	};
 };

--- a/shared/utils/productUtils/priceUtils/comparePrice/pricesAreSame.ts
+++ b/shared/utils/productUtils/priceUtils/comparePrice/pricesAreSame.ts
@@ -13,7 +13,9 @@ import {
 } from "@autumn/shared";
 
 /** Unset behavior follows the allocated v1 shape: derived from should_prorate. */
-const normalizedAllocatedBillingBehavior = (usageConfig: UsagePriceConfig) =>
+export const normalizedAllocatedBillingBehavior = (
+	usageConfig: UsagePriceConfig,
+) =>
 	usageConfig.allocated_billing_behavior ??
 	(usageConfig.should_prorate
 		? AllocatedBillingBehavior.Prorated


### PR DESCRIPTION
## Summary
- `billing.multi_update` / `preview_multi_update` now take `refund_last_payment` and `subscription_params` on the request, not on each `updates[]` item. Both apply to every update.
- Same refinements as before: refund cannot pair with any update's `proration_behavior`, and every update must be `cancel_immediately`.
- This is the current `dev` → `main` merge, including the subscription_params Stripe pass-through that was not on `main` yet.

## Test plan
- [x] Unit: schema refinements + mapper copies top-level fields onto each update
- [x] Integration: `multi-update-cancel-params` (full refund + cancellation_details on immediate and end-of-cycle)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `refund_last_payment` and `subscription_params` from each `updates[]` item to the request root in `multi_update` and `preview_multi_update`, and hashes billing-path fields into Stripe price identity so prices remint when those fields change.

**Multi-update changes**
- `refund_last_payment` is rejected when any update sets `proration_behavior` or has a `cancel_action` other than `cancel_immediately`.
- Includes the `subscription_params` Stripe pass-through not yet on `main`.

**Stripe price identity**
- `bill_when`, `should_prorate`, and `allocated_billing_behavior` now change the idempotency hash, so editing them creates a new Stripe price instead of reusing the old one.

<sup>Written for commit 4bac1c54636f008c7faaad126f2bbd34a224624d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves multi-update refund and Stripe subscription parameters to the request root and expands Stripe price identity for billing-path changes.
- **API changes:** Moves `refund_last_payment` and `subscription_params` from individual updates to the shared multi-update request across schemas, SDKs, and server mapping.
- **Improvements:** Applies the shared cancellation parameters to each update and validates refund compatibility across the full update list.
- **Bug fixes:** Includes billing-path fields in Stripe price identity so relevant catalog edits mint a new price.
- **Improvements:** Adds schema, integration, and price-identity coverage for the revised behavior.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking documentation example that should be updated to use the new request shape.

The implementation, schemas, and generated clients consistently move the fields to the request root, but the primary multi-update example still demonstrates the obsolete nested placement.

**Files Needing Attention:** apps/docs/mintlify/api-reference/billing/multiUpdate.mdx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| shared/api/billing/multiUpdate/multiUpdateParamsV0.ts | Moves shared cancellation fields to the request root and applies cross-update refund refinements. |
| server/src/internal/billing/v2/actions/multiUpdate/setup/setupMultiUpdateItemParams.ts | Copies request-level refund and subscription parameters into each internal update operation. |
| shared/utils/productUtils/priceUtils/comparePrice/priceToStripePriceIdempotencyShape.ts | Adds billing-path behavior to Stripe price idempotency identity using existing normalization. |
| packages/sdk/src/models/multi-update-op.ts | Regenerates the TypeScript multi-update request model with the fields at the root. |
| others/python-sdk/src/autumn_sdk/billing.py | Exposes and serializes the root-level fields in synchronous and asynchronous Python methods. |
| apps/docs/mintlify/api-reference/billing/multiUpdate.mdx | Moves parameter reference entries to the root, but leaves the cancellation example using the obsolete nested shape. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/docs/mintlify/api-reference/billing/multiUpdate.mdx:62-68
**Example uses obsolete nesting**

The “Cancel immediately with a refund and Stripe reason” example still places `refundLastPayment` and `subscriptionParams` inside `updates[0]`, although these fields now belong at the request root. Copying the example causes SDK validation to fail or the requested refund and cancellation details not to be sent.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into dev"](https://github.com/useautumn/autumn/commit/4bac1c54636f008c7faaad126f2bbd34a224624d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57606151)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Usage and billing API platform](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/api-platform.md)
- Knowledge Base — [Billing lifecycle and payment flows](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/billing-lifecycle.md)
- Knowledge Base — [SDKs and API contract delivery](https://app.greptile.com/autumn-org-2/-/custom-context/knowledge-base/useautumn/autumn/-/docs/sdk-and-api-contract-delivery.md)
</details>


<!-- /greptile_comment -->