### PR TITLE
fix: allow cancelling immediately when a subscription is already scheduled to cancel

### DIFF
--- a/vite/src/views/customers2/components/sheets/SubscriptionUncancelSheet.tsx
+++ b/vite/src/views/customers2/components/sheets/SubscriptionUncancelSheet.tsx
@@ -1,4 +1,4 @@
-import type { FullCusProduct, ProductV2 } from "@autumn/shared";
+import type { CancelAction, FullCusProduct, ProductV2 } from "@autumn/shared";
 import { useMemo } from "react";
 import { CancelAdvancedSection } from "@/components/forms/cancel-subscription/components/CancelAdvancedSection";
 import { CancelPreviewSection } from "@/components/forms/cancel-subscription/components/CancelPreviewSection";
@@ -67,8 +67,12 @@ function SheetContent() {
 
 export function SubscriptionUncancelSheet() {
 	const itemId = useSheetStore((s) => s.itemId);
+	const sheetData = useSheetStore((s) => s.data);
 	const { closeSheet } = useSheetStore();
 	const { customer } = useCusQuery();
+
+	const initialCancelAction: CancelAction =
+		(sheetData?.cancelAction as CancelAction | undefined) ?? "uncancel";
 
 	const { cusProduct, productV2 } = useSubscriptionById({ itemId });
 	const { prepaidItems } = usePrepaidItems({ product: productV2 });
@@ -116,7 +120,12 @@ export function SubscriptionUncancelSheet() {
 		<UpdateSubscriptionFormProvider
 			formContext={formContext}
 			originalItems={undefined}
-			defaultOverrides={{ cancelAction: "uncancel" }}
+			defaultOverrides={{
+				cancelAction: initialCancelAction,
+				...(initialCancelAction === "cancel_immediately" && {
+					billingBehavior: "prorate_immediately",
+				}),
+			}}
 			onSuccess={closeSheet}
 		>
 			<SheetContent />

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx
@@ -7,7 +7,7 @@ import {
 } from "@autumn/ui";
 import { FlaskIcon, PencilIcon } from "@phosphor-icons/react";
 import type { Row, Table } from "@tanstack/react-table";
-import { ArrowRightLeft, Delete, RotateCcw } from "lucide-react";
+import { ArrowRightLeft, Delete, RotateCcw, Zap } from "lucide-react";
 import {
 	hiddenSkeleton,
 	nameWithIconSkeleton,
@@ -114,6 +114,7 @@ export const CustomerProductsColumns = [
 				onCancelClick?: (product: FullCusProduct) => void;
 				onUpdateClick?: (product: FullCusProduct) => void;
 				onUncancelClick?: (product: FullCusProduct) => void;
+				onCancelImmediatelyClick?: (product: FullCusProduct) => void;
 				onTransferClick?: (product: FullCusProduct) => void;
 				onTestSheetClick?: (product: FullCusProduct) => void;
 				hasEntities?: boolean;
@@ -160,15 +161,26 @@ export const CustomerProductsColumns = [
 							</DropdownMenuItem>
 						)}
 						{isCanceling ? (
-							<DropdownMenuItem
-								className="flex items-center gap-2 text-xs"
-								onClick={(e) => {
-									e.stopPropagation();
-									meta.onUncancelClick?.(row.original);
-								}}
-							>
-								<RotateCcw size={16} /> Uncancel
-							</DropdownMenuItem>
+							<>
+								<DropdownMenuItem
+									className="flex items-center gap-2 text-xs"
+									onClick={(e) => {
+										e.stopPropagation();
+										meta.onUncancelClick?.(row.original);
+									}}
+								>
+									<RotateCcw size={16} /> Uncancel
+								</DropdownMenuItem>
+								<DropdownMenuItem
+									className="flex items-center gap-2 text-xs text-red-500 dark:text-red-400"
+									onClick={(e) => {
+										e.stopPropagation();
+										meta.onCancelImmediatelyClick?.(row.original);
+									}}
+								>
+									<Zap size={16} /> Cancel Immediately
+								</DropdownMenuItem>
+							</>
 						) : (
 							<DropdownMenuItem
 								className="flex items-center gap-2 text-xs text-red-500 dark:text-red-400"

--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx
@@ -136,6 +136,14 @@ export function CustomerProductsTable() {
 		setSheet({ type: "subscription-uncancel", itemId: product.id });
 	};
 
+	const handleCancelImmediatelyClick = (product: FullCusProduct) => {
+		setSheet({
+			type: "subscription-uncancel",
+			itemId: product.id,
+			data: { cancelAction: "cancel_immediately" },
+		});
+	};
+
 	const handleUpdateClick = (product: FullCusProduct) => {
 		setSheet({ type: "subscription-update", itemId: product.id });
 	};
@@ -151,6 +159,7 @@ export function CustomerProductsTable() {
 			meta: {
 				onCancelClick: handleCancelClick,
 				onUncancelClick: handleUncancelClick,
+				onCancelImmediatelyClick: handleCancelImmediatelyClick,
 				onTransferClick: handleTransferClick,
 				onUpdateClick: handleUpdateClick,
 				hasEntities,


### PR DESCRIPTION
## Summary
- Adds a "Cancel Immediately" item to the customer-products row dropdown when a product already has a scheduled cancellation (`canceled` is true), next to "Uncancel".
- It opens the existing uncancel sheet pre-set to `cancel_immediately` mode (reusing the toggle already built into `SubscriptionUncancelSheet`/`UncancelFooter`), so users no longer have to uncancel first and then cancel again.

Fixes feedback from Resend in Slack: https://autumnpricing.slack.com/archives/C0BCC5PDZ3L/p1787862829704059

## Test plan
- [x] `bun ts` passes in `vite/`
- [x] Biome check on changed files passes
- [ ] Manually verify in dashboard: attach a plan, schedule a cancellation, then use the new "Cancel Immediately" row action and confirm it cancels immediately without a separate uncancel step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the customer-products row dropdown to offer a "Cancel Immediately" action when a subscription is already scheduled to cancel, so users can cancel right away without uncanceling first. The action opens the existing uncancel sheet pre-set to immediate-cancel mode, reusing the same form logic.

<sup>Written for commit 2f5e69a98b934433dc3eff1beabc8f92bf0f6b6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a direct route for immediately canceling a subscription that already has a scheduled cancellation.
- **Bug fixes, Improvements:** Adds a "Cancel Immediately" dropdown action next to "Uncancel" for canceled customer-product rows.
- **Bug fixes, Improvements:** Opens the existing uncancel sheet in immediate-cancellation mode and defaults it to immediate proration.
- **Improvements:** Passes the new row action through the customer-products table metadata.
</details>


<h3>Confidence Score: 4/5</h3>

The immediate-cancellation flow needs an eligibility check before merging because expired products can expose an action that opens a permanently loading sheet.

The intended path for subscriptions awaiting end-of-cycle cancellation is connected correctly, but the same `canceled` flag also matches already-expired products that the destination sheet cannot resolve.

**Files Needing Attention:** vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/sheets/SubscriptionUncancelSheet.tsx | Initializes the existing sheet from optional action data and defaults immediate cancellation to immediate proration. |
| vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx | Adds the new menu item, but its broad `canceled` check also exposes the action on expired products where the sheet cannot load. |
| vite/src/views/customers2/components/table/customer-products/CustomerProductsTable.tsx | Connects the new dropdown callback to the uncancel sheet with `cancel_immediately` initial data. |


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Canceled product row] --> B{Selected action}
  B -->|Uncancel| C[Open subscription uncancel sheet]
  B -->|Cancel Immediately| D[Open same sheet in cancel_immediately mode]
  D --> E[Preview immediate cancellation]
  E --> F[Confirm subscription update]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx:163-183
**Expired cancellations stay loading**

When an already-expired product has `canceled: true`, this condition exposes “Cancel Immediately,” but expired products are excluded from the subscription collection used by the destination sheet, causing the sheet to remain on “Loading...” indefinitely.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: allow cancelling immediately when ..."](https://github.com/useautumn/autumn/commit/2f5e69a98b934433dc3eff1beabc8f92bf0f6b6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57699245)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->