### PR TITLE
fix: rename row action to "Manage Cancellation"

### DIFF
--- a/vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx
+++ b/vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx
@@ -169,7 +169,7 @@ export const CustomerProductsColumns = [
 										meta.onUncancelClick?.(row.original);
 									}}
 								>
-									<RotateCcw size={16} /> Uncancel
+									<RotateCcw size={16} /> Manage Cancellation
 								</DropdownMenuItem>
 								<DropdownMenuItem
 									className="flex items-center gap-2 text-xs text-red-500 dark:text-red-400"


### PR DESCRIPTION
## Summary
- Follow-up to #3134. Renames the row dropdown item from "Uncancel" to "Manage Cancellation" for a customer product with a scheduled cancellation, matching the label already used on the subscription detail sheet footer for the same case — "Uncancel" no longer fits now that this same sheet also lets you cancel immediately.

## Test plan
- [x] `bun ts` passes in `vite/`
- [x] Biome check on changed file passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the customer products row action from "Uncancel" to "Manage Cancellation" so the label matches the subscription detail sheet footer for the same case.

<sup>Written for commit 4860a0725a0b79c299ab67baab7bbe721ad6cd4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/useautumn/autumn/pull/3135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the scheduled-cancellation row action with the wording already used in the subscription details view.
- **[Bug fixes]** Renames “Uncancel” to “Manage Cancellation” because the opened sheet supports both restoring the subscription and canceling it immediately.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only updates user-facing copy to match the existing cancellation workflow.

The action retains the same callback and state gating, and the new wording matches the equivalent action in the subscription details view; no dependent repository code or tests use the previous label.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| vite/src/views/customers2/components/table/customer-products/CustomerProductsColumns.tsx | Renames one dropdown label without changing its visibility conditions, callback, or cancellation behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix: rename row action to &quot;Manage Cancel..."](https://github.com/useautumn/autumn/commit/4860a0725a0b79c299ab67baab7bbe721ad6cd4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57701968)</sub>

<!-- /greptile_comment -->